### PR TITLE
243

### DIFF
--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -15,7 +15,7 @@
 	<useTimeLine>false</useTimeLine>
         <maxBars>400</maxBars>
         <useTheRubberbandBpmChangeEvent>false</useTheRubberbandBpmChangeEvent>
-        <dataDirectory></dataDirectory>
+        <dataDirectory>/usr/local/share/hydrogen/data</dataDirectory>
 	<showDevelWarning>true</showDevelWarning>
 	<hearNewNotes>true</hearNewNotes>
 	<recordEvents>false</recordEvents>

--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -15,6 +15,7 @@
 	<useTimeLine>false</useTimeLine>
         <maxBars>400</maxBars>
         <useTheRubberbandBpmChangeEvent>false</useTheRubberbandBpmChangeEvent>
+        <dataDirectory></dataDirectory>
 	<showDevelWarning>true</showDevelWarning>
 	<hearNewNotes>true</hearNewNotes>
 	<recordEvents>false</recordEvents>

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -201,9 +201,10 @@ int main(int argc, char *argv[])
 		// Man your battle stations... this is not a drill.
 		Logger* logger = Logger::bootstrap( Logger::parse_log_level( logLevelOpt ) );
 		Object::bootstrap( logger, logger->should_log( Logger::Debug ) );
-		Filesystem::bootstrap( logger );
+        Preferences::create_instance();
+        Filesystem::bootstrap( logger );
 		MidiMap::create_instance();
-		Preferences::create_instance();
+
 		Preferences* preferences = Preferences::get_instance();
 		// See below for Hydrogen.
 

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -248,7 +248,12 @@ public:
 	const QString& getDemoPath() {
 		return demoPath;
 	}
-	const QString& getDataDirectory() {
+
+        void setDataDirectory( QString directory ){
+            m_sDataDirectory = directory;
+        }
+
+        const QString& getDataDirectory() {
 		return m_sDataDirectory;
 	}
 

--- a/src/core/include/hydrogen/helpers/filesystem.h
+++ b/src/core/include/hydrogen/helpers/filesystem.h
@@ -234,7 +234,6 @@ class Filesystem : public H2Core::Object
 		static bool check_permissions( const QString& path, const int perms, bool silent );
 
 		static QString __sys_data_path;     ///< the path to the system files
-		static QString __usr_data_path;     ///< the path to the user files
 };
 
 };

--- a/src/core/src/helpers/filesystem.cpp
+++ b/src/core/src/helpers/filesystem.cpp
@@ -1,6 +1,7 @@
 
 #include <hydrogen/config.h>
 #include <hydrogen/helpers/filesystem.h>
+#include <hydrogen/Preferences.h>
 
 #include <QtCore/QDir>
 #include <QtCore/QFile>
@@ -44,7 +45,6 @@ namespace H2Core
 Logger* Filesystem::__logger = 0;
 const char* Filesystem::__class_name = "Filesystem";
 QString Filesystem::__sys_data_path;
-QString Filesystem::__usr_data_path;
 
 /* TODO QCoreApplication is not instanciated */
 bool Filesystem::bootstrap( Logger* logger, const QString& sys_path )
@@ -67,8 +67,7 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sys_path )
 	__sys_data_path = QCoreApplication::applicationDirPath().append( "/data" ) ;
 	__usr_data_path = QDir::homePath().append( "/.hydrogen/data" ) ;
 #else
-	__sys_data_path = SYS_DATA_PATH;
-	__usr_data_path = QDir::homePath().append( "/"USR_DATA_PATH );
+    __sys_data_path = SYS_DATA_PATH;
 #endif
 	if( sys_path!=0 ) __sys_data_path = sys_path;
 
@@ -275,14 +274,14 @@ bool Filesystem::check_sys_paths()
 
 bool Filesystem::check_usr_paths()
 {
-	if( !path_usable( __usr_data_path ) ) return false;
+    if( !path_usable( Preferences::get_instance()->getDataDirectory() ) ) return false;
 	if( !path_usable( songs_dir() ) ) return false;
 	if( !path_usable( patterns_dir() ) ) return false;
 	if( !path_usable( playlists_dir() ) ) return false;
 	if( !path_usable( usr_drumkits_dir() ) ) return false;
 	if( !path_usable( cache_dir() ) ) return false;
 	if( !path_usable( repositories_cache_dir() ) ) return false;
-	INFOLOG( QString( "user path %1 is usable." ).arg( __usr_data_path ) );
+    INFOLOG( QString( "user path %1 is usable." ).arg( Preferences::get_instance()->getDataDirectory()) );
 	return true;
 }
 
