### PR TITLE
creating ./docs folder while compiling docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,11 +233,14 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+	file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs)
+	add_custom_target(doc_dir ALL COMMAND ${CMAKE_COMMAND}
+	        -E make_directory ${CMAKE_CURRENT_SOURCE_DIR}/docs)
 	add_custom_target(doc
 		${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
                 WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
-		COMMENT "Generating API documentation with Doxygen" VERBATIM
-		)
+		COMMENT "Generating API documentation with Doxygen"
+		VERBATIM DEPENDS doc_dir)
 endif(DOXYGEN_FOUND)
 
 #


### PR DESCRIPTION
As described in issue #630 the generation of the documentation using Doxygen via the build script `./build.sh d` was not working. The problem was located in *build/CMakeFiles/doc.dir/build.make* line 58 where the `CMakeFiles/doc` target tries to enter the *./docs* folder at the root directory of the repository. Since this folder is not created by either the build script or CMake the generation of the documentation fails.

To solve this issue I introduced a line in the *./CMakeList.txt* file creating the missing *./docs/* folder.