### PR TITLE
Fixed midi mapping

### DIFF
--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -207,6 +207,7 @@ public:
 	QString				m_sMidiPortName;
 	int					m_nMidiChannelFilter;
 	bool				m_bMidiNoteOffIgnore;
+	bool				m_bMidiFixedMapping;
 	bool				m_bMidiDiscardNoteAfterAction;
 
 	//	alsa audio driver properties ___

--- a/src/core/include/hydrogen/basics/instrument_list.h
+++ b/src/core/include/hydrogen/basics/instrument_list.h
@@ -109,6 +109,12 @@ class InstrumentList : public H2Core::Object
 		 */
 		Instrument* find( const QString& name );
 		/**
+		 * find an intrument which play the given midi note
+		 * \param note the Midi note of the instrument to find
+		 * \return 0 if not found
+		 */
+		Instrument* findMidiNote( const int note );
+		/**
 		 * swap the instruments of two different indexes
 		 * \param idx_a the first index
 		 * \param idx_b the second index

--- a/src/core/src/IO/midi_input.cpp
+++ b/src/core/src/IO/midi_input.cpp
@@ -243,38 +243,43 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 		static const float fPan_L = 0.5f;
 		static const float fPan_R = 0.5f;
 
+
 		int nInstrument = nNote - 36;
-		if ( nInstrument < 0 ) {
-				if(Preferences::get_instance()->__playselectedinstrument)
-				{
-					//we're in instrument mode -> we accept all notes
-				} else {
-					//we're in drumkit mode, lets drop everything < 36
-					nInstrument = 0;
-					return;
-				}
-
-		}
-		if ( nInstrument > ( MAX_INSTRUMENTS -1 ) ) {
-				nInstrument = MAX_INSTRUMENTS - 1;
-		}
-
 		InstrumentList *instrList = pEngine->getSong()->get_instrument_list();
-		Instrument *instr = instrList->get( nInstrument );
+		Instrument *pInstr = NULL;
+		if ( Preferences::get_instance()->__playselectedinstrument ){
+			nInstrument = pEngine->getSelectedInstrumentNumber();
+			pInstr= instrList->get( pEngine->getSelectedInstrumentNumber());
+		}
+		else if(Preferences::get_instance()->m_bMidiFixedMapping ){
+			pInstr = instrList->findMidiNote( nNote );
+			if(pInstr == NULL) {
+				ERRORLOG( QString( "Can't find correponding Intrument for note %1" ).arg( nNote ));
+				return;
+			}
+			nInstrument = instrList->index(pInstr);
+		} else {
+			if(nInstrument < 0) {
+				//Drop everything < 36
+				return;
+			}
+			pInstr = instrList->get(nInstrument);
+		}
+
 		/*
 		Only look to change instrument if the
 		current note is actually of hihat and
 		hihat openess is outside the instrument selected
 		*/