@@ -292,7 +291,7 @@ QString Filesystem::sys_data_path()
 }
 QString Filesystem::usr_data_path()
 {
-	return __usr_data_path;
+    return Preferences::get_instance()->getDataDirectory();
 }
 
 // FILES
@@ -302,7 +301,7 @@ QString Filesystem::sys_core_config()
 }
 QString Filesystem::usr_core_config()
 {
-	return __usr_data_path + CORE_CONFIG;
+    return usr_data_path() + CORE_CONFIG;
 }
 QString Filesystem::sys_gui_config()
 {
@@ -310,7 +309,7 @@ QString Filesystem::sys_gui_config()
 }
 QString Filesystem::usr_gui_config()
 {
-	return __usr_data_path + GUI_CONFIG;
+    return usr_data_path() + GUI_CONFIG;
 }
 QString Filesystem::empty_sample()
 {
@@ -326,7 +325,7 @@ QString Filesystem::click_file()
 }
 QString Filesystem::usr_click_file()
 {
-	if( file_readable( __usr_data_path + CLICK_SAMPLE, true ) ) return __usr_data_path + CLICK_SAMPLE;
+    if( file_readable( usr_data_path() + CLICK_SAMPLE, true ) ) return usr_data_path() + CLICK_SAMPLE;
 	return click_file();
 }
 QString Filesystem::drumkit_xsd( )
@@ -357,31 +356,31 @@ QString Filesystem::i18n_dir()
 }
 QString Filesystem::songs_dir()
 {
-	return __usr_data_path + SONGS;
+    return usr_data_path() + SONGS;
 }
 QString Filesystem::patterns_dir()
 {
-	return __usr_data_path + PATTERNS;
+    return usr_data_path() + PATTERNS;
 }
 QString Filesystem::sys_drumkits_dir()
 {
-	return __sys_data_path + DRUMKITS;
+    return usr_data_path() + DRUMKITS;
 }
 QString Filesystem::usr_drumkits_dir()
 {
-	return __usr_data_path + DRUMKITS;
+    return usr_data_path() + DRUMKITS;
 }
 QString Filesystem::playlists_dir()
 {
-	return __usr_data_path + PLAYLISTS;
+    return usr_data_path() + PLAYLISTS;
 }
 QString Filesystem::cache_dir()
 {
-	return __usr_data_path + CACHE;
+    return usr_data_path() + CACHE;
 }
 QString Filesystem::repositories_cache_dir()
 {
-	return __usr_data_path + CACHE + REPOSITORIES;
+    return usr_data_path() + CACHE + REPOSITORIES;
 }
 QString Filesystem::demos_dir()
 {

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -761,6 +761,8 @@ void Preferences::savePreferences()
 	LocalFileMng::writeXmlString( rootNode, "preDelete", QString("%1").arg(m_nRecPreDelete) );
 	LocalFileMng::writeXmlString( rootNode, "postDelete", QString("%1").arg(m_nRecPostDelete) );
 
+    LocalFileMng::writeXmlString( rootNode, "dataDirectory", m_sDataDirectory);
+
 	//show development version warning
 	LocalFileMng::writeXmlString( rootNode, "showDevelWarning", m_bShowDevelWarning ? "true": "false" );
 

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -60,7 +60,7 @@ const char* Preferences::__class_name = "Preferences";
 
 Preferences::Preferences()
 		: Object( __class_name )
-		, demoPath( Filesystem::demos_dir()+"/")
+        //, demoPath( Filesystem::demos_dir()+"/")
 		, m_sLastNews( "" )
 {
 	__instance = this;
@@ -310,7 +310,6 @@ void Preferences::loadPreferences( bool bGlobal )
 
 	QString sPreferencesDirectory;
 	QString sPreferencesFilename;
-	QString sDataDirectory;
 	if ( bGlobal ) {
 		sPreferencesDirectory = Filesystem::sys_data_path();
 		sPreferencesFilename = sPreferencesDirectory + "/hydrogen.default.conf";
@@ -318,7 +317,6 @@ void Preferences::loadPreferences( bool bGlobal )
 	} else {
 		sPreferencesFilename = m_sPreferencesFilename;
 		sPreferencesDirectory = m_sPreferencesDirectory;
-		sDataDirectory = QDir::homePath().append( "/.hydrogen/data" );
 		INFOLOG( "Loading preferences file (USER) [" + sPreferencesFilename + "]" );
 
 
@@ -335,33 +333,7 @@ void Preferences::loadPreferences( bool bGlobal )
 		}
 	}
 
-	// data directory exists?
-	QDir dataDir( sDataDirectory );
-	if ( !dataDir.exists() ) {
-		WARNINGLOG( "Data directory not found." );
-		createDataDirectory();
-	}
 
-	// soundLibrary directory exists?
-	QString sDir = sDataDirectory;
-	QString sDrumkitDir;
-	QString sSongDir;
-	QString sPatternDir;
-
-	INFOLOG( "Creating soundLibrary directories in " + sDir );
-
-	sDrumkitDir = sDir + "/drumkits";
-	sSongDir = sDir + "/songs";
-	sPatternDir = sDir + "/patterns";
-
-	QDir drumkitDir( sDrumkitDir );
-	QDir songDir( sSongDir );
-	QDir patternDir( sPatternDir );
-
-	if ( ! drumkitDir.exists() || ! songDir.exists() || ! patternDir.exists() )
-	{
-		createSoundLibraryDirectories();
-	}
 
 	// pref file exists?
 	std::ifstream input( sPreferencesFilename.toLocal8Bit() , std::ios::in | std::ios::binary );
@@ -380,7 +352,38 @@ void Preferences::loadPreferences( bool bGlobal )
 			}
 
 			//////// GENERAL ///////////
