### PR TITLE
Start to add quintuplet, septuplet and 9-tuplet support.

### DIFF
--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -330,6 +330,15 @@ public:
 	bool				isPatternEditorUsingTriplets();
 	void				setPatternEditorUsingTriplets( bool value );
 
+	bool				isPatternEditorUsingQuintuplets();
+	void				setPatternEditorUsingQuintuplets( bool value );
+
+	bool				isPatternEditorUsingSeptuplets();
+	void				setPatternEditorUsingSeptuplets( bool value );
+
+	bool				isPatternEditorUsing9tuplets();
+	void				setPatternEditorUsing9tuplets( bool value );
+
 	bool				isFXTabVisible();
 	void				setFXTabVisible( bool value );
 
@@ -472,6 +481,9 @@ private:
 	float				mixerFalloffSpeed;
 	int					m_nPatternEditorGridResolution;
 	bool				m_bPatternEditorUsingTriplets;
+	bool				m_bPatternEditorUsingQuintuplets;
+	bool				m_bPatternEditorUsingSeptuplets;
+	bool				m_bPatternEditorUsing9tuplets;
 	bool				m_bShowInstrumentPeaks;
 	bool				m_bIsFXTabVisible;
 	bool				m_bUseRelativeFilenamesForPlaylists;
@@ -721,11 +733,36 @@ inline void Preferences::setPatternEditorGridResolution( int value ) {
 	m_nPatternEditorGridResolution = value;
 }
 
+inline bool Preferences::isPatternEditorUsingQuintuplets() {
+	return m_bPatternEditorUsingQuintuplets;
+}
+
+inline bool Preferences::isPatternEditorUsingSeptuplets() {
+	return m_bPatternEditorUsingSeptuplets;
+}
+
+inline bool Preferences::isPatternEditorUsing9tuplets() {
+	return m_bPatternEditorUsing9tuplets;
+}
+
 inline bool Preferences::isPatternEditorUsingTriplets() {
 	return m_bPatternEditorUsingTriplets;
 }
