### PR TITLE
Enhancement #455: Open sample editor on double-click on waveform in instrument editor

### DIFF
--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -388,6 +388,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pWaveDisplay = new WaveDisplay( m_pLayerProp );
 	m_pWaveDisplay->updateDisplay( NULL );
 	m_pWaveDisplay->move( 5, 241 );
+	connect( m_pWaveDisplay, SIGNAL( doubleClicked(QWidget*) ), this, SLOT( waveDisplayDoubleClicked(QWidget*) ) );
 
 	m_pLoadLayerBtn = new Button(
 						  m_pLayerProp,
@@ -791,6 +792,25 @@ void InstrumentEditor::filterActiveBtnClicked(Button *ref)
 	}
 }
 
+
+void InstrumentEditor::waveDisplayDoubleClicked( QWidget* pRef )
+{		
+	if ( m_pInstrument ) {
+		InstrumentComponent* pCompo = m_pInstrument->get_component(m_nSelectedComponent);
+		if( pCompo ) {
+			H2Core::InstrumentLayer *pLayer = pCompo->get_layer( m_nSelectedLayer );
+			if ( pLayer ) {
+				Sample* pSample = pLayer->get_sample();
+				if( pSample == NULL) return;
+				QString name = pSample->get_filepath();
+				HydrogenApp::get_instance()->showSampleEditor( name, m_nSelectedComponent, m_nSelectedLayer );
+			}
+			else {
+				loadLayer();
+			}	
+		}
+	}
+}
 
 void InstrumentEditor::buttonClicked( Button* pButton )
 {

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -795,20 +795,26 @@ void InstrumentEditor::filterActiveBtnClicked(Button *ref)
 
 void InstrumentEditor::waveDisplayDoubleClicked( QWidget* pRef )
 {		
-	if ( m_pInstrument ) {
-		InstrumentComponent* pCompo = m_pInstrument->get_component(m_nSelectedComponent);
-		if( pCompo ) {
-			H2Core::InstrumentLayer *pLayer = pCompo->get_layer( m_nSelectedLayer );
-			if ( pLayer ) {
-				Sample* pSample = pLayer->get_sample();
-				if( pSample == NULL) return;
-				QString name = pSample->get_filepath();
-				HydrogenApp::get_instance()->showSampleEditor( name, m_nSelectedComponent, m_nSelectedLayer );
-			}
-			else {
-				loadLayer();
-			}	
+	if ( !m_pInstrument ) {
+		return;
+	}
+	
+	InstrumentComponent* pCompo = m_pInstrument->get_component(m_nSelectedComponent);
+	if( !pCompo ) {
+		return;
+	}
+			
+	H2Core::InstrumentLayer *pLayer = pCompo->get_layer( m_nSelectedLayer );
+	if ( pLayer ) {
+		Sample* pSample = pLayer->get_sample();
+		
+		if( pSample ) {
+			QString name = pSample->get_filepath();
+			HydrogenApp::get_instance()->showSampleEditor( name, m_nSelectedComponent, m_nSelectedLayer );
 		}
+	}
+	else {
+		loadLayer();
 	}
 }
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -92,6 +92,8 @@ class InstrumentEditor : public QWidget, public H2Core::Object, public EventList
 
 		void pSampleSelectionChanged( QString );
 
+		void waveDisplayDoubleClicked( QWidget *pRef );
+
 	private:
 		H2Core::Instrument *m_pInstrument;
 		int m_nSelectedLayer;

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -128,6 +128,7 @@ void WaveDisplay::updateDisplay( H2Core::InstrumentLayer *pLayer )
 
 void WaveDisplay::mouseDoubleClickEvent(QMouseEvent *ev)
 {
-	if (ev->button() == Qt::LeftButton)
+	if (ev->button() == Qt::LeftButton) {
 	    emit doubleClicked(this);
+	}	
 }

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -126,3 +126,8 @@ void WaveDisplay::updateDisplay( H2Core::InstrumentLayer *pLayer )
 	update();
 }
 
+void WaveDisplay::mouseDoubleClickEvent(QMouseEvent *ev)
+{
+	if (ev->button() == Qt::LeftButton)
+	    emit doubleClicked(this);
+}

--- a/src/gui/src/InstrumentEditor/WaveDisplay.h
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.h
@@ -46,6 +46,10 @@ class WaveDisplay : public QWidget, public H2Core::Object
 		void updateDisplay( H2Core::InstrumentLayer *pLayer );
 
 		void paintEvent(QPaintEvent *ev);
+		void mouseDoubleClickEvent(QMouseEvent *ev);
+
+	signals:
+		void doubleClicked(QWidget *pWidget);
 
 	private:
 		QPixmap m_background;


### PR DESCRIPTION
Open the sample editor when a sample waveform is double-clicked in instrument editor.

When the selected layer (and thus the waveform) is empty, double-clicking opens the "Load Layer"-dialog.
No action is triggered when the selected layer exists, but the sample cannot be found - to prevent accidental overwriting of sample editor settings.

Addressing (enhancement) issue hydrogen-music#455

Contributor @xjjx made a code-style proposal in the issue, as I'd like to contribute more in the future I would be happy to hear the maintainer's opinion :)