### PR TITLE
added MIDI action "SELECT_PREV_PATTERN_RELATIVE"

### DIFF
--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -164,6 +164,7 @@ MidiActionManager::MidiActionManager() : Object( __class_name )
 			  << "SELECT_NEXT_PATTERN_CC_ABSOLUT"
 			  << "SELECT_NEXT_PATTERN_PROMPTLY"
 			  << "SELECT_NEXT_PATTERN_RELATIVE"
+			  << "SELECT_PREV_PATTERN_RELATIVE"
 			  << "SELECT_AND_PLAY_PATTERN"
 			  << "PAN_RELATIVE"
 			  << "PAN_ABSOLUTE"
@@ -311,6 +312,18 @@ bool MidiActionManager::handleAction( MidiAction * pAction ){
 			return true;
 		int row = pEngine->getSelectedPatternNumber() + pAction->getParameter1().toInt(&ok,10);
 		if( row> pEngine->getSong()->get_pattern_list()->size() -1 )
+			return false;
+
+		pEngine->setSelectedPatternNumber( row );
+		return true;
+	}
+
+	if( sActionString == "SELECT_PREV_PATTERN_RELATIVE" ){
+		bool ok;
+		if(!Preferences::get_instance()->patternModePlaysSelected())
+			return true;
+		int row = pEngine->getSelectedPatternNumber() - pAction->getParameter1().toInt(&ok,10);
+		if( row < 0 )
 			return false;
 
 		pEngine->setSelectedPatternNumber( row );


### PR DESCRIPTION
I've added MIDI command to select the previous pattern. I needed it because i use Hydrogen as a rythm box and i've got a MIDI foot controller.
Maybe it could be useful for others.
++
