### PR TITLE
Setting default values for controls with ctrl+click

### DIFF
--- a/src/core/include/hydrogen/fx/LadspaFX.h
+++ b/src/core/include/hydrogen/fx/LadspaFX.h
@@ -102,6 +102,7 @@ public:
 	QString sName;
 	bool isToggle;
 	bool m_bIsInteger;
+	LADSPA_Data fDefaultValue;
 	LADSPA_Data fControlValue;
 	LADSPA_Data fLowerBound;
 	LADSPA_Data fUpperBound;

--- a/src/core/src/fx/ladspa_fx.cpp
+++ b/src/core/src/fx/ladspa_fx.cpp
@@ -326,6 +326,7 @@ LadspaFX* LadspaFX::load( const QString& sLibraryPath, const QString& sPluginLab
 			pControl->fLowerBound = fMin;
 			pControl->fUpperBound = fMax;
 			pControl->fControlValue = fDefault;
+			pControl->fDefaultValue = fDefault;
 			pControl->isToggle = isToggle;
 			pControl->m_bIsInteger = isInteger;
 
@@ -361,6 +362,7 @@ LadspaFX* LadspaFX::load( const QString& sLibraryPath, const QString& sPluginLab
 			pControl->fLowerBound = fMin;
 			pControl->fUpperBound = fMax;
 			pControl->fControlValue = fDefault;
+			pControl->fDefaultValue = fDefault;
 			//pFX->infoLog( "[LadspaFX::load] Output control port\t[" + sName + "]\tmin=" + to_string(fMin) + ",\tmax=" + to_string(fMax) + ",\tcontrolValue=" + to_string(pControl->fControlValue) );
 
 			pFX->outputControlPorts.push_back( pControl );

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -191,6 +191,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	connect( m_pFilterBypassBtn, SIGNAL( clicked(Button*) ), this, SLOT( filterActiveBtnClicked(Button*) ) );
 
 	m_pCutoffRotary = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Filter Cutoff" ), false, true );
+	m_pCutoffRotary->setDefaultValue( m_pCutoffRotary->getMax() );
 	connect( m_pCutoffRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 
 	m_pResonanceRotary = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Filter resonance" ), false, true );
@@ -205,7 +206,9 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pAttackRotary = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Attack" ), false, true );
 	m_pDecayRotary = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Decay" ), false, true );
 	m_pSustainRotary = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Sustain" ), false, true );
+	m_pSustainRotary->setDefaultValue( m_pSustainRotary->getMax() );
 	m_pReleaseRotary = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Release" ), false, true );
+	m_pReleaseRotary->setDefaultValue( 0.09 );
 	connect( m_pAttackRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 	connect( m_pDecayRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 	connect( m_pSustainRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
@@ -219,6 +222,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	// instrument gain
 	m_pInstrumentGainLCD = new LCDDisplay( m_pInstrumentProp, LCDDigit::SMALL_BLUE, 4 );
 	m_pInstrumentGain = new Rotary( m_pInstrumentProp, Rotary::TYPE_NORMAL, trUtf8( "Instrument gain" ), false, false );
+	m_pInstrumentGain->setDefaultValue( 0.2 ); // gain is multiplied with 5, so default is 1.0 from users view
 	connect( m_pInstrumentGain, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 	m_pInstrumentGainLCD->move( 67, 105 );
 	m_pInstrumentGain->move( 117, 100 );
@@ -427,10 +431,12 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	// Layer gain
 	m_pLayerGainLCD = new LCDDisplay( m_pLayerProp, LCDDigit::SMALL_BLUE, 4 );
 	m_pLayerGainRotary = new Rotary( m_pLayerProp,  Rotary::TYPE_NORMAL, trUtf8( "Layer gain" ), false, false );
+	m_pLayerGainRotary->setDefaultValue ( 0.2 ); // gain is multiplied with 5, so default is 1.0 from users view
 	connect( m_pLayerGainRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 
 	m_pCompoGainLCD = new LCDDisplay( m_pLayerProp, LCDDigit::SMALL_BLUE, 4 );
 	m_pCompoGainRotary = new Rotary( m_pLayerProp,  Rotary::TYPE_NORMAL, trUtf8( "Component volume" ), false, false );
+	m_pCompoGainRotary->setDefaultValue ( 0.2 ); // gain is multiplied with 5, so default is 1.0 from users view
 	connect( m_pCompoGainRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 
 	m_pLayerPitchCoarseLCD = new LCDDisplay( m_pLayerProp, LCDDigit::SMALL_BLUE, 4 );
@@ -441,7 +447,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pLayerPitchCoarseRotary->setMax( 24.0 );
 	connect( m_pLayerPitchCoarseRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 
-	m_pLayerPitchFineRotary = new Rotary( m_pLayerProp, Rotary::TYPE_CENTER, trUtf8( "Layer pitch (Fine)" ), false, false );
+	m_pLayerPitchFineRotary = new Rotary( m_pLayerProp, Rotary::TYPE_CENTER, trUtf8( "Layer pitch (Fine)" ), true, false );
 	m_pLayerPitchFineRotary->setMin( -50.0 );
 	m_pLayerPitchFineRotary->setMax( 50.0 );
 	connect( m_pLayerPitchFineRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -289,6 +289,7 @@ void LadspaFXProperties::updateControls()
 			pFader->setValue( pControlPort->fControlValue );
 			pFader->setPeak_L( pControlPort->fControlValue );
 			pFader->setPeak_R( pControlPort->fControlValue );
+			pFader->setDefaultValue( pControlPort->fDefaultValue );
 
 			//float fInterval = pControlPort->fUpperBound - pControlPort->fLowerBound;
 			//float fValue = ( pControlPort->fControlValue - pControlPort->fLowerBound ) / fInterval;
@@ -327,6 +328,7 @@ void LadspaFXProperties::updateControls()
 			pFader->setValue( pControl->fControlValue );
 			pFader->setPeak_L( pControl->fControlValue );
 			pFader->setPeak_R( pControl->fControlValue );
+			pFader->setDefaultValue( pControl->fDefaultValue );
 
 			m_pOutputControlFaders.push_back( pFader );
 		}

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -1279,6 +1279,7 @@ LadspaFXMixerLine::LadspaFXMixerLine(QWidget* parent)
 
 	// m_pRotary
 	m_pRotary = new Rotary( this,  Rotary::TYPE_NORMAL, trUtf8( "Effect return" ), false, false );
+	m_pRotary->setDefaultValue( m_pRotary->getMax() );
 	m_pRotary->move( 132, 4 );
 	connect( m_pRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 }

--- a/src/gui/src/widgets/Fader.cpp
+++ b/src/gui/src/widgets/Fader.cpp
@@ -47,7 +47,7 @@ Fader::Fader( QWidget *pParent, bool bUseIntSteps, bool bWithoutKnob )
  , m_fMinValue( 0.0 )
  , m_fMaxValue( 1.0 )
  , m_fDefaultValue( m_fMaxValue )
- , m_ignoreMouseMove( false )
+ , m_bIgnoreMouseMove( false )
 {
 	setAttribute( Qt::WA_NoBackground );
 	setMinimumSize( 23, 116 );
@@ -87,7 +87,7 @@ Fader::~Fader()
 
 void Fader::mouseMoveEvent( QMouseEvent *ev )
 {
-	if ( m_ignoreMouseMove ) {
+	if ( m_bIgnoreMouseMove ) {
 		return;
 	}
 
@@ -106,7 +106,7 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 {
 	if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
-		m_ignoreMouseMove = true;
+		m_bIgnoreMouseMove = true;
 		emit valueChanged(this);
 	}
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
@@ -122,7 +122,7 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 
 void Fader::mouseReleaseEvent(QMouseEvent *ev)
 {
-	m_ignoreMouseMove = false;
+	m_bIgnoreMouseMove = false;
 }
 
 
@@ -141,7 +141,7 @@ void Fader::wheelEvent ( QWheelEvent *ev )
 	}
 	else {
 		float step = ( m_fMaxValue - m_fMinValue ) / 50.0;
-
+ 
 		if ( ev->delta() > 0 ) {
 			setValue( m_fValue + step );
 		}
@@ -342,6 +342,7 @@ MasterFader::MasterFader(QWidget *pParent, bool bWithoutKnob)
  , m_fMin( 0.0 )
  , m_fMax( 1.0 )
  , m_fDefaultValue( m_fMax )
+ , m_bIgnoreMouseMove( false )
 {
 	setAttribute(Qt::WA_NoBackground);
 
@@ -399,7 +400,7 @@ void MasterFader::wheelEvent ( QWheelEvent *ev )
 
 void MasterFader::mouseMoveEvent( QMouseEvent *ev )
 {
-	if ( m_ignoreMouseMove ) {
+	if ( m_bIgnoreMouseMove ) {
 		return;
 	}
 
@@ -414,7 +415,7 @@ void MasterFader::mouseMoveEvent( QMouseEvent *ev )
 
 void MasterFader::mouseReleaseEvent(QMouseEvent *ev)
 {
-	m_ignoreMouseMove = false;
+	m_bIgnoreMouseMove = false;
 }
 
 
@@ -423,7 +424,7 @@ void MasterFader::mousePressEvent(QMouseEvent *ev)
 {
 	if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
-		m_ignoreMouseMove = true;
+		m_bIgnoreMouseMove = true;
 		emit valueChanged(this);
 	}
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
@@ -598,6 +599,7 @@ Knob::Knob( QWidget* pParent )
 	m_fDefaultValue = 0.0;
 	m_fMousePressValue = 0.0;
 	m_fMousePressY = 0.0;
+	m_bIgnoreMouseMove = false;
 
 	if ( m_background == NULL ) {
 		QString sBackground_path = Skin::getImagePath() + "/mixerPanel/knob_images.png";
@@ -689,7 +691,7 @@ void Knob::mousePressEvent(QMouseEvent *ev)
 {
     if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
-		m_ignoreMouseMove = true;
+		m_bIgnoreMouseMove = true;
 		emit valueChanged(this);
 	}
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
@@ -710,14 +712,14 @@ void Knob::mouseReleaseEvent( QMouseEvent *ev )
 	UNUSED( ev );
 	setCursor( QCursor( Qt::ArrowCursor ) );
 
-	m_ignoreMouseMove = false;
+	m_bIgnoreMouseMove = false;
 }
 
 
 
  void Knob::mouseMoveEvent( QMouseEvent *ev ) 
  {
-	if ( m_ignoreMouseMove ) {
+	if ( m_bIgnoreMouseMove ) {
 		return;
 	}
 

--- a/src/gui/src/widgets/Fader.cpp
+++ b/src/gui/src/widgets/Fader.cpp
@@ -87,15 +87,17 @@ Fader::~Fader()
 
 void Fader::mouseMoveEvent( QMouseEvent *ev )
 {
-	if ( !m_ignoreMouseMove ) {
-		float fVal = (float)( height() - ev->y() ) / (float)height();
-		fVal = fVal * ( m_fMaxValue - m_fMinValue );
-
-		fVal = fVal + m_fMinValue;
-
-		setValue( fVal );
-		emit valueChanged(this);
+	if ( m_ignoreMouseMove ) {
+		return;
 	}
+
+	float fVal = (float)( height() - ev->y() ) / (float)height();
+	fVal = fVal * ( m_fMaxValue - m_fMinValue );
+
+	fVal = fVal + m_fMinValue;
+
+	setValue( fVal );
+	emit valueChanged(this);
 }
 
 
@@ -397,13 +399,15 @@ void MasterFader::wheelEvent ( QWheelEvent *ev )
 
 void MasterFader::mouseMoveEvent( QMouseEvent *ev )
 {
-	if ( !m_ignoreMouseMove ) {
-		float fVal = (float)( height() - ev->y() ) / (float)height();
-		fVal = fVal * ( m_fMax - m_fMin );
-
-		setValue( fVal );
-		emit valueChanged(this);
+	if ( m_ignoreMouseMove ) {
+		return;
 	}
+
+	float fVal = (float)( height() - ev->y() ) / (float)height();
+	fVal = fVal * ( m_fMax - m_fMin );
+
+	setValue( fVal );
+	emit valueChanged(this);
 }
 
 

--- a/src/gui/src/widgets/Fader.cpp
+++ b/src/gui/src/widgets/Fader.cpp
@@ -104,15 +104,15 @@ void Fader::mouseMoveEvent( QMouseEvent *ev )
 
 void Fader::mousePressEvent(QMouseEvent *ev)
 {
-	if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ){
-		MidiSenseWidget midiSense( this, true, this->getAction() );
-		midiSense.exec();
-	} 
-	else if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
+	if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
 		m_ignoreMouseMove = true;
 		emit valueChanged(this);
 	}
+	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
+		MidiSenseWidget midiSense( this, true, this->getAction() );
+		midiSense.exec();
+	} 
 	else {
 		mouseMoveEvent(ev);
 	}
@@ -421,14 +421,14 @@ void MasterFader::mouseReleaseEvent(QMouseEvent *ev)
 
 void MasterFader::mousePressEvent(QMouseEvent *ev)
 {
-	if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ){
-		MidiSenseWidget midiSense( this, true, this->getAction() );
-		midiSense.exec();
-	}
-	else if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
+	if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
 		m_ignoreMouseMove = true;
 		emit valueChanged(this);
+	}
+	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
+		MidiSenseWidget midiSense( this, true, this->getAction() );
+		midiSense.exec();
 	}
 	else {
 		mouseMoveEvent(ev);
@@ -687,19 +687,20 @@ void Knob::resetValueToDefault()
 
 void Knob::mousePressEvent(QMouseEvent *ev)
 {
-    if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ){
-	MidiSenseWidget midiSense( this, true, this->getAction() );
-	midiSense.exec();
-    } 
-	else if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
+    if  ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
+		m_ignoreMouseMove = true;
 		emit valueChanged(this);
 	}
-
-    setCursor( QCursor( Qt::SizeVerCursor ) );
-
-	m_fMousePressValue = m_fValue;
-	m_fMousePressY = ev->y();
+	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
+		MidiSenseWidget midiSense( this, true, this->getAction() );
+		midiSense.exec();
+    } 
+	else {
+	    setCursor( QCursor( Qt::SizeVerCursor ) );
+		m_fMousePressValue = m_fValue;
+		m_fMousePressY = ev->y();
+	}
 }
 
 
@@ -708,11 +709,18 @@ void Knob::mouseReleaseEvent( QMouseEvent *ev )
 {
 	UNUSED( ev );
 	setCursor( QCursor( Qt::ArrowCursor ) );
+
+	m_ignoreMouseMove = false;
 }
 
 
 
- void Knob::mouseMoveEvent( QMouseEvent *ev ) {
+ void Knob::mouseMoveEvent( QMouseEvent *ev ) 
+ {
+	if ( m_ignoreMouseMove ) {
+		return;
+	}
+
 	float y = ev->y() - m_fMousePressY;
 	float fNewValue = m_fMousePressValue - ( y / 100.0 );
 	setValue( fNewValue );

--- a/src/gui/src/widgets/Fader.cpp
+++ b/src/gui/src/widgets/Fader.cpp
@@ -112,7 +112,7 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
 		MidiSenseWidget midiSense( this, true, this->getAction() );
 		midiSense.exec();
-	} 
+	}
 	else {
 		mouseMoveEvent(ev);
 	}
@@ -141,7 +141,7 @@ void Fader::wheelEvent ( QWheelEvent *ev )
 	}
 	else {
 		float step = ( m_fMaxValue - m_fMinValue ) / 50.0;
- 
+
 		if ( ev->delta() > 0 ) {
 			setValue( m_fValue + step );
 		}
@@ -697,7 +697,7 @@ void Knob::mousePressEvent(QMouseEvent *ev)
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
 		MidiSenseWidget midiSense( this, true, this->getAction() );
 		midiSense.exec();
-    } 
+    }
 	else {
 	    setCursor( QCursor( Qt::SizeVerCursor ) );
 		m_fMousePressValue = m_fValue;
@@ -717,7 +717,7 @@ void Knob::mouseReleaseEvent( QMouseEvent *ev )
 
 
 
- void Knob::mouseMoveEvent( QMouseEvent *ev ) 
+ void Knob::mouseMoveEvent( QMouseEvent *ev )
  {
 	if ( m_bIgnoreMouseMove ) {
 		return;

--- a/src/gui/src/widgets/Fader.h
+++ b/src/gui/src/widgets/Fader.h
@@ -78,7 +78,7 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 	private:
 		bool m_bWithoutKnob;
 		bool m_bUseIntSteps;
-		bool m_ignoreMouseMove;
+		bool m_bIgnoreMouseMove;
 
 		float m_fPeakValue_L;
 		float m_fPeakValue_R;
@@ -136,7 +136,7 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 
 	private:
 		bool m_bWithoutKnob;
-		bool m_ignoreMouseMove;
+		bool m_bIgnoreMouseMove;
 
 		float m_fPeakValue_L;
 		float m_fPeakValue_R;
@@ -176,7 +176,7 @@ class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 
 	private:
 		static QPixmap *m_background;
-		bool m_ignoreMouseMove;
+		bool m_bIgnoreMouseMove;
 
 		int m_nWidgetWidth;
 		int m_nWidgetHeight;

--- a/src/gui/src/widgets/Fader.h
+++ b/src/gui/src/widgets/Fader.h
@@ -176,6 +176,7 @@ class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 
 	private:
 		static QPixmap *m_background;
+		bool m_ignoreMouseMove;
 
 		int m_nWidgetWidth;
 		int m_nWidgetHeight;

--- a/src/gui/src/widgets/Fader.h
+++ b/src/gui/src/widgets/Fader.h
@@ -53,6 +53,9 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 		void setValue( float fVal );
 		float getValue();
 
+		void setDefaultValue( float fDefaultValue );
+		float getDefaultValue() { return m_fDefaultValue; }
+		void resetValueToDefault();
 
 		void setMaxPeak( float fMax );
 		void setMinPeak( float fMin );
@@ -65,6 +68,7 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 
 		virtual void mousePressEvent(QMouseEvent *ev);
 		virtual void mouseMoveEvent(QMouseEvent *ev);
+		virtual void mouseReleaseEvent(QMouseEvent *ev);
 		virtual void wheelEvent( QWheelEvent *ev );
 		virtual void paintEvent(QPaintEvent *ev);
 
@@ -74,6 +78,7 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 	private:
 		bool m_bWithoutKnob;
 		bool m_bUseIntSteps;
+		bool m_ignoreMouseMove;
 
 		float m_fPeakValue_L;
 		float m_fPeakValue_R;
@@ -83,6 +88,7 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 		float m_fValue;
 		float m_fMinValue;
 		float m_fMaxValue;
+		float m_fDefaultValue;
 
 		QPixmap m_back;
 		QPixmap m_leds;
@@ -109,6 +115,10 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 		void setValue( float newValue );
 		float getValue();
 
+		void setDefaultValue( float fDefaultValue );
+		float getDefaultValue() { return m_fDefaultValue; }
+		void resetValueToDefault();
+
 		void setPeak_L( float peak );
 		float getPeak_L() {	return m_fPeakValue_L;	}
 
@@ -117,6 +127,7 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 
 		virtual void mousePressEvent( QMouseEvent *ev );
 		virtual void mouseMoveEvent( QMouseEvent *ev );
+		virtual void mouseReleaseEvent(QMouseEvent *ev);
 		virtual void paintEvent( QPaintEvent *ev );
 		virtual void wheelEvent( QWheelEvent *ev );
 
@@ -125,12 +136,15 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 
 	private:
 		bool m_bWithoutKnob;
+		bool m_ignoreMouseMove;
+
 		float m_fPeakValue_L;
 		float m_fPeakValue_R;
 
 		float m_fValue;
 		float m_fMin;
 		float m_fMax;
+		float m_fDefaultValue;
 
 		QPixmap m_back;
 		QPixmap m_leds;
@@ -152,6 +166,11 @@ class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 		void setValue( float fValue );
 		float getValue() {	return m_fValue;	}
 
+		void setDefaultValue( float fDefaultValue );
+		float getDefaultValue() { return m_fDefaultValue; }
+		void resetValueToDefault();
+
+
 	signals:
 		void valueChanged( Knob *ref );
 
@@ -162,6 +181,7 @@ class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 		int m_nWidgetHeight;
 
 		float m_fValue;
+		float m_fDefaultValue;
 		float m_fMousePressValue;
 		float m_fMousePressY;
 

--- a/src/gui/src/widgets/Rotary.cpp
+++ b/src/gui/src/widgets/Rotary.cpp
@@ -75,6 +75,7 @@ Rotary::Rotary( QWidget* parent, RotaryType type, QString sToolTip, bool bUseInt
  , m_fMousePressValue( 0.0 )
  , m_fMousePressY( 0.0 )
  , m_bShowValueToolTip( bUseValueTip )
+ , m_bIgnoreMouseMove( false )
 {
 	setAttribute(Qt::WA_NoBackground);
 	setToolTip( sToolTip );
@@ -182,7 +183,7 @@ void Rotary::mousePressEvent(QMouseEvent *ev)
 {
 	if (ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier) {
 		resetValueToDefault();
-		m_ignoreMouseMove = true;
+		m_bIgnoreMouseMove = true;
 		emit valueChanged(this);
 	}
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
@@ -213,7 +214,7 @@ void Rotary::mouseReleaseEvent( QMouseEvent *ev )
 	setCursor( QCursor( Qt::ArrowCursor ) );
 	m_pValueToolTip->hide();
 
-	m_ignoreMouseMove = false;
+	m_bIgnoreMouseMove = false;
 }
 
 
@@ -245,7 +246,7 @@ void Rotary::wheelEvent ( QWheelEvent *ev )
 
  void Rotary::mouseMoveEvent( QMouseEvent *ev ) 
  {
-	if ( m_ignoreMouseMove ) {
+	if ( m_bIgnoreMouseMove ) {
 		return;
 	}
 

--- a/src/gui/src/widgets/Rotary.cpp
+++ b/src/gui/src/widgets/Rotary.cpp
@@ -180,25 +180,26 @@ void Rotary::setValue( float fValue )
 
 void Rotary::mousePressEvent(QMouseEvent *ev)
 {
-	setCursor( QCursor( Qt::SizeVerCursor ) );
-
 	if (ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier) {
 		resetValueToDefault();
+		m_ignoreMouseMove = true;
 		emit valueChanged(this);
 	}
-
-	m_fMousePressValue = m_fValue;
-	m_fMousePressY = ev->y();
-
-	if ( m_bShowValueToolTip ) {
-		char tmp[20];
-		sprintf( tmp, "%#.2f", m_fValue );
-		m_pValueToolTip->showTip( mapToGlobal( QPoint( -38, 1 ) ), QString( tmp ) );
-	}
-
-	if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ){
+	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
 		MidiSenseWidget midiSense( this, true, this->getAction() );
 		midiSense.exec();
+	}
+	else {
+		setCursor( QCursor( Qt::SizeVerCursor ) );
+
+		m_fMousePressValue = m_fValue;
+		m_fMousePressY = ev->y();
+
+		if ( m_bShowValueToolTip ) {
+			char tmp[20];
+			sprintf( tmp, "%#.2f", m_fValue );
+			m_pValueToolTip->showTip( mapToGlobal( QPoint( -38, 1 ) ), QString( tmp ) );
+		}
 	}
 }
 
@@ -208,9 +209,11 @@ void Rotary::mousePressEvent(QMouseEvent *ev)
 void Rotary::mouseReleaseEvent( QMouseEvent *ev )
 {
 	UNUSED( ev );
-
+	
 	setCursor( QCursor( Qt::ArrowCursor ) );
 	m_pValueToolTip->hide();
+
+	m_ignoreMouseMove = false;
 }
 
 
@@ -240,7 +243,12 @@ void Rotary::wheelEvent ( QWheelEvent *ev )
 
 
 
- void Rotary::mouseMoveEvent( QMouseEvent *ev ) {
+ void Rotary::mouseMoveEvent( QMouseEvent *ev ) 
+ {
+	if ( m_ignoreMouseMove ) {
+		return;
+	}
+
 	float fRange = fabs( m_fMax ) + fabs( m_fMin );
 
 	float deltaY = ev->y() - m_fMousePressY;

--- a/src/gui/src/widgets/Rotary.cpp
+++ b/src/gui/src/widgets/Rotary.cpp
@@ -83,7 +83,15 @@ Rotary::Rotary( QWidget* parent, RotaryType type, QString sToolTip, bool bUseInt
 
 	m_nWidgetWidth = 28;
 	m_nWidgetHeight = 26;
-	m_fValue = 0.0;
+
+	if (bUseIntSteps) {
+		m_fDefaultValue = (int) ( type == TYPE_CENTER ? ( ( m_fMax - m_fMin ) / 2.0 ) : m_fMin );
+	}
+	else {
+		m_fDefaultValue = ( type == TYPE_CENTER ? ( ( m_fMax - m_fMin ) / 2.0 ) : m_fMin );
+	}
+
+	m_fValue = m_fDefaultValue;
 
 	if ( m_background_normal == NULL ) {
 		m_background_normal = new QPixmap();
@@ -173,6 +181,11 @@ void Rotary::setValue( float fValue )
 void Rotary::mousePressEvent(QMouseEvent *ev)
 {
 	setCursor( QCursor( Qt::SizeVerCursor ) );
+
+	if (ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier) {
+		resetValueToDefault();
+		emit valueChanged(this);
+	}
 
 	m_fMousePressValue = m_fValue;
 	m_fMousePressY = ev->y();
@@ -268,4 +281,33 @@ void Rotary::setMax( float fMax )
 float Rotary::getMax()
 {
 	return m_fMax;
+}
+
+
+void Rotary::setDefaultValue( float fDefaultValue )
+{
+	if ( fDefaultValue == m_fDefaultValue ) {
+		return;
+	}
+
+	if ( fDefaultValue < m_fMin ) {
+		fDefaultValue = m_fMin;
+	}
+	else if ( fDefaultValue > m_fMax ) {
+		fDefaultValue = m_fMax;
+	}
+
+	if ( fDefaultValue != m_fDefaultValue ) {
+		m_fDefaultValue = fDefaultValue;
+	}
+}
+
+float Rotary::getDefaultValue()
+{
+	return m_fDefaultValue;
+}
+
+void Rotary::resetValueToDefault()
+{
+	setValue(m_fDefaultValue);
 }

--- a/src/gui/src/widgets/Rotary.cpp
+++ b/src/gui/src/widgets/Rotary.cpp
@@ -195,12 +195,12 @@ void Rotary::mousePressEvent(QMouseEvent *ev)
 
 		m_fMousePressValue = m_fValue;
 		m_fMousePressY = ev->y();
-
-		if ( m_bShowValueToolTip ) {
-			char tmp[20];
-			sprintf( tmp, "%#.2f", m_fValue );
-			m_pValueToolTip->showTip( mapToGlobal( QPoint( -38, 1 ) ), QString( tmp ) );
-		}
+	}
+	
+	if ( m_bShowValueToolTip ) {
+		char tmp[20];
+		sprintf( tmp, "%#.2f", m_fValue );
+		m_pValueToolTip->showTip( mapToGlobal( QPoint( -38, 1 ) ), QString( tmp ) );
 	}
 }
 

--- a/src/gui/src/widgets/Rotary.h
+++ b/src/gui/src/widgets/Rotary.h
@@ -86,7 +86,7 @@ class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 
 	private:
 		bool m_bUseIntSteps;
-		bool m_ignoreMouseMove;
+		bool m_bIgnoreMouseMove;
 
 		RotaryType m_type;
 		static QPixmap* m_background_normal;

--- a/src/gui/src/widgets/Rotary.h
+++ b/src/gui/src/widgets/Rotary.h
@@ -77,6 +77,10 @@ class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 				return m_fValue;
 		}
 
+		void setDefaultValue( float fDefaultValue );
+		float getDefaultValue();
+		void resetValueToDefault();
+
 	signals:
 		void valueChanged(Rotary *ref);
 
@@ -92,6 +96,7 @@ class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 		float m_fMin;
 		float m_fMax;
 		float m_fValue;
+		float m_fDefaultValue;
 
 		float m_fMousePressValue;
 		float m_fMousePressY;

--- a/src/gui/src/widgets/Rotary.h
+++ b/src/gui/src/widgets/Rotary.h
@@ -86,6 +86,8 @@ class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 
 	private:
 		bool m_bUseIntSteps;
+		bool m_ignoreMouseMove;
+
 		RotaryType m_type;
 		static QPixmap* m_background_normal;
 		static QPixmap* m_background_center;


### PR DESCRIPTION
Coming from Cubase, I've missed the possibility of resetting faders, rotary controls etc. to a reasonable default value by holding the control key and left-clicking the control.

For now, I've used following values for the control's default values:
- 1.0 for no change on gain and volume
- 0.0 for deactivating sends
- 0.0 for withdrawing optional "add"-style settings like attack, delay, random pitch (instrument editor) or humanizing parameters (mixer/master channel)
- 1.0 for withdrawing optional "reduce"-style settings like sustain, cutoff (instrument editor) or return (mixer/plugin section)
- 0.5 for centering balance and pan (though i'd prefer a range of -1 to 1 here, maybe look at it separately)
- 0 for withdrawing pitch adjustments
- whatever value ladspa plugins propose as default value for their individual settings

Implementing this, I've found the fine pitch rotary in instrument editor / layers defined as float though it can only be set in integer steps. I've changed this rotary type to integer, though it could be set to a non-integer value through a drumkit.xml config file - I'd suggest rounding the value to integer when loading?

Looking forward to comments and reviews :)