-		if ( instr != NULL &&
-			 instr->get_hihat_grp() >= 0 &&
-			 ( __hihat_cc_openess < instr->get_lower_cc() || __hihat_cc_openess > instr->get_higher_cc() ) )
+		if ( pInstr != NULL &&
+			 pInstr->get_hihat_grp() >= 0 &&
+			 ( __hihat_cc_openess < pInstr->get_lower_cc() || __hihat_cc_openess > pInstr->get_higher_cc() ) )
 		{
 			for(int i=0 ; i<=instrList->size() ; i++)
 			{
 				Instrument *instr_contestant = instrList->get( i );
 				if( instr_contestant != NULL &&
-						instr->get_hihat_grp() == instr_contestant->get_hihat_grp() &&
+						pInstr->get_hihat_grp() == instr_contestant->get_hihat_grp() &&
 						__hihat_cc_openess >= instr_contestant->get_lower_cc() &&
 						__hihat_cc_openess <= instr_contestant->get_higher_cc() )
 				{
@@ -317,22 +322,34 @@ void MidiInput::handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke )
 	int nNote = msg.m_nData1;
 	//float fVelocity = msg.m_nData2 / 127.0; //we need this in future to controll release velocity
 	int nInstrument = nNote - 36;
-	if ( nInstrument < 0 ) {
-		nInstrument = 0;
-	}
-	if ( nInstrument > ( MAX_INSTRUMENTS -1 ) ) {
-		nInstrument = MAX_INSTRUMENTS - 1;
-	}
-	Instrument *pInstr = pSong->get_instrument_list()->get( nInstrument );
-
-	float fStep = pow( 1.0594630943593, (nNote -36) );
-	if ( !Preferences::get_instance()->__playselectedinstrument )
-		fStep = 1;
+	Instrument *pInstr = NULL;
 
 	if ( Preferences::get_instance()->__playselectedinstrument ){
 		nInstrument = pEngine->getSelectedInstrumentNumber();
-		pInstr= pEngine->getSong()->get_instrument_list()->get( pEngine->getSelectedInstrumentNumber());
+		pInstr = pEngine->getSong()->get_instrument_list()->get( pEngine->getSelectedInstrumentNumber());
+	} else if( Preferences::get_instance()->m_bMidiFixedMapping ) {
+		pInstr = pSong->get_instrument_list()->findMidiNote( nNote );
+
+		if(pInstr == NULL) {
+			ERRORLOG( QString( "Note %1 not found" ).arg( nNote ));
+			return;
+		}
+		nInstrument = pSong->get_instrument_list()->index(pInstr);
 	}
+	else {
+		if(nInstrument < 0) {
+			//Drop everything < 36
+			return;
+		}
+		pInstr =  pSong->get_instrument_list()->get(nInstrument);
+	}
+
+
+	float fStep = pow( 1.0594630943593, (nNote) );
+	if ( !Preferences::get_instance()->__playselectedinstrument )
+		fStep = 1;
+
+
 
 	bool use_note_off = AudioEngine::get_instance()->get_sampler()->is_instrument_playing( pInstr );
 	if(use_note_off){

--- a/src/core/src/basics/instrument_list.cpp
+++ b/src/core/src/basics/instrument_list.cpp
@@ -166,6 +166,14 @@ Instrument*  InstrumentList::find( const QString& name )
 	return 0;
 }
 
+Instrument*  InstrumentList::findMidiNote( const int note )
+{
+	for( int i=0; i<__instruments.size(); i++ ) {
+		if ( __instruments[i]->get_midi_out_note()==note ) return __instruments[i];
+	}
+	return 0;
+}
+
 Instrument* InstrumentList::del( int idx )
 {
 	assert( idx >= 0 && idx < __instruments.size() );

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -190,6 +190,7 @@ Preferences::Preferences()
 	m_sMidiPortName = QString("None");
 	m_nMidiChannelFilter = -1;
 	m_bMidiNoteOffIgnore = false;
+	m_bMidiFixedMapping = false;
 	m_bMidiDiscardNoteAfterAction = false;
 
 	//___  alsa audio driver properties ___
@@ -525,6 +526,7 @@ void Preferences::loadPreferences( bool bGlobal )
 					m_sMidiPortName = LocalFileMng::readXmlString( midiDriverNode, "port_name", "None" );
 					m_nMidiChannelFilter = LocalFileMng::readXmlInt( midiDriverNode, "channel_filter", -1 );
 					m_bMidiNoteOffIgnore = LocalFileMng::readXmlBool( midiDriverNode, "ignore_note_off", true );
+					m_bMidiFixedMapping = LocalFileMng::readXmlBool( midiDriverNode, "fixed_mapping", false, true );
 				}
 
 
@@ -899,6 +901,14 @@ void Preferences::savePreferences()
 				LocalFileMng::writeXmlString( midiDriverNode, "discard_note_after_action", "true" );
 			} else {
 				LocalFileMng::writeXmlString( midiDriverNode, "discard_note_after_action", "false" );
+			}
+
+			if ( m_bMidiFixedMapping ) {
+				LocalFileMng::writeXmlString( midiDriverNode, "fixed_mapping", "true" );
+				INFOLOG("Saving fixed mapping\n");
+			} else {
+				LocalFileMng::writeXmlString( midiDriverNode, "fixed_mapping", "false" );
+				INFOLOG("Saving fixed mapping false\n");
 			}
 		}
 		audioEngineNode.appendChild( midiDriverNode );

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -119,6 +119,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	}
 
 	m_pIgnoreNoteOffCheckBox->setChecked( pPref->m_bMidiNoteOffIgnore );
+	m_pFixedMapping->setChecked( pPref->m_bMidiFixedMapping );
 
 	updateDriverInfo();
 
@@ -408,6 +409,7 @@ void PreferencesDialog::on_okBtn_clicked()
 
 
 	pPref->m_bMidiNoteOffIgnore = m_pIgnoreNoteOffCheckBox->isChecked();
+	pPref->m_bMidiFixedMapping = m_pFixedMapping->isChecked();
 
 	// Mixer falloff
 	QString falloffStr = mixerFalloffComboBox->currentText();

--- a/src/gui/src/UI/PreferencesDialog_UI.ui
+++ b/src/gui/src/UI/PreferencesDialog_UI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>559</width>
-    <height>448</height>
+    <height>451</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">
@@ -679,6 +679,17 @@
             <widget class="QCheckBox" name="m_pIgnoreNoteOffCheckBox">
              <property name="text">
               <string>Ignore note-off</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <item>
+            <widget class="QCheckBox" name="m_pFixedMapping">
+             <property name="text">
+              <string>Use output note as input note</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Following my message to the developer mailing list,

I have created a branch which use the midi output note instrument's member to find a instrument to play when an midi input note event occurs.

As Sebastian suggested me, it is an optional mode selectable using the preference dialog

Guillaume