### PR TITLE
Updated Windows cross compile scripts and 64 bit fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,32 +376,37 @@ ENDIF(VERSION_SUFFIX)
 SET(CPACK_PACKAGE_INSTALL_DIRECTORY "Hydrogen")
 
 IF(MINGW)
+    #Read in the filenames from the files created by cross_compile.sh
+    FILE(READ libs.txt mylibs)
+    FILE(READ qtlibs.txt myqtlibs)
+    FILE(READ gccversion.txt mygccversion)
+    FILE(READ gcclibs.txt mygcclibs)
     #Set the other files that will be used in CPack
     SET(WIN64 "OFF" CACHE BOOL "Windows 64 Bit")
 	SET(CPACK_STRIP_FILES "${WINDOWS_DIR}/src/cli/h2cli.exe" "${WINDOWS_DIR}/src/gui/hydrogen.exe" "${WINDOWS_DIR}/src/player/h2player.exe" "${WINDOWS_DIR}/src/synth/h2synth.exe")
     #Program Files for Hydrogen
     SET(WINDOWS_DIR "windows")
     INSTALL(FILES "${WINDOWS_DIR}/src/cli/h2cli.exe" "${WINDOWS_DIR}/src/core/libhydrogen-core-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.dll" "${WINDOWS_DIR}/src/gui/hydrogen.exe" "${WINDOWS_DIR}/src/player/h2player.exe" "${WINDOWS_DIR}/src/synth/h2synth.exe" DESTINATION ./)
+    #Install files from the extralibs dir
+    INSTALL(DIRECTORY ${WINDOWS_DIR}/extralibs/ DESTINATION ./)
+
     #DLL Files from the mxe /bin
-    SET(MXE_BIN "mxe/bin")
-    INSTALL(FILES ${MXE_BIN}/libgnurx-0.dll ${MXE_BIN}/libsndfile-1.dll ${MXE_BIN}/libFLAC-8.dll ${MXE_BIN}/libogg-0.dll ${MXE_BIN}/libvorbis-0.dll ${MXE_BIN}/libvorbisenc-2.dll ${MXE_BIN}/zlib1.dll ${MXE_BIN}/libwinpthread-1.dll ${MXE_BIN}/libeay32.dll ${MXE_BIN}/ssleay32.dll ${MXE_BIN}/libarchive-13.dll ${MXE_BIN}/libbz2.dll ${MXE_BIN}/liblzma-5.dll ${MXE_BIN}/libnettle-6-0.dll ${MXE_BIN}/libxml2-2.dll ${MXE_BIN}/libpng16-16.dll ${MXE_BIN}/libportmidi.dll ${MXE_BIN}/libportaudio-2.dll ${MXE_BIN}/libiconv-2.dll ${MXE_BIN}/libiconv-2.dll ${MXE_BIN}/jack-0.dll DESTINATION ./)
+#    SET(MXE_BIN "mxe/bin")
+    
+#    INSTALL(FILES ${mylibs} DESTINATION ./)
     #DLL Files for QT
-    SET(QT_BIN "mxe/qt/bin")
-    INSTALL(FILES ${QT_BIN}/QtCore4.dll ${QT_BIN}/QtXml4.dll ${QT_BIN}/QtXmlPatterns4.dll ${QT_BIN}/QtNetwork4.dll ${QT_BIN}/QtGui4.dll DESTINATION ./)
+    #SET(QT_BIN "mxe/qt/bin")
+    #INSTALL(FILES ${myqtlibs} DESTINATION ./)
 
 #DLL Files for gcc and libc6
-    IF (WIN64)
-		SET(GCC_MXE_DIR "gcc/x86_64-w64-mingw32.shared/5.2.0")
-    ELSE()
-		SET(GCC_MXE_DIR "gcc/i686-w64-mingw32.shared/5.2.0")
-    ENDIF()
+    #IF (WIN64)
+#		SET(GCC_MXE_DIR "gcc/x86_64-w64-mingw32.shared/${mygccversion}")
+#    ELSE()
+#		SET(GCC_MXE_DIR "gcc/i686-w64-mingw32.shared/${mygccversion}")
+#    ENDIF()
 
