### PR TITLE
Use variable velocity when playing sample when clicking on instrument list

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -45,6 +45,7 @@ using namespace H2Core;
 #include <QtGui>
 #include <QClipboard>
 #include <cassert>
+#include <algorithm> // for std::min
 
 using namespace std;
 
@@ -194,7 +195,8 @@ void InstrumentLine::mousePressEvent(QMouseEvent *ev)
 	HydrogenApp::get_instance()->getPatternEditorPanel()->updatePianorollEditor();
 
 	if ( ev->button() == Qt::LeftButton ) {
-		const float velocity = 0.8f;
+		const int width = m_pMuteBtn->x() - 5; // clickable field width
+		const float velocity = std::min((float)ev->x()/(float)width, 1.0f);
 		const float pan_L = 0.5f;
 		const float pan_R = 0.5f;
 		const int nLength = -1;


### PR DESCRIPTION
Currently, clicking on instrument name on instrument list plays sample of that instrument with constant velocity = 0.8. This patch makes velocity depend on click position, with velocity rising from left to right.
