### PR TITLE
Bunch of minor MIDI fixes

### DIFF
--- a/data/drumkits/GMkit/drumkit.xml
+++ b/data/drumkits/GMkit/drumkit.xml
@@ -27,7 +27,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>35</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -59,7 +59,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>37</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -91,7 +91,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>38</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -123,7 +123,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>39</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -155,7 +155,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>40</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -187,7 +187,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>41</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -219,7 +219,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>42</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -251,7 +251,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>43</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -283,7 +283,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>44</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -315,7 +315,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>45</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -347,7 +347,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>46</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -379,7 +379,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>56</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -411,7 +411,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>51</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -443,7 +443,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>49</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -475,7 +475,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>59</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -507,7 +507,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>57</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>

--- a/data/drumkits/TR808EmulationKit/drumkit.xml
+++ b/data/drumkits/TR808EmulationKit/drumkit.xml
@@ -27,7 +27,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>35</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -59,7 +59,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>36</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -91,7 +91,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>38</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -123,7 +123,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>40</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -155,7 +155,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>39</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -187,7 +187,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>43</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -219,7 +219,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>45</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -251,7 +251,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>48</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -283,7 +283,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>42</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -315,7 +315,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>44</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -347,7 +347,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>46</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -379,7 +379,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>49</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -411,7 +411,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>70</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -443,7 +443,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>63</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -475,7 +475,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>75</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>
@@ -507,7 +507,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>60</midiOutNote>
+   <midiOutNote>56</midiOutNote>
    <isStopNote>false</isStopNote>
    <FX1Level>0</FX1Level>
    <FX2Level>0</FX2Level>

--- a/src/core/src/basics/instrument.cpp
+++ b/src/core/src/basics/instrument.cpp
@@ -55,7 +55,7 @@ Instrument::Instrument( const int id, const QString& name, ADSR* adsr )
 	, __filter_cutoff( 1.0 )
 	, __filter_resonance( 0.0 )
 	, __random_pitch_factor( 0.0 )
-	, __midi_out_note( MIDI_MIDDLE_C )
+	, __midi_out_note( 36 + id )
 	, __midi_out_channel( -1 )
 	, __stop_notes( false )
 	, __active( true )
@@ -212,7 +212,7 @@ Instrument* Instrument::load_from( XMLNode* node, const QString& dk_path, const 
 	instrument->set_gain( node->read_float( "gain", 1.0f, true, false ) );
 	instrument->set_mute_group( node->read_int( "muteGroup", -1, true, false ) );
 	instrument->set_midi_out_channel( node->read_int( "midiOutChannel", -1, true, false ) );
-	instrument->set_midi_out_note( node->read_int( "midiOutNote", MIDI_MIDDLE_C, true, false ) );
+	instrument->set_midi_out_note( node->read_int( "midiOutNote", instrument->__midi_out_note, true, false ) );
 	instrument->set_stop_notes( node->read_bool( "isStopNote", true ,false ) );
 	for ( int i=0; i<MAX_FX; i++ ) {
 		instrument->set_fx_level( node->read_float( QString( "FX%1Level" ).arg( i+1 ), 0.0 ), i );

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1667,7 +1667,9 @@ void audioEngine_startAudioDrivers()
 #endif
 	   } else if ( preferencesMng->m_sMidiDriver == "CoreMidi" ) {
 #ifdef H2CORE_HAVE_COREMIDI
-			  m_pMidiDriver = new CoreMidiDriver();
+			  CoreMidiDriver *coreMidiDriver = new CoreMidiDriver();
+			  m_pMidiDriver = coreMidiDriver;
+			  m_pMidiDriverOut = coreMidiDriver;
 			  m_pMidiDriver->open();
 			  m_pMidiDriver->setActive( true );
 #endif

--- a/src/core/src/smf/smf.cpp
+++ b/src/core/src/smf/smf.cpp
@@ -267,7 +267,8 @@ void SMFWriter::save( const QString& sFilename, Song *pSong )
 							(int)( 127.0 * pNote->get_velocity() );
 						int nInstr =
 							iList->index(pNote->get_instrument());
-						int nPitch = 36 + nInstr;
+						Instrument *pInstr = pNote->get_instrument();
+						int nPitch = pInstr->get_midi_out_note();
 						eventList.push_back(
 							new SMFNoteOnEvent(
 								nStartTicks + nNote,


### PR DESCRIPTION
- Use Instrument::get_midi_out_note for MIDI export
- Assign sequential midi_out_notes to instruments instead of middle C
- Modify MIDI note numbers in drumkits to match GM spec
- Initialize p_midiDriverOut to CoreMidi
