### PR TITLE
Updated Windows cross compile scripts for QT5 and other goodies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ SET(LIBSNDFILE_VERSION_PREV "1.0.17")
 #
 SET(WANT_LIBTAR TRUE)
 OPTION(WANT_DEBUG           "Build with debug information" ON)
-IF(WANT_OLD_BUILD FALSE)
+IF(NOT WANT_OLD_BUILD)
     OPTION(WANT_QT5             "Build with Qt5" ON)
 ENDIF()
 IF(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,9 @@ SET(LIBSNDFILE_VERSION_PREV "1.0.17")
 #
 SET(WANT_LIBTAR TRUE)
 OPTION(WANT_DEBUG           "Build with debug information" ON)
-OPTION(WANT_QT5             "Build with Qt5" ON)
-
+IF(WANT_OLD_BUILD FALSE)
+    OPTION(WANT_QT5             "Build with Qt5" ON)
+ENDIF()
 IF(APPLE)
     OPTION(WANT_SHARED      "Build the core library shared." OFF)
 ELSE()
@@ -289,7 +290,8 @@ COLOR_MESSAGE("${cyan}Installation Summary${reset}
 * core library build as        : ${H2CORE_LIBRARY_TYPE}
 * debug capabilities           : ${H2CORE_HAVE_DEBUG}
 * macosx bundle                : ${H2CORE_HAVE_BUNDLE}
-* fat build                    : ${WANT_FAT_BUILD}\n"
+* fat build                    : ${WANT_FAT_BUILD}
+* old build                    : ${WANT_OLD_BUILD}\n"
 )
 
 COLOR_MESSAGE("${cyan}Main librarires${reset}")

--- a/windows/cross_compile.sh
+++ b/windows/cross_compile.sh
@@ -119,9 +119,12 @@ mxe_files(){
             declare -a qtlibs=("QtCore4" "QtXml4" "QtXmlPatterns4" "QtNetwork4" "QtGui4")
             qtdir="$mxedir/../qt/bin"
         else
-            declare -a qtlibs=("Qt5Core" "Qt5Xml" "Qt5XmlPatterns" "Qt5Network" "Qt5Gui" "Qt5Widgets")
+            declare -a qtlibs=("Qt5Core" "Qt5Xml." "Qt5XmlPatterns" "Qt5Network" "Qt5Gui" "Qt5Widgets")
             libs+=("libpcre-1" "libpcre16-0" "libharfbuzz-0" "libfreetype-6" "libglib-2" "libintl-8")
             qtdir="$mxedir/../qt5/bin"
+            platforms="$extralibs/platforms"
+            mkdir -p $platforms
+            cp "$qtdir/../plugins/platforms/qwindows.dll" "$platforms/"
         fi
         #loop through the libs, and put them into a text file.
 	cd $mxedir
@@ -156,6 +159,7 @@ setqt5(){
         qtprefix="-DCMAKE_PREFIX_PATH=$qt5dir"
     fi
 }
+
 cleanbuild(){
     if [ -d windows ]; then
         cd windows
@@ -266,13 +270,13 @@ build_hydrogen(){
 usage(){
 	echo -e "\nManual mode:\t\tcross_compile.sh [-f] [-d SOURCE_DIR] [-c] -b i686|x86_64"
 	echo -e "Interactive mode:\tcross_compile.sh -i"
-	echo -e "Usage: \n\t-i:\tUse interactive mode \n\t-b:\tBuild hydrogen. Valid values: i686 or x86_64 \n\t-f:\tFat build (includes Jack and Ladspa installers). Only useful in combination with -b \n\t-o:\tOld build uses QT4 to build hydrogen instead of the new QT5"
+	echo -e "Usage: \n\t-i:\tUse interactive mode \n\t-b:\tBuild hydrogen. Valid values: i686 or x86_64 \n\t-f:\tFat build (includes Jack and Ladspa installers). Only useful in combination with -b \n\t-o:\tOld build uses QT4 to build hydrogen instead of the new QT5 \n\t-c:\tClean the CMake files from the windows directory. Used if building fails, or compiling a different version.\n\t-r:\tBuild release packages. This will build both the 32 bit and 64 bit installers for releases."
 }
 
 fatbuild=false
 
-while getopts "d:fob:i:c" v; do
-    case "${v}" in
+while getopts "d:fob:icr" o; do
+    case "${o}" in
 	d)
             HYDROGEN=${OPTARG}
             if [ ! -d $HYDROGEN ]; then
@@ -304,6 +308,16 @@ while getopts "d:fob:i:c" v; do
             ;;
         c)
             cleanbuild
+            ;;
+        r)
+            cleanbuild
+            mxe_files 32
+            setqt5
+            build_32bit
+            cleanbuild
+            mxe_files 64
+            setqt5
+            build_64bit
             ;;
         *)
             usage

