### PR TITLE
Fix buffer overflow in updateMixerLine()

### DIFF
--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -207,7 +207,7 @@ void MixerLine::updateMixerLine()
 			m_nPeakTimer = 0;
 		}
 		char tmp[20];
-		sprintf(tmp, "%#.2f", m_fMaxPeak );
+		snprintf(tmp, 20, "%#.2f", (double)m_fMaxPeak );
 		m_pPeakLCD->setText(tmp);
 		if ( m_fMaxPeak > 1.0 ) {
 			m_pPeakLCD->setSmallRed();


### PR DESCRIPTION
Hydrogen randomly crashes with glibc error  **\* buffer overflow detected ***, with a stack trace pointing to the function MixerLine::updateMixerLine() and then sprintf(). This patch fixes this by replacing sprintf() with snprintf(). Also, the argument is now converted from float to double, since printf-like functions expect a double for "%f" (see man 3 sprintf).
