### PR TITLE
Fix MIDI change pattern crash

### DIFF
--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -22,6 +22,7 @@
 #ifndef HYDROGEN_H
 #define HYDROGEN_H
 
+#include <atomic>
 #include <stdint.h> // for uint32_t et al
 #include "hydrogen/config.h"
 #include <hydrogen/midi_action.h>
@@ -238,7 +239,7 @@ public:
 private:
 	static Hydrogen* __instance;
 
-	Song*	__song; /// < Current song
+	std::atomic<Song*>	__song; /// < Current song
 
 	void initBeatcounter(void);
 

--- a/src/core/src/IO/midi_input.cpp
+++ b/src/core/src/IO/midi_input.cpp
@@ -220,6 +220,11 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 	MidiActionManager * aH = MidiActionManager::get_instance();
 	MidiMap * mM = MidiMap::get_instance();
 	Hydrogen *pEngine = Hydrogen::get_instance();
+	Song *pSong = pEngine->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song loaded, skipping note" );
+		return;
+	}
 
 	pEngine->lastMidiEvent = "NOTE";
 	pEngine->lastMidiEventParameter = msg.m_nData1;
@@ -315,6 +320,10 @@ void MidiInput::handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke )
 
 	Hydrogen *pEngine = Hydrogen::get_instance();
 	Song *pSong = pEngine->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song loaded, skipping note" );
+		return;
+	}
 
 	__noteOffTick = pEngine->getTickPosition();
 	unsigned long notelength = computeDeltaNoteOnOfftime();

--- a/src/core/src/IO/midi_input.cpp
+++ b/src/core/src/IO/midi_input.cpp
@@ -85,6 +85,11 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 		if ( !bIsChannelValid) return;
 
 		Hydrogen* pHydrogen = Hydrogen::get_instance();
+		if ( ! pHydrogen->getSong() ) {
+			ERRORLOG( "No song loaded, skipping note" );
+			return;
+		}
+
 		switch ( type ) {
 		case MidiMessage::SYSEX:
 				handleSysexMessage( msg );

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1725,6 +1725,11 @@ Hydrogen::Hydrogen()
 	INFOLOG( "[Hydrogen]" );
 
 	__song = NULL;
+	if ( __song.is_lock_free() ) {
+		INFOLOG( "Hydrogen::__song is lock-free" );
+	} else {
+		WARNINGLOG( "Hydrogen::__song is NOT lock-free" );
+	}
 
 	m_bExportSessionIsActive = false;
 	m_pTimeline = new Timeline();


### PR DESCRIPTION
Hi,

I had a quick look at #661. I managed to reproduce this error:

```
* thread #10, stop reason = EXC_BAD_ACCESS (code=1, address=0x50)
    frame #0: 0x0000000100035fcc hydrogen`H2Core::Song::get_instrument_list(this=0x0000000000000000) at song.h:130
   127 	
   128 			InstrumentList* get_instrument_list()
   129 			{
-> 130 				return __instrument_list;
   131 			}
   132 			void set_instrument_list( InstrumentList* list )
   133 			{
Target 0: (hydrogen) stopped.
```

As I supposed, this happened when MIDI message arrived when song hasn't been loaded yet.

This fix is modular, three commits are independent and can be cherry-picked individually.

a6169d3 skips note on/off MIDI messages if no song is loaded - and this commit alone fixes this issue.

502f556 skips all MIDI messages if no song is loaded. I didn't manage to reproduce situation when this fix is necessary, however I imagine CC message might, for example, modify instrument volume, and when no song is loaded there are no instruments Hydrogen would crash.

62b9b2a makes pointer to `Song` atomic, so that reading/writing song pointer should be synchronized across threads. On current hardware it shouldn't incur performance penalty, as is should use atomic CPU instructions.