### PR TITLE
Feature/hidpi

### DIFF
--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -36,7 +36,6 @@ AboutDialog::AboutDialog(QWidget* parent)
 	setupUi( this );
 
 	setWindowTitle( tr( "About" ) );
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	setMinimumSize( width(), height() );
 	setMaximumSize( width(), height() );

--- a/src/gui/src/DonationDialog.cpp
+++ b/src/gui/src/DonationDialog.cpp
@@ -33,7 +33,6 @@ DonationDialog::DonationDialog(QWidget* parent)
 	setupUi( this );
 
 	setWindowTitle( tr( "Donations" ) );
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 }
 
 DonationDialog::~DonationDialog()

--- a/src/gui/src/HelpBrowser.cpp
+++ b/src/gui/src/HelpBrowser.cpp
@@ -39,8 +39,6 @@ SimpleHTMLBrowser::SimpleHTMLBrowser( QWidget *pParent, const QString& sDataPath
  , m_sDataPath( sDataPath )
  , m_sFilename( sFilename )
 {
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
-
 	if (m_type == MANUAL ) {
 		setWindowTitle( trUtf8( "Manual" ) );
 		resize( 800, 600 );
@@ -73,8 +71,6 @@ SimpleHTMLBrowser::SimpleHTMLBrowser( QWidget *pParent, const QString& sDataPath
 	m_pBrowser->setReadOnly( true );
 	m_pBrowser->setSearchPaths( QStringList( m_sDataPath ) );
 	//m_pBrowser->setStyleSheet("background-color:#000000;");
-
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	QFile file( m_sFilename.toLocal8Bit() ); // Read the text from a file
 	if ( file.open( QIODevice::ReadOnly ) ) {

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -54,7 +54,6 @@ LadspaFXProperties::LadspaFXProperties(QWidget* parent, uint nLadspaFX)
 	resize( 500, 200 );
 	setMinimumSize( width(), height() );
 	setFixedHeight( height() );
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	QHBoxLayout *hbox = new QHBoxLayout();
 	hbox->setSpacing( 0 );

--- a/src/gui/src/LadspaFXSelector.cpp
+++ b/src/gui/src/LadspaFXSelector.cpp
@@ -47,7 +47,6 @@ LadspaFXSelector::LadspaFXSelector(int nLadspaFX)
 	setFixedSize( width(), height() );
 
 	setWindowTitle( trUtf8( "Select LADSPA FX" ) );
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	m_sSelectedPluginName = "";
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -95,7 +95,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename )
 	, Object( __class_name )
 {
 	setMinimumSize( QSize( 1000, 500 ) );
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 #ifndef WIN32
 	if (::socketpair(AF_UNIX, SOCK_STREAM, 0, sigusr1Fd))
@@ -205,7 +204,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename )
 
 	undoView = new QUndoView(h2app->m_undoStack);
 	undoView->setWindowTitle(tr("Undo history"));
-	undoView->setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	//restore last playlist
 	if(		Preferences::get_instance()->isRestoreLastPlaylistEnabled() 
@@ -805,7 +803,6 @@ void MainForm::action_file_openDemo()
 	fd.setNameFilter( trUtf8("Hydrogen Song (*.h2song)") );
 
 	fd.setWindowTitle( trUtf8( "Open song" ) );
-	fd.setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	fd.setDirectory( QString( Preferences::get_instance()->getDemoPath() ) );
 
@@ -1553,7 +1550,6 @@ void MainForm::action_file_export_midi()
 	fd.setDirectory( QDir::homePath() );
 	fd.setWindowTitle( trUtf8( "Export MIDI file" ) );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
-	fd.setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	QString sFilename;
 	if ( fd.exec() == QDialog::Accepted ) {
@@ -1600,7 +1596,6 @@ void MainForm::action_file_export_lilypond()
 	fd.setDirectory( QDir::homePath() );
 	fd.setWindowTitle( trUtf8( "Export LilyPond file" ) );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
-	fd.setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	QString sFilename;
 	if ( fd.exec() == QDialog::Accepted ) {

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -57,7 +57,6 @@ Mixer::Mixer( QWidget* pParent )
 	setMaximumHeight( 284 );
 	setMinimumHeight( 284 );
 	setFixedHeight( 284 );
-	setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 // fader Panel
 	m_pFaderHBox = new QHBoxLayout();

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -55,7 +55,6 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	setupUi( this );
 
 	setWindowTitle( trUtf8( "Preferences" ) );
-	setWindowIcon( QPixmap( Skin::getImagePath()  + "/icon16.png" ) );
 
 	setMinimumSize( width(), height() );
 

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1089,7 +1089,7 @@ void SongEditorPatternList::inlineEditingFinished()
 void SongEditorPatternList::paintEvent( QPaintEvent *ev )
 {
 	QPainter painter(this);
-	qreal pixelRatio = painter.device()->devicePixelRatio();
+	qreal pixelRatio = devicePixelRatio();
 	QRectF srcRect(
 			pixelRatio * ev->rect().x(),
 			pixelRatio * ev->rect().y(),
@@ -1139,7 +1139,7 @@ void SongEditorPatternList::createBackground()
 			newHeight = 1;	// the pixmap should not be empty
 		}
 		delete m_pBackgroundPixmap;
-		qreal pixelRatio = qApp->devicePixelRatio();
+		qreal pixelRatio = devicePixelRatio();
 		m_pBackgroundPixmap = new QPixmap( m_nWidth  * pixelRatio , newHeight * pixelRatio );	// initialize the pixmap
 		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
 		this->resize( m_nWidth, newHeight );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1877,7 +1877,9 @@ SongEditorPositionRuler::SongEditorPositionRuler( QWidget *parent )
 	resize( m_nInitialWidth, m_nHeight );
 	setFixedHeight( m_nHeight );
 
-	m_pBackgroundPixmap = new QPixmap( m_nInitialWidth, m_nHeight );	// initialize the pixmap
+	qreal pixelRatio = devicePixelRatio();
+	m_pBackgroundPixmap = new QPixmap( m_nInitialWidth * pixelRatio, m_nHeight * pixelRatio );	// initialize the pixmap
+	m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
 
 	createBackground();	// create m_backgroundPixmap pixmap
 
@@ -2118,7 +2120,14 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	}
 
 	QPainter painter(this);
-	painter.drawPixmap( ev->rect(), *m_pBackgroundPixmap, ev->rect() );
+	qreal pixelRatio = devicePixelRatio();
+	QRectF srcRect(
+			pixelRatio * ev->rect().x(),
+			pixelRatio * ev->rect().y(),
+			pixelRatio * ev->rect().width(),
+			pixelRatio * ev->rect().height()
+	);
+	painter.drawPixmap( ev->rect(), *m_pBackgroundPixmap, srcRect );
 
 	if (fPos != -1) {
 		uint x = (int)( 10 + fPos * m_nGridWidth - 11 / 2 );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1089,7 +1089,14 @@ void SongEditorPatternList::inlineEditingFinished()
 void SongEditorPatternList::paintEvent( QPaintEvent *ev )
 {
 	QPainter painter(this);
-	painter.drawPixmap( ev->rect(), *m_pBackgroundPixmap, ev->rect() );
+	qreal pixelRatio = painter.device()->devicePixelRatio();
+	QRectF srcRect(
+			pixelRatio * ev->rect().x(),
+			pixelRatio * ev->rect().y(),
+			pixelRatio * ev->rect().width(),
+			pixelRatio * ev->rect().height()
+	);
+	painter.drawPixmap( ev->rect(), *m_pBackgroundPixmap, srcRect );
 }
 
 
@@ -1132,7 +1139,9 @@ void SongEditorPatternList::createBackground()
 			newHeight = 1;	// the pixmap should not be empty
 		}
 		delete m_pBackgroundPixmap;
-		m_pBackgroundPixmap = new QPixmap( m_nWidth, newHeight );	// initialize the pixmap
+		qreal pixelRatio = qApp->devicePixelRatio();
+		m_pBackgroundPixmap = new QPixmap( m_nWidth  * pixelRatio , newHeight * pixelRatio );	// initialize the pixmap
+		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
 		this->resize( m_nWidth, newHeight );
 	}
 	m_pBackgroundPixmap->fill( Qt::black );

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -38,7 +38,6 @@ SongPropertiesDialog::SongPropertiesDialog(QWidget* parent)
 	setMinimumSize( width(), height() );
 
 	setWindowTitle( trUtf8( "Song properties" ) );
-        setWindowIcon( QPixmap( Skin::getImagePath() + "/icon16.png" ) );
 
 	Song *song = Hydrogen::get_instance()->getSong();
 	songNameTxt->setText( song->__name );

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -33,6 +33,7 @@
 #include "HydrogenApp.h"
 #include "MainForm.h"
 #include "PlaylistEditor/PlaylistDialog.h"
+#include "Skin.h"
 
 #ifdef H2CORE_HAVE_LASH
 #include <hydrogen/LashClient.h>
@@ -125,6 +126,21 @@ static int setup_unix_signal_handlers()
 		return 1;
 
 	return 0;
+#endif
+}
+
+static void setApplicationIcon(QApplication *app)
+{
+#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN)
+	/* macOS uses icons from .icns file and Windows use icons from .ico
+	   file. On other platforms, manually specify icons to use */
+	QIcon icon;
+	icon.addFile(Skin::getImagePath() + "/icon16.png", QSize(16, 16));
+	icon.addFile(Skin::getImagePath() + "/icon24.png", QSize(24, 24));
+	icon.addFile(Skin::getImagePath() + "/icon32.png", QSize(32, 32));
+	icon.addFile(Skin::getImagePath() + "/icon48.png", QSize(48, 48));
+	icon.addFile(Skin::getImagePath() + "/icon64.png", QSize(64, 64));
+	app->setWindowIcon(icon);
 #endif
 }
 
@@ -289,6 +305,7 @@ int main(int argc, char *argv[])
 		}
 
 		setPalette( pQApp );
+		setApplicationIcon(pQApp);
 
 		SplashScreen *pSplash = new SplashScreen();
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -131,9 +131,6 @@ static int setup_unix_signal_handlers()
 
 static void setApplicationIcon(QApplication *app)
 {
-#if !defined(Q_OS_MACOS) && !defined(Q_OS_WIN)
-	/* macOS uses icons from .icns file and Windows use icons from .ico
-	   file. On other platforms, manually specify icons to use */
 	QIcon icon;
 	icon.addFile(Skin::getImagePath() + "/icon16.png", QSize(16, 16));
 	icon.addFile(Skin::getImagePath() + "/icon24.png", QSize(24, 24));
@@ -141,7 +138,6 @@ static void setApplicationIcon(QApplication *app)
 	icon.addFile(Skin::getImagePath() + "/icon48.png", QSize(48, 48));
 	icon.addFile(Skin::getImagePath() + "/icon64.png", QSize(64, 64));
 	app->setWindowIcon(icon);
-#endif
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Hi,


I have been playing with high dpi support in Qt5. This branch should fix pixelated text on pattern list and song editor ruler. It also makes Hydrogen use higher resolution icons.

Before:
![zrzut ekranu 2017-03-09 o 18 01 00](https://cloud.githubusercontent.com/assets/1619113/23761304/a95895b0-04f2-11e7-9821-2d17a18c1e4e.png)

After:
![zrzut ekranu 2017-03-09 o 17 05 20](https://cloud.githubusercontent.com/assets/1619113/23761309/adc7c936-04f2-11e7-9ebc-ba383e67fa70.png)

(to see the difference, open two images in new tabs, and switch between them back and forth)

**I need your help!** I don't have high DPI screen, so I was only able to test this issue by forcing Qt5 UI scaling by setting environment variable `QT_SCALE_FACTOR=2`. I'd be grateful for testing this PR on real Retina-like screens, preferably on different OSes.