### PR TITLE
set package _FOUND flag when using cached variables

### DIFF
--- a/cmake/FindHelper.cmake
+++ b/cmake/FindHelper.cmake
@@ -17,6 +17,7 @@ macro(FIND_HELPER prefix pkg_name header lib)
     if(${prefix}_INCLUDE_DIRS AND ${prefix}_LIBRARIES)
         # use cached variables
         set(${prefix}_FIND_QUIETLY TRUE)
+        set(${prefix}_FOUND TRUE)
     else()
         # use pkg-config if available to set find_path and find_library hints
         if(NOT WIN32)


### PR DESCRIPTION
cmake stores the paths of found libraries and header files in its cache. However, when running cmake a second time without clearing the cache before (a common scenario when working with Qt Creator), libraries which were found in the first pass are now reported as "not found". Here is a proposed fix.