### PR TITLE
Fix MIDI output

### DIFF
--- a/src/core/include/hydrogen/basics/note.h
+++ b/src/core/include/hydrogen/basics/note.h
@@ -44,6 +44,9 @@
 #define LEAD_LAG_MIN            -1.0f
 #define LEAD_LAG_MAX            1.0f
 
+/* Should equal (default __octave + OCTAVE_OFFSET) * KEYS_PER_OCTAVE + default __key */
+#define MIDI_DEFAULT_OFFSET     36
+
 namespace H2Core
 {
 
@@ -505,7 +508,7 @@ inline int Note::get_midi_key() const
 	/* TODO ???
 	if( !has_instrument() ) { return (__octave + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE + __key; }
 	*/
-	return ( __octave + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE + __key + __instrument->get_midi_out_note()-MIDI_MIDDLE_C;
+	return ( __octave + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE + __key + __instrument->get_midi_out_note() - MIDI_DEFAULT_OFFSET;
 }
 
 inline int Note::get_midi_velocity() const

--- a/src/core/src/IO/alsa_midi_driver.cpp
+++ b/src/core/src/IO/alsa_midi_driver.cpp
@@ -447,8 +447,7 @@ void AlsaMidiDriver::handleQueueNote(Note* pNote)
 	if (channel < 0) {
 		return;
 	}
-	int key = (pNote->get_octave() +3 ) * 12 + pNote->get_key() + pNote->get_instrument()->get_midi_out_note() - 60;
-	//int key = pNote->get_instrument()->get_midi_out_note();
+	int key = pNote->get_midi_key();
 	int velocity = pNote->get_midi_velocity();
 
 	snd_seq_event_t ev;

--- a/src/core/src/IO/jack_midi_driver.cpp
+++ b/src/core/src/IO/jack_midi_driver.cpp
@@ -442,7 +442,7 @@ void JackMidiDriver::handleQueueNote(Note* pNote)
 	if (channel < 0 || channel > 15)
 		return;
 
-	key = (pNote->get_octave() +3 ) * 12 + pNote->get_key() + pNote->get_instrument()->get_midi_out_note() - 60;
+	key = pNote->get_midi_key();
 	if (key < 0 || key > 127)
 		return;
 

--- a/src/core/src/IO/portmidi_driver.cpp
+++ b/src/core/src/IO/portmidi_driver.cpp
@@ -285,7 +285,7 @@ void PortMidiDriver::handleQueueNote(Note* pNote)
 		return;
 	}
 
-	int key = (pNote->get_octave() +3 ) * 12 + pNote->get_key() + pNote->get_instrument()->get_midi_out_note() -60;
+	int key = pNote->get_midi_key();
 	int velocity = pNote->get_midi_velocity();
 
 	PmEvent event;

--- a/src/core/src/smf/smf.cpp
+++ b/src/core/src/smf/smf.cpp
@@ -290,7 +290,7 @@ void SMFWriter::save( const QString& sFilename, Song *pSong )
 						
 						int nInstr = iList->index(pNote->get_instrument());
 						Instrument *pInstr = pNote->get_instrument();
-						int nPitch = pInstr->get_midi_out_note();
+						int nPitch = pNote->get_midi_key();
 						
 						eventList.push_back(
 							new SMFNoteOnEvent(


### PR DESCRIPTION
I have been looking at #411 and tried to fix Issues with incorrect MIDI values. It seems that Hydrogen sends wrong MIDI note (24 tones lower than it should) - for example it sends 12 instead of 36. I fixed that and I hope I hadn't break anything else.

# Acceptance criteria

1. Instrument should send MIDI Note On message with pich set to MIDI note of 
instrument being played. That Note On message should be followed by
Note Off message with the same pitch.

*Eg. playing instrument with note 36 should play note 36 (C3).*

2. When "Use output note as input note" is **not** enabled,
*n*-th instrument should respond to NoteOn messages
with pitch set to 35+*n*.

*Eg. Note On with pitch 47 (B3) should trigger 12th instrument*

3. When "Use output note as input note" **is** enabled,
each instrument should respond to Note On messages with pitch
set to MIDI note assigned to that instrument.

*Eg. Note On with pitch 56 (G#4) should trigger instrument that
has MIDI note set to 56.*

4. When exporting MIDI file, exported MIDI notes should have
correct pitches (i.e. the same pitches that are assigned to
respective instruments).

*Eg. every note from instrument with MIDI note 38 should
have pitch 38 (D3) in output MIDI file.*

<sub>That case should be covered by automated tests</sub>

# Test results

Hydrogen provides 4 MIDI drivers: ALSA, CoreMIDI, Jack and PortMIDI. Unfortunately, I've been only able to test CoreMIDI, so I need your help! Please write your test results along with driver name in comment, and I'll update the table:

|    | ALSA | CoreMIDI | Jack | PortMIDI |
|---|---|---|---|---|
| Case 1 | ✓ | ✓ | ✓ | |
| Case 2 | ✓ | ✓ | ✓ | |
| Case 3 | ✓ | ✓ | ✓ | |
| Case 4 | ✓ | ✓ | ✓ | |

In my testing I've been using [MidiPipe](http://www.subtlesoft.square7.net/MidiPipe.html) utility:

![zrzut ekranu 2018-10-14 o 20 47 12](https://user-images.githubusercontent.com/1619113/46920861-b0347d80-cff4-11e8-9692-07ad052b7cdd.png)

I think there are similar utilities for other platforms.

---
<sub>Note names assume C5 = 60</sub>