### PR TITLE
Produce Standard MIDI Format (SMF) compliant MIDI files

### DIFF
--- a/src/core/include/hydrogen/smf/SMF.h
+++ b/src/core/include/hydrogen/smf/SMF.h
@@ -55,7 +55,8 @@ class SMFTrack : public SMFBase, public H2Core::Object
 {
 	H2_OBJECT
 public:
-	SMFTrack( const QString& sTrackName );
+
+	SMFTrack();
 	~SMFTrack();
 
 	void addEvent( SMFEvent *pEvent );

--- a/src/core/include/hydrogen/smf/SMFEvent.h
+++ b/src/core/include/hydrogen/smf/SMFEvent.h
@@ -100,12 +100,53 @@ class SMFTrackNameMetaEvent : public SMFEvent
 	H2_OBJECT
 public:
 	SMFTrackNameMetaEvent( const QString& sTrackName, unsigned nDeltaTime );
-
 	virtual std::vector<char> getBuffer();
 
 private:
 	QString m_sTrackName;
 
+};
+
+
+
+class SMFSetTempoMetaEvent : public SMFEvent
+{
+	H2_OBJECT
+public:
+	SMFSetTempoMetaEvent( float fBPM, unsigned nDeltaTime );
+	virtual std::vector<char> getBuffer();
+
+private:
+	unsigned m_fBPM;
+
+};
+
+
+
+class SMFCopyRightNoticeMetaEvent : public SMFEvent
+{
+	H2_OBJECT
+public:
+	SMFCopyRightNoticeMetaEvent( const QString& sAuthor, unsigned nDeltaTime );
+	virtual std::vector<char> getBuffer();
+
+private:
+	QString m_sAuthor;
+
+};
+
+
+
+class SMFTimeSignatureMetaEvent : public SMFEvent
+{
+	H2_OBJECT
+public:
+	SMFTimeSignatureMetaEvent( unsigned nBeats, unsigned nNote , unsigned nMTPMC , unsigned nTSNP24 , unsigned nTicks );
+	virtual std::vector<char> getBuffer();
+	// MTPMC = MIDI ticks per metronome click
+	// TSNP24 = Thirty Second Notes Per 24 MIDI Ticks.
+private:
+	unsigned m_nBeats, m_nNote, m_nMTPMC , m_nTSNP24 , m_nTicks;
 };
 
 