+	
 inline void Preferences::setPatternEditorUsingTriplets( bool value ) {
 	m_bPatternEditorUsingTriplets = value;
+}
+
+inline void Preferences::setPatternEditorUsingQuintuplets( bool value ) {
+  m_bPatternEditorUsingQuintuplets = value;
+}
+
+inline void Preferences::setPatternEditorUsingSeptuplets( bool value ) {
+  m_bPatternEditorUsingSeptuplets = value;
+}
+
+inline void Preferences::setPatternEditorUsing9tuplets( bool value ) {
+  m_bPatternEditorUsing9tuplets = value;
 }
 
 inline bool Preferences::isFXTabVisible() {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1836,7 +1836,17 @@ void Hydrogen::addRealtimeNote( int instrument,
 	Preferences *pref = Preferences::get_instance();
 	unsigned int realcolumn = 0;
 	unsigned res = pref->getPatternEditorGridResolution();
-	int nBase = pref->isPatternEditorUsingTriplets() ? 3 : 4;
+	int nBase;
+	if(pref->isPatternEditorUsingTriplets())
+		nBase = 3;
+	else if(pref->isPatternEditorUsingQuintuplets())
+		nBase = 5;
+	else if(pref->isPatternEditorUsingSeptuplets())
+		nBase = 7;
+	else if(pref->isPatternEditorUsing9tuplets())
+		nBase = 9;
+	else
+		nBase = 4;
 	int scalar = ( 4 * MAX_NOTES ) / ( res * nBase );
 	bool hearnote = forcePlay;
 	int currentPatternNumber;

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -58,6 +58,9 @@ DrumPatternEditor::DrumPatternEditor(QWidget* parent, PatternEditorPanel *panel)
  , Object( __class_name )
  , m_nResolution( 8 )
  , m_bUseTriplets( false )
+ , m_bUseQuintuplets( false )
+ , m_bUseSeptuplets( false )
+ , m_bUse9tuplets( false )
  , m_bRightBtnPressed( false )
  , m_pDraggedNote( NULL )
  , m_pPattern( NULL )
@@ -128,6 +131,15 @@ int DrumPatternEditor::getColumn(QMouseEvent *ev)
 	int nBase;
 	if (m_bUseTriplets) {
 		nBase = 3;
+	}
+	else if (m_bUseQuintuplets) {
+		nBase = 5;
+	}
+	else if (m_bUseSeptuplets) {
+		nBase = 7;
+	}
+	else if (m_bUse9tuplets) {
+		nBase = 9;
 	}
 	else {
 		nBase = 4;
@@ -646,6 +658,15 @@ void DrumPatternEditor::__draw_grid( QPainter& p )
 	if (m_bUseTriplets) {
 		nBase = 3;
 	}
+	else if (m_bUseQuintuplets) {
+		nBase = 5;
+	}
+	else if (m_bUseSeptuplets) {
+		nBase = 7;
+	}
+	else if (m_bUse9tuplets) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
@@ -660,7 +681,7 @@ void DrumPatternEditor::__draw_grid( QPainter& p )
 	if ( m_pPattern ) {
 		nNotes = m_pPattern->get_length();
 	}
-	if (!m_bUseTriplets) {
+	if (!m_bUseTriplets && !m_bUseQuintuplets && !m_bUseSeptuplets && !m_bUse9tuplets) {
 		for ( int i = 0; i < nNotes + 1; i++ ) {
 			uint x = 20 + i * m_nGridWidth;
 
@@ -700,11 +721,25 @@ void DrumPatternEditor::__draw_grid( QPainter& p )
 		uint nCounter = 0;
 		int nSize = 4 * MAX_NOTES / (nBase * m_nResolution);
 
+		int tuplet_size;
+		if(m_bUseTriplets) {
+			tuplet_size = 3;
+		}
+		else if (m_bUseQuintuplets) {
+			tuplet_size = 5;
+		}
+		else if (m_bUseSeptuplets) {
+			tuplet_size = 7;
+		}
+		else if (m_bUse9tuplets) {
+			tuplet_size = 9;
+		}
+
 		for ( int i = 0; i < nNotes + 1; i++ ) {
 			uint x = 20 + i * m_nGridWidth;
 
 			if ( (i % nSize) == 0) {
-				if ((nCounter % 3) == 0) {
+				if ((nCounter % tuplet_size) == 0) {
 					p.setPen( QPen( res_1, 0 ) );
 				}
 				else {
@@ -806,10 +841,13 @@ void DrumPatternEditor::hideEvent ( QHideEvent *ev )
 
 
 
-void DrumPatternEditor::setResolution(uint res, bool bUseTriplets)
+void DrumPatternEditor::setResolution(uint res, bool bUseTriplets, bool bUseQuintuplets, bool bUseSeptuplets, bool bUse9tuplets)
 {
 	this->m_nResolution = res;
 	this->m_bUseTriplets = bUseTriplets;
+	this->m_bUseQuintuplets = bUseQuintuplets;
+	this->m_bUseSeptuplets = bUseSeptuplets;
+	this->m_bUse9tuplets = bUse9tuplets;
 
 	// redraw all
 	update( 0, 0, width(), height() );

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -50,9 +50,12 @@ class DrumPatternEditor : public QWidget, public EventListener, public H2Core::O
 		DrumPatternEditor(QWidget* parent, PatternEditorPanel *panel);
 		~DrumPatternEditor();
 
-		void setResolution(uint res, bool bUseTriplets);
+	void setResolution(uint res, bool bUseTriplets, bool bUseQuintuplets, bool bUseSeptuplets, bool bUse9tuplets);
 		uint getResolution() {	return m_nResolution;	}
 		bool isUsingTriplets() { return m_bUseTriplets;	}
+	  bool isUsingQuintuplets() { return m_bUseQuintuplets;	}
+	  bool isUsingSeptuplets() { return m_bUseSeptuplets;	}
+	  bool isUsing9tuplets() { return m_bUse9tuplets;	}
 
 		void zoom_in();
 		void zoom_out();
@@ -113,6 +116,9 @@ class DrumPatternEditor : public QWidget, public EventListener, public H2Core::O
 		int m_nEditorHeight;
 		uint m_nResolution;
 		bool m_bUseTriplets;
+	  bool m_bUseQuintuplets;
+	  bool m_bUseSeptuplets;
+	  bool m_bUse9tuplets;
 
 		bool m_bRightBtnPressed;
 		H2Core::Note *m_pDraggedNote;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -133,6 +133,17 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	__resolution_combo->addItem( "16T" );
 	__resolution_combo->addItem( "32T" );
 	__resolution_combo->addSeparator();
+	__resolution_combo->addItem("2Q");
+	__resolution_combo->addItem("4Q");
+	__resolution_combo->addItem("8Q");
+	__resolution_combo->addItem("16Q");
+	__resolution_combo->addSeparator();
+	__resolution_combo->addItem("8S");
+	__resolution_combo->addItem("16S");
+	__resolution_combo->addSeparator();
+	__resolution_combo->addItem("8N");
+	__resolution_combo->addItem("16N");
+	__resolution_combo->addSeparator();
 	__resolution_combo->addItem( "off" );
 	__resolution_combo->update();
 	__resolution_combo->move( 121, 2 );
@@ -463,7 +474,10 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	// restore grid resolution
 	int nIndex;
-	if ( pPref->isPatternEditorUsingTriplets() == false ) {
+	if ( pPref->isPatternEditorUsingTriplets() == false
+			 && pPref->isPatternEditorUsingQuintuplets() == false
+			 && pPref->isPatternEditorUsingSeptuplets() == false
+			 && pPref->isPatternEditorUsing9tuplets() == false) {
 		switch ( pPref->getPatternEditorGridResolution() ) {
 			case 4:
 				__resolution_combo->set_text( "4" );
@@ -496,7 +510,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 				nIndex = 0;
 		}
 	}
-	else {
+	else if ( pPref->isPatternEditorUsingTriplets() ){
 		switch ( pPref->getPatternEditorGridResolution() ) {
 			case 8:
 				__resolution_combo->set_text( "4T" );
@@ -524,6 +538,74 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 				nIndex = 5;
 		}
 	}
+
+	else if ( pPref->isPatternEditorUsingQuintuplets() ){
+		switch ( pPref->getPatternEditorGridResolution() ) {
+		  case 4:
+			  __resolution_combo->set_text( "2Q" );
+				nIndex = 9;
+				break;
+				
+			case 8:
+				__resolution_combo->set_text( "4Q" );
+				nIndex = 10;
+				break;
+
+			case 16:
+				__resolution_combo->set_text( "8Q" );
+				nIndex = 11;
+				break;
+
+			case 32:
+				__resolution_combo->set_text( "16Q" );
+				nIndex = 12;
+				break;
+
+			default:
+				ERRORLOG( QString("Wrong grid resolution: %1").arg( pPref->getPatternEditorGridResolution() ) );
+				__resolution_combo->set_text( "4Q" );
+				nIndex = 10;
+		}
+	}
+
+	else if ( pPref->isPatternEditorUsingSeptuplets() ){
+		switch ( pPref->getPatternEditorGridResolution() ) {
+		  case 16:
+			  __resolution_combo->set_text( "8S" );
+				nIndex = 13;
+				break;
+				
+			case 32:
+				__resolution_combo->set_text( "16S" );
+				nIndex = 14;
+				break;
+
+			default:
+				ERRORLOG( QString("Wrong grid resolution: %1").arg( pPref->getPatternEditorGridResolution() ) );
+				__resolution_combo->set_text( "8S" );
+				nIndex = 13;
+		}
+	}
+
+	else if ( pPref->isPatternEditorUsing9tuplets() ){
+		switch ( pPref->getPatternEditorGridResolution() ) {
+		  case 16:
+			  __resolution_combo->set_text( "8N" );
+				nIndex = 15;
+				break;
+				
+			case 32:
+				__resolution_combo->set_text( "16N" );
+				nIndex = 16;
+				break;
+
+			default:
+				ERRORLOG( QString("Wrong grid resolution: %1").arg( pPref->getPatternEditorGridResolution() ) );
+				__resolution_combo->set_text( "8N" );
+				nIndex = 15;
+		}
+	}
+	
 	gridResolutionChanged(__resolution_combo->getText());
 
 	//set pre delete
@@ -600,9 +682,30 @@ void PatternEditorPanel::gridResolutionChanged( QString str )
 {
 	int nResolution;
 	bool bUseTriplets = false;
+	bool bUseQuintuplets = false;
+	bool bUseSeptuplets = false;
+	bool bUse9tuplets = false;
 
 	if ( str.contains( "off" ) ) {
 		nResolution=MAX_NOTES;
+	}
+	else if ( str.contains( "Q" ) ) {
+		bUseQuintuplets = true;
+		QString temp = str;
+		temp.chop( 1 );
+		nResolution = temp.toInt() * 2;
+	}
+	else if ( str.contains( "S" ) ) {
+		bUseSeptuplets = true;
+		QString temp = str;
+		temp.chop( 1 );
+		nResolution = temp.toInt() * 2;
+	}
+	else if ( str.contains( "N" ) ) {
+		bUse9tuplets = true;
+		QString temp = str;
+		temp.chop( 1 );
+		nResolution = temp.toInt() * 2;
 	}
 	else if ( str.contains( "T" ) ) {
 		bUseTriplets = true;
@@ -615,11 +718,14 @@ void PatternEditorPanel::gridResolutionChanged( QString str )
 	}
 
 	//INFOLOG( to_string( nResolution ) );
-	m_pDrumPatternEditor->setResolution( nResolution, bUseTriplets );
+	m_pDrumPatternEditor->setResolution( nResolution, bUseTriplets, bUseQuintuplets, bUseSeptuplets, bUse9tuplets );
 	m_pPianoRollEditor->setResolution( nResolution, bUseTriplets );
 
 	Preferences::get_instance()->setPatternEditorGridResolution( nResolution );
 	Preferences::get_instance()->setPatternEditorUsingTriplets( bUseTriplets );
+	Preferences::get_instance()->setPatternEditorUsingQuintuplets( bUseQuintuplets );
+	Preferences::get_instance()->setPatternEditorUsingSeptuplets( bUseSeptuplets );
+	Preferences::get_instance()->setPatternEditorUsing9tuplets( bUse9tuplets );
 }
 
 


### PR DESCRIPTION
Hello guys, 
Hydrogen is wonderful, however it lacks a support for custom tuplet organizations. For example, you can have Quintuplets inside 4/4.. Just like triplets. With this, it would be very powerful drum machine.
Ideally, any number of tuplets should be possible.

I have added some code to make this possible. (Very very minimally). However, the visualization is not correct. But, when I add notes, they are added at the right places. I hope someone can help me fix the viz. I don't understand the code really well. 

Thanks!
Chittaranjan