-    SET(GCC_BIN ${GCC_MXE_DIR})
-    IF(WIN64)
-		INSTALL(FILES ${GCC_BIN}/libgcc_s_seh-1.dll ${GCC_BIN}/libstdc++-6.dll DESTINATION ./)
-    ELSE()
-		INSTALL(FILES ${GCC_BIN}/libgcc_s_sjlj-1.dll ${GCC_BIN}/libstdc++-6.dll DESTINATION ./)
-    ENDIF()
+#    SET(GCC_BIN ${GCC_MXE_DIR})
+#    INSTALL(FILES ${mygccfiles} DESTINATION ./)
    
 	IF(WANT_FAT_BUILD)
 		INSTALL(DIRECTORY windows/jack_installer DESTINATION ./)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,11 +376,6 @@ ENDIF(VERSION_SUFFIX)
 SET(CPACK_PACKAGE_INSTALL_DIRECTORY "Hydrogen")
 
 IF(MINGW)
-    #Read in the filenames from the files created by cross_compile.sh
-    FILE(READ libs.txt mylibs)
-    FILE(READ qtlibs.txt myqtlibs)
-    FILE(READ gccversion.txt mygccversion)
-    FILE(READ gcclibs.txt mygcclibs)
     #Set the other files that will be used in CPack
     SET(WIN64 "OFF" CACHE BOOL "Windows 64 Bit")
 	SET(CPACK_STRIP_FILES "${WINDOWS_DIR}/src/cli/h2cli.exe" "${WINDOWS_DIR}/src/gui/hydrogen.exe" "${WINDOWS_DIR}/src/player/h2player.exe" "${WINDOWS_DIR}/src/synth/h2synth.exe")
@@ -390,24 +385,6 @@ IF(MINGW)
     #Install files from the extralibs dir
     INSTALL(DIRECTORY ${WINDOWS_DIR}/extralibs/ DESTINATION ./)
 
-    #DLL Files from the mxe /bin
-#    SET(MXE_BIN "mxe/bin")
-    
-#    INSTALL(FILES ${mylibs} DESTINATION ./)
-    #DLL Files for QT
-    #SET(QT_BIN "mxe/qt/bin")
-    #INSTALL(FILES ${myqtlibs} DESTINATION ./)
-
-#DLL Files for gcc and libc6
-    #IF (WIN64)
-#		SET(GCC_MXE_DIR "gcc/x86_64-w64-mingw32.shared/${mygccversion}")
-#    ELSE()
-#		SET(GCC_MXE_DIR "gcc/i686-w64-mingw32.shared/${mygccversion}")
-#    ENDIF()
-
-#    SET(GCC_BIN ${GCC_MXE_DIR})
-#    INSTALL(FILES ${mygccfiles} DESTINATION ./)
-   
 	IF(WANT_FAT_BUILD)
 		INSTALL(DIRECTORY windows/jack_installer DESTINATION ./)
 		INSTALL(DIRECTORY windows/plugins DESTINATION ./)

--- a/windows/README.md
+++ b/windows/README.md
@@ -7,7 +7,7 @@
 
 	then,
 
-	run the script cross_compile.sh located in the windows folder.
+	run the script cross_compile.sh with the -i switch (./cross_compile -i)located in the windows folder.
 
 ### The manual way: 
 

--- a/windows/README.md
+++ b/windows/README.md
@@ -3,13 +3,23 @@
 ## Cross-compiling on a Unix System
 
 ### The easy way:
+#### Interactive method
 	run the script mxe_installer.sh located in the windows folder
 
 	then,
 
-	run the script cross_compile.sh with the -i switch (./cross_compile -i)located in the windows folder.
+	run the script cross_compile.sh with the -i switch located in the windows folder.
+	
+	$./cross_compile.sh -i
+#### Manual package
+	Simply run the script with the -b switch and pass in the architecture you want to build, either i686 or x86_64
+	
+	If you want the "fat" package, which bundles with the jack installer, and the ladspa plugins, then pass in the -f as well.
 
-### The manual way: 
+	$./cross_compile.sh -b x86_64
+
+### The manual way:
+
 
 ### Installing all necessary packages
 

