### PR TITLE
remove qt5_use_modules to fix build with Qt 5.11

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -54,7 +54,6 @@ TARGET_LINK_LIBRARIES(hydrogen
 	hydrogen-core-${VERSION}
 	Qt5::Widgets
 )
-qt5_use_modules(hydrogen Widgets)
 ADD_DEPENDENCIES(hydrogen hydrogen-core-${VERSION})
 
 INSTALL(TARGETS hydrogen RUNTIME DESTINATION bin BUNDLE DESTINATION bin )


### PR DESCRIPTION
* it is not necessary - all libs are linked by TARGET_LINK_LIBRARIES
* was removed in Qt 5.11

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>