### PR TITLE
Use CoreMIDI driver to send outcoming MIDI messages

### DIFF
--- a/src/core/include/hydrogen/IO/CoreMidiDriver.h
+++ b/src/core/include/hydrogen/IO/CoreMidiDriver.h
@@ -63,6 +63,10 @@ public:
 	MIDIPortRef h2OutputRef;
 	MIDIEndpointRef cmH2Dst;
 
+	MIDIEndpointRef h2VirtualOut;
+
+private:
+	void sendMidiPacket (MIDIPacketList *packetList);
 };
 
 }

--- a/src/core/src/IO/coremidi_driver.cpp
+++ b/src/core/src/IO/coremidi_driver.cpp
@@ -109,8 +109,24 @@ CoreMidiDriver::CoreMidiDriver()
 
 	QString sMidiPortName = Preferences::get_instance()->m_sMidiPortName;
 	err = MIDIClientCreate ( CFSTR( "h2MIDIClient" ), NULL, NULL, &h2MIDIClient );
+	if ( err != noErr ) {
+		ERRORLOG( QString( "Cannot create CoreMIDI client: %1" ).arg( err )); 
+	}
+
 	err = MIDIInputPortCreate ( h2MIDIClient, CFSTR( "h2InputPort" ), midiProc, this, &h2InputRef );
+	if ( err != noErr ) {
+		ERRORLOG( QString( "Cannot create CoreMIDI input port: %1" ).arg( err )); 
+	}
+
 	err = MIDIOutputPortCreate ( h2MIDIClient, CFSTR( "h2OutputPort" ), &h2OutputRef );
+	if ( err != noErr ) {
+		ERRORLOG( QString( "Cannot create CoreMIDI output port: %1" ).arg( err )); 
+	}
+
+	err = MIDISourceCreate ( h2MIDIClient, CFSTR( "Hydrogen" ), &h2VirtualOut );
+	if ( err != noErr ) {
+		ERRORLOG( QString( "Cannot create CoreMIDI virtual output: %1" ).arg( err )); 
+	}
 }
 
 
@@ -178,6 +194,7 @@ void CoreMidiDriver::close()
 	OSStatus err = noErr;
 	err = MIDIPortDisconnectSource( h2InputRef, cmH2Src );
 	err = MIDIPortDispose( h2InputRef );
+	err = MIDIEndpointDispose( h2VirtualOut );
 	//err = MIDIPortDisconnectSource( h2OutputRef, cmH2Dst );
 	//err = MIDIPortDispose( h2OutputRef );
 	err = MIDIClientDispose( h2MIDIClient );
@@ -241,14 +258,13 @@ void CoreMidiDriver::handleQueueNote(Note* pNote)
 	packetList.packet->data[1] = key;
 	packetList.packet->data[2] = velocity;
 
-
-	MIDISend(h2OutputRef, cmH2Dst, &packetList);
+	sendMidiPacket ( &packetList );
 
 	packetList.packet->data[0] = 0x90 | channel;
 	packetList.packet->data[1] = key;
 	packetList.packet->data[2] = velocity;
 
-	MIDISend(h2OutputRef, cmH2Dst, &packetList);
+	sendMidiPacket ( &packetList );
 }
 
 void CoreMidiDriver::handleQueueNoteOff( int channel, int key, int velocity )
@@ -275,8 +291,7 @@ void CoreMidiDriver::handleQueueNoteOff( int channel, int key, int velocity )
 	packetList.packet->data[1] = key;
 	packetList.packet->data[2] = velocity;
 
-
-	MIDISend(h2OutputRef, cmH2Dst, &packetList);
+	sendMidiPacket ( &packetList );
 }
 
 void CoreMidiDriver::handleQueueAllNoteOff()
@@ -307,8 +322,22 @@ void CoreMidiDriver::handleQueueAllNoteOff()
 		packetList.packet->data[1] = key;
 		packetList.packet->data[2] = 0;
 
-		MIDISend(h2OutputRef, cmH2Dst, &packetList);
+		sendMidiPacket ( &packetList );
+	}
+}
 
+void CoreMidiDriver::sendMidiPacket (MIDIPacketList *packetList)
+{
+	OSStatus err = noErr;
+
+	err = MIDISend(h2OutputRef, cmH2Dst, packetList);
+	if ( err != noErr ) {
+		ERRORLOG( QString( "Cannot send MIDI packet to output port: %1" ).arg( err )); 
+	}
+
+	err = MIDIReceived(h2VirtualOut, packetList);
+	if ( err != noErr ) {
+		ERRORLOG( QString( "Cannot send MIDI packet to virtual output: %1" ).arg( err )); 
 	}
 }
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1581,7 +1581,9 @@ void audioEngine_startAudioDrivers()
 #endif
 	} else if ( preferencesMng->m_sMidiDriver == "CoreMidi" ) {
 #ifdef H2CORE_HAVE_COREMIDI
-		m_pMidiDriver = new CoreMidiDriver();
+		CoreMidiDriver *coreMidiDriver = new CoreMidiDriver();
+		m_pMidiDriver = coreMidiDriver;
+		m_pMidiDriverOut = coreMidiDriver;
 		m_pMidiDriver->open();
 		m_pMidiDriver->setActive( true );
 #endif


### PR DESCRIPTION
Currently CoreMIDI driver is used only for receiving MIDI messages which is strange, because it is capable of sending MIDI messages (it implements `MidiOutput` interface). This branch fixes this - it uses CoreMIDI drivedr for both input and output.

Moreover, it creates MIDI virtual output (by `MIDISourceCreate`), which can route MIDI messages to other applications (as opposed to outputting to hardware MIDI ports only).

As a bonus, this branch implements error logging within CoreMIDI driver.