### PR TITLE
update installation requirements

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -116,7 +116,7 @@ installed on your system, and the development header files:
 	qt5-default libqt5xmlpatterns5-dev libarchive-dev
 	libsndfile1-dev libasound2-dev liblo-dev libpulse-dev
 	libcppunit-dev liblrdf-dev liblash-compat-dev
-	librubberband-dev
+	librubberband-dev qttools5-dev qttools5-dev-tools
 
 	In addition, either the libjack-jackd2-dev or libjack-dev
 	package must be present. Which one to pick depends on whether

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -2,7 +2,7 @@ Source: hydrogen
 Section: Multimedia
 Priority: optional
 Maintainer: Sebastian Moors <smoors@users.sf.net>
-Build-Depends: debhelper (>= 4.0.0), libsndfile1-dev, libtar-dev, liblrdf-dev, cmake, librubberband-dev, qt5-default, libqt5xmlpatterns5-dev, libarchive-dev, libasound2-dev, libjack-jackd2-dev | libjack-dev, liblo-dev, libpulse-dev, libcppunit-dev, liblash-compat-dev
+Build-Depends: debhelper (>= 4.0.0), libsndfile1-dev, libtar-dev, liblrdf-dev, cmake, librubberband-dev, qt5-default, libqt5xmlpatterns5-dev, libarchive-dev, libasound2-dev, libjack-jackd2-dev | libjack-dev, liblo-dev, libpulse-dev, libcppunit-dev, liblash-compat-dev, qttools5-dev, qttools5-dev-tools
 Standards-Version: 3.6.2
 
 Package: hydrogen


### PR DESCRIPTION
Since commit 033379f2814a0d96a6c9724701058a70aac75951 the Qt5LinguistTools package is introduced. To use it, two additional libraries have to be installed