-			//m_sLadspaPath = LocalFileMng::readXmlString( this, rootNode, "ladspaPath", m_sLadspaPath );
+
+            /* Get Data Directory */
+            m_sDataDirectory = LocalFileMng::readXmlString( rootNode, "dataDirectory", m_sDataDirectory );
+            // data directory exists?
+            QDir dataDir( m_sDataDirectory );
+            if ( !dataDir.exists() ) {
+                WARNINGLOG( "Data directory not found." );
+                createDataDirectory();
+            }
+
+            // soundLibrary directory exists?
+            QString sDir = m_sDataDirectory;
+            QString sDrumkitDir;
+            QString sSongDir;
+            QString sPatternDir;
+
+            INFOLOG( "Creating soundLibrary directories in " + sDir );
+
+            sDrumkitDir = sDir + "/drumkits";
+            sSongDir = sDir + "/songs";
+            sPatternDir = sDir + "/patterns";
+
+            QDir drumkitDir( sDrumkitDir );
+            QDir songDir( sSongDir );
+            QDir patternDir( sPatternDir );
+
+            if ( ! drumkitDir.exists() || ! songDir.exists() || ! patternDir.exists() )
+            {
+                createSoundLibraryDirectories();
+            }
+
+            //m_sLadspaPath = LocalFileMng::readXmlString( this, rootNode, "ladspaPath", m_sLadspaPath );
 			m_bShowDevelWarning = LocalFileMng::readXmlBool( rootNode, "showDevelWarning", m_bShowDevelWarning );
 			m_brestoreLastSong = LocalFileMng::readXmlBool( rootNode, "restoreLastSong", m_brestoreLastSong );
 			m_brestoreLastPlaylist = LocalFileMng::readXmlBool( rootNode, "restoreLastPlaylist", m_brestoreLastPlaylist );
@@ -762,7 +765,6 @@ void Preferences::savePreferences()
 	LocalFileMng::writeXmlString( rootNode, "postDelete", QString("%1").arg(m_nRecPostDelete) );
 
     LocalFileMng::writeXmlString( rootNode, "dataDirectory", m_sDataDirectory);
-
 	//show development version warning
 	LocalFileMng::writeXmlString( rootNode, "showDevelWarning", m_bShowDevelWarning ? "true": "false" );
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -779,8 +779,8 @@ void MainForm::action_file_openDemo()
 	fd.setWindowTitle( trUtf8( "Open song" ) );
 	fd.setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
-	fd.setDirectory( QString( Preferences::get_instance()->getDemoPath() ) );
-
+    //fd.setDirectory( QString( Preferences::get_instance()->getDemoPath() ) );
+    fd.setDirectory( QString ( Filesystem::demos_dir() ) );
 
 	QString filename;
 	if (fd.exec() == QDialog::Accepted) {

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -42,6 +42,8 @@
 #include <hydrogen/sampler/Sampler.h>
 #include "SongEditor/SongEditor.h"
 #include "SongEditor/SongEditorPanel.h"
+#include "InstrumentRack.h"
+#include "SoundLibrary/SoundLibraryPanel.h"
 
 
 using namespace H2Core;
@@ -443,9 +445,17 @@ void PreferencesDialog::on_okBtn_clicked()
 	pPref->m_bsetLash = useLashCheckbox->isChecked(); //restore m_bsetLash after saving pref.
 
     // Path to data directory
-    pPref->setDataDirectory( dataDirectoryLineEdit->text() );
+	HydrogenApp *pH2App = HydrogenApp::get_instance();
+	if (  pPref->getDataDirectory().compare( dataDirectoryLineEdit->text()) != 0  ){
+		pPref->setDataDirectory( dataDirectoryLineEdit->text() );
+		// reload the drumkit list from the new directory
+		pH2App->getInstrumentRack()->getSoundLibraryPanel()->updateDrumkitList();
+	}
 
 	//path to rubberband
+
+
+
 	pPref-> m_rubberBandCLIexecutable = rubberbandLineEdit->text();
 
 	//check preferences
@@ -480,11 +490,9 @@ void PreferencesDialog::on_okBtn_clicked()
 			break;
 	}
 
