### PR TITLE
Fix usleep argument

### DIFF
--- a/src/core/src/logger.cpp
+++ b/src/core/src/logger.cpp
@@ -31,7 +31,7 @@
 #define LOGGER_SLEEP Sleep( 100 )
 #else
 #include <unistd.h>
-#define LOGGER_SLEEP usleep( 1000000 )
+#define LOGGER_SLEEP do { usleep( 500000 ); usleep( 500000 ); } while (0)
 #endif
 
 namespace H2Core {


### PR DESCRIPTION
According to POSIX (http://pubs.opengroup.org/onlinepubs/009695399/functions/usleep.html):
````The useconds argument shall be less than one million.````
Make it so.