### PR TITLE
Fix h2player to use applicationDirPath for data

### DIFF
--- a/src/player/main.cpp
+++ b/src/player/main.cpp
@@ -52,16 +52,14 @@ int main(int argc, char** argv){
 	H2Core::Logger* logger = H2Core::Logger::get_instance();
 	H2Core::Object::bootstrap( logger, logger->should_log(H2Core::Logger::Debug) );
 
+	QApplication a(argc, argv);
+
 	H2Core::Filesystem::bootstrap( logger );
-
-
 
 	if (argc != 2) {
 		usage();
 	}
 	cout << "Hydrogen player starting..." << endl << endl;
-
-	QApplication a(argc, argv);
 
 	QString filename = argv[1];
 


### PR DESCRIPTION
Hi, 

I've ran into this when using h2player without installation. It couldn't read any data relative to its executable location because of late QApplication instantiation.

Cheers
Dmitriy

h2player: QApplication instantiation moved before H2Core::Filesystem::bootstrap to satisfy applicationDirPath() call