### PR TITLE
Fix #30 Tag editor drag-n-drop will show copy.

### DIFF
--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget_UI.ui
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget_UI.ui
@@ -17,7 +17,10 @@
    <item>
     <widget class="QTableWidget" name="tagTableWidget">
      <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
+      <enum>QAbstractItemView::DragDrop</enum>
+     </property>
+     <property name="defaultDropAction">
+      <enum>Qt::CopyAction</enum>
      </property>
      <attribute name="horizontalHeaderDefaultSectionSize">
       <number>100</number>


### PR DESCRIPTION
The current, drag-and-drop, related behavior of tagTableWidget does not represent the resulting tags if OK is clicked. So if the GUI represents Copy on drag and drop of items on the list, at least it is consistent.
Means if you click "ok" and re-open the dialog you will get the same list.