### PR TITLE
Fix for issue #314: song name is now displayed in main window's title…

### DIFF
--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -381,7 +381,7 @@ void HydrogenApp::updateWindowTitle()
 	QString qsSongName( pSong->__name );
 
 	if( qsSongName == "Untitled Song" && !pSong->get_filename().isEmpty() ){
-		qsSongName = qsSongName.section( '/', -1 );
+        qsSongName = pSong->get_filename().section( '/', -1);
 	}
 
 	if(pSong->get_is_modified()){

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -381,7 +381,7 @@ void HydrogenApp::updateWindowTitle()
 	QString qsSongName( pSong->__name );
 
 	if( qsSongName == "Untitled Song" && !pSong->get_filename().isEmpty() ){
-        qsSongName = pSong->get_filename().section( '/', -1);
+		qsSongName = pSong->get_filename().section( '/', -1 );
 	}
 
 	if(pSong->get_is_modified()){


### PR DESCRIPTION
This fix will ensure that the name of the currently opened song is displayed in the main window's title bar.