### PR TITLE
Document cross-compiling for Windows using MXE.

### DIFF
--- a/win32/README.md
+++ b/win32/README.md
@@ -20,6 +20,22 @@
 
 http://mxe.cc/#requirements
 
+### Cloning Hydrogen from the github repository
+
+If you have not already done it.
+
+    $ git clone -b master https://github.com/hydrogen-music/hydrogen.git
+
+### Setting the Hydrogen environment variable
+
+Change to your Hydrogen directory.
+
+    $ cd hydrogen
+    
+    $ export HYDROGEN=$PWD
+    
+    $ cd ..
+
 ### Cloning MXE from the github repository
 
 Clone the master branch, since it should be more up-to-date than the stable branch.
@@ -30,17 +46,23 @@ Clone the master branch, since it should be more up-to-date than the stable bran
 
     $ cd mxe
 
-Edit *Makefile* and set the value of *MXE_TARGETS* as follows.
+    $ export MXE=$PWD
+
+Edit *Makefile* and set the value of *MXE_TARGETS* as follows (for 32-bit Windows target).
 
     MXE_TARGETS        := i686-w64-mingw32.shared
 
 ### Configuring and cross-compiling packages
 
-All *make* operations below take time. They should be executed in the MXE root directory, where the *Makefile* resides. Packages along with their dependencies are downloaded and cross-compiled.
+Most *make* operations below take a considerable amount of time. The lengthy ones have been timed, in order to give you a rough estimate. Adjust your completion expectations according to the values presented and your system capabilities. All operations in this section should be executed in the MXE root directory, where the *Makefile* resides. Packages along with their dependencies are downloaded and cross-compiled automatically as needed.
 
 #### Cross-compiling gcc
 
     $ make gcc
+
+    real    13m10.244s
+    user    30m51.456s
+    sys     4m17.841s
 
 #### Cross-compiling winpthreads
 
@@ -56,20 +78,56 @@ Also set the value of *--enable-threads* as follows.
 
     --enable-threads=posix
 
+Then cross-compile gcc again.
+
     $ make gcc
+
+    real    8m32.152s
+    user    24m34.296s
+    sys     2m47.471s
 
 #### Cross-compiling other packages
 
     $ make qt libarchive libsndfile
 
+    real    70m17.737s
+    user    199m0.451s
+    sys     15m14.591s
+
 ### Cross-compiling Hydrogen
 
-    $ cd /path/to/hydrogen
-
-    $ mkdir build
-
-    $ cd build
-
-    $ cmake .. -DCMAKE_TOOLCHAIN_FILE=/path/to/mxe/usr/i686-w64-mingw32.shared/share/cmake/mxe-conf.cmake
-
+    $ cd $HYDROGEN
+    
+    $ cd win32
+    
+    $ mkdir windows_32_bit_build
+    
+    $ cd windows_32_bit_build
+    
+    $ export HYDROGEN_BUILD=$PWD
+    
+    $ cmake ../.. -DCMAKE_TOOLCHAIN_FILE=$MXE/usr/i686-w64-mingw32.shared/share/cmake/mxe-conf.cmake
+    
     $ make
+
+    real    4m32.063s
+    user    4m14.671s
+    sys     0m17.105s
+
+    $ cd ..
+
+### Creating the bundle
+
+    $ ./create_bundle.sh
+
+This creates a directory *hydrogen_windows_32_bit*, which you can copy to your Windows machine and launch Hydrogen!
+
+### Troubleshooting
+
+When copying the directory above to your Windows machine, you will get a copy conflict. This is because Windows' case-insensitivity is put to the test, since two files named *Director.png* and *director.png* exist in the same directory. Resolve the conflict in whichever way you wish, since the aforementioned files seem to be unused.
+
+Using the method described above, I experience Hydrogen crashing at startup. To fix this, download the precompiled libsndfile-1.dll from *http://www.mega-nerd.com/libsndfile/#Download* and put it in the Hydrogen directory.
+
+### Bugs?
+
+Bugs.

--- a/win32/create_bundle.sh
+++ b/win32/create_bundle.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+BUNDLE_DIR=hydrogen_windows_32_bit
+mkdir $BUNDLE_DIR
+cd $BUNDLE_DIR
+cp $HYDROGEN_BUILD/src/gui/hydrogen.exe .
+cp $HYDROGEN_BUILD/src/core/libhydrogen-core-0.9.6.dll .
+cp $HYDROGEN_BUILD/src/cli/h2cli.exe .
+cp $HYDROGEN_BUILD/src/player/h2player.exe .
+cp $HYDROGEN_BUILD/src/synth/h2synth.exe .
+
+cp $MXE/usr/i686-w64-mingw32.shared/qt/bin/QtCore4.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/qt/bin/QtXml4.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/qt/bin/QtXmlPatterns4.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/qt/bin/QtNetwork4.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/qt/bin/QtGui4.dll .
+
+cp $MXE/usr/lib/gcc/i686-w64-mingw32.shared/4.8.2/libgcc_s_sjlj-1.dll .
+cp $MXE/usr/lib/gcc/i686-w64-mingw32.shared/4.8.2/libstdc++-6.dll .
+
+cp $MXE/usr/i686-w64-mingw32.shared/bin/libsndfile-1.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/bin/libFLAC-8.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/bin/libogg-0.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/bin/libvorbis-0.dll .
+cp $MXE/usr/i686-w64-mingw32.shared/bin/libvorbisenc-2.dll .
+
+cp -r $HYDROGEN/data .


### PR DESCRIPTION
This commits create a directory named 'win32' in the root directory with a README.md file and one script inside it. Right now the README.md contains full cross-compilation instructions using MXE. More can be added both in the directory and in the README.md file. The script collects all generated .exe and .dll files, plus all needed .dll files, plus the data directory, and creates a bundle (in another directory) that can be used directly in a Windows machine. Definitely people need to play around. No sound is tested yet and, in case of a crash, I also found that using the pre-built version of libsndfile from the website helped me. All is documented for now.
