### PR TITLE
Fix for issue #606 - Automation path checkbox 

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -346,7 +346,9 @@ void MainForm::createMenuBar()
 	m_pViewMixerInstrumentRackAction->setCheckable( true );
 	update_instrument_checkbox( true );	// check it as Instrument panel is always open on start
 
-	m_pViewMenu->addAction( trUtf8("&Automation path"), this, SLOT( action_window_showAutomationArea() ), QKeySequence( "Alt+A" ) );
+	m_pViewAutomationPathAction = m_pViewMenu->addAction( trUtf8("&Automation path"), this, SLOT( action_window_showAutomationArea() ), QKeySequence( "Alt+A" ) );
+	m_pViewAutomationPathAction->setCheckable( true );
+	update_automation_checkbox();
 
 	m_pViewMenu->addSeparator();				// -----
 
@@ -1115,6 +1117,16 @@ void MainForm::update_instrument_checkbox( bool show )
 	m_pViewMixerInstrumentRackAction->setChecked( show );
 }
 
+void MainForm::update_automation_checkbox()
+{
+	Preferences *pref = Preferences::get_instance();
+	
+	if(pref->getShowAutomationArea()){
+		m_pViewAutomationPathAction->setChecked(true);	
+	} else {
+		m_pViewAutomationPathAction->setChecked(false);
+	}
+}
 
 void MainForm::closeAll() {
 	// save window properties in the preferences files

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -108,6 +108,7 @@ public slots:
 
 		void update_mixer_checkbox();
 		void update_instrument_checkbox( bool show );
+		void update_automation_checkbox();
 		void update_director_checkbox();
 		void update_playlist_checkbox();
 
@@ -158,6 +159,7 @@ public slots:
 		QAction *	m_pViewDirectorAction;
 		QAction *	m_pViewMixerAction;
 		QAction *	m_pViewMixerInstrumentRackAction;
+		QAction *	m_pViewAutomationPathAction;
 		QAction *	m_pInstrumentAction;
 		QAction *	m_pDrumkitAction;
 


### PR DESCRIPTION
    Hi there, 

 This is a fix for the automation path checkbox never being set.

 Basically I created a new  `QAction *` responsible for  the automatic path action view in which I set it as a checkable and also created a function that depending on the actual preferences it updates the checkbox to checked/unchecked ( `update_automation_checkbox()` ).

  Cheers, 
   
      Francisco
