### PR TITLE
Sample editor dialog is now modal

### DIFF
--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -87,6 +87,7 @@ SampleEditor::SampleEditor ( QWidget* pParent, int nSelectedComponent, int nSele
 
 	setWindowTitle ( QString( "SampleEditor " + newfilename) );
 	setFixedSize ( width(), height() );
+	setModal ( true );
 
 	//this new sample give us the not changed real samplelength
 	m_pSampleFromFile = Sample::load( mSamplefilename );


### PR DESCRIPTION
Adressing issue #492: Sampleeditor crashes when edited instrument layer is changed or deleted