--- a/windows/cross_compile.sh
+++ b/windows/cross_compile.sh
@@ -96,37 +96,46 @@ mxe_files(){
 	#set the dir to search
 	if [ "$1" == "64" ]; then
 	    mxedir="/opt/mxe/usr/x86_64-w64-mingw32.shared/bin"
-	    qtdir="$mxedir/../qt/bin"
 	    gccdir="/opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.shared"
 	else
 	    mxedir="/opt/mxe/usr/i686-w64-mingw32.shared/bin"
-	    qtdir="$mxedir/../qt/bin"
 	    gccdir="/opt/mxe/usr/lib/gcc/i686-w64-mingw32.shared"
 	fi
-	
-	hydrogendir=`pwd`
+	if [ -d windows ]; then
+            hydrogendir=`pwd`"/windows"
+        else
+            hydrogendir=`pwd`
+        fi
 	extralibs="$hydrogendir/extralibs"
-	mkdir $extralibs
+	
+        mkdir $extralibs
 	
 	#Make arrays for the filenames to loop through.
 	declare -a libs=("libgnurx" "libsndfile" "libFLAC" "libogg" "libvorbis" "libvorbisenc" "zlib1" "libwinpthread" "libeay32" "ssleay32" "libarchive" "libbz2" "liblzma" "libnettle" "libxml2" "libpng16" "libportmidi" "libportaudio" "libiconv" "libiconv" "jack")
-	declare -a qtlibs=("QtCore4" "QtXml4" "QtXmlPatterns4" "QtNetwork4" "QtGui4")
 	declare -a gcclibs=("libgcc" "libstdc++")
-	#loop through the libs, and put them into a text file.
+	
+        #special stuff for qt5 handling
+        if [ $OLDBUILD == true ]; then
+            declare -a qtlibs=("QtCore4" "QtXml4" "QtXmlPatterns4" "QtNetwork4" "QtGui4")
+            qtdir="$mxedir/../qt/bin"
+        else
+            declare -a qtlibs=("Qt5Core" "Qt5Xml" "Qt5XmlPatterns" "Qt5Network" "Qt5Gui" "Qt5Widgets")
+            libs+=("libpcre-1" "libpcre16-0" "libharfbuzz-0" "libfreetype-6" "libglib-2" "libintl-8")
+            qtdir="$mxedir/../qt5/bin"
+        fi
+        #loop through the libs, and put them into a text file.
 	cd $mxedir
 	for mylibs in "${libs[@]}"
 	do
 		cp `ls -v $mylibs*dll| tail -n 1` $extralibs
 	done
-        if [ $OLDBUILD = true ]; then
-            #loop through the qt files and put them into a text file
-            cd $qtdir
-            for myqtlibs in "${qtlibs[@]}"
-            do
-                    cp `ls -v $myqtlibs*dll| tail -n 1` $extralibs
-                    spa=" "
-            done
-        fi
+        #loop through the qt files and put them into a text file
+        cd $qtdir
+        for myqtlibs in "${qtlibs[@]}"
+        do
+            cp `ls -v $myqtlibs*dll| tail -n 1` $extralibs
+            spa=" "
+        done
 	#find the latest gcc dir from mxe
 	cd $gccdir
 	echo `ls -v | tail -n 1` > $hydrogendir/../gccversion.txt
@@ -134,8 +143,27 @@ mxe_files(){
 	cd $mxedir
 	for mygcclibs in "${gcclibs[@]}"
 	do
-		cp `ls -v $mygcclibs*dll| tail -n 1` $extralibs
+            cp `ls -v $mygcclibs*dll| tail -n 1` $extralibs
 	done
+}
+setqt5(){
+    if [ "$1" == "64" ]; then
+        qt5dir="/opt/mxe/usr/x86_64-w64-mingw32.shared/qt5/lib/cmake"
+    else
+        qt5dir="/opt/mxe/usr/i686-w64-mingw32.shared/qt5/lib/cmake"
+    fi
+    if [ $OLDBUILD != true ]; then
+        qtprefix="-DCMAKE_PREFIX_PATH=$qt5dir"
+    fi
+}
+cleanbuild(){
+    if [ -d windows ]; then
+        cd windows
+    fi
+    if [ -f CMakeCache.txt ]; then
+        rm -rf _CPack_Packages CMakeFiles try src extralibs
+        rm -f CMakeCache.txt CPackConfig.cmake cmake_install.cmake CPackSourceConfig.cmake install_manifest.txt ladspa_listplugins Makefile uninstall.cmake
+    fi
 }
 
 build_hydrogen(){
@@ -236,21 +264,21 @@ build_hydrogen(){
 }
 
 usage(){
-	echo -e "\nManual mode:\t\tcross_compile.sh [-f] [-d SOURCE_DIR] -b i686|x86_64"
+	echo -e "\nManual mode:\t\tcross_compile.sh [-f] [-d SOURCE_DIR] [-c] -b i686|x86_64"
 	echo -e "Interactive mode:\tcross_compile.sh -i"
 	echo -e "Usage: \n\t-i:\tUse interactive mode \n\t-b:\tBuild hydrogen. Valid values: i686 or x86_64 \n\t-f:\tFat build (includes Jack and Ladspa installers). Only useful in combination with -b \n\t-o:\tOld build uses QT4 to build hydrogen instead of the new QT5"
 }
 
 fatbuild=false
 
-while getopts "d:fb:i:o" o; do
-    case "${o}" in
+while getopts "d:fob:i:c" v; do
+    case "${v}" in
 	d)
             HYDROGEN=${OPTARG}
             if [ ! -d $HYDROGEN ]; then
 		echo "Hydrogen source not found in $HYDROGEN."
 		exit
-		fi
+            fi
             ;;
 	f)
             FATBUILD=true
