### PR TITLE
adding a man page

### DIFF
--- a/linux/hydrogen.1
+++ b/linux/hydrogen.1
@@ -1,0 +1,70 @@
+.TH HYDROGEN "1" "September 2016" "hydrogen 0.9.7-beta3" "User Commands"
+.SH NAME
+hydrogen \- a simple drum machine/step sequencer.
+.SH SYNOPSIS
+.PP
+.B hydrogen
+[\fI-v\fR] [\fI-h\fR] \fI-s file\fR
+.SH DESCRIPTION
+.PP
+Hydrogen 0.9.7-beta3 [Sept 03 2016]  [http://www.hydrogen\-music.org].
+Copyright 2002\-2008 Alessandro Cominu,
+Copyright 2008\-2016 The hydrogen development team.
+.PP
+Hydrogen is an advanced drum machine for GNU/Linux.
+It's main goal is to bring professional yet simple and intuitive pattern-based drum programming.
+.PP
+Hydrogen comes with ABSOLUTELY NO WARRANTY.
+This is free software, and you are welcome to redistribute it
+under certain conditions. See the file COPYING for details.
+.SH OPTIONS
+.HP
+\fB\-P\fR, \fB\-\-data\fR PATH \- Use an alternate system data path
+.HP
+\fB\-d\fR, \fB\-\-driver\fR AUDIODRIVER \- Use the selected audio driver (jack, alsa, oss)
+.HP
+\fB\-s\fR, \fB\-\-song\fR FILE \- Load a song (*.h2song) at startup
+.HP
+\fB\-S\fR, \fB\-\-jacksessionid\fR ID \- Start a JackSessionHandler session
+.HP
+\fB\-p\fR, \fB\-\-playlist\fR FILE \- Load a playlist (*.h2playlist) at startup
+.HP
+\fB\-k\fR, \fB\-\-kit\fR drumkit_name - Load a drumkit at startup
+.HP
+\fB\-i\fR, \fB\-\-install\fR FILE - install a drumkit (*.h2drumkit)
+.HP
+\fB\-n\fR, \fB\-\-nosplash\fR \- Hide splash screen
+.HP
+\fB\-V[Level]\fR, \fB\-\-verbose\fR[=\fILevel\fR] \- Print a lot of debugging info
+.IP
+Level, if present, may be None, Error, Warning, Info, Debug or 0xHHHH
+.HP
+\fB\-v\fR, \fB\-\-version\fR \- Show version info
+.HP
+\fB\-h\fR, \fB\-\-help\fR \- Show this help message
+.SH FILES
+.TP
+.B hydrogen.conf
+.PP
+Defaults and startup settings for Hydrogen.
+.TP
+.B data/*
+.PP
+Can contains user's data such as drumkits, patterns, playlists, songs, ...
+.SH ENVIRONMENT
+.PP
+.B LADSPA_PATH
+.HP 
+Path to LADSPA plugins.
+.SH BUGS & FEATURES REQUEST
+.PP
+If you find any bug or if you would like to propose a new feature, please report it to https://github.com/hydrogen-music/hydrogen/issues
+.SH AUTHORS
+.PP
+The hydrogen development team. See complete list at Hydrogen's "About" Dialog. You can contact them at <hydrogen-devel@lists.sourceforge.net>.
+.TP
+Subscription to the mailing list can be done here :
+.br
+http://lists.sourceforge.net/lists/listinfo/hydrogen-devel .
+.SH MISC
+This manual page was written by Olivier Humbert <trebmuh@tuxfamily.org> as a part of the Hydrogen project.


### PR DESCRIPTION
As discussed on the devel ML, here is a manpage.

To write it I :

1. started it with the 0.9.4 from the debian packaging : https://anonscm.debian.org/cgit/pkg-multimedia/hydrogen.git/tree/debian/hydrogen.1
2. took off the lash related stuffs (`--lash-no-start-server` and `--lash-no-autoresume`)
3. took inspiration from other software manpage

I hope this is fine.

It would be great if it could be incorporated in the build process (if someone would like to take care of that).