--- a/src/core/src/smf/smf.cpp
+++ b/src/core/src/smf/smf.cpp
@@ -277,9 +277,11 @@ void SMFWriter::save( const QString& sFilename, Song *pSong )
 					if ( pNote ) {
 						int nVelocity =
 							(int)( 127.0 * pNote->get_velocity() );
-						int nInstr =
-							iList->index(pNote->get_instrument());
-						int nPitch = 36 + nInstr;
+						
+						int nInstr = iList->index(pNote->get_instrument());
+						Instrument *pInstr = pNote->get_instrument();
+						int nPitch = pInstr->get_midi_out_note();
+						
 						eventList.push_back(
 							new SMFNoteOnEvent(
 								nStartTicks + nNote,

--- a/src/core/src/smf/smf_event.cpp
+++ b/src/core/src/smf/smf_event.cpp
@@ -116,6 +116,110 @@ std::vector<char> SMFTrackNameMetaEvent::getBuffer()
 	return buf.getBuffer();
 }
 
+// ::::::::::::::::::
+
+const char* SMFSetTempoMetaEvent::__class_name = "SMFSetTempoMetaEvent";
+
+SMFSetTempoMetaEvent::SMFSetTempoMetaEvent( float fBPM, unsigned nTicks )
+		: SMFEvent( __class_name, nTicks )
+		, m_fBPM( fBPM )
+{
+	// it's always at the start of the song
+	m_nDeltaTime = 0;
+}
+
+
+std::vector<char> SMFSetTempoMetaEvent::getBuffer()
+{
+	SMFBuffer buf;
+	long msPerBeat;
+	
+	msPerBeat = long( 60000000 / m_fBPM ); // 60 seconds * mills \ BPM
+	
+	buf.writeVarLen( m_nDeltaTime );
+	buf.writeByte( 0xFF );
+	buf.writeByte( SET_TEMPO );
+	buf.writeByte( 0x03 );	// Length 
+	
+	buf.writeByte( msPerBeat >> 16 );
+	buf.writeByte( msPerBeat >> 8 );
+	buf.writeByte( msPerBeat );
+	
+	return buf.getBuffer();
+}
+
+// ::::::::::::::::::
+
+const char* SMFCopyRightNoticeMetaEvent::__class_name = "SMFCopyRightNoticeMetaEvent";
+
+SMFCopyRightNoticeMetaEvent::SMFCopyRightNoticeMetaEvent( const QString& sAuthor, unsigned nTicks )
+		: SMFEvent( __class_name, nTicks )
+		, m_sAuthor( sAuthor )
+{
+	// it's always at the start of the song
+	m_nDeltaTime = 0;
+}
+
+
+std::vector<char> SMFCopyRightNoticeMetaEvent::getBuffer()
+{
+	SMFBuffer buf;
+	QString sCopyRightString;
+	
+	time_t now = time(0);
+	tm *ltm = localtime(&now);						// Extract the local system time.
+	
+	// Construct the copyright string in the form "(C) [Author] [CurrentYear]"
+	sCopyRightString.append("(C) ");				// Start with the copyright symbol and a seperator space.
+	sCopyRightString.append( m_sAuthor );			// add the author
+	sCopyRightString.append(" ");					// add a seperator space
+	sCopyRightString.append( QString::number( 1900 + ltm->tm_year, 10 ) );	// and finish with the year.
+	
+	buf.writeVarLen( m_nDeltaTime );
+	buf.writeByte( 0xFF );
+	buf.writeByte( COPYRIGHT_NOTICE );
+	buf.writeString( sCopyRightString );
+
+	return buf.getBuffer();
+}
+
+// ::::::::::::::::::
+		
+const char* SMFTimeSignatureMetaEvent::__class_name = "SMFTimeSignatureMetaEvent";
+
+SMFTimeSignatureMetaEvent::SMFTimeSignatureMetaEvent( unsigned nBeats, unsigned nNote , unsigned nMTPMC , unsigned nTSNP24 , unsigned nTicks )
+		: SMFEvent( __class_name, nTicks )
+		, m_nBeats( nBeats )
+		, m_nNote( nNote )
+		, m_nMTPMC( nMTPMC )
+		, m_nTSNP24( nTSNP24 )
+		, m_nTicks( nTicks )
+
+{
+	// it's always at the start of the song
+	m_nDeltaTime = 0;
+}
+
+
+std::vector<char> SMFTimeSignatureMetaEvent::getBuffer()
+{
+	SMFBuffer buf;
+	
+	unsigned nBeatsCopy = m_nNote , Note2Log =  0;	// Copy Nbeats as the process to generate Note2Log alters the value.
+	
+	while (nBeatsCopy >>= 1) ++Note2Log;			// Generate a log to base 2 of the note value, so 8 (as in 6/8) becomes 3
+	
+	buf.writeVarLen( m_nDeltaTime );
+	buf.writeByte( 0xFF );
+	buf.writeByte( TIME_SIGNATURE );
+	buf.writeByte( 0x04 );		// Event length in bytes.
+	buf.writeByte( m_nBeats );	// Top line of time signature, eg 6 for 6/8 time
+	buf.writeByte( Note2Log );	// Bottom line of time signature expressed as Log2 of the Note value. 
+	buf.writeByte( m_nMTPMC );	// MIDI Ticks per Metronome click, normally 24 ( i.e. each quarter note ).
+	buf.writeByte( m_nTSNP24 );	// Thirty Second Notes ( as in 1/32 ) per 24 MIDI clocks, normally 8.
+
+	return buf.getBuffer();
+}
 
 // :::::::::::::
 


### PR DESCRIPTION
Resolves these issues:

https://github.com/hydrogen-music/hydrogen/issues/307
https://github.com/hydrogen-music/hydrogen/issues/124

Correct a bug introduced in 0.9.7 which caused all
note on/note off events to be written with a note number of
60 irrespective of the note in the song.

Modify SMF.h, SMFEvent.h, smf_event.cpp, & smf.cpp to generate the MIDI
Tempo track as the first track and populate it with the Copyright Notice
,Time Signature & Set Tempo meta events. The Track Name meta event is
moved to the tempo map.

The name in the Copyright Notice meta event will be extracted from the
Song properites as filled in at the Project->Show Info dialog, which
will be preceded with the copyright (C) symbol and followed with the
current year as specified in the SMF standard. This will be the first
event in the file, also as specified in the SMF standard.

The Track Name meta event will now be extracted from the Song properites
as filled in at the Project->Show Info dialog and will be located in the
tempo map as per the SMF standard.

The Time Signature meta event will be created assuming 4/4 time.

The note on & note off events will start in the second track in the
file.