### PR TITLE
set the Tag column header to stretch over the whole window

### DIFF
--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget_UI.ui
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget_UI.ui
@@ -19,6 +19,12 @@
      <property name="dragDropMode">
       <enum>QAbstractItemView::InternalMove</enum>
      </property>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>100</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
      <column>
       <property name="text">
        <string>Tag</string>


### PR DESCRIPTION
Previously only a part of the SongEditorPanelTagWidget window was used.
With this commit the complete window width is used.