### PR TITLE
Added SELECT_NEXT_PATTERN_RELATIVE MIDI action

### DIFF
--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -156,6 +156,7 @@ MidiActionManager::MidiActionManager() : Object( __class_name )
 	<< "SELECT_NEXT_PATTERN"
         << "SELECT_NEXT_PATTERN_CC_ABSOLUT"
         << "SELECT_NEXT_PATTERN_PROMPTLY"
+	<< "SELECT_NEXT_PATTERN_RELATIVE"
         << "SELECT_AND_PLAY_PATTERN"
 	<< "PAN_RELATIVE"
 	<< "PAN_ABSOLUTE"
@@ -297,6 +298,18 @@ bool MidiActionManager::handleAction( MidiAction * pAction ){
                 else
                         pEngine->sequencer_setNextPattern( row, false, true );
                 return true;
+        }
+
+        if( sActionString == "SELECT_NEXT_PATTERN_RELATIVE" ){
+		bool ok;
+                if(!Preferences::get_instance()->patternModePlaysSelected())
+		    return true;
+		int row = pEngine->getSelectedPatternNumber() + pAction->getParameter1().toInt(&ok,10);
+                if( row> pEngine->getSong()->get_pattern_list()->size() -1 )
+                    return false;
+
+		pEngine->setSelectedPatternNumber( row );
+		return true;
         }
 
         if( sActionString == "SELECT_NEXT_PATTERN_CC_ABSOLUT" ){


### PR DESCRIPTION
Hi there!

I'm using Hydrogen in a live environment for beats (works pretty well!). For that, I have created multiple patterns that should be played consecutively, but since our song structures change spontaneously, I'm using the pattern mode, not the song mode. I'd now like to select the next pattern with a MIDI controller, but don't want to use one pad for each pattern. So I've implemented a `SELECT_NEXT_PATTERN_RELATIVE` action that can be used to select the next pattern. The numeric parameter is interpreted as the offset of the new pattern (so a parameter of 0 doesn't make much sense, I'm using 1). I thought this might be of use for someone else, so I'm doing that pull request. :)