-	HydrogenApp *pH2App = HydrogenApp::get_instance();
 	SongEditorPanel* pSongEditorPanel = pH2App->getSongEditorPanel();
 	SongEditor * pSongEditor = pSongEditorPanel->getSongEditor();
 	pSongEditor->updateEditorandSetTrue();
-
 	pPref->savePreferences();
 
 

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -273,8 +273,9 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 
 	sBmaxBars->setValue( pPref->getMaxBars() );
 
-	QString pathtoRubberband = pPref->m_rubberBandCLIexecutable;
+    dataDirectoryLineEdit->setText( pPref->getDataDirectory() );
 
+	QString pathtoRubberband = pPref->m_rubberBandCLIexecutable;
 
 	rubberbandLineEdit->setText( pathtoRubberband );
 
@@ -440,6 +441,9 @@ void PreferencesDialog::on_okBtn_clicked()
 	pPref->setRestoreLastSongEnabled( restoreLastUsedSongCheckbox->isChecked() );
 	pPref->setRestoreLastPlaylistEnabled( restoreLastUsedPlaylistCheckbox->isChecked() );
 	pPref->m_bsetLash = useLashCheckbox->isChecked(); //restore m_bsetLash after saving pref.
+
+    // Path to data directory
+    pPref->setDataDirectory( dataDirectoryLineEdit->text() );
 
 	//path to rubberband
 	pPref-> m_rubberBandCLIexecutable = rubberbandLineEdit->text();

--- a/src/gui/src/UI/PreferencesDialog_UI.ui
+++ b/src/gui/src/UI/PreferencesDialog_UI.ui
@@ -76,6 +76,40 @@
         </widget>
        </item>
        <item>
+        <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0">
+         <item row="1" column="1">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLineEdit" name="dataDirectoryLineEdit">
+           <property name="minimumSize">
+            <size>
+             <width>181</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QLabel" name="dataDirectoryLabel">
+           <property name="text">
+            <string>Data Directory</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -187,6 +221,11 @@
         </layout>
        </item>
       </layout>
+      <zorder>restoreLastUsedSongCheckbox</zorder>
+      <zorder>restoreLastUsedPlaylistCheckbox</zorder>
+      <zorder>useLashCheckbox</zorder>
+      <zorder>horizontalSpacer_2</zorder>
+      <zorder>gridLayoutWidget</zorder>
      </widget>
      <widget class="QWidget" name="tab_2">
       <attribute name="title">

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -263,13 +263,14 @@ int main(int argc, char *argv[])
 		H2Core::Logger::set_bit_mask( logLevelOpt );
 		H2Core::Logger* logger = H2Core::Logger::get_instance();
 		H2Core::Object::bootstrap( logger, logger->should_log(H2Core::Logger::Debug) );
-		if(sys_data_path.length()==0 ) {
+        H2Core::Preferences::create_instance();
+        if(sys_data_path.length()==0 ) {
 			H2Core::Filesystem::bootstrap( logger );
 		} else {
 			H2Core::Filesystem::bootstrap( logger, sys_data_path );
 		}
 		MidiMap::create_instance();
-		H2Core::Preferences::create_instance();
+
 		// See below for H2Core::Hydrogen.
 
 


### PR DESCRIPTION
This is my attempt at implementing issue 243: Customize standard save paths. I added an option to the preferences dialog for the user to specify the path of their data directory. Changing this setting will cause the drum list window to be reloaded with the data from the new folder.

This change makes the preferences object the home of record for the data directory, so I modified the FileSystem class to get the current user directory from the preferences object instead of the default values that were hard coded in that class.

I'm new to Hydrogen and I hope this change is align with the project's development standards. If not, please let me know how I can improve it. Thanks.
