### PR TITLE
Enable C++11 support in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,9 @@ ELSE()
 ENDIF()
 
 #SET(CMAKE_CXX_FLAGS "-fno-implement-inlines -finline-small-functions -findirect-inlining -fpartial-inlining")
-IF(APPLE)
-	SET(CMAKE_CXX_FLAGS "-O2")
-ELSE()
-	SET(CMAKE_CXX_FLAGS "-O2 -fno-implement-inlines")
+SET(CMAKE_CXX_FLAGS "-O2 -std=c++11 -Wno-deprecated-register")
+IF (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-implement-inlines")
 ENDIF()
 
 SET(CMAKE_CXX_FLAGS_RELEASE "")

--- a/src/core/src/helpers/filesystem.cpp
+++ b/src/core/src/helpers/filesystem.cpp
@@ -68,7 +68,7 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sys_path )
 	__usr_data_path = QCoreApplication::applicationDirPath().append( "/hydrogen/data" ) ;
 #else
 	__sys_data_path = SYS_DATA_PATH;
-	__usr_data_path = QDir::homePath().append( "/"USR_DATA_PATH );
+	__usr_data_path = QDir::homePath().append( "/" USR_DATA_PATH );
 #endif
 	if( sys_path!=0 ) __sys_data_path = sys_path;
 


### PR DESCRIPTION
I added `-std=c++11` switch to CMakeLists to enable support for C++11. This also adds `-Wno-deprecated-register` to silent warnings emitted by Qt headers.

This patch has been tested on Debian unstable (gcc 4.9.2 and clang 3.4.2) and on Mac OS X 10.10 Yosemite (clang 3.6.0svn). I have no access to Windows machine right now.

I have created this patch to check if anyone experiences any problems with compilers that do not support C++11.