### PR TITLE
Adding Anaconda path in CMakeFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,12 @@ ENDIF(VERSION_SUFFIX)
 
 SET(LIBSNDFILE_VERSION_PREV "1.0.17")
 
+# Check whether anaconda is installed on the system
+STRING(FIND "$ENV{PATH}" "anaconda" ANACONDA_FIND)
+IF(NOT ANACONDA_FIND EQUAL "-1")
+	SET(CMAKE_LIBRARY_PATH "$ENV{HOME}/.anaconda3/lib")
+ENDIF()
+
 #
 # CONFIG OPTIONS
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,15 @@ SET(LIBSNDFILE_VERSION_PREV "1.0.17")
 # Check whether anaconda is installed on the system
 STRING(FIND "$ENV{PATH}" "anaconda" ANACONDA_FIND)
 IF(NOT ANACONDA_FIND EQUAL "-1")
-	SET(CMAKE_LIBRARY_PATH "$ENV{HOME}/.anaconda3/lib")
+      EXECUTE_PROCESS(
+            COMMAND echo "$ENV{PATH}"
+	    COMMAND tr : "\n"
+	    COMMAND awk "/anaconda/ {print $0}"
+	    COMMAND sed "s/bin/lib/"
+	    OUTPUT_VARIABLE ANACONDA_PATH
+	    OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+      SET(CMAKE_LIBRARY_PATH "${ANACONDA_PATH}")
 ENDIF()
 
 #


### PR DESCRIPTION
In case Anaconda is installed on the system it will easily mask some of the libraries and shared objects needed for compilation. The `find_` commands of CMAKE, e.g. `findZLIB`, seem to be agnostic of the lib path set up in the user home. As a result CMAKE finds e.g. `zlib` in /usr/lib but during the compilation gcc tries to link against the installation in $HOME/anaconda/lib causing the build to fail.

Via an `if` clause the library path of Anaconda will be included as soon as the string "anaconda" is present in the `PATH` environmental variable.

EDIT: The problem below is fixed
There is still a problem I do not quite know how to fix in a platform-independent way: one has to detect the actual path to the anaconda installation. For me it is `.anaconda3` but this is not the default and each user is able to choose her own one. Therefore it should be grep'd from the `PATH` variable.