--- a/windows/cross_compile.sh
+++ b/windows/cross_compile.sh
@@ -88,6 +88,52 @@ build_32bit(){
 build_64bit(){
 			build_hydrogen x86_64 -DCMAKE_{C,CXX}_FLAGS=-m64 -DWIN64:BOOL=ON
 }
+mxe_files(){
+			# This will search for the required files to package and put their names into a file to be read by cmake.
+			# This is necessary due to version differences with the libraries and compilers that mxe uses across build systems.
+
+	#set the dir to search
+	if [ "$1" == "64" ]; then
+	    mxedir="/opt/mxe/usr/x86_64-w64-mingw32.shared/bin"
+	    qtdir="$mxedir/../qt/bin"
+	    gccdir="/opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.shared"
+	else
+	    mxedir="/opt/mxe/usr/i686-w64-mingw32.shared/bin"
+	    qtdir="$mxedir/../qt/bin"
+	    gccdir="/opt/mxe/usr/lib/gcc/i686-w64-mingw32.shared"
+	fi
+	
+	hydrogendir=`pwd`
+	extralibs="$hydrogendir/extralibs"
+	mkdir $extralibs
+	
+	#Make arrays for the filenames to loop through.
+	declare -a libs=("libgnurx" "libsndfile" "libFLAC" "libogg" "libvorbis" "libvorbisenc" "zlib1" "libwinpthread" "libeay32" "ssleay32" "libarchive" "libbz2" "liblzma" "libnettle" "libxml2" "libpng16" "libportmidi" "libportaudio" "libiconv" "libiconv" "jack")
+	declare -a qtlibs=("QtCore4" "QtXml4" "QtXmlPatterns4" "QtNetwork4" "QtGui4")
+	declare -a gcclibs=("libgcc" "libstdc++")
+	#loop through the libs, and put them into a text file.
+	cd $mxedir
+	for mylibs in "${libs[@]}"
+	do
+		cp `ls -v $mylibs*dll| tail -n 1` $extralibs
+	done
+	#loop through the qt files and put them into a text file
+	cd $qtdir
+	for myqtlibs in "${qtlibs[@]}"
+	do
+		cp `ls -v $myqtlibs*dll| tail -n 1` $extralibs
+		spa=" "
+	done
+	#find the latest gcc dir from mxe
+	cd $gccdir
+	echo `ls -v | tail -n 1` > $hydrogendir/../gccversion.txt
+	#loop through the gcclibs
+	cd $mxedir
+	for mygcclibs in "${gcclibs[@]}"
+	do
+		cp `ls -v $mygcclibs*dll| tail -n 1` $extralibs
+	done
+}
 
 build_hydrogen(){
 	# Passes either i686 or x86_64 for 32 or 64 bit respectively.
@@ -117,9 +163,9 @@ build_hydrogen(){
 	
 	#Build hydrogen itself now.
 	echo "Now building Hydrogen."
-	HYDROGEN_BUILD="$HYDROGEN/windows"
+	HYDROGEN_BUILD=$HYDROGEN"windows"
 	if [ ! -e "$HYDROGEN_BUILD" ]; then
-		mkdir "$HYDROGEN/windows"
+		mkdir $HYDROGEN"windows"
 	fi
 	echo "We will now build Hydrogen at $HYDROGEN_BUILD"
 	cd "$HYDROGEN_BUILD"
@@ -174,6 +220,9 @@ build_hydrogen(){
 			rm -rf $HYDROGEN/mxe
 		fi
 	fi
+	if [ -e $HYDROGEN/extralibs ]; then
+		rm -rf $HYDROGEN/extralibs
+	fi
 	if [ ! -e $HYDROGEN/mxe ]; then
 		ln -s $MXE/usr/$1-w64-mingw32.shared $HYDROGEN/mxe
 	fi
@@ -191,7 +240,7 @@ usage(){
 
 fatbuild=false
 
-while getopts "d:fb:i:" o; do
+while getopts "d:fb:i" o; do
     case "${o}" in
 		d)
 			HYDROGEN=${OPTARG}
@@ -206,9 +255,11 @@ while getopts "d:fb:i:" o; do
 		b)
             arch=${OPTARG}
 
-			if [ "$arch" != "64" ]; then
+			if [ "$arch" != "x86_64" ]; then
+				mxe_files 32
 				build_32bit
 			else
+				mxe_files 64
 				build_64bit
 			fi
 

--- a/windows/cross_compile.sh
+++ b/windows/cross_compile.sh
@@ -191,7 +191,7 @@ usage(){
 
 fatbuild=false
 
-while getopts "d:fb:i" o; do
+while getopts "d:fb:i:" o; do
     case "${o}" in
 		d)
 			HYDROGEN=${OPTARG}
@@ -221,4 +221,5 @@ while getopts "d:fb:i" o; do
             ;;
     esac
 done
+if [ $OPTIND -eq 1 ]; then usage; fi
 shift $((OPTIND-1))


### PR DESCRIPTION
Hey there,
I updated the cross compile scripts today a fair bit, here are some of the changes: 
Fix: Cleaned up the path errors in the script which was preventing it from cleaning up after itself.
Added: ability to let people make cross_compile builds without the need to hardcode file names in the CMakesLists file
Fix: the 64 bit packages should now compile again @mauser, my test ones went fine.
Updated: Readme.md to reflect the changes made to the way you build Windows packages now.