@@ -260,9 +288,11 @@ while getopts "d:fb:i:o" o; do
 
             if [ "$arch" != "x86_64" ]; then
                 mxe_files 32
+                setqt5
 		build_32bit
             else
 		mxe_files 64
+                setqt5
                 build_64bit
             fi
             ;;
@@ -271,6 +301,9 @@ while getopts "d:fb:i:o" o; do
             ;;
         o)
             OLDBUILD=true
+            ;;
+        c)
+            cleanbuild
             ;;
         *)
             usage

--- a/windows/mxe_installer.sh
+++ b/windows/mxe_installer.sh
@@ -32,7 +32,7 @@ install_mxe(){
 	sed -i 's/--enable-threads=win32/--enable-threads=posix/g' $MXE/src/gcc.mk
 	make gcc $1
 	#Build the dependancies for hydrogen
-	make qt libarchive libsndfile portaudio portmidi fftw rubberband jack qtbase l-j4 JOBS=4 $1
+	make qt libarchive libsndfile portaudio portmidi fftw rubberband jack qt5 -j4 JOBS=4 $1
 	sed -i 's/:= gcc/:= gcc jack/g' $MXE/src/portaudio.mk
 	make portaudio
 }

--- a/windows/mxe_installer.sh
+++ b/windows/mxe_installer.sh
@@ -32,7 +32,7 @@ install_mxe(){
 	sed -i 's/--enable-threads=win32/--enable-threads=posix/g' $MXE/src/gcc.mk
 	make gcc $1
 	#Build the dependancies for hydrogen
-	make qt libarchive libsndfile portaudio portmidi fftw rubberband jack -j4 JOBS=4 $1
+	make qt libarchive libsndfile portaudio portmidi fftw rubberband jack qtbase l-j4 JOBS=4 $1
 	sed -i 's/:= gcc/:= gcc jack/g' $MXE/src/portaudio.mk
 	make portaudio
 }


### PR DESCRIPTION
Added qt5 to mxe.sh
Added compilation for Windows using QT5
Added a new option (-o) called old build to compile for Windows using QT4 for backwards compatibility.
Added a new option (-r) to build releases for Windows. This will build both the 32bit and 64bit packages
Added a new option (-c) to clean the CMake files out of the windows directory, making it a fresh compile next time you run it.
Fixed up some path issues so now you can run the script from either the windows directory, or from the parent hydrogen directory. This could be used to chain load the cross compile from the main build script.

Note: I ran into some issues when making qt5 on my existing mxe installation. It hung up on the qt5system package (IIRC). I had to manually copy the new qt5system.mk file from the mxe github to the src dir in /opt/mxe and then I was able to proceed with my install (which took a little over an hour to complete). This issue should not be present on a fresh install of mxe.