### PR TITLE
Fixing bugs in the JACK audio driver

### DIFF
--- a/src/core/include/hydrogen/IO/TransportInfo.h
+++ b/src/core/include/hydrogen/IO/TransportInfo.h
@@ -76,21 +76,22 @@ public:
 	 * minimum duration of a Note as well as the minimum distance
 	 * between two of them.
 	 * 
-	 * It is calculated by the sample rate * 60.0 / ( #m_nBPM *
+	 * It will only be used by the JackAudioDriver and is
+	 * calculated by the sample rate * 60.0 / ( #m_fBPM *
 	 * Song::__resolution ). The factor 60.0 will be used to convert
-	 * the sample rate, which is given in second, into minutes (as the
-	 * #m_nBPM).
+	 * the sample rate, which is given in second, into minutes (as
+	 * the #m_fBPM).
 	 */
-	float m_nTickSize;
+	float m_fTickSize;
 	/** Current tempo in beats per minute. */
-	float m_nBPM;
+	float m_fBPM;
 
 	/**
 	 * Constructor of TransportInfo
 	 *
 	 * - Sets #m_status to TransportInfo::STOPPED
-	 * - Sets #m_nFrames and #m_nTickSize to 0
-	 * - Sets #m_nBPM to 120
+	 * - Sets #m_nFrames and #m_fTickSize to 0
+	 * - Sets #m_fBPM to 120
 	 */
 	TransportInfo();
 	/** Destructor of TransportInfo */
@@ -98,7 +99,7 @@ public:
 	/** Displays general information about the transport state in
 	    the #INFOLOG
 	  *
-	  * Prints out #m_status, #m_nFrames, and #m_nTickSize.
+	  * Prints out #m_status, #m_nFrames, and #m_fTickSize.
 	  */
 	void printInfo();
 };

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -551,7 +551,7 @@ protected:
 	 *                          m_transport.m_fTickSize ) ) 
 	 * \endcode
 	 * - __ticks_per_beat__ :  the output of
-	 * Hydrogen::getTickForHumanPosition() with the __bar__ member
+	 * Hydrogen::getPatternLength() with the __bar__ member
 	 * supplied as input argument.
 	 * - __valid__ : to ( _JackPositionBBT_ | _JackBBTFrameOffset_
 	 * ), transport states defined

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -52,37 +52,19 @@ class Song;
 class Instrument;
 class InstrumentComponent;
 /**
- * JACK (Jack Audio Connection Kit) server driver. 
- *
- * __Timebase Master__:
- *
- * The timebase master is responsible to update additional information
- * in the transport information of the JACK server apart from the
- * transport position in frames (see TransportInfo::m_nFrames if you
- * aren't familiar with frames), like the current beat, bar, tick,
- * tick size, speed etc. Every client can be registered as timebase
- * master by supplying a callback (for Hydrogen this would be
- * jack_timebase_callback()) but there can be at most one timebase
- * master at a time. Having none at all is perfectly fine too. Apart
- * from this additional responsibility, the registered client has no
- * other rights compared to others.
- *
- * After the status of the JACK transport has changed from
- * _JackTransportStarting_ to _JackTransportRolling_, the timebase
- * master needs an additional cycle to update its information.
+ * JACK (Jack Audio Connection Kit) server driver.
  *
  * __Transport Control__:
  *
- * Each JACK client can start and stop the transport or relocate its
- * current position. The request will take place in cycles. During the
- * first the status of the transport changes to
+ * Each JACK client can start and stop the transport or relocate the
+ * current transport position. The request will take place in
+ * cycles. During the first the status of the transport changes to
  * _JackTransportStarting_ to inform all clients a change is about to
  * happen. During the second the status is again
  * _JackTransportRolling_ and the transport position is updated
- * according to the request. But only its raw representation in frames
- * in the _frame_ member. The current timebase master, if present,
- * needs another cycle to update the additional transport
- * information. 
+ * according to the request. The current timebase master (see below),
+ * if present, needs another cycle to update the additional transport
+ * information.
  *
  * Such a relocation request is also triggered when clicking on the
  * timeline or the player control buttons of Hydrogen. Internally,
@@ -101,7 +83,29 @@ class InstrumentComponent;
  * during a cycle and incremented by the buffer size in
  * audioEngine_process() at the very end of the cycle. The same
  * happens for the transport information of the JACK server but in
- * parallel. 
+ * parallel.
+ *
+ * __Timebase Master__:
+ *
+ * The timebase master is responsible to update additional information
+ * in the transport information of the JACK server apart from the
+ * transport position in frames (see TransportInfo::m_nFrames if you
+ * aren't familiar with frames), like the current beat, bar, tick,
+ * tick size, speed etc. Every client can be registered as timebase
+ * master by supplying a callback (for Hydrogen this would be
+ * jack_timebase_callback()) but there can be at most one timebase
+ * master at a time. Having none at all is perfectly fine too. Apart
+ * from this additional responsibility, the registered client has no
+ * other rights compared to others.
+ *
+ * After the status of the JACK transport has changed from
+ * _JackTransportStarting_ to _JackTransportRolling_, the timebase
+ * master needs an additional cycle to update its information.
+ *
+ * Having an external timebase master present will change the general
+ * behavior of Hydrogen. All local tempo settings on the Timeline will
+ * be disregarded and the tempo broadcasted by the JACK server will be
+ * used instead.
  *
  * This object will only be accessible if #H2CORE_HAVE_JACK was defined
  * during the configuration and the user enables the support of the
@@ -121,31 +125,15 @@ public:
 	/**
 	 * Constructor of the JACK server driver.
 	 *
-	 * Sets a number of variables:
-	 * - #m_nLocateCountDown = 0
-	 * - #m_bbtFrameOffset = 0
-	 * - #m_nTrackPortCount = 0
-	 * - #__track_out_enabled = Preferences::m_bJackTrackOuts
-	 *
-	 * In addition, it also assigned the provided @a
-	 * m_processCallback argument, the audioEngine_process()
-	 * function, to the corresponding #m_processCallback variable
-	 * and overwrites the memory allocated by the
-	 * #m_pTrackOutputPortsL and #m_pTrackOutputPortsR variable
-	 * with zeros.
-	 *
 	 * @param m_processCallback Prototype for the client supplied
-			 function that is called by the engine anytime 
-			 there is work to be done. It gets two input
-			 arguments _nframes_ of type
-			 jack_nframes_t, which specifies the number of
-			 frames to process, and a void pointer called
-			 _arg_, which points to a client supplied
-			 structure.  Two preconditions do act on the
-			 _nframes_ argument: _nframes_ ==
-			 getBufferSize() and _nframes_ == pow(2,x) It
-			 returns zero on success and non-zero on
-			 error.
+			 function that is called by the engine anytime there is
+			 work to be done. It gets two input arguments _nframes_ of
+			 type jack_nframes_t, which specifies the number of frames
+			 to process, and a void pointer called _arg_, which points
+			 to a client supplied structure.  Two preconditions do act
+			 on the _nframes_ argument: _nframes_ == getBufferSize()
+			 and _nframes_ == pow(2,x) It returns zero on success and
+			 non-zero on error.
 	 */
 	JackAudioDriver( JackProcessCallback m_processCallback );
 	/**
@@ -161,79 +149,66 @@ public:
 	 * Starts by telling the JACK server that Hydrogen is ready to
 	 * process audio using the jack_activate function (from the
 	 * jack/jack.h header) and overwriting the memory allocated by
-	 * #m_pTrackOutputPortsL and #m_pTrackOutputPortsR with
-	 * zeros. If the #m_bConnectDefaults variable is true or
-	 * LashClient is used and Hydrogen is not within a new Lash
-	 * project, the function attempts to connect the
-	 * #m_pOutputPort1 port with #m_sOutputPortName1 and the
-	 * #m_pOutputPort2 port with #m_sOutputPortName2. To establish
-	 * the connection _jack_connect()_ (jack/jack.h) will be
-	 * used. In case this was not successful, the function will
-	 * look up all ports containing the _JackPortIsInput_
-	 * (jack/types.h) flag using _jack_get_ports()_ (jack/jack.h)
-	 * and attempts to connect to the first two it found.
+	 * #m_pTrackOutputPortsL and #m_pTrackOutputPortsR with zeros. If
+	 * the #m_bConnectDefaults variable is true or LashClient is used
+	 * and Hydrogen is not within a new Lash project, the function
+	 * attempts to connect the #m_pOutputPort1 port with
+	 * #m_sOutputPortName1 and the #m_pOutputPort2 port with
+	 * #m_sOutputPortName2. To establish the connection,
+	 * _jack_connect()_ (jack/jack.h) will be used. In case this was
+	 * not successful, the function will look up all ports containing
+	 * the _JackPortIsInput_ (jack/types.h) flag using
+	 * _jack_get_ports()_ (jack/jack.h) and attempts to connect to the
+	 * first two it found.
 	 *
 	 * @return 
-	 * - __0__ : if either the connection of the output ports
-	 *       did work, two ports having the _JackPortIsInput_ flag
-	 *       where found and the #m_pOutputPort1 and #m_pOutputPort2
-	 *       ports where successfully connected to them, or the
-	 *       user enabled Lash during compilation and an
-	 *       established project was used.
+	 * - __0__ : if either the connection of the output ports did
+	 *       work, two ports having the _JackPortIsInput_ flag where
+	 *       found and the #m_pOutputPort1 and #m_pOutputPort2 ports
+	 *       where successfully connected to them, or the user enabled
+	 *       Lash during compilation and an established project was
+	 *       used.
 	 * - __1__ : The activation of the JACK client using
 	 *       _jack_activate()_ (jack/jack.h) did fail.
 	 * - __2__ : The connections to #m_sOutputPortName1 and
 	 *       #m_sOutputPortName2 could not be established and the
 	 *       there were either no JACK ports holding the
-	 *       JackPortIsInput flag found or no connection to them
-	 *       could be established.
+	 *       JackPortIsInput flag found or no connection to them could
+	 *       be established.
 	 */
 	int connect();
 	/**
-	 * Disconnects the JACK client of the Hydrogen app from the
-	 * JACK server.
+	 * Disconnects the JACK client of the Hydrogen from the JACK
+	 * server.
 	 *
-	 * Firstly, it calls deactivate(). Then, it closes the
-	 * connection between the JACK server and the local client
-	 * using jack_client_close (jack/jack.h), and sets the
-	 * #m_pClient pointer to NULL.
+	 * Firstly, it calls deactivate(). Then, it closes the connection
+	 * between the JACK server and the local client using
+	 * jack_client_close (jack/jack.h), and sets the #m_pClient
+	 * pointer to nullptr.
 	 */
 	void disconnect();
 	/**
-	 * Deactivates JACK client of Hydrogen and disconnects all
+	 * Deactivates the JACK client of Hydrogen and disconnects all
 	 * ports belonging to it.
 	 *
-	 * It calls the _jack_deactivate()_ (jack/jack.h) function on
-	 * the current client #m_pClient and overwrites the memory
-	 * allocated by #m_pTrackOutputPortsL and
-	 * #m_pTrackOutputPortsR with zeros.
+	 * It calls the _jack_deactivate()_ (jack/jack.h) function on the
+	 * current client #m_pClient and overwrites the memory allocated
+	 * by #m_pTrackOutputPortsL and #m_pTrackOutputPortsR with zeros.
 	 */
 	void deactivate();
-	/**
-	 * Returns the global variable H2Core::jack_server_bufferSize,
-	 * which is defined in the corresponding source file. The
-	 * setting is performed by the inline function 
-	 * _jackDriverBufferSize()_, which is also defined on
-	 * source-side. 
-	 */
+	/** \return Global variable #jackServerBufferSize. */
 	unsigned getBufferSize();
-	/**
-	 * Returns the global variable H2Core::jack_server_sampleRate,
-	 * which is defined in the corresponding source file. The
-	 * setting is performed by the inline function
-	 * _jackDriverSampleRate()_, which is also defined on
-	 * source-side.
-	 */
+	/** \return Global variable #jackServerSampleRate. */
 	unsigned getSampleRate();
 	/** Accesses the number of output ports currently in use.
 	 * \return #m_nTrackPortCount */
 	int getNumTracks();
 
-	/** Returns #m_JackTransportState */
+	/** \return #m_JackTransportState */
 	jack_transport_state_t getTransportState() {
 		return m_JackTransportState;
 	}
-	/** Returns #m_JackTransportPos */
+	/** \return #m_JackTransportPos */
 	jack_position_t getTransportPos() {
 		return m_JackTransportPos;
 	}
@@ -242,15 +217,15 @@ public:
 	 * Creates per component output ports for each instrument.
 	 *
 	 * Firstly, it resets #m_trackMap with zeros. Then, it loops
-	 * through all the instruments and their components, creates a
-	 * new output or resets an existing one for each of them using
-	 * setTrackOutput(), and stores the corresponding track number
-	 * in #m_trackMap. Finally, all ports in #m_pTrackOutputPortsL
-	 * and #m_pTrackOutputPortsR, which haven't been used in the
-	 * previous step, are unregistered using
-	 * _jack_port_unregister()_ (jack/jack.h) and overwritten with
-	 * 0. #m_nTrackPortCount will be set to biggest track number
-	 * encountered during the creation/reassignment step.
+	 * through all the instruments and their components, creates a new
+	 * output or resets an existing one for each of them using
+	 * setTrackOutput(), and stores the corresponding track number in
+	 * #m_trackMap. Finally, all ports in #m_pTrackOutputPortsL and
+	 * #m_pTrackOutputPortsR, which haven't been used in the previous
+	 * step, are unregistered using _jack_port_unregister()_
+	 * (jack/jack.h) and overwritten with 0. #m_nTrackPortCount will
+	 * be set to biggest track number encountered during the
+	 * creation/reassignment step.
 	 *
 	 * The function will only perform its tasks if the
 	 * Preferences::m_bJackTrackOuts is set to true.
@@ -258,7 +233,7 @@ public:
 	void makeTrackOutputs( Song* pSong );
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
-	 * its not already present. 
+	 * it's not already present. 
 	 *
 	 * If the track number @a n is bigger than the number of ports
 	 * currently in usage #m_nTrackPortCount, @a n + 1 -
@@ -266,13 +241,13 @@ public:
 	 * _jack_port_register()_ (jack/jack.h) and #m_nTrackPortCount
 	 * updated to @a n + 1.
 	 *
-	 * Afterwards, the @a n 'th port is renamed to a concatenation
-	 * of "Track_", DrumkitComponent::__name, "_", @a n + 1, "_",
+	 * Afterwards, the @a n 'th port is renamed to a concatenation of
+	 * "Track_", DrumkitComponent::__name, "_", @a n + 1, "_",
 	 * Instrument::__name, and "_L", or "_R" using either
-	 * _jack_port_rename()_ (if HAVE_JACK_PORT_RENAME is defined)
-	 * or _jack_port_set_name()_ (both jack/jack.h). The former
-	 * renaming function triggers a _PortRename_ notifications to
-	 * clients that have registered a port rename handler.
+	 * _jack_port_rename()_ (if HAVE_JACK_PORT_RENAME is defined) or
+	 * _jack_port_set_name()_ (both jack/jack.h). The former renaming
+	 * function triggers a _PortRename_ notifications to clients that
+	 * have registered a port rename handler.
 	 *
 	 * \param n Track number for which a port should be renamed
 	 *   (and created).
@@ -283,77 +258,91 @@ public:
 	 */
 	void setTrackOutput( int n, Instrument* instr, InstrumentComponent* pCompo, Song* pSong );
 
-	/** Sets #m_bConnectDefaults to @a flag.*/
+	/** \param flag Sets #m_bConnectDefaults*/
 	void setConnectDefaults( bool flag ) {
 		m_bConnectDefaults = flag;
 	}
-	/** Returns #m_bConnectDefaults */
+	/** \return #m_bConnectDefaults */
 	bool getConnectDefaults() {
 		return m_bConnectDefaults;
 	}
 
 	/**
-	 * Get and return the content in the left stereo output
-	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * both the port name #m_pOutputPort1 and buffer size
-	 * #jack_server_bufferSize.
+	 * Get content in the left stereo output port.
+	 *
+	 * It calls _jack_port_get_buffer()_ (jack/jack.h) with both the
+	 * port name #m_pOutputPort1 and buffer size
+	 * #jackServerBufferSize.
+	 *
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
 	float* getOut_L();
 	/**
-	 * Get and return the content in the right stereo output
-	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * both the port name #m_pOutputPort2 and buffer size
-	 * #jack_server_bufferSize.
+	 * Get content in the right stereo output port.
+	 *
+	 * It calls _jack_port_get_buffer()_ (jack/jack.h) with both the
+	 * port name #m_pOutputPort2 and buffer size
+	 * #jackServerBufferSize.
+	 *
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
 	float* getOut_R();
 	/**
-	 * Get and return the content of a specific left output
-	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * the port in @a nTrack element of #m_pTrackOutputPortsL and
-	 * buffer size #jack_server_bufferSize.
+	 * Get content of left output port of a specific track.
+	 *
+	 * It calls _jack_port_get_buffer()_ (jack/jack.h) with the port
+	 * in the @a nTrack element of #m_pTrackOutputPortsL and buffer
+	 * size #jackServerBufferSize.
+	 *
 	 * \param nTrack Track number. Must not be bigger than
 	 * #m_nTrackPortCount.
+	 *
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
 	float* getTrackOut_L( unsigned nTrack );
 	/**
-	 * Get and return the content of a specific right output
-	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * the port in @a nTrack element of #m_pTrackOutputPortsR and
-	 * buffer size #jack_server_bufferSize.
+	 * Get content of right output port of a specific track.
+	 *
+	 * It calls _jack_port_get_buffer()_ (jack/jack.h) with the port
+	 * in the @a nTrack element of #m_pTrackOutputPortsR and buffer
+	 * size #jackServerBufferSize.
+	 *
 	 * \param nTrack Track number. Must not be bigger than
 	 * #m_nTrackPortCount.
+	 *
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
 	float* getTrackOut_R( unsigned nTrack );
 	/** 
-	 * Convenience function looking up the track number of a
-	 * component of an instrument using in #m_trackMap using their
-	 * IDs Instrument::__id and
-	 * InstrumentComponent::__related_drumkit_componentID. Using
-	 * the track number it then calls getTrackOut_L( unsigned )
-	 * and returns its result.
-	 * \param instr Pointer to an instrument
+	 * Convenience function looking up the track number of a component
+	 * of an instrument using in #m_trackMap using their IDs
+	 * Instrument::__id and
+	 * InstrumentComponent::__related_drumkit_componentID. Using the
+	 * track number it then calls getTrackOut_L( unsigned ) and
+	 * returns its result.
+	 *
+	 * \param instr Pointer to an Instrument
 	 * \param pCompo Pointer to one of the instrument's components.
+	 *
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
 	float* getTrackOut_L( Instrument* instr, InstrumentComponent* pCompo );
 	/** 
-	 * Convenience function looking up the track number of a
-	 * component of an instrument using in #m_trackMap using their
-	 * IDs Instrument::__id and
-	 * InstrumentComponent::__related_drumkit_componentID. Using
-	 * the track number it then calls getTrackOut_R( unsigned )
-	 * and returns its result.
-	 * \param instr Pointer to an instrument
+	 * Convenience function looking up the track number of a component
+	 * of an instrument using in #m_trackMap using their IDs
+	 * Instrument::__id and
+	 * InstrumentComponent::__related_drumkit_componentID. Using the
+	 * track number it then calls getTrackOut_R( unsigned ) and
+	 * returns its result.
+	 *
+	 * \param instr Pointer to an Instrument
 	 * \param pCompo Pointer to one of the instrument's components.
+	 *
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
@@ -363,37 +352,34 @@ public:
 	 * Initializes the JACK audio driver.
 	 *
 	 * Firstly, it determines the destination ports
-	 * #m_sOutputPortName1 and #m_sOutputPortName2 the output
-	 * ports of Hydrogen will be connected to in connect() from
+	 * #m_sOutputPortName1 and #m_sOutputPortName2 the output ports of
+	 * Hydrogen will be connected to in connect() from
 	 * Preferences::m_sJackPortName1 and
-	 * Preferences::m_sJackPortName2. The name of the JACK client
-	 * is either set to "Hydrogen" or, if #H2CORE_HAVE_OSC was
-	 * defined during compilation and OSC support is enabled, to
-	 * Preferences::m_sNsmClientId via
-	 * Preferences::getNsmClientId(). 
+	 * Preferences::m_sJackPortName2. The name of the JACK client is
+	 * either set to "Hydrogen" or, if #H2CORE_HAVE_OSC was defined
+	 * during compilation and OSC support is enabled, to
+	 * Preferences::m_sNsmClientId via Preferences::getNsmClientId().
 	 *
-	 * Next, the function attempts to open an external client
-	 * session with the JACK server using _jack_client_open()_
-	 * (jack/jack.h) and saves it to the pointer #m_pClient. In
-	 * case this didn't work properly, it will start two more
-	 * attempts. Sometime JACK doesn't stop and start fast
-	 * enough. If the compiler flag #H2CORE_HAVE_JACKSESSION was
-	 * set and the user enabled the usage of JACK session, the
-	 * client will be opened using the corresponding option and
-	 * the sessionID Token Preferences::jackSessionUUID, obtained
-	 * via Preferences::getJackSessionUUID(), will be provided so
-	 * the sessionmanager can identify the client again.
+	 * Next, the function attempts to open an external client session
+	 * with the JACK server using _jack_client_open()_ (jack/jack.h)
+	 * and saves it to the pointer #m_pClient. In case this didn't
+	 * work properly, it will start two more attempts. Sometime JACK
+	 * doesn't stop and start fast enough. If the compiler flag
+	 * #H2CORE_HAVE_JACKSESSION was set and the user enabled the usage
+	 * of JACK session, the client will be opened using the
+	 * corresponding option and the sessionID Token
+	 * Preferences::jackSessionUUID, obtained via
+	 * Preferences::getJackSessionUUID(), will be provided so the
+	 * sessionmanager can identify the client again.
 	 *
-	 * If the client was opened properly, the function will get
-	 * its sample rate using _jack_get_sample_rate()_ and buffer
-	 * size using _jack_get_buffer_size()_ (both jack/jack.h) and
-	 * stores them in H2Core::jack_server_sampleRate,
-	 * Preferences::m_nSampleRate, H2Core::jack_server_bufferSize,
-	 * and Preferences::m_nBufferSize. In addition, it also
-	 * registers JackAudioDriver::m_processCallback,
-	 * H2Core::jackDriverSampleRate, H2Core::jackDriverBufferSize,
-	 * and H2Core::jackDriverShutdown using
-	 * _jack_set_process_callback()_,
+	 * If the client was opened properly, the function will get its
+	 * sample rate using _jack_get_sample_rate()_ and buffer size
+	 * using _jack_get_buffer_size()_ (both jack/jack.h) and stores
+	 * them in #jackServerSampleRate, Preferences::m_nSampleRate,
+	 * #jackServerBufferSize, and Preferences::m_nBufferSize. In
+	 * addition, it also registers JackAudioDriver::m_processCallback,
+	 * H2Core::jackDriverSampleRate, H2Core::jackDriverBufferSize, and
+	 * H2Core::jackDriverShutdown using _jack_set_process_callback()_,
 	 * _jack_set_sample_rate_callback()_,
 	 * _jack_set_buffer_size_callback()_, and _jack_on_shutdown()_
 	 * (all in jack/jack.h).
@@ -404,18 +390,15 @@ public:
 	 *
 	 * If everything worked properly, LASH is used
 	 * (Preferences::useLash()) by the user, and the LashClient is
-	 * LashClient::isConnected() the name of the client will be
-	 * stored in LashClient::jackClientName using
-	 * LashClient::setJackClientName. If JACK session was enabled,
-	 * the jack_session_callback() will be registered using
+	 * LashClient::isConnected() the name of the client will be stored
+	 * in LashClient::jackClientName using
+	 * LashClient::setJackClientName. If JACK session was enabled, the
+	 * jack_session_callback() will be registered using
 	 * _jack_set_session_callback()_ (jack/session.h).
 	 *
-	 * Finally, the function will check whether Hydrogen should be
-	 * the JACK timebase master or not via
-	 * Preferences::m_bJackMasterMode and calls initTimeMaster()
-	 * if its indeed the case. It sets #m_nJackConditionalTakeOver
-	 * to 1 so Hydrogen will become the timebase master regardless if
-	 * there is already one present or not.
+	 * Finally, the function will check whether Hydrogen should be the
+	 * JACK timebase master or not via Preferences::m_bJackMasterMode
+	 * and calls initTimeMaster() if its indeed the case.
 	 *
 	 * \param bufferSize Unused and only present to assure
 	 * compatibility with the JACK API.
@@ -433,27 +416,23 @@ public:
 	/**
 	 * Starts the JACK transport.
 	 *
-	 * If either Preferences::m_bJackTransportMode equals
-	 * Preferences::USE_JACK_TRANSPORT or
-	 * Preferences::m_bJackMasterMode equals
-	 * Preferences::USE_JACK_TIME_MASTER the
-	 * _jack_transport_start()_ (jack/transport.h) function will
-	 * be called to start the JACK transport. If neither
-	 * of the two equalities is true, TransportInfo::m_status is
-	 * set to TransportInfo::ROLLING instead.
+	 * If the JACK transport was activated in the GUI by clicking
+	 * either the "J.TRANS" or "J.MASTER" button, the
+	 * _jack_transport_start()_ (jack/transport.h) function will be
+	 * called to start the JACK transport. Else, the internal
+	 * TransportInfo::m_status will be set to TransportInfo::ROLLING
+	 * instead.
 	 */
 	virtual void play();
 	/**
 	 * Stops the JACK transport.
 	 *
-	 * If either Preferences::m_bJackTransportMode equals
-	 * Preferences::USE_JACK_TRANSPORT or
-	 * Preferences::m_bJackMasterMode equals
-	 * Preferences::USE_JACK_TIME_MASTER the
-	 * _jack_transport_stop()_ (jack/transport.h) function will
-	 * be called to start the JACK transport. If neither
-	 * of the two equalities is true, TransportInfo::m_status is
-	 * set to TransportInfo::STOPPED instead.
+	 * If the JACK transport was activated in the GUI by clicking
+	 * either the "J.TRANS" or "J.MASTER" button, the
+	 * _jack_transport_stop()_ (jack/transport.h) function will be
+	 * called to stop the JACK transport. Else, the internal
+	 * TransportInfo::m_status will be set to TransportInfo::STOPPED
+	 * instead.
 	 */
 	virtual void stop();
 	/**
@@ -461,11 +440,14 @@ public:
 	 *
 	 * If the Preferences::USE_JACK_TRANSPORT mode is chosen in
 	 * Preferences::m_bJackTransportMode, the
-	 * _jack_transport_locate()_ (jack/transport.h) function will
-	 * be used to request the new transport position. If not, @a
-	 * nFrame will be assigned to TransportInfo::m_nFrames of the
-	 * local instance of the TransportInfo
-	 * AudioOutput::m_transport.
+	 * _jack_transport_locate()_ (jack/transport.h) function will be
+	 * used to request the new transport position. If not, @a nFrame
+	 * will be assigned to TransportInfo::m_nFrames of the local
+	 * instance of the TransportInfo AudioOutput::m_transport.
+	 *
+	 * The new position takes effect in two process cycles during
+	 * which JACK's state will be in JackTransportStarting and the
+	 * transport won't be rolling.
 	 *   
 	 * \param nFrame Requested new transport position.
 	 */
@@ -475,49 +457,32 @@ public:
 	 * AudioOutput::m_transport.
 	 *
 	 * The function queries the transport position and additional
-	 * information from the JACK server and updates the information
-	 * stored in AudioOutput::m_transport in case of a mismatch.
+	 * information from the JACK server, writes them to
+	 * #m_JackTransportPos and in #m_JackTransportState, and updates
+	 * the information stored in AudioOutput::m_transport in case of a
+	 * mismatch.
 	 *
-	 * - Calls _jack_transport_query()_ (jack/transport.h), stores
-             the current transport position in #m_JackTransportPos,
-             and its state in #m_JackTransportState.
-	 * - If #m_JackTransportState is either _JackTransportStopped_
-             or _JackTransportStarting_, TransportInfo::m_status will
-             be set to TransportInfo::STOPPED. If its
-             _JackTransportRolling_, TransportInfo::m_status will be
-             set to TransportInfo::ROLLING.
-	 * - Calls Hydrogen::setTimelineBpm() to update both the
-             global speed of the Song Song::__bpm, as well as the
-	     fallback speed Hydrogen::m_fNewBpmJTM() with the local
-             tempo at the current position on the timeline.
-	 * - Checks whether the speed was changed by another JACK time
-             master (there can only be one). In that case we will just
-             store the changes in TransportInfo::m_nBpm of the current
-             instance of the TransportInfo
-             AudioOutput::m_transport. The tempo will be set by the
-             calling function audioEngine_process_transport()
-             afterwards.
-	 * - In case the transport position changed due to an user
-             interaction (e.g. clicking somewhere at the Timeline) or
-             a relocation triggered by another JACK client, we will
-             detect this change since the position stored in
-             TransportInfo::m_nFrames plus the constant offset
-             #m_bbtFrameOffset does not equate to the _frame_ member
-             of #m_JackTransportPos anymore. It there is a timebase
-             master present and it is us or no timebase master was set
-             at all, #m_bbtFrameOffset will be reset to zero and
-             TransportInfo::m_nFrames will be set to the _frame_ member
-             of #m_JackTransportPos. The relocation itself will be
-             handled by locate() and we trust the JACK server to do
-             its job properly. If there is an external timebase
-             master, a change in speed (or relocation into a region of
-             different speed) could have occurred. Therefore,
-             TransportInfo::m_nFrames will be scaled properly using
-             #m_fOldTickSize and TransportInfo::m_fTickSize. In addition, 
-	     Hydrogen::triggerRelocateDuringPlay() will be called if
-             no timebase master is present and the transport is rolling.
-	 * - Finally, #m_nHumantimeFrames will be set to the _frame_
-             member of #m_JackTransportPos.
+	 * If #m_JackTransportState is either _JackTransportStopped_ or
+     * _JackTransportStarting_, transport will be (temporarily)
+     * stopped - TransportInfo::m_status will be set to
+     * TransportInfo::STOPPED. If it's _JackTransportRolling_,
+     * transport will be started - TransportInfo::m_status will be set
+     * to TransportInfo::ROLLING.
+	 *
+     * The function will check whether a relocation took place by the
+	 * JACK server and (afterwards) whether the current tempo did
+	 * change with respect to the last transport cycle. In case of a
+	 * relocation, #m_bbtFrameOffset will be reset to 0,
+	 * TransportInfo::m_nFrames updated to the new value provided by
+	 * JACK, and - if Hydrogen is in Song::PATTERN_MODE - the playback
+	 * moved to the beginning of the pattern. A change in speed, on
+	 * the other hand, depends on the local JACK setup. If there is a
+	 * timebase master, which broadcasts tempo information via JACK,
+	 * and it's not Hydrogen itself, all customizations in the
+	 * Timeline will be disregarded and the tempo of the master will
+	 * be used instead. If Hydrogen is the timebase master or there is
+	 * none at all, Hydrogen::setTimelineBpm() will be used to keep
+	 * the transport tempo aligned the settings in the Timeline.
 	 *
 	 * If Preferences::USE_JACK_TRANSPORT was not selected in
 	 * Preferences::m_bJackTransportMode, the function will return
@@ -535,49 +500,29 @@ public:
 	 * TransportInfo::m_nFrames and stores it in
 	 * #m_bbtFrameOffset.
 	 *
-	 * It is triggered in audioEngine_process_checkBPMChanged() in
-	 * case the tick size did changed. Imagine the following
-	 * setting: During the playback you decide to change the speed
-	 * of the song. This would cause a lot of position information
-	 * within Hydrogen, which are given in ticks, to be off since
-	 * the tick size depends on the speed and just got changed
-	 * too. Instead, TransportInfo::m_nFrames will scaled to
-	 * reflect the changes and everything will be still in place
-	 * with the user to not note a single thing. Unfortunately,
-	 * now the transport position in frames of the audio engine
-	 * and of the JACK server are off by a constant offset. To
-	 * nevertheless be able to identify relocation in
-	 * updateTransportInfo(), this constant offset is stored in
-	 * #m_bbtFrameOffset.
+	 * It is triggered in audioEngine_process_checkBPMChanged() if a
+	 * BPM marker in the Timeline was passed, which causes the tick
+	 * size to be changed.
 	 */
 	void calculateFrameOffset();
 
 	/**
 	 * Registers Hydrogen as JACK timebase master.
 	 *
-	 * Called at the very end of init() if
-	 * Preferences::m_bJackMasterMode is equal to
-	 * Preferences::USE_JACK_TIME_MASTER. In this case
-	 * _jack_set_timebase_callback()_ (jack/transport.h) is called
-	 * to set Hydrogen as timebase master.
-	 *
-	 * If for some reason registering Hydrogen as timebase master
-	 * does not work, the function sets
-	 * Preferences::m_bJackMasterMode to
+	 * If for some reason registering Hydrogen as timebase master does
+	 * not work, the function sets Preferences::m_bJackMasterMode to
 	 * Preferences::NO_JACK_TIME_MASTER.
 	 *
 	 * If the function is called with Preferences::m_bJackMasterMode
-	 * set to Preferences::NO_JACK_TIME_MASTER,
-	 * _jack_release_timebase()_ (jack/transport.h) will be called
-	 * instead.
+	 * set to Preferences::NO_JACK_TIME_MASTER, releaseTimebase() will
+	 * be called instead.
 	 */ 
 	void initTimeMaster();
 	/**
-	 * Calls _jack_release_timebase()_ (jack/transport.h) to
-	 * release Hydrogen from the JACK timebase master
-	 * responsibilities. This causes the jack_timebase_callback()
-	 * callback function to not be called by the JACK server
-	 * anymore.
+	 * Calls _jack_release_timebase()_ (jack/transport.h) to release
+	 * Hydrogen from the JACK timebase master responsibilities. This
+	 * causes the jack_timebase_callback() callback function to not be
+	 * called by the JACK server anymore.
 	 */
 	void releaseTimebase();
 	
@@ -589,8 +534,7 @@ public:
 protected:
 	/**
 	 * Callback function registered to the JACK server in
-	 * initTimeMaster() if Hydrogen is set as JACK timebase
-	 * master.
+	 * initTimeMaster() if Hydrogen is set as JACK timebase master.
 	 *
 	 * It will update the current position not just in frames till
 	 * the beginning of the song, but also in terms of beat, bar,
@@ -673,109 +617,104 @@ protected:
 
 private:
 	/**
-	 * Internal tick size used before a tempo change.
-	 *
-	 * This variable will only be used in the very particular
-	 * border case of having an external JACK timebase master,
-	 * which did update the tempo, and one of the clients 
-	 */
-	float				m_fOldTickSize;
-	/**
 	 * Constant offset between the transport position in
 	 * TransportInfo::m_nFrames and the one obtained by the JACK
-	 * server query. 
+	 * server query.
 	 *
-	 * This can happen when changing the speed during
-	 * playback. Note that contrary its name, which involves
-	 * bar-beat-tick set by the JACK timebase master, this
-	 * constant will be assigned and used even if no JACK timebase
-	 * master is present at all! Positive values correspond to a
-	 * position ahead of the current transport information. The
-	 * variable is initialized with 0 in JackAudioDriver() and
-	 * updated in calculateFrameOffset().
+	 * Imagine the following setting: During the playback you decide
+	 * to change the speed of the song. This would cause a lot of
+	 * position information within Hydrogen, which are given in ticks,
+	 * to be off since the tick size depends on the speed and just got
+	 * changed too. Instead, TransportInfo::m_nFrames will scaled to
+	 * reflect the changes and everything will be still in place with
+	 * the user to not note a single thing. Unfortunately, now the
+	 * transport position in frames of the audio engine and of the
+	 * JACK server are off by a constant offset. To nevertheless be
+	 * able to identify relocation in updateTransportInfo(), this
+	 * constant offset is stored in this variable and used in
+	 * updateTransportInfo() to determine whether a relocation did
+	 * happen..
+	 *
+	 * Positive values correspond to a position ahead of the current
+	 * transport information. The variable is initialized with 0 in
+	 * JackAudioDriver() and updated in calculateFrameOffset().
 	 */
 	long long			m_bbtFrameOffset;
 	/**
-	 * Function the JACK server will call whenever there is work
-	 * to do. 
+	 * Function the JACK server will call whenever there is work to
+	 * do.
 	 *
-	 * The audioEngine_process() function will be used and
-	 * registered using _jack_set_process_callback()_
-	 * (jack/jack.h) in init().
+	 * The audioEngine_process() function will be used and registered
+	 * using _jack_set_process_callback()_ (jack/jack.h) in init().
 	 *
-	 * The code must be suitable for real-time execution.  That
-	 * means that it cannot call functions that might block for a
-	 * long time. This includes _malloc()_, _free()_, _printf()_,
+	 * The code must be suitable for real-time execution.  That means
+	 * that it cannot call functions that might block for a long
+	 * time. This includes _malloc()_, _free()_, _printf()_,
 	 * _pthread_mutex_lock()_, _sleep()_, _wait()_, _poll()_,
-	 * _select()_, _pthread_join()_, _pthread_cond_wait()_, etc,
-	 * etc.
+	 * _select()_, _pthread_join()_, _pthread_cond_wait()_, etc, etc.
 	 */
 	JackProcessCallback		m_processCallback;
 	/**
-	 * Left source port for which a connection to
-	 * #m_sOutputPortName1 will be established in connect() via
-	 * the JACK server.
+	 * Left source port for which a connection to #m_sOutputPortName1
+	 * will be established in connect() via the JACK server.
 	 */
 	jack_port_t*			m_pOutputPort1;
 	/**
-	 * Right source port for which a connection to
-	 * #m_sOutputPortName2 will be established in connect() via
-	 * the JACK server.
+	 * Right source port for which a connection to #m_sOutputPortName2
+	 * will be established in connect() via the JACK server.
 	 */
 	jack_port_t*			m_pOutputPort2;
 	/**
-	 * Destination of the left source port #m_pOutputPort1, for
-	 * which a connection will be established in connect(). It is
-	 * set to Preferences::m_sJackPortName1 during the call of
-	 * init(). 
+	 * Destination of the left source port #m_pOutputPort1, for which
+	 * a connection will be established in connect(). It is set to
+	 * Preferences::m_sJackPortName1 during the call of init().
 	 */
 	QString				m_sOutputPortName1;
 	/**
-	 * Destination of the right source port #m_pOutputPort2, for
-	 * which a connection will be established in connect(). It is
-	 * set to Preferences::m_sJackPortName2 during the call of
-	 * init(). 
+	 * Destination of the right source port #m_pOutputPort2, for which
+	 * a connection will be established in connect(). It is set to
+	 * Preferences::m_sJackPortName2 during the call of init().
 	 */
 	QString				m_sOutputPortName2;
 	/**
-	 * Matrix containing the track number of each component of
-	 * of all instruments. Its rows represent the instruments and
-	 * its columns their components. _m_trackMap[2][1]=6_ thus
-	 * therefore mean the output of the second component of the
-	 * third instrument is assigned the seventh output port. Since
-	 * its total size is defined by #MAX_INSTRUMENTS and
-	 * #MAX_COMPONENTS, most of its entries will be zero.
+	 * Matrix containing the track number of each component of of all
+	 * instruments. Its rows represent the instruments and its columns
+	 * their components. _m_trackMap[2][1]=6_ thus therefore mean the
+	 * output of the second component of the third instrument is
+	 * assigned the seventh output port. Since its total size is
+	 * defined by #MAX_INSTRUMENTS and #MAX_COMPONENTS, most of its
+	 * entries will be zero.
 	 *
 	 * It gets updated by makeTrackOutputs().
 	 */
 	int				m_trackMap[MAX_INSTRUMENTS][MAX_COMPONENTS];
 	/**
-	 * Total number of output ports currently in use. It gets
-	 * updated by makeTrackOutputs().
+	 * Total number of output ports currently in use. It gets updated
+	 * by makeTrackOutputs().
 	 */
 	int				m_nTrackPortCount;
 	/**
 	 * Vector of all left audio output ports currently used by the
-	 * local JACK client. 
+	 * local JACK client.
 	 *
 	 * They will be initialized with all zeros in both
 	 * JackAudioDriver(), deactivate(), and connect(). Individual
 	 * components will be created, renamed, or reassigned in
-	 * setTrackOutput(), deleted in makeTrackOutputs(), and
-	 * accessed via getTrackOut_L().
-	 * It is set to a length of #MAX_INSTRUMENTS.
+	 * setTrackOutput(), deleted in makeTrackOutputs(), and accessed
+	 * via getTrackOut_L().  It is set to a length of
+	 * #MAX_INSTRUMENTS.
 	 */
 	jack_port_t*			m_pTrackOutputPortsL[MAX_INSTRUMENTS];
 	/**
 	 * Vector of all right audio output ports currently used by the
-	 * local JACK client. 
+	 * local JACK client.
 	 *
 	 * They will be initialized with all zeros in both
 	 * JackAudioDriver(), deactivate(), and connect(). Individual
 	 * components will be created, renamed, or reassigned in
-	 * setTrackOutput(), deleted in makeTrackOutputs(), and
-	 * accessed via getTrackOut_R().
-	 * It is set to a length of #MAX_INSTRUMENTS.
+	 * setTrackOutput(), deleted in makeTrackOutputs(), and accessed
+	 * via getTrackOut_R().  It is set to a length of
+	 * #MAX_INSTRUMENTS.
 	 */
 	jack_port_t*		 	m_pTrackOutputPortsR[MAX_INSTRUMENTS];
 
@@ -801,9 +740,9 @@ private:
 	 * Current transport position obtained using
 	 * _jack_transport_query()_ (jack/transport.h).
 	 *
-	 * It corresponds to the first frame of the current cycle. If
-	 * it is NULL, _jack_transport_query()_ won't return any
-	 * position information.
+	 * It corresponds to the first frame of the current cycle. If it
+	 * is NULL, _jack_transport_query()_ won't return any position
+	 * information.
 	 *
 	 * The __valid__ member of #m_JackTransportPos will show which
 	 * fields contain valid data. Thus, if it is set to
@@ -825,8 +764,8 @@ private:
 	 * position. 
 	 *
 	 * It is set in updateTransportInfo(). Please see the
-	 * documentation of jack_timebase_callback() for more
-	 * information about its different members.
+	 * documentation of jack_timebase_callback() for more information
+	 * about its different members.
 	 */
 	jack_position_t			m_JackTransportPos;
 
@@ -847,12 +786,12 @@ private:
 	/**
 	 * While Hydrogen can unregister as timebase master on its own, it
 	 * can not be observed directly whether another application has
-	 * taken over as timebase master. When the JACK server is release
-	 * Hydrogen in the later case, it won't advertise this fact but
-	 * simply not call the jack_timebase_callback() anymore. But since
-	 * this will be called in every cycle after updateTransportInfo(),
-	 * we can use this variable to determine if Hydrogen is still
-	 * timebase master.
+	 * taken over as timebase master. When the JACK server is
+	 * releasing Hydrogen in the later case, it won't advertise this
+	 * fact but simply won't call the jack_timebase_callback()
+	 * anymore. But since this will be called in every cycle after
+	 * updateTransportInfo(), we can use this variable to determine if
+	 * Hydrogen is still timebase master.
 	 *
 	 * It will be initialized with 0, incremented in
 	 * updateTransportInfo(), and reset to zero in
@@ -861,18 +800,14 @@ private:
 	 * false.
 	 */
 	int					m_nTimebaseMasterCount;
-	/**
-	 * Specifies whether to use a conditional take over in the
-	 * switching of the JACK timebase master. If set to non-zero
-	 * the take over will fail if there is already a timebase
-	 * master present. Currently it will always be set to 0.
-	 */
-	int				m_nJackConditionalTakeOver;
 
 };
 	
 inline bool JackAudioDriver::getIsTimebaseMaster() {
 	return m_bIsTimebaseMaster;
+}
+inline int JackAudioDriver::getNumTracks() {
+	return m_nTrackPortCount;
 }
 
 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -491,6 +491,12 @@ public:
 	virtual void updateTransportInfo();
 	/** Set the tempo stored TransportInfo::m_fBPM of the local
 	 * instance of the TransportInfo AudioOutput::m_transport.
+	 *
+	 * Only sets the tempo to @a fBPM if its value is at least
+	 * 1. Sometime (especially during the first cycle after locating
+	 * with transport stopped) the JACK server sends some artifacts
+	 * (6.95334e-310) which should not be assigned.
+	 * 
 	 * \param fBPM new tempo. 
 	 */
 	virtual void setBpm( float fBPM );

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -93,7 +93,7 @@ class InstrumentComponent;
  * aren't familiar with frames), like the current beat, bar, tick,
  * tick size, speed etc. Every client can be registered as timebase
  * master by supplying a callback (for Hydrogen this would be
- * jack_timebase_callback()) but there can be at most one timebase
+ * JackTimebaseCallback()) but there can be at most one timebase
  * master at a time. Having none at all is perfectly fine too. Apart
  * from this additional responsibility, the registered client has no
  * other rights compared to others.
@@ -521,7 +521,7 @@ public:
 	/**
 	 * Calls _jack_release_timebase()_ (jack/transport.h) to release
 	 * Hydrogen from the JACK timebase master responsibilities. This
-	 * causes the jack_timebase_callback() callback function to not be
+	 * causes the JackTimebaseCallback() callback function to not be
 	 * called by the JACK server anymore.
 	 */
 	void releaseTimebaseMaster();
@@ -588,7 +588,7 @@ protected:
 	 * used within the function but to ensure compatibility.
 	 * \param arg Pointer to a JackAudioDriver instance.
 	 */
-	static void jack_timebase_callback( jack_transport_state_t state,
+	static void JackTimebaseCallback( jack_transport_state_t state,
 					    jack_nframes_t nFrames,
 					    jack_position_t* pJackPosition,
 					    int new_pos,
@@ -764,7 +764,7 @@ private:
 	 * position. 
 	 *
 	 * It is set in updateTransportInfo(). Please see the
-	 * documentation of jack_timebase_callback() for more information
+	 * documentation of JackTimebaseCallback() for more information
 	 * about its different members.
 	 */
 	jack_position_t			m_JackTransportPos;
@@ -788,14 +788,14 @@ private:
 	 * can not be observed directly whether another application has
 	 * taken over as timebase master. When the JACK server is
 	 * releasing Hydrogen in the later case, it won't advertise this
-	 * fact but simply won't call the jack_timebase_callback()
+	 * fact but simply won't call the JackTimebaseCallback()
 	 * anymore. But since this will be called in every cycle after
 	 * updateTransportInfo(), we can use this variable to determine if
 	 * Hydrogen is still timebase master.
 	 *
 	 * It will be initialized with 0, incremented in
 	 * updateTransportInfo(), and reset to zero in
-	 * jack_timebase_callback(). Whenever it is larger than zero in
+	 * JackTimebaseCallback(). Whenever it is larger than zero in
 	 * updateTransportInfo(), #m_bIsTimebaseMaster will be set to
 	 * false.
 	 */

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -608,6 +608,11 @@ public:
 	 * anymore.
 	 */
 	void releaseTimebase();
+	
+	/**
+	 * \return #m_bIsTimebaseMaster
+	 */
+	bool getIsTimebaseMaster();
 
 protected:
 	/**
@@ -880,6 +885,23 @@ private:
 	 */
 	bool				m_bIsTimebaseMaster;
 	/**
+	 * While Hydrogen can unregister as timebase master on its own, it
+	 * can not be observed directly whether another application has
+	 * taken over as timebase master. When the JACK server is release
+	 * Hydrogen in the later case, it won't advertise this fact but
+	 * simply not call the jack_timebase_callback() anymore. But since
+	 * this will be called in every cycle after updateTransportInfo(),
+	 * we can use this variable to determine if Hydrogen is still
+	 * timebase master.
+	 *
+	 * It will be initialized with 0, incremented in
+	 * updateTransportInfo(), and reset to zero in
+	 * jack_timebase_callback(). Whenever it is larger than zero in
+	 * updateTransportInfo(), #m_bIsTimebaseMaster will be set to
+	 * false.
+	 */
+	int					m_nTimebaseMasterCount;
+	/**
 	 * Specifies whether to use a conditional take over in the
 	 * switching of the JACK timebase master. If set to non-zero
 	 * the take over will fail if there is already a timebase
@@ -888,6 +910,12 @@ private:
 	int				m_nJackConditionalTakeOver;
 
 };
+	
+inline bool JackAudioDriver::getIsTimebaseMaster() {
+	return m_bIsTimebaseMaster;
+}
+
+
 
 }; // H2Core namespace
 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -542,42 +542,7 @@ protected:
 	 *
 	 * The function it will be called after the
 	 * audioEngine_process() function and only if the
-	 * #m_JackTransportState is _JackTransportRolling_. It sets
-	 * the following members of the JACK position object @a pos is
-	 * pointing to:
-	 * - __bar__ : current position corrected by the #m_frameOffset
-	 * \code{.cpp} 
-	 * Hydrogen::getPosForTick( ( pos->frame - m_frameOffset )/ 
-	 *                          m_transport.m_fTickSize ) ) 
-	 * \endcode
-	 * - __ticks_per_beat__ :  the output of
-	 * Hydrogen::getPatternLength() with the __bar__ member
-	 * supplied as input argument.
-	 * - __valid__ : to ( _JackPositionBBT_ | _JackBBTFrameOffset_
-	 * ), transport states defined
-	 * in jack/types.h telling JACK we are willing to provide bar,
-	 * beat, and trick information as well as an constant offset.
-	 * - __beats_per_bar__ : the __ticks_per_beat__ member divided
-	 * by 48.
-	 * - __beat_type__ : 4.0
-	 * - __beats_per_minute__ : the local speed returned by
-	 * Hydrogen::setTimelineBpm() at the __bar__ member.
-	 * - __bbt_offset__ : 0
-	 *
-	 * Afterwards the __bar__ member is incremented by 1 the
-	 * following information will be set as well.
-	 * - __bar_start_tick__ : the corrected position used in the
-	 * first __bar__ assignment minus the number of ticks elapsed
-	 * from the last bar
-	 * - __beat__ : The number of elapsed ticks from the last bar
-	 * divided by the __ticks_per_beat__ member plus one.
-	 * - __tick__ : The number of elapsed ticks from the last bar
-	 * modulo the __ticks_per_beat__ member.
-	 *
-	 * If Hydrogen::getHumantimeFrames() returns a number smaller
-	 * than 1, we are at the beginning of the Song and __beat__ =
-	 * 1, __tick__ = 0, and __bar_start_tick__ = 0 will be used
-	 * instead.
+	 * #m_JackTransportState is _JackTransportRolling_.
 	 *
 	 * \param state Current transport state. Not used within the
 	 * function but to ensure compatibility.

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -533,9 +533,9 @@ public:
 	void releaseTimebaseMaster();
 	
 	/**
-	 * \return #m_bIsTimebaseMaster
+	 * \return #m_nIsTimebaseMaster
 	 */
-	bool getIsTimebaseMaster();
+	int getIsTimebaseMaster();
 
 protected:
 	/**
@@ -751,10 +751,15 @@ private:
 	 */
 	bool				m_bConnectDefaults;
 	/**
-	 * Whether Hydrogen is the current Jack timebase master.
-	 */
-	bool				m_bIsTimebaseMaster;
-	/**
+	 * Whether Hydrogen or another program is Jack timebase master.
+	 *
+	 * - #m_nIsTimebaseMaster > 0 - Hydrogen itself is timebase
+          master.
+	 * - #m_nIsTimebaseMaster == 0 - an external program is timebase
+          master and Hydrogen will disregard all tempo marker on the
+          Timeline and, instead, only use the BPM provided by JACK.
+	 * - #m_nIsTimebaseMaster < 0 - only normal clients registered.
+	 *
 	 * While Hydrogen can unregister as timebase master on its own, it
 	 * can not be observed directly whether another application has
 	 * taken over as timebase master. When the JACK server is
@@ -764,18 +769,19 @@ private:
 	 * updateTransportInfo(), we can use this variable to determine if
 	 * Hydrogen is still timebase master.
 	 *
-	 * It will be initialized with 0, incremented in
-	 * updateTransportInfo(), and reset to zero in
-	 * JackTimebaseCallback(). Whenever it is larger than zero in
-	 * updateTransportInfo(), #m_bIsTimebaseMaster will be set to
-	 * false.
+	 * As Hydrogen registered as timebase master using
+	 * initTimebaseMaster() it will be initialized with 1, decremented
+	 * in updateTransportInfo(), and reset to 1 in
+	 * JackTimebaseCallback(). Whenever it is zero in
+	 * updateTransportInfo(), #m_nIsTimebaseMaster will be updated
+	 * accordingly.
 	 */
-	int					m_nTimebaseMasterCount;
+	int				m_nIsTimebaseMaster;
 
 };
 	
-inline bool JackAudioDriver::getIsTimebaseMaster() {
-	return m_bIsTimebaseMaster;
+inline int JackAudioDriver::getIsTimebaseMaster() {
+	return m_nIsTimebaseMaster;
 }
 inline int JackAudioDriver::getNumTracks() {
 	return m_nTrackPortCount;

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -543,8 +543,8 @@ public:
 	 * \return #m_nIsTimebaseMaster
 	 */
 	int getIsTimebaseMaster();
-	/** Stores the current transport position in case transport is not
-	 *	rolling.
+	/** Stores the latest transport position (for both rolling and
+	 * stopped transport).
 	 *
 	 * In case the user is clicking on the
 	 * SongEditor::mousePressEvent() will trigger both a relocation

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -514,7 +514,7 @@ public:
              master, a change in speed (or relocation into a region of
              different speed) could have occurred. Therefore,
              TransportInfo::m_nFrames will be scaled properly using
-             #m_fOldTickSize and TransportInfo::m_nTickSize. In addition, 
+             #m_fOldTickSize and TransportInfo::m_fTickSize. In addition, 
 	     Hydrogen::triggerRelocateDuringPlay() will be called if
              no timebase master is present and the transport is rolling.
 	 * - Finally, #m_nHumantimeFrames will be set to the _frame_
@@ -525,7 +525,7 @@ public:
 	 * without performing any action.
 	 */
 	virtual void updateTransportInfo();
-	/** Set the tempo stored TransportInfo::m_nBPM of the local
+	/** Set the tempo stored TransportInfo::m_fBPM of the local
 	 * instance of the TransportInfo AudioOutput::m_transport.
 	 * \param fBPM new tempo. 
 	 */
@@ -632,7 +632,7 @@ protected:
 	 * - __bar__ : current position corrected by the #m_bbtFrameOffset
 	 * \code{.cpp} 
 	 * Hydrogen::getPosForTick( ( pos->frame - m_bbtFrameOffset )/ 
-	 *                          m_transport.m_nTickSize ) ) 
+	 *                          m_transport.m_fTickSize ) ) 
 	 * \endcode
 	 * - __ticks_per_beat__ :  the output of
 	 * Hydrogen::getTickForHumanPosition() with the __bar__ member

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -474,10 +474,9 @@ public:
 	 * Updating the local instance of the TransportInfo
 	 * AudioOutput::m_transport.
 	 *
-	 * The function queries the transport position and addition
-	 * information from the JACK server and adjusts the
-	 * information stored in AudioOutput::m_transport if there is
-	 * a mismatch.
+	 * The function queries the transport position and additional
+	 * information from the JACK server and updates the information
+	 * stored in AudioOutput::m_transport in case of a mismatch.
 	 *
 	 * - Calls _jack_transport_query()_ (jack/transport.h), stores
              the current transport position in #m_JackTransportPos,
@@ -489,7 +488,7 @@ public:
              set to TransportInfo::ROLLING.
 	 * - Calls Hydrogen::setTimelineBpm() to update both the
              global speed of the Song Song::__bpm, as well as the
-	     fallback speed Hydrogen::m_nNewBpmJTM() with the local
+	     fallback speed Hydrogen::m_fNewBpmJTM() with the local
              tempo at the current position on the timeline.
 	 * - Checks whether the speed was changed by another JACK time
              master (there can only be one). In that case we will just
@@ -552,33 +551,6 @@ public:
 	 * #m_bbtFrameOffset.
 	 */
 	void calculateFrameOffset();
-	/**
-	 * Relocate the transport position to @a frame @a
-	 * cycles_to_wait cycles.
-	 *
-	 * The function is triggered in audioEngine_process() after
-	 * audioEngine_updateNoteQueue() returned -1, stop() was
-	 * called, and transport location was moved to the beginning
-	 * of the Song using locate().
-	 *
-	 * Judging from comments in the code, this additional
-	 * repositioning was introduced to keep Hydrogen synchronized
-	 * with Ardour.
-	 *
-	 * Internally, it sets the variable #m_nLocateCountDown to @a
-	 * cycles_to_wait and #m_locateFrame to @a frame.
-	 *
-	 * The audioEngine_updateNoteQueue() function is called after
-	 * audioEngine_process_transport() and its decrement of
-	 * #m_nLocateCountDown. It thus only take @a cycles_to_wait - 1
-	 * cycles calls to audioEngine_process() for the relocation to
-	 * happen.
-	 *
-	 * \param frame New position
-	 * \param cycles_to_wait In how many cycles the repositioning
-	 *   should take place.
-	 */
-	void locateInNCycles( unsigned long frame, int cycles_to_wait = 2 );
 
 	/**
 	 * Registers Hydrogen as JACK timebase master.
@@ -723,18 +695,6 @@ private:
 	 * updated in calculateFrameOffset().
 	 */
 	long long			m_bbtFrameOffset;
-	/** 
-	 * #m_nLocateCountdown - 1 of cycles (calls to
-	 * audioEngine_process()) until to locate() to #m_locateFrame in
-	 * updateTransportInfo(). It is set in locateInNCycles().
-	 */
-	int				m_nLocateCountdown;
-	/** 
-	 * Frame to locate() to in updateTransportInfo() after
-	    #m_nLocateCountDown cycles - 1 cycles.   
-	 * It is set in locateInNCycles(). 
-	 */
-	unsigned long			m_locateFrame;
 	/**
 	 * Function the JACK server will call whenever there is work
 	 * to do. 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -398,7 +398,7 @@ public:
 	 *
 	 * Finally, the function will check whether Hydrogen should be the
 	 * JACK timebase master or not via Preferences::m_bJackMasterMode
-	 * and calls initTimeMaster() if its indeed the case.
+	 * and calls initTimebaseMaster() if its indeed the case.
 	 *
 	 * \param bufferSize Unused and only present to assure
 	 * compatibility with the JACK API.
@@ -472,7 +472,7 @@ public:
      * The function will check whether a relocation took place by the
 	 * JACK server and (afterwards) whether the current tempo did
 	 * change with respect to the last transport cycle. In case of a
-	 * relocation, #m_bbtFrameOffset will be reset to 0,
+	 * relocation, #m_frameOffset will be reset to 0,
 	 * TransportInfo::m_nFrames updated to the new value provided by
 	 * JACK, and - if Hydrogen is in Song::PATTERN_MODE - the playback
 	 * moved to the beginning of the pattern. A change in speed, on
@@ -498,7 +498,7 @@ public:
 	 * Calculates the difference between the transport position
 	 * obtained by querying JACK and the value stored in
 	 * TransportInfo::m_nFrames and stores it in
-	 * #m_bbtFrameOffset.
+	 * #m_frameOffset.
 	 *
 	 * It is triggered in audioEngine_process_checkBPMChanged() if a
 	 * BPM marker in the Timeline was passed, which causes the tick
@@ -514,17 +514,17 @@ public:
 	 * Preferences::NO_JACK_TIME_MASTER.
 	 *
 	 * If the function is called with Preferences::m_bJackMasterMode
-	 * set to Preferences::NO_JACK_TIME_MASTER, releaseTimebase() will
-	 * be called instead.
+	 * set to Preferences::NO_JACK_TIME_MASTER,
+	 * releaseTimebaseMaster() will be called instead.
 	 */ 
-	void initTimeMaster();
+	void initTimebaseMaster();
 	/**
 	 * Calls _jack_release_timebase()_ (jack/transport.h) to release
 	 * Hydrogen from the JACK timebase master responsibilities. This
 	 * causes the jack_timebase_callback() callback function to not be
 	 * called by the JACK server anymore.
 	 */
-	void releaseTimebase();
+	void releaseTimebaseMaster();
 	
 	/**
 	 * \return #m_bIsTimebaseMaster
@@ -534,7 +534,7 @@ public:
 protected:
 	/**
 	 * Callback function registered to the JACK server in
-	 * initTimeMaster() if Hydrogen is set as JACK timebase master.
+	 * initTimebaseMaster() if Hydrogen is set as JACK timebase master.
 	 *
 	 * It will update the current position not just in frames till
 	 * the beginning of the song, but also in terms of beat, bar,
@@ -545,9 +545,9 @@ protected:
 	 * #m_JackTransportState is _JackTransportRolling_. It sets
 	 * the following members of the JACK position object @a pos is
 	 * pointing to:
-	 * - __bar__ : current position corrected by the #m_bbtFrameOffset
+	 * - __bar__ : current position corrected by the #m_frameOffset
 	 * \code{.cpp} 
-	 * Hydrogen::getPosForTick( ( pos->frame - m_bbtFrameOffset )/ 
+	 * Hydrogen::getPosForTick( ( pos->frame - m_frameOffset )/ 
 	 *                          m_transport.m_fTickSize ) ) 
 	 * \endcode
 	 * - __ticks_per_beat__ :  the output of
@@ -639,7 +639,7 @@ private:
 	 * transport information. The variable is initialized with 0 in
 	 * JackAudioDriver() and updated in calculateFrameOffset().
 	 */
-	long long			m_bbtFrameOffset;
+	long long			m_frameOffset;
 	/**
 	 * Function the JACK server will call whenever there is work to
 	 * do.

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -122,19 +122,19 @@ public:
 	 * Constructor of the JACK server driver.
 	 *
 	 * Sets a number of variables:
-	 * - #locate_countdown = 0
-	 * - #bbt_frame_offset = 0
-	 * - #track_port_count = 0
+	 * - #m_nLocateCountDown = 0
+	 * - #m_bbtFrameOffset = 0
+	 * - #m_nTrackPortCount = 0
 	 * - #__track_out_enabled = Preferences::m_bJackTrackOuts
 	 *
 	 * In addition, it also assigned the provided @a
-	 * processCallback argument, the audioEngine_process()
-	 * function, to the corresponding #processCallback variable
+	 * m_processCallback argument, the audioEngine_process()
+	 * function, to the corresponding #m_processCallback variable
 	 * and overwrites the memory allocated by the
-	 * #track_output_ports_L and #track_output_ports_R variable
+	 * #m_pTrackOutputPortsL and #m_pTrackOutputPortsR variable
 	 * with zeros.
 	 *
-	 * @param processCallback Prototype for the client supplied
+	 * @param m_processCallback Prototype for the client supplied
 			 function that is called by the engine anytime 
 			 there is work to be done. It gets two input
 			 arguments _nframes_ of type
@@ -147,7 +147,7 @@ public:
 			 returns zero on success and non-zero on
 			 error.
 	 */
-	JackAudioDriver( JackProcessCallback processCallback );
+	JackAudioDriver( JackProcessCallback m_processCallback );
 	/**
 	 * Destructor of the JACK server driver.
 	 *
@@ -161,12 +161,12 @@ public:
 	 * Starts by telling the JACK server that Hydrogen is ready to
 	 * process audio using the jack_activate function (from the
 	 * jack/jack.h header) and overwriting the memory allocated by
-	 * #track_output_ports_L and #track_output_ports_R with
-	 * zeros. If the #m_bConnectOutFlag variable is true or
+	 * #m_pTrackOutputPortsL and #m_pTrackOutputPortsR with
+	 * zeros. If the #m_bConnectDefaults variable is true or
 	 * LashClient is used and Hydrogen is not within a new Lash
 	 * project, the function attempts to connect the
-	 * #output_port_1 port with #output_port_name_1 and the
-	 * #output_port_2 port with #output_port_name_2. To establish
+	 * #m_pOutputPort1 port with #m_sOutputPortName1 and the
+	 * #m_pOutputPort2 port with #m_sOutputPortName2. To establish
 	 * the connection _jack_connect()_ (jack/jack.h) will be
 	 * used. In case this was not successful, the function will
 	 * look up all ports containing the _JackPortIsInput_
@@ -176,14 +176,14 @@ public:
 	 * @return 
 	 * - __0__ : if either the connection of the output ports
 	 *       did work, two ports having the _JackPortIsInput_ flag
-	 *       where found and the #output_port_1 and #output_port_2
+	 *       where found and the #m_pOutputPort1 and #m_pOutputPort2
 	 *       ports where successfully connected to them, or the
 	 *       user enabled Lash during compilation and an
 	 *       established project was used.
 	 * - __1__ : The activation of the JACK client using
 	 *       _jack_activate()_ (jack/jack.h) did fail.
-	 * - __2__ : The connections to #output_port_name_1 and
-	 *       #output_port_name_2 could not be established and the
+	 * - __2__ : The connections to #m_sOutputPortName1 and
+	 *       #m_sOutputPortName2 could not be established and the
 	 *       there were either no JACK ports holding the
 	 *       JackPortIsInput flag found or no connection to them
 	 *       could be established.
@@ -205,8 +205,8 @@ public:
 	 *
 	 * It calls the _jack_deactivate()_ (jack/jack.h) function on
 	 * the current client #m_pClient and overwrites the memory
-	 * allocated by #track_output_ports_L and
-	 * #track_output_ports_R with zeros.
+	 * allocated by #m_pTrackOutputPortsL and
+	 * #m_pTrackOutputPortsR with zeros.
 	 */
 	void deactivate();
 	/**
@@ -226,7 +226,7 @@ public:
 	 */
 	unsigned getSampleRate();
 	/** Accesses the number of output ports currently in use.
-	 * \return #track_port_count */
+	 * \return #m_nTrackPortCount */
 	int getNumTracks();
 
 	/** Returns #m_JackTransportState */
@@ -241,15 +241,15 @@ public:
 	/**
 	 * Creates per component output ports for each instrument.
 	 *
-	 * Firstly, it resets #track_map with zeros. Then, it loops
+	 * Firstly, it resets #m_trackMap with zeros. Then, it loops
 	 * through all the instruments and their components, creates a
 	 * new output or resets an existing one for each of them using
 	 * setTrackOutput(), and stores the corresponding track number
-	 * in #track_map. Finally, all ports in #track_output_ports_L
-	 * and #track_output_ports_R, which haven't been used in the
+	 * in #m_trackMap. Finally, all ports in #m_pTrackOutputPortsL
+	 * and #m_pTrackOutputPortsR, which haven't been used in the
 	 * previous step, are unregistered using
 	 * _jack_port_unregister()_ (jack/jack.h) and overwritten with
-	 * 0. #track_port_count will be set to biggest track number
+	 * 0. #m_nTrackPortCount will be set to biggest track number
 	 * encountered during the creation/reassignment step.
 	 *
 	 * The function will only perform its tasks if the
@@ -261,9 +261,9 @@ public:
 	 * its not already present. 
 	 *
 	 * If the track number @a n is bigger than the number of ports
-	 * currently in usage #track_port_count, @a n + 1 -
-	 * #track_port_count new stereo ports will be created using
-	 * _jack_port_register()_ (jack/jack.h) and #track_port_count
+	 * currently in usage #m_nTrackPortCount, @a n + 1 -
+	 * #m_nTrackPortCount new stereo ports will be created using
+	 * _jack_port_register()_ (jack/jack.h) and #m_nTrackPortCount
 	 * updated to @a n + 1.
 	 *
 	 * Afterwards, the @a n 'th port is renamed to a concatenation
@@ -283,19 +283,19 @@ public:
 	 */
 	void setTrackOutput( int n, Instrument* instr, InstrumentComponent* pCompo, Song* pSong );
 
-	/** Sets #m_bConnectOutFlag to @a flag.*/
+	/** Sets #m_bConnectDefaults to @a flag.*/
 	void setConnectDefaults( bool flag ) {
-		m_bConnectOutFlag = flag;
+		m_bConnectDefaults = flag;
 	}
-	/** Returns #m_bConnectOutFlag */
+	/** Returns #m_bConnectDefaults */
 	bool getConnectDefaults() {
-		return m_bConnectOutFlag;
+		return m_bConnectDefaults;
 	}
 
 	/**
 	 * Get and return the content in the left stereo output
 	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * both the port name #output_port_1 and buffer size
+	 * both the port name #m_pOutputPort1 and buffer size
 	 * #jack_server_bufferSize.
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
@@ -304,7 +304,7 @@ public:
 	/**
 	 * Get and return the content in the right stereo output
 	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * both the port name #output_port_2 and buffer size
+	 * both the port name #m_pOutputPort2 and buffer size
 	 * #jack_server_bufferSize.
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
@@ -313,10 +313,10 @@ public:
 	/**
 	 * Get and return the content of a specific left output
 	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * the port in @a nTrack element of #track_output_ports_L and
+	 * the port in @a nTrack element of #m_pTrackOutputPortsL and
 	 * buffer size #jack_server_bufferSize.
 	 * \param nTrack Track number. Must not be bigger than
-	 * #track_port_count.
+	 * #m_nTrackPortCount.
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
@@ -324,17 +324,17 @@ public:
 	/**
 	 * Get and return the content of a specific right output
 	 * port. It calls _jack_port_get_buffer()_ (jack/jack.h) with
-	 * the port in @a nTrack element of #track_output_ports_R and
+	 * the port in @a nTrack element of #m_pTrackOutputPortsR and
 	 * buffer size #jack_server_bufferSize.
 	 * \param nTrack Track number. Must not be bigger than
-	 * #track_port_count.
+	 * #m_nTrackPortCount.
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
 	float* getTrackOut_R( unsigned nTrack );
 	/** 
 	 * Convenience function looking up the track number of a
-	 * component of an instrument using in #track_map using their
+	 * component of an instrument using in #m_trackMap using their
 	 * IDs Instrument::__id and
 	 * InstrumentComponent::__related_drumkit_componentID. Using
 	 * the track number it then calls getTrackOut_L( unsigned )
@@ -347,7 +347,7 @@ public:
 	float* getTrackOut_L( Instrument* instr, InstrumentComponent* pCompo );
 	/** 
 	 * Convenience function looking up the track number of a
-	 * component of an instrument using in #track_map using their
+	 * component of an instrument using in #m_trackMap using their
 	 * IDs Instrument::__id and
 	 * InstrumentComponent::__related_drumkit_componentID. Using
 	 * the track number it then calls getTrackOut_R( unsigned )
@@ -363,7 +363,7 @@ public:
 	 * Initializes the JACK audio driver.
 	 *
 	 * Firstly, it determines the destination ports
-	 * #output_port_name_1 and #output_port_name_2 the output
+	 * #m_sOutputPortName1 and #m_sOutputPortName2 the output
 	 * ports of Hydrogen will be connected to in connect() from
 	 * Preferences::m_sJackPortName1 and
 	 * Preferences::m_sJackPortName2. The name of the JACK client
@@ -390,7 +390,7 @@ public:
 	 * stores them in H2Core::jack_server_sampleRate,
 	 * Preferences::m_nSampleRate, H2Core::jack_server_bufferSize,
 	 * and Preferences::m_nBufferSize. In addition, it also
-	 * registers JackAudioDriver::processCallback,
+	 * registers JackAudioDriver::m_processCallback,
 	 * H2Core::jackDriverSampleRate, H2Core::jackDriverBufferSize,
 	 * and H2Core::jackDriverShutdown using
 	 * _jack_set_process_callback()_,
@@ -503,10 +503,10 @@ public:
              a relocation triggered by another JACK client, we will
              detect this change since the position stored in
              TransportInfo::m_nFrames plus the constant offset
-             #bbt_frame_offset does not equate to the _frame_ member
+             #m_bbtFrameOffset does not equate to the _frame_ member
              of #m_JackTransportPos anymore. It there is a timebase
              master present and it is us or no timebase master was set
-             at all, #bbt_frame_offset will be reset to zero and
+             at all, #m_bbtFrameOffset will be reset to zero and
              TransportInfo::m_nFrames will be set to the _frame_ member
              of #m_JackTransportPos. The relocation itself will be
              handled by locate() and we trust the JACK server to do
@@ -534,7 +534,7 @@ public:
 	 * Calculates the difference between the transport position
 	 * obtained by querying JACK and the value stored in
 	 * TransportInfo::m_nFrames and stores it in
-	 * #bbt_frame_offset.
+	 * #m_bbtFrameOffset.
 	 *
 	 * It is triggered in audioEngine_process_checkBPMChanged() in
 	 * case the tick size did changed. Imagine the following
@@ -549,7 +549,7 @@ public:
 	 * and of the JACK server are off by a constant offset. To
 	 * nevertheless be able to identify relocation in
 	 * updateTransportInfo(), this constant offset is stored in
-	 * #bbt_frame_offset.
+	 * #m_bbtFrameOffset.
 	 */
 	void calculateFrameOffset();
 	/**
@@ -565,12 +565,12 @@ public:
 	 * repositioning was introduced to keep Hydrogen synchronized
 	 * with Ardour.
 	 *
-	 * Internally, it sets the variable #locate_countdown to @a
-	 * cycles_to_wait and #locate_frame to @a frame.
+	 * Internally, it sets the variable #m_nLocateCountDown to @a
+	 * cycles_to_wait and #m_locateFrame to @a frame.
 	 *
 	 * The audioEngine_updateNoteQueue() function is called after
 	 * audioEngine_process_transport() and its decrement of
-	 * #locate_countdown. It thus only take @a cycles_to_wait - 1
+	 * #m_nLocateCountDown. It thus only take @a cycles_to_wait - 1
 	 * cycles calls to audioEngine_process() for the relocation to
 	 * happen.
 	 *
@@ -607,7 +607,7 @@ public:
 	 * callback function to not be called by the JACK server
 	 * anymore.
 	 */
-	void com_release();
+	void releaseTimebase();
 
 protected:
 	/**
@@ -624,9 +624,9 @@ protected:
 	 * #m_JackTransportState is _JackTransportRolling_. It sets
 	 * the following members of the JACK position object @a pos is
 	 * pointing to:
-	 * - __bar__ : current position corrected by the #bbt_frame_offset
+	 * - __bar__ : current position corrected by the #m_bbtFrameOffset
 	 * \code{.cpp} 
-	 * Hydrogen::getPosForTick( ( pos->frame - bbt_frame_offset )/ 
+	 * Hydrogen::getPosForTick( ( pos->frame - m_bbtFrameOffset )/ 
 	 *                          m_transport.m_nTickSize ) ) 
 	 * \endcode
 	 * - __ticks_per_beat__ :  the output of
@@ -717,19 +717,19 @@ private:
 	 * variable is initialized with 0 in JackAudioDriver() and
 	 * updated in calculateFrameOffset().
 	 */
-	long long			bbt_frame_offset;
+	long long			m_bbtFrameOffset;
 	/** 
-	 * #locate_countdown - 1 of cycles (calls to audioEngine_process())
-	 * until to locate() to #locate_frame in
+	 * #m_nLocateCountdown - 1 of cycles (calls to
+	 * audioEngine_process()) until to locate() to #m_locateFrame in
 	 * updateTransportInfo(). It is set in locateInNCycles().
 	 */
-	int				locate_countdown;
+	int				m_nLocateCountdown;
 	/** 
 	 * Frame to locate() to in updateTransportInfo() after
-	    #locate_countdown cycles - 1 cycles.   
+	    #m_nLocateCountDown cycles - 1 cycles.   
 	 * It is set in locateInNCycles(). 
 	 */
-	unsigned long			locate_frame;
+	unsigned long			m_locateFrame;
 	/**
 	 * Function the JACK server will call whenever there is work
 	 * to do. 
@@ -745,37 +745,37 @@ private:
 	 * _select()_, _pthread_join()_, _pthread_cond_wait()_, etc,
 	 * etc.
 	 */
-	JackProcessCallback		processCallback;
+	JackProcessCallback		m_processCallback;
 	/**
 	 * Left source port for which a connection to
-	 * #output_port_name_1 will be established in connect() via
+	 * #m_sOutputPortName1 will be established in connect() via
 	 * the JACK server.
 	 */
-	jack_port_t*			output_port_1;
+	jack_port_t*			m_pOutputPort1;
 	/**
 	 * Right source port for which a connection to
-	 * #output_port_name_2 will be established in connect() via
+	 * #m_sOutputPortName2 will be established in connect() via
 	 * the JACK server.
 	 */
-	jack_port_t*			output_port_2;
+	jack_port_t*			m_pOutputPort2;
 	/**
-	 * Destination of the left source port #output_port_1, for
+	 * Destination of the left source port #m_pOutputPort1, for
 	 * which a connection will be established in connect(). It is
 	 * set to Preferences::m_sJackPortName1 during the call of
 	 * init(). 
 	 */
-	QString				output_port_name_1;
+	QString				m_sOutputPortName1;
 	/**
-	 * Destination of the right source port #output_port_2, for
+	 * Destination of the right source port #m_pOutputPort2, for
 	 * which a connection will be established in connect(). It is
 	 * set to Preferences::m_sJackPortName2 during the call of
 	 * init(). 
 	 */
-	QString				output_port_name_2;
+	QString				m_sOutputPortName2;
 	/**
 	 * Matrix containing the track number of each component of
 	 * of all instruments. Its rows represent the instruments and
-	 * its columns their components. _track_map[2][1]=6_ thus
+	 * its columns their components. _m_trackMap[2][1]=6_ thus
 	 * therefore mean the output of the second component of the
 	 * third instrument is assigned the seventh output port. Since
 	 * its total size is defined by #MAX_INSTRUMENTS and
@@ -783,12 +783,12 @@ private:
 	 *
 	 * It gets updated by makeTrackOutputs().
 	 */
-	int				track_map[MAX_INSTRUMENTS][MAX_COMPONENTS];
+	int				m_trackMap[MAX_INSTRUMENTS][MAX_COMPONENTS];
 	/**
 	 * Total number of output ports currently in use. It gets
 	 * updated by makeTrackOutputs().
 	 */
-	int				track_port_count;
+	int				m_nTrackPortCount;
 	/**
 	 * Vector of all left audio output ports currently used by the
 	 * local JACK client. 
@@ -800,7 +800,7 @@ private:
 	 * accessed via getTrackOut_L().
 	 * It is set to a length of #MAX_INSTRUMENTS.
 	 */
-	jack_port_t*			track_output_ports_L[MAX_INSTRUMENTS];
+	jack_port_t*			m_pTrackOutputPortsL[MAX_INSTRUMENTS];
 	/**
 	 * Vector of all right audio output ports currently used by the
 	 * local JACK client. 
@@ -812,7 +812,7 @@ private:
 	 * accessed via getTrackOut_R().
 	 * It is set to a length of #MAX_INSTRUMENTS.
 	 */
-	jack_port_t*		 	track_output_ports_R[MAX_INSTRUMENTS];
+	jack_port_t*		 	m_pTrackOutputPortsR[MAX_INSTRUMENTS];
 
 	/**
 	 * Current transport state returned by
@@ -866,26 +866,24 @@ private:
 	jack_position_t			m_JackTransportPos;
 
 	/**
-	 * Probably tells whether or not the output ports of the
-	 * current session ARE already properly connected in the JACK
-	 * server. Or maybe if they SHOULD be connected.
+	 * Specifies whether the default left and right (master) audio
+	 * JACK ports will be automatically connected to the system's sink
+	 * when registering the JACK client in connect().
 	 *
-	 * After the JackAudioDriver has been created by
-	 * createDriver(), Preferences::m_bJackConnectDefaults will be
-	 * used to initialize this variable.
+	 * After the JackAudioDriver has been created by createDriver(),
+	 * the variable will be, again, set to
+	 * Preferences::m_bJackConnectDefaults.
 	 */
-	bool				m_bConnectOutFlag;
+	bool				m_bConnectDefaults;
 	/**
 	 * Whether Hydrogen is the current Jack timebase master.
-	 *
-	 * It gets initialized in init().
 	 */
-	bool				m_bHydrogenIsJackTimebaseMaster;
+	bool				m_bIsTimebaseMaster;
 	/**
 	 * Specifies whether to use a conditional take over in the
 	 * switching of the JACK timebase master. If set to non-zero
 	 * the take over will fail if there is already a timebase
-	 * master present. It will be initialized with 0 in init().
+	 * master present. Currently it will always be set to 0.
 	 */
 	int				m_nJackConditionalTakeOver;
 
@@ -907,7 +905,7 @@ public:
 	 * and the usage of the JACK audio server is not intended by
 	 * the user.
 	 */
-	JackAudioDriver( audioProcessCallback processCallback ) : NullDriver( processCallback ) {}
+	JackAudioDriver( audioProcessCallback m_processCallback ) : NullDriver( m_processCallback ) {}
 
 };
 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -542,7 +542,7 @@ public:
 	/**
 	 * \return #m_nIsTimebaseMaster
 	 */
-	int getIsTimebaseMaster();
+	int getIsTimebaseMaster() const;
 	/** Stores the latest transport position (for both rolling and
 	 * stopped transport).
 	 *
@@ -799,7 +799,7 @@ private:
 
 };
 	
-inline int JackAudioDriver::getIsTimebaseMaster() {
+inline int JackAudioDriver::getIsTimebaseMaster() const {
 	return m_nIsTimebaseMaster;
 }
 inline int JackAudioDriver::getNumTracks() {

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -660,16 +660,16 @@ protected:
 	 *
 	 * \param state Current transport state. Not used within the
 	 * function but to ensure compatibility.
-	 * \param nframes Buffer size. Not used within the function but
+	 * \param nFrames Buffer size. Not used within the function but
 	 * to ensure compatibility.
-	 * \param pos Current transport position.
+	 * \param pJackPosition Current transport position.
 	 * \param new_pos Updated transport position in frames. Not
 	 * used within the function but to ensure compatibility.
 	 * \param arg Pointer to a JackAudioDriver instance.
 	 */
 	static void jack_timebase_callback( jack_transport_state_t state,
-					    jack_nframes_t nframes,
-					    jack_position_t* pos,
+					    jack_nframes_t nFrames,
+					    jack_position_t* pJackPosition,
 					    int new_pos,
 					    void* arg );
 

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -341,7 +341,7 @@ public:
 	 * has two states: Preferences::USE_JACK_TIME_MASTER and
 	 * Preferences::NO_JACK_TIME_MASTER. It is set to
 	 * Preferences::NO_JACK_TIME_MASTER by the
-	 * JackAudioDriver::initTimeMaster() if Hydrogen couldn't be
+	 * JackAudioDriver::initTimebaseMaster() if Hydrogen couldn't be
 	 * registered as time master.
 	 */
 	int				m_bJackMasterMode;

--- a/src/core/include/hydrogen/basics/song.h
+++ b/src/core/include/hydrogen/basics/song.h
@@ -62,7 +62,15 @@ class Song : public H2Core::Object
 
 		bool __is_muted;
 		unsigned __resolution;		///< Resolution of the song (number of ticks per quarter)
-		float __bpm;			///< Beats per minute
+		/**
+		 * Current speed in beats per minutes.
+		 *
+		 * One of its purposes is an intermediate storage of the
+		 * tempo at the current transport position in
+		 * Hydrogen::setTimelineBpm() in order to detect local changes
+		 * in speed (set by the user).
+		 */
+		float __bpm;
 
 		QString __name;		///< song name
 		QString __author;	///< author of the song

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -290,10 +290,12 @@ public:
 	 *   arguments.
 	 */
 	int			getPosForTick( unsigned long TickPos );
-	/** Resetting #m_nPatternStartTick to -1 if the current Song
-	    mode is Song::PATTERN_MODE
+	/** Move playback in Pattern mode to the beginning of the pattern.
+	 *
+	 * Resetting the global variable #m_nPatternStartTick to -1 if the
+	 * current Song mode is Song::PATTERN_MODE.
 	 */
-	void			triggerRelocateDuringPlay();
+	void			resetPatternStartTick();
 	
 		/**
 		 * Get the total number of ticks passed up to a Pattern at

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -632,6 +632,11 @@ void			previewSample( Sample *pSample );
 	 * \return Frame offset*/
 	int 			calculateLookahead( float fTickSize );
 	/**
+	 * \return Whether JackAudioDriver is used as current audio
+	 * driver.
+	 */
+	bool			haveJackAudioDriver() const;
+	/**
 	 * \return Whether JackAudioDriver is used as current audio driver
 	 * and JACK transport was activated via the GUI
 	 * (#Preferences::m_bJackTransportMode).

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -470,7 +470,7 @@ void			previewSample( Sample *pSample );
 	/** Sets #m_nHumantimeFrames.
 	    \param hframes New transport position in frames.*/
 	void			setHumantimeFrames(unsigned long hframes);
-	/** Calling JackAudioDriver::com_release() directly from
+	/** Calling JackAudioDriver::releaseTimebase() directly from
 	    the GUI*/
 	void			offJackMaster();
 	/** Calling JackAudioDriver::initTimeMaster() directly from

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -517,8 +517,10 @@ void			previewSample( Sample *pSample );
 	 * fallback speed #m_fNewBpmJTM, getRealtimeTickPosition() will be
 	 * used instead.
 	 *
-	 * If Preferences::__useTimelineBpm is set to false, the
-	 * function will return without performing any actions.
+	 * If Preferences::__useTimelineBpm is set to false or Hydrogen
+	 * uses JACK transport in the presence of an external timebase
+	 * master, the function will return without performing any
+	 * actions.
 	 */
 	void			setTimelineBpm();
 	/**

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -215,9 +215,7 @@ public:
 
 		void			getLadspaFXPeak( int nFX, float *fL, float *fR );
 		void			setLadspaFXPeak( int nFX, float fL, float fR );
-	/**
-	 * \return The global variable H2Core::m_nPatternTickPosition
-	 */
+	/** \return #m_nPatternTickPosition */
 	unsigned long		getTickPosition();
 	/** Keep track of the tick position in realtime.
 	 *
@@ -282,14 +280,22 @@ public:
 	void			setPatternPos( int pos );
 	/** Returns the pattern number corresponding to the tick
 	 * position @a TickPos.
+	 *
+	 * Wrapper around function findPatternInTick() (globally defined
+	 * in hydrogen.cpp).
+	 *
 	 * \param TickPos Position in ticks.
+	 * \param nPatternStartTick Pointer to an int the starting
+	 * position (in ticks) of the corresponding pattern will be
+	 * written to.
+	 *
 	 * \return 
 	 * - __0__ : if the Song isn't specified yet.
 	 * - the output of the findPatternInTick() function called
 	 *   with @a TickPos and Song::is_loop_enabled() as input
 	 *   arguments.
 	 */
-	int			getPosForTick( unsigned long TickPos );
+	int			getPosForTick( unsigned long TickPos, int* nPatternStartTick );
 	/** Move playback in Pattern mode to the beginning of the pattern.
 	 *
 	 * Resetting the global variable #m_nPatternStartTick to -1 if the
@@ -480,21 +486,21 @@ void			previewSample( Sample *pSample );
 	void			onJackMaster();
 	/**
 	 * Access the length of the first Pattern found in the
-	 * PatternList at @a humanpos - 1.
+	 * PatternList at @a nHumanPos - 1.
 	 *
 	 * This function should also work if the loop mode is enabled
 	 * in Song::is_loop_enabled().
 	 *
-	 * \param humanpos Position + 1 of the desired PatternList.
+	 * \param nHumanPos Position + 1 of the desired PatternList.
 	 * \return 
 	 * - __-1__ : if not Song was initialized yet.
-	 * - #MAX_NOTES : if @a humanpos was smaller than 1, larger
+	 * - #MAX_NOTES : if @a nHumanPos was smaller than 1, larger
 	 * than the length of the vector of the PatternList in
 	 * Song::__pattern_group_sequence or no Pattern could be found
-	 * in the PatternList at @a humanpos - 1.
-	 * - __else__ : length of first Pattern found at @a humanpos.
+	 * in the PatternList at @a nHumanPos - 1.
+	 * - __else__ : length of first Pattern found at @a nHumanPos.
 	 */
-	long			getTickForHumanPosition( int humanpos );
+	long			getTickForHumanPosition( int nHumanPos );
 	/** Returns the fallback speed.
 	 * \return #m_fNewBpmJTM */
 	float			getNewBpmJTM();
@@ -520,12 +526,12 @@ void			previewSample( Sample *pSample );
 	 */
 	void			setTimelineBpm();
 	/**
-	 * Returns the local speed at a specific @a Beat in the
+	 * Returns the local speed at a specific @a nBar in the
 	 * Timeline.
 	 *
 	 * Timeline::HTimelineVector::m_htimelinebpm of the first
 	 * Timeline::HTimelineVector::m_htimelinebeat bigger than @a
-	 * Beat will be returned.
+	 * nBar will be returned.
 	 *
 	 * If Hydrogen is in Song::PATTERN_MODE or
 	 * Preferences::__useTimelineBpm is set to false, the global
@@ -535,12 +541,12 @@ void			previewSample( Sample *pSample );
 	 *
 	 * Its counterpart is setTimelineBpm().
 	 *
-	 * \param Beat Position along the Timeline to access the tempo
-	 *   at.
+	 * \param nBar Position (in whole patterns) along the Timeline to
+	 *   access the tempo at.
+	 *
 	 * \return Speed in beats per minute.
 	 */
-	float			getTimelineBpm( int Beat );
-	/** \return #m_pTimeline*/
+	float			getTimelineBpm( int nBar );
 	Timeline*		getTimeline() const;
 	
 	//export management
@@ -595,9 +601,48 @@ void			previewSample( Sample *pSample );
 	/**\param pNextSong Sets #m_pNextSong. #Song which is about to be
 	   loaded by the GUI.*/
 	void			setNextSong( Song* pNextSong );
+	/** Calculates the lookahead for a specific tick size.
+	 *
+	 * During the humanization the onset of a Note will be moved
+	 * Note::__lead_lag times the value calculated by this function.
+	 *
+	 * Since the size of a tick is tempo dependent, @a fTickSize
+	 * allows you to calculate the lead-lag factor for an arbitrary
+	 * position on the Timeline.
+	 *
+	 * \param fTickSize Number of frames that make up one tick.
+	 *
+	 * \return Five times the current size of a tick
+	 * (TransportInfo::m_fTickSize) (in frames)
+	 */
+	int 			calculateLeadLagFactor( float fTickSize );
+	/** Calculates time offset (in frames) used to determine the notes
+	 * process by the audio engine.
+	 *
+	 * Due to the humanization there might be negative offset in the
+	 * position of a particular note. To be able to still render it
+	 * appropriately, we have to look into and handle notes from the
+	 * future.
+	 *
+	 * The Lookahead is the sum of the #m_nMaxTimeHumanize and
+	 * calculateLeadLagFactor() plus one (since it has to be larger
+	 * than that).
+	 *
+	 * \param fTickSize Number of frames that make up one tick. Passed
+	 * to calculateLeadLagFactor().
+	 *
+	 * \return Frame offset*/
+	int 			calculateLookahead( float fTickSize );
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
+	/**
+	 * Maximum time (in frames) a note's position can be off due to
+	 * the humanization (lead-lag).
+	 *
+	 * Required to calculateLookahead(). Set to 2000.
+	 */
+	int 			m_nMaxTimeHumanize;
 
 private:
 	/**

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -494,9 +494,9 @@ void			previewSample( Sample *pSample );
 	 */
 	long			getTickForHumanPosition( int humanpos );
 	/** Returns the fallback speed.
-	 * \return #m_nNewBpmJTM */
+	 * \return #m_fNewBpmJTM */
 	float			getNewBpmJTM();
-	/** Set the fallback speed #m_nNewBpmJTM.
+	/** Set the fallback speed #m_fNewBpmJTM.
 	 * \param bpmJTM New default tempo. */ 
 	void			setNewBpmJTM( float bpmJTM);
 
@@ -504,13 +504,14 @@ void			previewSample( Sample *pSample );
 	unsigned int	__getMidiRealtimeNoteTickPosition();
 
 	/**
-	 * Updates Song::__bpm and #m_nNewBpmJTM to the local speed.
+	 * Updates Song::__bpm, TransportInfo::m_fBPM, and #m_fNewBpmJTM
+	 * to the local speed.
 	 *
-	 * To set the of the Song Song::__bpm, the local speed will be
-	 * obtained by calling getTimelineBpm() with getPatternPos()
-	 * as input argument. For setting the fallback speed
-	 * #m_nNewBpmJTM, getRealtimeTickPosition() will be used
-	 * instead.
+	 * The local speed will be obtained by calling getTimelineBpm()
+	 * with getPatternPos() as input argument and set for the current
+	 * song and transport. For setting the
+	 * fallback speed #m_fNewBpmJTM, getRealtimeTickPosition() will be
+	 * used instead.
 	 *
 	 * If Preferences::__useTimelineBpm is set to false, the
 	 * function will return without performing any actions.

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -631,6 +631,19 @@ void			previewSample( Sample *pSample );
 	 *
 	 * \return Frame offset*/
 	int 			calculateLookahead( float fTickSize );
+	/**
+	 * \return Whether JackAudioDriver is used as current audio driver
+	 * and JACK transport was activated via the GUI
+	 * (#Preferences::m_bJackTransportMode).
+	 */
+	bool			haveJackTransport() const;
+	/**
+	 * \return Whether we haveJackTransport() and there is an external
+	 * JACK timebase master broadcasting us tempo information and
+	 * making use disregard Hydrogen's Timeline information (see
+	 * #JackAudioDriver::m_nIsTimebaseMaster).
+	 */
+	bool			haveJackTimebaseClient() const;
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -472,12 +472,6 @@ void			previewSample( Sample *pSample );
 	void			handleBeatCounter();
 	void			setBcOffsetAdjust();
 
-	/** Returns the latest transport position of the JACK server.
-	 * \return #m_nHumantimeFrames*/
-	unsigned long		getHumantimeFrames();
-	/** Sets #m_nHumantimeFrames.
-	    \param hframes New transport position in frames.*/
-	void			setHumantimeFrames(unsigned long hframes);
 	/** Calling JackAudioDriver::releaseTimebaseMaster() directly from
 	    the GUI*/
 	void			offJackMaster();

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -470,10 +470,10 @@ void			previewSample( Sample *pSample );
 	/** Sets #m_nHumantimeFrames.
 	    \param hframes New transport position in frames.*/
 	void			setHumantimeFrames(unsigned long hframes);
-	/** Calling JackAudioDriver::releaseTimebase() directly from
+	/** Calling JackAudioDriver::releaseTimebaseMaster() directly from
 	    the GUI*/
 	void			offJackMaster();
-	/** Calling JackAudioDriver::initTimeMaster() directly from
+	/** Calling JackAudioDriver::initTimebaseMaster() directly from
 	    the GUI*/
 	void			onJackMaster();
 	/**

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -223,7 +223,7 @@ public:
 	 *
 	 * Firstly, it gets the current transport position in frames
 	 * #m_nRealtimeFrames and converts it into ticks using
-	 * TransportInfo::m_nTickSize. Afterwards, it accesses how
+	 * TransportInfo::m_fTickSize. Afterwards, it accesses how
 	 * much time passed since the last update of
 	 * #m_currentTickTime, converts the time difference +
 	 * AudioOutput::getBufferSize()/ AudioOutput::getSampleRate()
@@ -257,43 +257,43 @@ public:
 	/** \return #m_pNextPatterns*/
 	PatternList *		getNextPatterns();
 
-		/** Get the position of the current Pattern in the Song.
-		 * \return #m_nSongPos */
-		int			getPatternPos();
-		/**
-		 * Relocate the position to another Pattern in the Song.
-		 *
-		 * The position of a Pattern in frames (see
-		 * TransportInfo::m_nFrames for details) will be determined by
-		 * retrieving the tick number the Pattern is located at using
-		 * getTickForPosition() and multiplying it with
-		 * TransportInfo::m_nTickSize. The resulting value will be
-		 * used by the AudioOutput::locate() function of your audio
-		 * driver to relocate the playback position.
-		 *
-		 * If #m_audioEngineState is not #STATE_PLAYING, the variables
-		 * #m_nSongPos and #m_nPatternTickPosition will be set to @a
-		 * pos and 0 right away.
-		 *
-		 * \param pos Position of the Pattern to relocate at. All
-		 *   values smaller than -1 will be set to -1, which marks the
-		 *   beginning of the Song.
-		 */
-		void			setPatternPos( int pos );
-		/** Returns the pattern number corresponding to the tick
-		 * position @a TickPos.
-		 * \param TickPos Position in ticks.
-		 * \return 
-		 * - __0__ : if the Song isn't specified yet.
-		 * - the output of the findPatternInTick() function called
-		 *   with @a TickPos and Song::is_loop_enabled() as input
-		 *   arguments.
-		 */
-		int			getPosForTick( unsigned long TickPos );
-		/** Resetting #m_nPatternStartTick to -1 if the current Song
-		    mode is Song::PATTERN_MODE
-		*/
-		void			triggerRelocateDuringPlay();
+	/** Get the position of the current Pattern in the Song.
+	 * \return #m_nSongPos */
+	int			getPatternPos();
+	/**
+	 * Relocate the position to another Pattern in the Song.
+	 *
+	 * The position of a Pattern in frames (see
+	 * TransportInfo::m_nFrames for details) will be determined by
+	 * retrieving the tick number the Pattern is located at using
+	 * getTickForPosition() and multiplying it with
+	 * TransportInfo::m_fTickSize. The resulting value will be
+	 * used by the AudioOutput::locate() function of your audio
+	 * driver to relocate the playback position.
+	 *
+	 * If #m_audioEngineState is not #STATE_PLAYING, the variables
+	 * #m_nSongPos and #m_nPatternTickPosition will be set to @a
+	 * pos and 0 right away.
+	 *
+	 * \param pos Position of the Pattern to relocate at. All
+	 *   values smaller than -1 will be set to -1, which marks the
+	 *   beginning of the Song.
+	 */
+	void			setPatternPos( int pos );
+	/** Returns the pattern number corresponding to the tick
+	 * position @a TickPos.
+	 * \param TickPos Position in ticks.
+	 * \return 
+	 * - __0__ : if the Song isn't specified yet.
+	 * - the output of the findPatternInTick() function called
+	 *   with @a TickPos and Song::is_loop_enabled() as input
+	 *   arguments.
+	 */
+	int			getPosForTick( unsigned long TickPos );
+	/** Resetting #m_nPatternStartTick to -1 if the current Song
+	    mode is Song::PATTERN_MODE
+	 */
+	void			triggerRelocateDuringPlay();
 	
 		/**
 		 * Get the total number of ticks passed up to a Pattern at

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -485,22 +485,24 @@ void			previewSample( Sample *pSample );
 	    the GUI*/
 	void			onJackMaster();
 	/**
+	 * Get the length (in ticks) of the @a nPattern th pattern.
+	 *
 	 * Access the length of the first Pattern found in the
-	 * PatternList at @a nHumanPos - 1.
+	 * PatternList at @a nPattern - 1.
 	 *
 	 * This function should also work if the loop mode is enabled
 	 * in Song::is_loop_enabled().
 	 *
-	 * \param nHumanPos Position + 1 of the desired PatternList.
+	 * \param nPattern Position + 1 of the desired PatternList.
 	 * \return 
 	 * - __-1__ : if not Song was initialized yet.
-	 * - #MAX_NOTES : if @a nHumanPos was smaller than 1, larger
+	 * - #MAX_NOTES : if @a nPattern was smaller than 1, larger
 	 * than the length of the vector of the PatternList in
 	 * Song::__pattern_group_sequence or no Pattern could be found
-	 * in the PatternList at @a nHumanPos - 1.
-	 * - __else__ : length of first Pattern found at @a nHumanPos.
+	 * in the PatternList at @a nPattern - 1.
+	 * - __else__ : length of first Pattern found at @a nPattern.
 	 */
-	long			getTickForHumanPosition( int nHumanPos );
+	long			getPatternLength( int nPattern );
 	/** Returns the fallback speed.
 	 * \return #m_fNewBpmJTM */
 	float			getNewBpmJTM();

--- a/src/core/src/IO/alsa_audio_driver.cpp
+++ b/src/core/src/IO/alsa_audio_driver.cpp
@@ -323,7 +323,7 @@ void AlsaAudioDriver::locate( unsigned long nFrame )
 void AlsaAudioDriver::setBpm( float fBPM )
 {
 //	warningLog( "[setBpm] " + to_string(fBPM) );
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 };

--- a/src/core/src/IO/coreaudio_driver.cpp
+++ b/src/core/src/IO/coreaudio_driver.cpp
@@ -369,7 +369,7 @@ void CoreAudioDriver::locate( unsigned long nFrame )
 void CoreAudioDriver::setBpm( float fBPM )
 {
 	//INFOLOG( "[setBpm]" + to_string( fBPM ));
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 }

--- a/src/core/src/IO/disk_writer_driver.cpp
+++ b/src/core/src/IO/disk_writer_driver.cpp
@@ -200,7 +200,7 @@ void* diskWriterDriver_thread( void* param )
 		else
 		{
 			fTicksize = pDriver->m_nSampleRate * 60.0 /  Hydrogen::get_instance()->getSong()->__bpm / Hydrogen::get_instance()->getSong()->__resolution;
-			//pDriver->m_transport.m_nTickSize = ticksize;
+			//pDriver->m_transport.m_fTickSize = ticksize;
 		}
 		
 		
@@ -377,7 +377,7 @@ void DiskWriterDriver::updateTransportInfo()
 void DiskWriterDriver::setBpm( float fBPM )
 {
 	INFOLOG( QString( "SetBpm: %1" ).arg( fBPM ) );
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 void DiskWriterDriver::audioEngine_process_checkBPMChanged()
@@ -387,15 +387,15 @@ void DiskWriterDriver::audioEngine_process_checkBPMChanged()
 						/ Hydrogen::get_instance()->getSong()->__bpm
 						/ Hydrogen::get_instance()->getSong()->__resolution;
 
-		if ( fNewTickSize != m_transport.m_nTickSize ) {
+		if ( fNewTickSize != m_transport.m_fTickSize ) {
 				// cerco di convertire ...
 				float fTickNumber =
 								( float )m_transport.m_nFrames
-								/ ( float )m_transport.m_nTickSize;
+								/ ( float )m_transport.m_fTickSize;
 
-				m_transport.m_nTickSize = fNewTickSize;
+				m_transport.m_fTickSize = fNewTickSize;
 
-				if ( m_transport.m_nTickSize == 0 ) {
+				if ( m_transport.m_fTickSize == 0 ) {
 						return;
 				}
 

--- a/src/core/src/IO/fake_driver.cpp
+++ b/src/core/src/IO/fake_driver.cpp
@@ -122,7 +122,7 @@ void FakeDriver::updateTransportInfo()
 
 void FakeDriver::setBpm( float fBPM )
 {
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 };

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -1111,21 +1111,10 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 
 	if ( pDriver->m_transport.m_nFrames < 1 ) {
 		pJackPosition->bar = 0;
-#ifndef JACK_NO_BBT_OFFSET
-		pJackPosition->valid = JackBBTFrameOffset;
-		pJackPosition->bbt_offset = 0;
-#endif
 		pJackPosition->beat = 1;
 		pJackPosition->tick = 0;
 		pJackPosition->bar_start_tick = 0;
 	} else {
-
-#ifndef JACK_NO_BBT_OFFSET
-		pJackPosition->valid = static_cast<jack_position_bits_t> ( pJackPosition->valid | JackBBTFrameOffset );
-		pJackPosition->bbt_offset =
-			max( (uint32_t)0, pJackPosition->frame -
-				 (uint32_t)(nNextPatternStartTick * fTickSize));
-#endif
 		// +1 since the counting bars starts at 1.
 		pJackPosition->bar = nNextPattern + 1;
 		
@@ -1142,6 +1131,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 
 		// Counting ticks starts at 0.
 		pJackPosition->tick = nTicksFromBar % (int32_t) pJackPosition->ticks_per_beat;
+		
 		// std::cout << "[JackTimebaseCallback] BPM: "
 		// 		  << pJackPosition->beats_per_minute
 		// 		  << ", bar: " << pJackPosition->bar 
@@ -1168,7 +1158,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		// 		  << std::endl; 
 			
 	}
-	
+    
 	// Tell Hydrogen it is still timebase master.
 	pDriver->m_nTimebaseMasterCount = 0;
 }

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -857,7 +857,9 @@ void JackAudioDriver::locate( unsigned long frame )
 void JackAudioDriver::setBpm( float fBPM )
 {
 	// std::cout << "[JackAudioDriver::setBpm] " << fBPM << std::endl;
-	m_transport.m_fBPM = fBPM;
+	if ( fBPM >= 1 ) {
+		m_transport.m_fBPM = fBPM;
+	}
 }
 
 #ifdef H2CORE_HAVE_JACKSESSION

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -61,7 +61,7 @@ namespace H2Core {
  * Hydrogen's external JACK client via _jack_get_sample_rate()_
  * (jack/jack.h). 
  */
-unsigned long		jack_server_sampleRate = 0;
+unsigned long		jackServerSampleRate = 0;
 /**
  * Buffer size of the JACK audio server.
  *
@@ -72,16 +72,16 @@ unsigned long		jack_server_sampleRate = 0;
  * Hydrogen's external JACK client via _jack_get_buffer_size()_
  * (jack/jack.h). 
  */
-jack_nframes_t		jack_server_bufferSize = 0;
+jack_nframes_t		jackServerBufferSize = 0;
 /**
  * Instance of the JackAudioDriver.
  */
-JackAudioDriver *	pJackDriverInstance = nullptr;
+JackAudioDriver*	pJackDriverInstance = nullptr;
 
 
 /**
  * Callback function for the JACK audio server to set the sample rate
- * #H2Core::jack_server_sampleRate and prints a message to
+ * #H2Core::jackServerSampleRate and prints a message to
  * the #__INFOLOG, which has to be included via a Logger instance in
  * the provided @a param.
  *
@@ -104,12 +104,12 @@ int jackDriverSampleRate( jack_nframes_t nframes, void* param ){
 	// __object->logger()->log( H2Core::Logger::Info, ..., msg )
 	// (see object.h).
 	__INFOLOG( msg );
-	jack_server_sampleRate = nframes;
+	jackServerSampleRate = nframes;
 	return 0;
 }
 /**
  * Callback function for the JACK audio server to set the buffer size
- * #H2Core::jack_server_bufferSize.
+ * #H2Core::jackServerBufferSize.
  *
  * It gets registered as a callback function of the JACK server in
  * JackAudioDriver::init() using _jack_set_buffer_size_callback()_.
@@ -125,7 +125,7 @@ int jackDriverSampleRate( jack_nframes_t nframes, void* param ){
  */
 int jackDriverBufferSize( jack_nframes_t nframes, void* arg ){
 	// This function does _NOT_ have to be realtime safe.
-	jack_server_bufferSize = nframes;
+	jackServerBufferSize = nframes;
 	return 0;
 }
 /**
@@ -155,26 +155,44 @@ void jackDriverShutdown( void* arg )
 
 const char* JackAudioDriver::__class_name = "JackAudioDriver";
 
-JackAudioDriver::JackAudioDriver( JackProcessCallback processCallback )
+JackAudioDriver::JackAudioDriver( JackProcessCallback m_processCallback )
 	: AudioOutput( __class_name )
 {
 	INFOLOG( "INIT" );
+	
+	auto pPreferences = Preferences::get_instance();
+	
 	// __track_out_enabled is inherited from AudioOutput and
 	// instantiated with false. It will be used by the Sampler and
 	// Hydrogen itself to check whether JackAudioDriver is ordered
 	// to create per-track audio output ports.
-	__track_out_enabled = Preferences::get_instance()->m_bJackTrackOuts;
+	__track_out_enabled = pPreferences->m_bJackTrackOuts;
 
 	pJackDriverInstance = this;
-	this->processCallback = processCallback;
+	this->m_processCallback = m_processCallback;
 
-	locate_countdown = 0;
-	bbt_frame_offset = 0;
-	track_port_count = 0;
+	m_nLocateCountdown = 0;
+	m_locateFrame = 0;
+	m_bbtFrameOffset = 0;
+	m_nTrackPortCount = 0;
+	m_fOldTickSize = 0;
 	m_pClient = nullptr;
+	m_pOutputPort1 = nullptr;
+	m_pOutputPort2 = nullptr;
+	m_bConnectDefaults = pPreferences->m_bJackConnectDefaults;
+	m_bIsTimebaseMaster = false;
 	
-	memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
-	memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
+	// Make Hydrogen the timebase master, regardless if there is
+	// already a timebase master present.
+	m_nJackConditionalTakeOver = 0;
+	
+	// Destination ports the output of Hydrogen will be connected
+	// to.
+	m_sOutputPortName1 = pPreferences->m_sJackPortName1;
+	m_sOutputPortName2 = pPreferences->m_sJackPortName2;
+	
+	memset( m_pTrackOutputPortsL, 0, sizeof(m_pTrackOutputPortsL) );
+	memset( m_pTrackOutputPortsR, 0, sizeof(m_pTrackOutputPortsR) );
 }
 
 JackAudioDriver::~JackAudioDriver()
@@ -199,10 +217,10 @@ int JackAudioDriver::connect()
 		return 1;
 	}
 
-	bool connect_output_ports = m_bConnectOutFlag;
+	bool bConnectDefaults = m_bConnectDefaults;
 
-	memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
-	memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
+	memset( m_pTrackOutputPortsL, 0, sizeof(m_pTrackOutputPortsL) );
+	memset( m_pTrackOutputPortsR, 0, sizeof(m_pTrackOutputPortsR) );
 
 #ifdef H2CORE_HAVE_LASH
 	if ( Preferences::get_instance()->useLash() ){
@@ -212,13 +230,13 @@ int JackAudioDriver::connect()
 			lashClient->sendJackClientName();
 
 			if (!lashClient->isNewProject()){
-				connect_output_ports = false;
+				bConnectDefaults = false;
 			}
 		}
 	}
 #endif
 
-	if ( connect_output_ports ) {
+	if ( bConnectDefaults ) {
 		// Connect the ports.
 		// The `jack_connect' function is defined in the
 		// jack/jack.h file. It establishes a connection between
@@ -234,10 +252,10 @@ int JackAudioDriver::connect()
 		// The `jack_port_name' function is also defined in
 		// the jack/jack.h header returns the full name of a
 		// provided port of type jack_port_t.
-		if ( jack_connect( m_pClient, jack_port_name( output_port_1 ),
-				   output_port_name_1.toLocal8Bit() ) == 0 &&
-		     jack_connect( m_pClient, jack_port_name( output_port_2 ),
-				   output_port_name_2.toLocal8Bit() ) == 0 ) {
+		if ( jack_connect( m_pClient, jack_port_name( m_pOutputPort1 ),
+				   m_sOutputPortName1.toLocal8Bit() ) == 0 &&
+		     jack_connect( m_pClient, jack_port_name( m_pOutputPort2 ),
+				   m_sOutputPortName2.toLocal8Bit() ) == 0 ) {
 			return 0;
 		}
 
@@ -255,9 +273,9 @@ int JackAudioDriver::connect()
 			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CONNECT_OUTPUT_PORT );
 			return 2;
 		}
-		if ( jack_connect( m_pClient, jack_port_name( output_port_1 ),
+		if ( jack_connect( m_pClient, jack_port_name( m_pOutputPort1 ),
 				   portnames[0] ) != 0 ||
-		     jack_connect( m_pClient, jack_port_name( output_port_2 ),
+		     jack_connect( m_pClient, jack_port_name( m_pOutputPort2 ),
 				   portnames[1] ) != 0 ) {
 			ERRORLOG( "Couldn't connect to first pair of Jack input ports" );
 			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CONNECT_OUTPUT_PORT );
@@ -274,12 +292,15 @@ void JackAudioDriver::disconnect()
 	INFOLOG( "disconnect" );
 
 	deactivate();
-	jack_client_t *oldClient = m_pClient;
+	
+	jack_client_t* pOldClient = m_pClient;
+	
 	m_pClient = nullptr;
-	if ( oldClient ) {
+	
+	if ( pOldClient ) {
 		INFOLOG( "calling jack_client_close" );
-		int res = jack_client_close( oldClient );
-		if ( res ) {
+		int nReturnCode = jack_client_close( pOldClient );
+		if ( nReturnCode ) {
 			ERRORLOG( "Error in jack_client_close" );
 			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CLOSE_CLIENT );
 		}
@@ -292,35 +313,35 @@ void JackAudioDriver::deactivate()
 	INFOLOG( "[deactivate]" );
 	if ( m_pClient != nullptr ) {
 		INFOLOG( "calling jack_deactivate" );
-		int res = jack_deactivate( m_pClient );
-		if ( res ) {
+		int nReturnCode = jack_deactivate( m_pClient );
+		if ( nReturnCode ) {
 			ERRORLOG( "Error in jack_deactivate" );
 		}
 	}
-	memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
-	memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
+	memset( m_pTrackOutputPortsL, 0, sizeof(m_pTrackOutputPortsL) );
+	memset( m_pTrackOutputPortsR, 0, sizeof(m_pTrackOutputPortsR) );
 }
 
 unsigned JackAudioDriver::getBufferSize()
 {
-	return jack_server_bufferSize;
+	return jackServerBufferSize;
 }
 
 unsigned JackAudioDriver::getSampleRate()
 {
-	return jack_server_sampleRate;
+	return jackServerSampleRate;
 }
 
 void JackAudioDriver::calculateFrameOffset()
 {
-	bbt_frame_offset = m_JackTransportPos.frame - m_transport.m_nFrames;
-	INFOLOG( QString( "bbt_frame_offset: %1" ). arg( bbt_frame_offset ) );
+	m_bbtFrameOffset = m_JackTransportPos.frame - m_transport.m_nFrames;
+	INFOLOG( QString( "m_bbtFrameOffset: %1" ). arg( m_bbtFrameOffset ) );
 }
 
 void JackAudioDriver::locateInNCycles( unsigned long frame, int cycles_to_wait )
 {
-	locate_countdown = cycles_to_wait;
-	locate_frame = frame;
+	m_nLocateCountdown = cycles_to_wait;
+	m_locateFrame = frame;
 }
 
 void JackAudioDriver::updateTransportInfo()
@@ -331,10 +352,10 @@ void JackAudioDriver::updateTransportInfo()
 	// of the transport position to the beginning of the song
 	// using locateInNCycles() to possibly keep synchronization
 	// with Ardour.
-	if ( locate_countdown == 1 )
-		locate( locate_frame );
-	if ( locate_countdown > 0 )
-		locate_countdown--;
+	if ( m_nLocateCountdown == 1 )
+		locate( m_locateFrame );
+	if ( m_nLocateCountdown > 0 )
+		m_nLocateCountdown--;
 	
 	if ( Preferences::get_instance()->m_bJackTransportMode !=
 	     Preferences::USE_JACK_TRANSPORT ){
@@ -382,13 +403,13 @@ void JackAudioDriver::updateTransportInfo()
 	}
 
 	// Updating TickSize and BPM
-	Hydrogen * H = Hydrogen::get_instance();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	// JACK may have re-located us anywhere. Therefore, we have to
-	// check for a bpm change every cycle. We will do so by
-	// updating both the global speed of the song, as well as the
-	// fallback speed (H->getNewBpmJTM) with the local tempo at
-	// the current position on the timeline.
-	H->setTimelineBpm(); 
+	// check for a bpm change every cycle. We will do so by updating
+	// both the global speed of the song, as well as the fallback
+	// speed (pHydrogen->getNewBpmJTM()) with the local tempo at the
+	// current position on the timeline.
+	pHydrogen->setTimelineBpm(); 
 
 	// Check whether another JACK master is present (the second if
 	// clause won't evaluate to true if Hydrogen itself is the
@@ -398,14 +419,14 @@ void JackAudioDriver::updateTransportInfo()
 	// an a relocation according to the bar, beat, and tick
 	// information will be triggered right away.
 	if ( m_JackTransportPos.valid & JackPositionBBT ) {
-		float bpm = ( float )m_JackTransportPos.beats_per_minute;
-		if ( m_transport.m_nBPM != bpm ) {
+		float fBPM = ( float )m_JackTransportPos.beats_per_minute;
+		if ( m_transport.m_nBPM != fBPM ) {
 			if ( Preferences::get_instance()->m_bJackMasterMode ==
 			     Preferences::NO_JACK_TIME_MASTER ){
 					// The speed of the Song will be updated by function
 					// calling update_transport_info()
 					// audioEngine_process_transport().
-					m_transport.m_nBPM = bpm;
+					m_transport.m_nBPM = fBPM;
 
 					// The tick size will be updated by the
 					// audioEngine_process_checkBPMChanged()
@@ -418,29 +439,29 @@ void JackAudioDriver::updateTransportInfo()
         // triggered by an user-interaction (e.g. clicking the forward
         // button or clicking somewhere on the timeline) or by a
         // different JACK client.
-	if ( m_transport.m_nFrames + bbt_frame_offset != m_JackTransportPos.frame ) {
+	if ( m_transport.m_nFrames + m_bbtFrameOffset != m_JackTransportPos.frame ) {
 		INFOLOG( "A relocation took place" );
 		if ( ( m_JackTransportPos.valid & JackPositionBBT ) ){
 			// There is a JACK timebase master.
-			if ( !m_bHydrogenIsJackTimebaseMaster ){
+			if ( !m_bIsTimebaseMaster ){
 				// But it's not us.
-				// Absorbing the current bbt_frame_offset value.
+				// Absorbing the current m_bbtFrameOffset value.
 				m_transport.m_nFrames = m_JackTransportPos.frame *
 					m_fOldTickSize/ m_transport.m_nTickSize;
-				bbt_frame_offset = 0;
+				m_bbtFrameOffset = 0;
 				// INFOLOG( QString( "External JACK timebase master. Resetting frame from %1 to %2 using the old tick size %3 and new one %4" )
 				// 	 .arg( m_transport.m_nFrames )
 				// 	 .arg( m_JackTransportPos.frame )
 				// 	 .arg( m_fOldTickSize )
 				// 	 .arg( m_transport.m_nTickSize ) );
 			} else {
-				// INFOLOG( QString( "Hydrogen as JACK timebase master. Possible mismatch between transport %1, client %2, bbt_frame_offset %3" )
+				// INFOLOG( QString( "Hydrogen as JACK timebase master. Possible mismatch between transport %1, client %2, m_bbtFrameOffset %3" )
 				// 	 .arg( m_transport.m_nFrames )
 				// 	 .arg( m_JackTransportPos.frame )
-				// 	 .arg( bbt_frame_offset ) );
+				// 	 .arg( m_bbtFrameOffset ) );
 				// We are timebase master ourselves.
 				// Resetting the offset.
-				bbt_frame_offset = 0;
+				m_bbtFrameOffset = 0;
 				// We do not update the position in frames directly.
 				// Instead, the JACK server is asked to relocate
 				// and we use its current location.
@@ -451,15 +472,15 @@ void JackAudioDriver::updateTransportInfo()
 			// to the server.
 			// INFOLOG( "Relocation as normal JACK client" );
 			m_transport.m_nFrames = m_JackTransportPos.frame;
-			bbt_frame_offset = 0;
+			m_bbtFrameOffset = 0;
 			if ( m_transport.m_status == TransportInfo::ROLLING )
-				H->triggerRelocateDuringPlay();
+				pHydrogen->triggerRelocateDuringPlay();
 		}
 	}
 	// Only used if Hydrogen is in JACK timebase master
 	// mode. Updated every cycle.
-	if ( H->getHumantimeFrames() != m_JackTransportPos.frame ) {
-		H->setHumantimeFrames(m_JackTransportPos.frame);
+	if ( pHydrogen->getHumantimeFrames() != m_JackTransportPos.frame ) {
+		pHydrogen->setHumantimeFrames( m_JackTransportPos.frame );
 		// WARNINGLOG( QString( "fix Humantime: %1" ).arg( m_JackTransportPos.frame ) );
 	}
 }
@@ -474,46 +495,52 @@ float* JackAudioDriver::getOut_L()
 	 * or zero-filled. if there are multiple inbound connections,
 	 * the data will be mixed appropriately.
 	 */
-	jack_default_audio_sample_t *out = ( jack_default_audio_sample_t * ) jack_port_get_buffer ( output_port_1, jack_server_bufferSize );
+	jack_default_audio_sample_t *out = ( jack_default_audio_sample_t * ) jack_port_get_buffer ( m_pOutputPort1, jackServerBufferSize );
 	return out;
 }
 
 float* JackAudioDriver::getOut_R()
 {
-	jack_default_audio_sample_t *out = ( jack_default_audio_sample_t * ) jack_port_get_buffer ( output_port_2, jack_server_bufferSize );
+	jack_default_audio_sample_t *out = ( jack_default_audio_sample_t * ) jack_port_get_buffer ( m_pOutputPort2, jackServerBufferSize );
 	return out;
 }
 
 float* JackAudioDriver::getTrackOut_L( unsigned nTrack )
 {
-	if(nTrack > (unsigned)track_port_count ) return nullptr;
-	jack_port_t *p = track_output_ports_L[nTrack];
+	if ( nTrack > (unsigned)m_nTrackPortCount ) {
+		return nullptr;
+	}
+	
+	jack_port_t* pPort = m_pTrackOutputPortsL[nTrack];
 	jack_default_audio_sample_t* out = nullptr;
-	if( p ) {
-		out = (jack_default_audio_sample_t*) jack_port_get_buffer( p, jack_server_bufferSize);
+	if( pPort ) {
+		out = (jack_default_audio_sample_t*) jack_port_get_buffer( pPort, jackServerBufferSize);
 	}
 	return out;
 }
 
 float* JackAudioDriver::getTrackOut_R( unsigned nTrack )
 {
-	if(nTrack > (unsigned)track_port_count ) return nullptr;
-	jack_port_t *p = track_output_ports_R[nTrack];
-	jack_default_audio_sample_t* out = nullptr;
-	if( p ) {
-		out = (jack_default_audio_sample_t*) jack_port_get_buffer( p, jack_server_bufferSize);
+	if( nTrack > (unsigned)m_nTrackPortCount ) {
+		return nullptr;
 	}
-		return out;
+	
+	jack_port_t* pPort = m_pTrackOutputPortsR[nTrack];
+	jack_default_audio_sample_t* out = nullptr;
+	if( pPort ) {
+		out = (jack_default_audio_sample_t*) jack_port_get_buffer( pPort, jackServerBufferSize);
+	}
+	return out;
 }
 
-float* JackAudioDriver::getTrackOut_L( Instrument * instr, InstrumentComponent * pCompo)
+float* JackAudioDriver::getTrackOut_L( Instrument* instr, InstrumentComponent* pCompo)
 {
-	return getTrackOut_L(track_map[instr->get_id()][pCompo->get_drumkit_componentID()]);
+	return getTrackOut_L(m_trackMap[instr->get_id()][pCompo->get_drumkit_componentID()]);
 }
 
-float* JackAudioDriver::getTrackOut_R( Instrument * instr, InstrumentComponent * pCompo)
+float* JackAudioDriver::getTrackOut_R( Instrument* instr, InstrumentComponent* pCompo)
 {
-	return getTrackOut_R(track_map[instr->get_id()][pCompo->get_drumkit_componentID()]);
+	return getTrackOut_R(m_trackMap[instr->get_id()][pCompo->get_drumkit_componentID()]);
 }
 
 
@@ -535,18 +562,14 @@ float* JackAudioDriver::getTrackOut_R( Instrument * instr, InstrumentComponent *
 
 int JackAudioDriver::init( unsigned bufferSize )
 {
-	// Destination ports the output of Hydrogen will be connected
-	// to.
-	Preferences* pPref = Preferences::get_instance();
-	output_port_name_1 = pPref->m_sJackPortName1;
-	output_port_name_2 = pPref->m_sJackPortName2;
-
+	auto pPreferences = Preferences::get_instance();
+	
 	QString sClientName = "Hydrogen";
 
 #ifdef H2CORE_HAVE_OSC
-	QString sNsmClientId = pPref->getNsmClientId();
+	QString sNsmClientId = pPreferences->getNsmClientId();
 
-	if(!sNsmClientId.isEmpty()){
+	if( !sNsmClientId.isEmpty() ){
 		sClientName = sNsmClientId;
 	}
 #endif
@@ -585,14 +608,14 @@ int JackAudioDriver::init( unsigned bufferSize )
 		// includes JackFailure and the caller is not a JACK
 		// client.
 #ifdef H2CORE_HAVE_JACKSESSION
-		if (pPref->getJackSessionUUID().isEmpty()){
+		if ( pPreferences->getJackSessionUUID().isEmpty() ){
 			m_pClient = jack_client_open( sClientName.toLocal8Bit(),
 						      JackNullOption,
 						      &status);
 		} else {
 			// Unique name of the JACK server used within
 			// the JACK session.
-			const QByteArray uuid = pPref->getJackSessionUUID().toLocal8Bit();
+			const QByteArray uuid = pPreferences->getJackSessionUUID().toLocal8Bit();
 			// Using the JackSessionID option and the
 			// supplied SessionID Token the sessionmanager
 			// is able to identify the client again.
@@ -667,16 +690,16 @@ int JackAudioDriver::init( unsigned bufferSize )
 	}
 
 	// Here, client should either be valid, or NULL.
-	jack_server_sampleRate = jack_get_sample_rate( m_pClient );
-	jack_server_bufferSize = jack_get_buffer_size( m_pClient );
+	jackServerSampleRate = jack_get_sample_rate( m_pClient );
+	jackServerBufferSize = jack_get_buffer_size( m_pClient );
 
-	pPref->m_nSampleRate = jack_server_sampleRate;
-	pPref->m_nBufferSize = jack_server_bufferSize;
+	pPreferences->m_nSampleRate = jackServerSampleRate;
+	pPreferences->m_nBufferSize = jackServerBufferSize;
 
 	/* tell the JACK server to call `process()' whenever
 	   there is work to be done.
 	*/
-	jack_set_process_callback( m_pClient, this->processCallback, nullptr );
+	jack_set_process_callback( m_pClient, this->m_processCallback, nullptr );
 
 	/* tell the JACK server to call `srate()' whenever
 	   the sample rate of the system changes.
@@ -700,29 +723,29 @@ int JackAudioDriver::init( unsigned bufferSize )
 	// function `jack_port_register' (jack/jack.h) is called like
 	// jack_port_register( jack_client_t *client, 
 	//                     const char *port_name,
-        //                     const char *port_type,
-        //                     unsigned long flags,
-        //                     unsigned long buffer_size)
+	//                     const char *port_type,
+	//                     unsigned long flags,
+	//                     unsigned long buffer_size)
 	//
 	// All ports have a type, which may be any non-NULL and non-zero
 	// length string, passed as an argument. Some port types are built
 	// into the JACK API, currently only JACK_DEFAULT_AUDIO_TYPE.
 	// It returns a _jack_port_t_ pointer on success, otherwise NULL.
-	output_port_1 = jack_port_register( m_pClient, "out_L", JACK_DEFAULT_AUDIO_TYPE,
+	m_pOutputPort1 = jack_port_register( m_pClient, "out_L", JACK_DEFAULT_AUDIO_TYPE,
 					    JackPortIsOutput, 0 );
-	output_port_2 = jack_port_register( m_pClient, "out_R", JACK_DEFAULT_AUDIO_TYPE,
+	m_pOutputPort2 = jack_port_register( m_pClient, "out_R", JACK_DEFAULT_AUDIO_TYPE,
 					    JackPortIsOutput, 0 );
 
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	if ( ( output_port_1 == nullptr ) || ( output_port_2 == nullptr ) ) {
-		pEngine->raiseError( Hydrogen::JACK_ERROR_IN_PORT_REGISTER );
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	if ( ( m_pOutputPort1 == nullptr ) || ( m_pOutputPort2 == nullptr ) ) {
+		pHydrogen->raiseError( Hydrogen::JACK_ERROR_IN_PORT_REGISTER );
 		return 4;
 	}
 
 #ifdef H2CORE_HAVE_LASH
-	if ( pPref->useLash() ){
+	if ( pPreferences->useLash() ){
 		LashClient* lashClient = LashClient::get_instance();
-		if (lashClient->isConnected()) {
+		if ( lashClient->isConnected() ) {
 			lashClient->setJackClientName(sClientName.toLocal8Bit().constData());
 		}
 	}
@@ -732,14 +755,11 @@ int JackAudioDriver::init( unsigned bufferSize )
 	jack_set_session_callback(m_pClient, jack_session_callback, (void*)this);
 #endif
 
-	if ( pPref->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ){
-		// Make Hydrogen the timebase master, regardless if there
-		// is already a timebase master present.
-		m_nJackConditionalTakeOver = 0;
+	if ( pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ){
 		// Make Hydrogen the JACK timebase master.
 		initTimeMaster();
 	} else {
-		m_bHydrogenIsJackTimebaseMaster = false;
+		m_bIsTimebaseMaster = false;
 	}
 	
 	return 0;
@@ -750,100 +770,106 @@ void JackAudioDriver::makeTrackOutputs( Song* pSong )
 
 	// Only execute the body of this function if a per-track
 	// creation of the output ports is desired.
-	if( Preferences::get_instance()->m_bJackTrackOuts == false )
+	if( Preferences::get_instance()->m_bJackTrackOuts == false ) {
 		return;
+	}
 
-	InstrumentList * pInstruments = pSong->get_instrument_list();
-	Instrument * pInstr;
-	int nInstruments = ( int ) pInstruments->size();
+	InstrumentList* pInstrumentList = pSong->get_instrument_list();
+	Instrument* pInstrument;
+	int nInstruments = ( int ) pInstrumentList->size();
 
 	// create dedicated channel output ports
 	WARNINGLOG( QString( "Creating / renaming %1 ports" ).arg( nInstruments ) );
 
 	int nTrackCount = 0;
 
-	// Resets the `track_map' matrix.
+	// Resets the `m_trackMap' matrix.
 	for( int i = 0 ; i < MAX_INSTRUMENTS ; i++ ){
 		for ( int j = 0 ; j < MAX_COMPONENTS ; j++ ){
-			track_map[i][j] = 0;
+			m_trackMap[i][j] = 0;
 		}
 	}
 	// Creates a new output track or reassigns an existing one for
 	// each component of each instrument and stores the result in
-	// the `track_map'.
+	// the `m_trackMap'.
+	InstrumentComponent* pInstrumentComponent;
 	for ( int n = 0; n <= nInstruments - 1; n++ ) {
-		pInstr = pInstruments->get( n );
-		for (std::vector<InstrumentComponent*>::iterator it = pInstr->get_components()->begin() ; it != pInstr->get_components()->end(); ++it) {
-			InstrumentComponent* pCompo = *it;
-			setTrackOutput( nTrackCount, pInstr, pCompo, pSong);
-			track_map[pInstr->get_id()][pCompo->get_drumkit_componentID()] = nTrackCount;
+		pInstrument = pInstrumentList->get( n );
+		for ( auto it = pInstrument->get_components()->begin();
+			  it != pInstrument->get_components()->end(); ++it) {
+			
+			pInstrumentComponent = *it;
+			setTrackOutput( nTrackCount, pInstrument, pInstrumentComponent, pSong);
+			m_trackMap[pInstrument->get_id()][pInstrumentComponent->get_drumkit_componentID()] = 
+				nTrackCount;
 			nTrackCount++;
 		}
 	}
 	// clean up unused ports
-	jack_port_t *p_L, *p_R;
-	for ( int n = nTrackCount; n < track_port_count; n++ ) {
-		p_L = track_output_ports_L[n];
-		p_R = track_output_ports_R[n];
-		track_output_ports_L[n] = nullptr;
-		jack_port_unregister( m_pClient, p_L );
-		track_output_ports_R[n] = nullptr;
-		jack_port_unregister( m_pClient, p_R );
+	jack_port_t *pPortL, *pPortR;
+	for ( int n = nTrackCount; n < m_nTrackPortCount; n++ ) {
+		pPortL = m_pTrackOutputPortsL[n];
+		pPortR = m_pTrackOutputPortsR[n];
+		m_pTrackOutputPortsL[n] = nullptr;
+		jack_port_unregister( m_pClient, pPortL );
+		m_pTrackOutputPortsR[n] = nullptr;
+		jack_port_unregister( m_pClient, pPortR );
 	}
 
-	track_port_count = nTrackCount;
+	m_nTrackPortCount = nTrackCount;
 }
 
 /**
  * Give the @a n 'th port the name of @a instr .
  * If the n'th port doesn't exist, new ports up to n are created.
  */
-void JackAudioDriver::setTrackOutput( int n, Instrument * instr, InstrumentComponent * pCompo, Song * pSong )
+void JackAudioDriver::setTrackOutput( int n, Instrument* pInstrument, InstrumentComponent *pInstrumentComponent, Song* pSong )
 {
-	QString chName;
+	QString sComponentName;
 
-	// The function considers `track_port_count' as the number of
+	// The function considers `m_nTrackPortCount' as the number of
 	// ports already present. If its smaller than `n', new ports
 	// have to be created.
-	if ( track_port_count <= n ) {
-		for ( int m = track_port_count; m <= n; m++ ) {
-			chName = QString( "Track_%1_" ).arg( m + 1 );
-			track_output_ports_L[m] =
-				jack_port_register( m_pClient, ( chName + "L" ).toLocal8Bit(),
+	if ( m_nTrackPortCount <= n ) {
+		for ( int m = m_nTrackPortCount; m <= n; m++ ) {
+			sComponentName = QString( "Track_%1_" ).arg( m + 1 );
+			m_pTrackOutputPortsL[m] =
+				jack_port_register( m_pClient, ( sComponentName + "L" ).toLocal8Bit(),
 						     JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0 );
 
-			track_output_ports_R[m] =
-				jack_port_register( m_pClient, ( chName + "R" ).toLocal8Bit(),
+			m_pTrackOutputPortsR[m] =
+				jack_port_register( m_pClient, ( sComponentName + "R" ).toLocal8Bit(),
 						    JACK_DEFAULT_AUDIO_TYPE, JackPortIsOutput, 0 );
 
-			if ( ! track_output_ports_R[m] || ! track_output_ports_L[m] ) {
+			if ( ! m_pTrackOutputPortsR[m] || ! m_pTrackOutputPortsL[m] ) {
 				Hydrogen::get_instance()->raiseError( Hydrogen::JACK_ERROR_IN_PORT_REGISTER );
 			}
 		}
-		track_port_count = n + 1;
+		m_nTrackPortCount = n + 1;
 	}
 
 	// Now we're sure there is an n'th port, rename it.
-	DrumkitComponent* pDrumkitComponent = pSong->get_component( pCompo->get_drumkit_componentID() );
-	chName = QString( "Track_%1_%2_%3_" ).arg( n + 1 ).arg( instr->get_name() ).arg( pDrumkitComponent->get_name() );
+	DrumkitComponent* pDrumkitComponent = pSong->get_component( pInstrumentComponent->get_drumkit_componentID() );
+	sComponentName = QString( "Track_%1_%2_%3_" ).arg( n + 1 )
+		.arg( pInstrument->get_name() ).arg( pDrumkitComponent->get_name() );
 
 #ifdef HAVE_JACK_PORT_RENAME
 	// This differs from jack_port_set_name() by triggering
 	// PortRename notifications to clients that have registered a
 	// port rename handler.
-	jack_port_rename( m_pClient, track_output_ports_L[n], ( chName + "L" ).toLocal8Bit() );
-	jack_port_rename( m_pClient, track_output_ports_R[n], ( chName + "R" ).toLocal8Bit() );
+	jack_port_rename( m_pClient, m_pTrackOutputPortsL[n], ( sComponentName + "L" ).toLocal8Bit() );
+	jack_port_rename( m_pClient, m_pTrackOutputPortsR[n], ( sComponentName + "R" ).toLocal8Bit() );
 #else
-	jack_port_set_name( track_output_ports_L[n], ( chName + "L" ).toLocal8Bit() );
-	jack_port_set_name( track_output_ports_R[n], ( chName + "R" ).toLocal8Bit() );
+	jack_port_set_name( m_pTrackOutputPortsL[n], ( sComponentName + "L" ).toLocal8Bit() );
+	jack_port_set_name( m_pTrackOutputPortsR[n], ( sComponentName + "R" ).toLocal8Bit() );
 #endif
 }
 
 void JackAudioDriver::play()
 {
-	Preferences* P = Preferences::get_instance();
-	if ( P->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT ||
-		 P->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER
+	Preferences* pPreferences = Preferences::get_instance();
+	if ( pPreferences->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT ||
+		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER
 		 ) {
 		if ( m_pClient != nullptr ) {
 			INFOLOG( "jack_transport_start()" );
@@ -856,9 +882,9 @@ void JackAudioDriver::play()
 
 void JackAudioDriver::stop()
 {
-	Preferences* P = Preferences::get_instance();
-	if ( P->m_bJackTransportMode ==  Preferences::USE_JACK_TRANSPORT ||
-	     P->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ) {
+	Preferences* pPreferences = Preferences::get_instance();
+	if ( pPreferences->m_bJackTransportMode ==  Preferences::USE_JACK_TRANSPORT ||
+	     pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ) {
 		if ( m_pClient != nullptr ) {
 			INFOLOG( "jack_transport_stop()" );
 			jack_transport_stop( m_pClient );
@@ -868,7 +894,7 @@ void JackAudioDriver::stop()
 	}
 }
 
-void JackAudioDriver::locate( unsigned long nFrame )
+void JackAudioDriver::locate( unsigned long frame )
 {
 	if ( ( Preferences::get_instance() )->m_bJackTransportMode ==
 	     Preferences::USE_JACK_TRANSPORT /*||
@@ -879,10 +905,10 @@ void JackAudioDriver::locate( unsigned long nFrame )
 			// re-positions the transport to a new frame number.
 			// May be called at any time by any client.  The new
 			// position takes effect in two process cycles.
-			jack_transport_locate( m_pClient, nFrame );
+			jack_transport_locate( m_pClient, frame );
 		}
 	} else {
-		m_transport.m_nFrames = nFrame;
+		m_transport.m_nFrames = (long long)frame;
 	}
 }
 
@@ -895,21 +921,23 @@ void JackAudioDriver::setBpm( float fBPM )
 int JackAudioDriver::getNumTracks()
 {
 	//	INFOLOG( "get num tracks()" );
-	return track_port_count;
+	return m_nTrackPortCount;
 }
 
 #ifdef H2CORE_HAVE_JACKSESSION
 void JackAudioDriver::jack_session_callback(jack_session_event_t *event, void *arg)
 {
-	JackAudioDriver *me = static_cast<JackAudioDriver*>(arg);
-	if(me) me->jack_session_callback_impl(event);
+	JackAudioDriver* pDriver = static_cast<JackAudioDriver*>(arg);
+	if ( pDriver != nullptr ) {
+		pDriver->jack_session_callback_impl( event );
+	}
 }
 
-static QString baseName ( QString path ) {
-	return QFileInfo( path ).fileName();
+static QString baseName ( QString sPath ) {
+	return QFileInfo( sPath ).fileName();
 }
 
-void JackAudioDriver::jack_session_callback_impl(jack_session_event_t *event)
+void JackAudioDriver::jack_session_callback_impl(jack_session_event_t* event)
 {
 	INFOLOG("jack session callback");
 	enum session_events{
@@ -918,67 +946,72 @@ void JackAudioDriver::jack_session_callback_impl(jack_session_event_t *event)
 		SAVE_TEMPLATE
 	};
 
-	Hydrogen* H = Hydrogen::get_instance();
-	Song* S = H->getSong();
-	Preferences* P = Preferences::get_instance();
-	EventQueue* EQ = EventQueue::get_instance();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Song* pSong = pHydrogen->getSong();
+	Preferences* pPreferences = Preferences::get_instance();
+	EventQueue* pEventQueue = EventQueue::get_instance();
 
-	jack_session_event_t *ev = (jack_session_event_t *) event;
+	jack_session_event_t* ev = (jack_session_event_t *) event;
 
-	QString jackSessionDirectory = (QString) ev->session_dir;
-	QString retval = P->getJackSessionApplicationPath() + " --jacksessionid " + ev->client_uuid;
+	QString sJackSessionDirectory = (QString) ev->session_dir;
+	QString sRetval = pPreferences->getJackSessionApplicationPath() + 
+		" --jacksessionid " + ev->client_uuid;
 
 	/* Playlist mode */
-	Playlist* playlist = Playlist::get_instance();
-	if ( playlist->size() > 0 ) {
+	Playlist* pPlaylist = Playlist::get_instance();
+	if ( pPlaylist->size() > 0 ) {
 
-		if ( playlist->getFilename().isEmpty() ) playlist->setFilename( Filesystem::untitled_playlist_file_name() );
+		if ( pPlaylist->getFilename().isEmpty() ) {
+			pPlaylist->setFilename( Filesystem::untitled_playlist_file_name() );
+		}
 
-		QString FileName = baseName ( playlist->getFilename() );
-		FileName.replace ( QString(" "), QString("_") );
-		retval += " -p \"${SESSION_DIR}" + FileName + "\"";
+		QString sFileName = baseName( pPlaylist->getFilename() );
+		sFileName.replace( QString(" "), QString("_") );
+		sRetval += " -p \"${SESSION_DIR}" + sFileName + "\"";
 
 		/* Copy all songs to Session Directory and update playlist */
 		SongReader reader;
-		for ( uint i = 0; i < playlist->size(); ++i ) {
-			QString BaseName = baseName( playlist->get( i )->filePath );
-			QString newName = jackSessionDirectory + BaseName;
-			QString SongPath = reader.getPath( playlist->get( i )->filePath );
-			if ( SongPath != nullptr && QFile::copy ( SongPath, newName ) ) {
+		for ( uint i = 0; i < pPlaylist->size(); ++i ) {
+			QString sBaseName = baseName( pPlaylist->get( i )->filePath );
+			QString sNewName = sJackSessionDirectory + sBaseName;
+			QString sSongPath = reader.getPath( pPlaylist->get( i )->filePath );
+			if ( sSongPath != nullptr && QFile::copy( sSongPath, sNewName ) ) {
 				/* Keep only filename on list for relative read */
-				playlist->get( i )->filePath = BaseName;
-				// playlist->get( i )->m_hScript;
+				pPlaylist->get( i )->filePath = sBaseName;
 			} else {
 				/* Note - we leave old path in playlist */
-				ERRORLOG( "Can't copy " + playlist->get( i )->filePath + " to " + newName );
+				ERRORLOG( "Can't copy " + pPlaylist->get( i )->filePath + " to " + sNewName );
 				ev->flags = JackSessionSaveError;
 			}
 		}
 
 		/* Save updated playlist */
-		bool relativePaths = Preferences::get_instance()->isPlaylistUsingRelativeFilenames();
-		if ( Files::savePlaylistPath( jackSessionDirectory + FileName, playlist, relativePaths ) == nullptr ) {
+		bool bRelativePaths = Preferences::get_instance()->isPlaylistUsingRelativeFilenames();
+		if ( Files::savePlaylistPath( sJackSessionDirectory + sFileName, 
+									  pPlaylist, bRelativePaths ) == nullptr ) {
 			ev->flags = JackSessionSaveError;
 		}
 		/* Song Mode */
 	} else {
 		/* Valid Song is needed */
-		if ( S->get_filename().isEmpty() ) S->set_filename( Filesystem::untitled_song_file_name() );
+		if ( pSong->get_filename().isEmpty() ) {
+			pSong->set_filename( Filesystem::untitled_song_file_name() );
+		}
 
-		QString FileName = baseName ( S->get_filename() );
-		FileName.replace ( QString(" "), QString("_") );
-		S->set_filename(jackSessionDirectory + FileName);
+		QString sFileName = baseName( pSong->get_filename() );
+		sFileName.replace( QString(" "), QString("_") );
+		pSong->set_filename( sJackSessionDirectory + sFileName);
 
 		/* SongReader will look into SESSION DIR anyway */
-		retval += " -s \"" + FileName + "\"";
+		sRetval += " -s \"" + sFileName + "\"";
 
 		switch (ev->type) {
 			case JackSessionSave:
-				EQ->push_event(EVENT_JACK_SESSION, SAVE_SESSION);
+				pEventQueue->push_event(EVENT_JACK_SESSION, SAVE_SESSION);
 				break;
 			case JackSessionSaveAndQuit:
-				EQ->push_event(EVENT_JACK_SESSION, SAVE_SESSION);
-				EQ->push_event(EVENT_JACK_SESSION, SAVE_AND_QUIT);
+				pEventQueue->push_event(EVENT_JACK_SESSION, SAVE_SESSION);
+				pEventQueue->push_event(EVENT_JACK_SESSION, SAVE_AND_QUIT);
 				break;
 			default:
 				ERRORLOG( "JackSession: Unknown event type" );
@@ -986,9 +1019,9 @@ void JackAudioDriver::jack_session_callback_impl(jack_session_event_t *event)
 		}
 	}
 
-	ev->command_line = strdup( retval.toUtf8().constData() );
-	jack_session_reply (m_pClient, ev );
-	jack_session_event_free (ev);
+	ev->command_line = strdup( sRetval.toUtf8().constData() );
+	jack_session_reply( m_pClient, ev );
+	jack_session_event_free( ev );
 }
 #endif
 
@@ -1032,27 +1065,27 @@ void JackAudioDriver::initTimeMaster()
 						     jack_timebase_callback, this);
 		if ( nReturnValue != 0 ){
 			pPreferences->m_bJackMasterMode = Preferences::NO_JACK_TIME_MASTER;
-			m_bHydrogenIsJackTimebaseMaster = false;
+			m_bIsTimebaseMaster = false;
 		} else {
-			m_bHydrogenIsJackTimebaseMaster = true;
+			m_bIsTimebaseMaster = true;
 		}
 	} else {
 		// Called by the timebase master to release itself
 		// from that responsibility (defined in
 		// jack/transport.h).
 		jack_release_timebase(m_pClient);
-		m_bHydrogenIsJackTimebaseMaster = false;
+		m_bIsTimebaseMaster = false;
 	}
 }
 
-void JackAudioDriver::com_release()
+void JackAudioDriver::releaseTimebase()
 {
 	if ( m_pClient == nullptr ) {
 		return;
 	}
 
 	jack_release_timebase( m_pClient );
-	m_bHydrogenIsJackTimebaseMaster = false;
+	m_bIsTimebaseMaster = false;
 }
 
 void JackAudioDriver::jack_timebase_callback(jack_transport_state_t state,
@@ -1072,7 +1105,7 @@ void JackAudioDriver::jack_timebase_callback(jack_transport_state_t state,
 		return;
 	}
 
-	unsigned long PlayTick = ( pJackPosition->frame - pDriver->bbt_frame_offset ) / 
+	unsigned long PlayTick = ( pJackPosition->frame - pDriver->m_bbtFrameOffset ) / 
 		pDriver->m_transport.m_nTickSize;
 	pJackPosition->bar = pHydrogen->getPosForTick( PlayTick );
 
@@ -1082,7 +1115,7 @@ void JackAudioDriver::jack_timebase_callback(jack_transport_state_t state,
 	}
 
 	/* We'll cheat there is ticks_per_beat * 4 in bar
-	   so every Hydrogen tick will be multipled by 4 ticks */
+	   so every Hydrogen tick will be multiplied by 4 ticks */
 	pJackPosition->ticks_per_beat = TPB;
 	pJackPosition->valid = JackPositionBBT;
 	pJackPosition->beats_per_bar = TPB / 48;

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -407,7 +407,7 @@ void JackAudioDriver::updateTransportInfo()
 	}
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-		
+
 	// The relocation could be either triggered by an user interaction
 	// (e.g. clicking the forward button or clicking somewhere on the
 	// timeline) or by a different JACK client.

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -432,7 +432,9 @@ void JackAudioDriver::updateTransportInfo()
 		float fBPM = ( float )m_JackTransportPos.beats_per_minute;
 
 		if ( m_transport.m_fBPM != fBPM ) {
-			pHydrogen->setBPM( fBPM );
+			setBpm( fBPM );
+			pHydrogen->getSong()->__bpm = fBPM;
+			pHydrogen->setNewBpmJTM( fBPM );
 		}
 	} else {
 		// Checks for local changes in speed (introduced by the user

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -372,6 +372,8 @@ void JackAudioDriver::updateTransportInfo()
 		ERRORLOG( "Unknown jack transport state" );
 	}
 	
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	
 	// The relocation could be either triggered by an user interaction
 	// (e.g. clicking the forward button or clicking somewhere on the
 	// timeline) or by a different JACK client.
@@ -379,12 +381,14 @@ void JackAudioDriver::updateTransportInfo()
 
 		m_transport.m_nFrames = m_JackTransportPos.frame;
 		
+		// Reset playback to the beginning of the pattern if Hydrogen
+		// is in pattern mode.
+		pHydrogen->resetPatternStartTick();
+		
 		// Resetting the previous frame offset (introduced
 		// when passing a tempo marker).
 		m_frameOffset = 0;
 	}
-	
-	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	
 	// std::cout << "[updateTransport] m_nFrames: " << m_transport.m_nFrames
 	// 		  << ", m_fBPM: " << m_transport.m_fBPM

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -407,7 +407,7 @@ void JackAudioDriver::updateTransportInfo()
 	}
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	
+		
 	// The relocation could be either triggered by an user interaction
 	// (e.g. clicking the forward button or clicking somewhere on the
 	// timeline) or by a different JACK client.
@@ -815,9 +815,7 @@ void JackAudioDriver::setTrackOutput( int n, Instrument* pInstrument, Instrument
 void JackAudioDriver::play()
 {
 	Preferences* pPreferences = Preferences::get_instance();
-	if ( pPreferences->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT ||
-		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER
-		 ) {
+	if ( pPreferences->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT ) {
 		if ( m_pClient != nullptr ) {
 			INFOLOG( "jack_transport_start()" );
 			jack_transport_start( m_pClient );
@@ -830,8 +828,7 @@ void JackAudioDriver::play()
 void JackAudioDriver::stop()
 {
 	Preferences* pPreferences = Preferences::get_instance();
-	if ( pPreferences->m_bJackTransportMode ==  Preferences::USE_JACK_TRANSPORT ||
-	     pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ) {
+	if ( pPreferences->m_bJackTransportMode ==  Preferences::USE_JACK_TRANSPORT ) {
 		if ( m_pClient != nullptr ) {
 			INFOLOG( "jack_transport_stop()" );
 			jack_transport_stop( m_pClient );
@@ -1140,7 +1137,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		pJackPosition->tick = nTicksFromBar % (int32_t) pJackPosition->ticks_per_beat;
 				
 	}
-	
+    
 	// Tell Hydrogen it is still timebase master.
 	pDriver->m_nIsTimebaseMaster = 2;
 }

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -1078,7 +1078,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 
 	// Calculate the length of the next pattern in ticks == number
 	// of ticks in the next bar.
-	long ticksPerBar = pHydrogen->getTickForHumanPosition( nNextPattern );
+	long ticksPerBar = pHydrogen->getPatternLength( nNextPattern );
 	if ( ticksPerBar < 1 ) {
 		return;
 	}

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -713,8 +713,8 @@ int JackAudioDriver::init( unsigned bufferSize )
 	jack_set_session_callback(m_pClient, jack_session_callback, (void*)this);
 #endif
 
-	if ( pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ){
-		// Make Hydrogen the JACK timebase master.
+	if ( pPreferences->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT &&
+		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ){
 		initTimebaseMaster();
 	}
 	
@@ -1140,8 +1140,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		pJackPosition->tick = nTicksFromBar % (int32_t) pJackPosition->ticks_per_beat;
 				
 	}
-
-    
+	
 	// Tell Hydrogen it is still timebase master.
 	pDriver->m_nIsTimebaseMaster = 2;
 }

--- a/src/core/src/IO/oss_driver.cpp
+++ b/src/core/src/IO/oss_driver.cpp
@@ -319,7 +319,7 @@ void OssDriver::updateTransportInfo()
 void OssDriver::setBpm( float fBPM )
 {
 	INFOLOG( QString( "setBpm: %1" ).arg( fBPM ) );
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 };

--- a/src/core/src/IO/portaudio_driver.cpp
+++ b/src/core/src/IO/portaudio_driver.cpp
@@ -168,7 +168,7 @@ void PortAudioDriver::locate( unsigned long nFrame )
 
 void PortAudioDriver::setBpm( float fBPM )
 {
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 };

--- a/src/core/src/IO/pulse_audio_driver.cpp
+++ b/src/core/src/IO/pulse_audio_driver.cpp
@@ -166,7 +166,7 @@ void PulseAudioDriver::locate( unsigned long nFrame )
 
 void PulseAudioDriver::setBpm( float fBPM )
 {
-	m_transport.m_nBPM = fBPM;
+	m_transport.m_fBPM = fBPM;
 }
 
 

--- a/src/core/src/IO/transport_info.cpp
+++ b/src/core/src/IO/transport_info.cpp
@@ -33,8 +33,8 @@ TransportInfo::TransportInfo()
 //	INFOLOG( "INIT" );
 	m_status = STOPPED;
 	m_nFrames = 0;
-	m_nTickSize = 0;
-	m_nBPM = 120;
+	m_fTickSize = 0;
+	m_fBPM = 120;
 }
 
 
@@ -63,7 +63,7 @@ void TransportInfo::printInfo()
 		ERRORLOG( "status = unknown" );
 	}
 	INFOLOG( QString( "frames = %1" ).arg( m_nFrames ) );
-	INFOLOG( QString( "tickSize = %1" ).arg( m_nTickSize ) );
+	INFOLOG( QString( "tickSize = %1" ).arg( m_fTickSize ) );
 }
 
 };

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -928,7 +928,7 @@ inline void audioEngine_process_checkBPMChanged(Song* pSong)
 	___WARNINGLOG( QString( "Tempo change: Recomputing ticksize and frame position. Old TS: %1, new TS: %2, new pos: %3" )
 		.arg( fOldTickSize ).arg( fNewTickSize )
 		.arg( m_pAudioDriver->m_transport.m_nFrames ) );
-
+	
 #ifdef H2CORE_HAVE_JACK
 	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() ){
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->calculateFrameOffset(oldFrame);
@@ -1131,6 +1131,7 @@ inline void audioEngine_process_transport()
 				.arg( pSong->__bpm )
 				.arg( m_pAudioDriver->m_transport.m_fBPM )
 			);
+
 			pHydrogen->setBPM( m_pAudioDriver->m_transport.m_fBPM );
 		}
 
@@ -4014,6 +4015,33 @@ void Hydrogen::setTimelineBpm()
 	// FIXME: this was already done in setBPM but for "engine" time
 	//        so this is actually forcibly overwritten here
 	setNewBpmJTM( fRealtimeBPM );
+}
+
+bool Hydrogen::haveJackTransport() const {
+#ifdef H2CORE_HAVE_JACK
+	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() &&
+		 Preferences::get_instance()->m_bJackTransportMode ==
+	     Preferences::USE_JACK_TRANSPORT ){
+		return true;
+	} else {
+		return false;
+	}
+#else
+	return false;
+#endif	
+}
+
+bool Hydrogen::haveJackTimebaseClient() const {
+#ifdef H2CORE_HAVE_JACK
+	if ( haveJackTransport() ) {
+		if ( static_cast<JackAudioDriver*>(m_pAudioDriver)->getIsTimebaseMaster() == 0 ) {
+			return true;
+		}
+	} 
+	return false;
+#else
+	return false;
+#endif	
 }
 
 #ifdef H2CORE_HAVE_OSC

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1656,9 +1656,6 @@ inline int audioEngine_updateNoteQueue( unsigned nFrames )
 				return -1;
 			}
 
-			// Return the pattern list number based on the current
-			// tick and writes the starting position of the current
-			// pattern into `m_nPatternStartTick`.
 			m_nSongPos = findPatternInTick( tick, pSong->is_loop_enabled(), &m_nPatternStartTick );
 
 			// The `m_nSongSizeInTicks` variable is only set to some
@@ -1965,11 +1962,6 @@ inline int findPatternInTick( int nTick, bool bLoopMode, int* pPatternStartTick 
 
 		if ( ( nTick >= nTotalTick ) && ( nTick < nTotalTick + nPatternSize ) ) {
 			( *pPatternStartTick ) = nTotalTick;
-			// std::cout << "[findPatternInTick] nTick (input): " << nTick 
-			// 		  << ", pPatternStartTick (output): " << nTotalTick
-			// 		  << ", i (pattern number): " << i
-			// 		  << ", nPatternSize: " << nPatternSize
-			// 		  << std::endl;
 			return i;
 		}
 		nTotalTick += nPatternSize;
@@ -3874,7 +3866,7 @@ void Hydrogen::onJackMaster()
 }
 #endif
 
-long Hydrogen::getTickForHumanPosition( int nHumanPos )
+long Hydrogen::getPatternLength( int nPattern )
 {
 	Song* pSong = getSong();
 	if ( pSong == nullptr ){
@@ -3884,19 +3876,19 @@ long Hydrogen::getTickForHumanPosition( int nHumanPos )
 	std::vector< PatternList* > *pColumns = pSong->get_pattern_group_vector();
 
 	int nPatternGroups = pColumns->size();
-	if ( nHumanPos >= nPatternGroups ) {
+	if ( nPattern >= nPatternGroups ) {
 		if ( pSong->is_loop_enabled() ) {
-			nHumanPos = nHumanPos % nPatternGroups;
+			nPattern = nPattern % nPatternGroups;
 		} else {
 			return MAX_NOTES;
 		}
 	}
 
-	if ( nHumanPos < 1 ){
+	if ( nPattern < 1 ){
 		return MAX_NOTES;
 	}
 
-	PatternList* pPatternList = pColumns->at( nHumanPos - 1 );
+	PatternList* pPatternList = pColumns->at( nPattern - 1 );
 	Pattern* pPattern = pPatternList->get( 0 );
 	if ( pPattern ) {
 		return pPattern->get_length();
@@ -4028,8 +4020,6 @@ void Hydrogen::setTimelineBpm()
 	Song* pSong = getSong();
 	// Obtain the local speed specified for the current Pattern.
 	float fBPM = getTimelineBpm( getPatternPos() );
-	// std::cout << "[Hydrogen::setTimelineBpm] getPatternPos(): " << getPatternPos() 
-	// 		  << ", fBPM: " << fBPM << std::endl;
 		
 	if ( fBPM != pSong->__bpm ) {
 		setBPM( fBPM );

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -109,25 +109,6 @@ float				m_fMaxProcessTime = 0.0f;	///< max ms usable in process with no xrun
  * Hydrogen::getNewBpmJTM().
  */
 float				m_fNewBpmJTM = 120;
-/**
- * Stores the current transport position in frames obtained by a query
- * of the transport state of the JACK server in
- * JackAudioDriver::updateTransportInfo(). 
- *
- * If will be used to update the JACK transport information in
- * JackAudioDriver::jack_timebase_callback() if Hydrogen is registered
- * as the timebase master.
- *
- * It will be also used to make the local transport position
- * TransportInfo::m_nFrames lack one cycle behind the transport
- * position of the JACK server if the speed of the Song was changed
- * with Hydrogen as timebase master and a relocation of the position
- * was done. No idea why.
- *
- * Set by Hydrogen::setHumantimeFrames() and accessed via
- * Hydrogen::getHumantimeFrames().
- */
-unsigned long			m_nHumantimeFrames = 0;
 
 /**
  * Pointer to the current instance of the audio driver.
@@ -3839,16 +3820,6 @@ void Hydrogen::handleBeatCounter()
 	return;
 }
 //~ m_nBeatCounter
-
-unsigned long Hydrogen::getHumantimeFrames()
-{
-	return m_nHumantimeFrames;
-}
-
-void Hydrogen::setHumantimeFrames(unsigned long hframes)
-{
-	m_nHumantimeFrames = hframes;
-}
 
 #ifdef H2CORE_HAVE_JACK
 void Hydrogen::offJackMaster()

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -897,7 +897,7 @@ inline void audioEngine_process_checkBPMChanged(Song* pSong)
 
 	long long oldFrame;
 #ifdef H2CORE_HAVE_JACK
-	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() &&
+	if ( Hydrogen::get_instance()->haveJackTransport() && 
 		 m_audioEngineState != STATE_PLAYING ) {
 		oldFrame = static_cast< JackAudioDriver* >( m_pAudioDriver )->m_currentPos;
 			
@@ -930,7 +930,7 @@ inline void audioEngine_process_checkBPMChanged(Song* pSong)
 		.arg( m_pAudioDriver->m_transport.m_nFrames ) );
 	
 #ifdef H2CORE_HAVE_JACK
-	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() ){
+	if ( Hydrogen::get_instance()->haveJackTransport() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->calculateFrameOffset(oldFrame);
 	}
 #endif
@@ -1501,7 +1501,7 @@ void audioEngine_renameJackPorts(Song * pSong)
 	// renames jack ports
 	if ( ! pSong ) return;
 
-	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
+	if ( Hydrogen::get_instance()->haveJackAudioDriver() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->makeTrackOutputs( pSong );
 	}
 #endif
@@ -3831,14 +3831,14 @@ void Hydrogen::handleBeatCounter()
 #ifdef H2CORE_HAVE_JACK
 void Hydrogen::offJackMaster()
 {
-	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
+	if ( haveJackTransport() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->releaseTimebaseMaster();
 	}
 }
 
 void Hydrogen::onJackMaster()
 {
-	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
+	if ( haveJackTransport() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->initTimebaseMaster();
 	}
 }
@@ -3992,7 +3992,7 @@ float Hydrogen::getTimelineBpm( int nBar )
 void Hydrogen::setTimelineBpm()
 {
 	if ( ! Preferences::get_instance()->getUseTimelineBpm() ||
-		 static_cast<JackAudioDriver*>(m_pAudioDriver)->getIsTimebaseMaster() == 0 ) {
+		 haveJackTimebaseClient() ) {
 		return;
 	}
 
@@ -4015,6 +4015,18 @@ void Hydrogen::setTimelineBpm()
 	// FIXME: this was already done in setBPM but for "engine" time
 	//        so this is actually forcibly overwritten here
 	setNewBpmJTM( fRealtimeBPM );
+}
+
+bool Hydrogen::haveJackAudioDriver() const {
+#ifdef H2CORE_HAVE_JACK
+	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() ){
+		return true;
+	} else {
+		return false;
+	}
+#else
+	return false;
+#endif	
 }
 
 bool Hydrogen::haveJackTransport() const {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3851,14 +3851,14 @@ void Hydrogen::setHumantimeFrames(unsigned long hframes)
 void Hydrogen::offJackMaster()
 {
 	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
-		static_cast< JackAudioDriver* >( m_pAudioDriver )->releaseTimebase();
+		static_cast< JackAudioDriver* >( m_pAudioDriver )->releaseTimebaseMaster();
 	}
 }
 
 void Hydrogen::onJackMaster()
 {
 	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
-		static_cast< JackAudioDriver* >( m_pAudioDriver )->initTimeMaster();
+		static_cast< JackAudioDriver* >( m_pAudioDriver )->initTimebaseMaster();
 	}
 }
 #endif

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3599,6 +3599,11 @@ void Hydrogen::setBPM( float fBPM )
 	if ( ! m_pAudioDriver || ! pSong ){
 		return;
 	}
+	
+	if ( haveJackTimebaseClient() ) {
+		ERRORLOG( "Unable to change tempo directly in the presence of an external JACK timebase master. Press 'J.MASTER' get tempo control." );
+		return;
+	}
 
 	m_pAudioDriver->setBpm( fBPM );
 	pSong->__bpm = fBPM;

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2564,7 +2564,7 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 	unsigned int column = 0;
 	float fTickSize = m_pAudioDriver->m_transport.m_fTickSize;
 	unsigned int lookaheadTicks = calculateLookahead( fTickSize ) / fTickSize;
-	bool doRecord = pref->getRecordEvents();
+	bool doRecord = pPreferences->getRecordEvents();
 	if ( pSong->get_mode() == Song::SONG_MODE && doRecord &&
 		 m_audioEngineState == STATE_PLAYING )
 	{

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3905,7 +3905,7 @@ void Hydrogen::setNewBpmJTM( float bpmJTM )
 }
 
 //~ jack transport master
-void Hydrogen::triggerRelocateDuringPlay()
+void Hydrogen::resetPatternStartTick()
 {
 	// This forces the barline position
 	if ( getSong()->get_mode() == Song::PATTERN_MODE ) {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3990,7 +3990,8 @@ float Hydrogen::getTimelineBpm( int nBar )
 
 void Hydrogen::setTimelineBpm()
 {
-	if ( ! Preferences::get_instance()->getUseTimelineBpm() ) {
+	if ( ! Preferences::get_instance()->getUseTimelineBpm() ||
+		 static_cast<JackAudioDriver*>(m_pAudioDriver)->getIsTimebaseMaster() == 0 ) {
 		return;
 	}
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1335,14 +1335,6 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 			return 1;	// kill the audio AudioDriver thread
 		}
 
-#ifdef H2CORE_HAVE_JACK
-		else if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() )
-		{
-			// Do something clever :-s ... Jakob Lund
-			// Mainly to keep sync with Ardour.
-			static_cast<JackAudioDriver*>(m_pAudioDriver)->locateInNCycles( 0 );
-		}
-#endif
 		return 0;
 	} else if ( nResNoteQueue == 2 ) { // send pattern change
 		bSendPatternChange = true;
@@ -4024,10 +4016,6 @@ void Hydrogen::setTimelineBpm()
 	// Obtain the local speed specified for the current Pattern.
 	float fBPM = getTimelineBpm( getPatternPos() );
 	if ( fBPM != pSong->__bpm ) {
-		// std::cout << "[setTimelineBpm] update BPM from: " 
-		// 		  << pSong->__bpm << " to " << fBPM
-		// 		  << " at pos: " << getPatternPos() 
-		// 		  << std::endl;
 		setBPM( fBPM );
 	}
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3854,7 +3854,7 @@ void Hydrogen::setHumantimeFrames(unsigned long hframes)
 void Hydrogen::offJackMaster()
 {
 	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
-		static_cast< JackAudioDriver* >( m_pAudioDriver )->com_release();
+		static_cast< JackAudioDriver* >( m_pAudioDriver )->releaseTimebase();
 	}
 }
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1119,7 +1119,6 @@ inline void audioEngine_process_transport()
 			// this should set STATE_PLAYING
 			audioEngine_start( false, m_pAudioDriver->m_transport.m_nFrames );
 		}
-
 		// So, we are not playing even after attempt to start engine
 		if ( m_audioEngineState != STATE_PLAYING ) {
 			return;
@@ -3599,12 +3598,12 @@ void Hydrogen::setBPM( float fBPM )
 	if ( ! m_pAudioDriver || ! pSong ){
 		return;
 	}
-	
+
 	if ( haveJackTimebaseClient() ) {
 		ERRORLOG( "Unable to change tempo directly in the presence of an external JACK timebase master. Press 'J.MASTER' get tempo control." );
 		return;
 	}
-
+	
 	m_pAudioDriver->setBpm( fBPM );
 	pSong->__bpm = fBPM;
 	setNewBpmJTM ( fBPM );
@@ -4004,7 +4003,7 @@ void Hydrogen::setTimelineBpm()
 	Song* pSong = getSong();
 	// Obtain the local speed specified for the current Pattern.
 	float fBPM = getTimelineBpm( getPatternPos() );
-		
+
 	if ( fBPM != pSong->__bpm ) {
 		setBPM( fBPM );
 	}
@@ -4024,11 +4023,12 @@ void Hydrogen::setTimelineBpm()
 
 bool Hydrogen::haveJackAudioDriver() const {
 #ifdef H2CORE_HAVE_JACK
-	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() ){
-		return true;
-	} else {
-		return false;
+	if ( m_pAudioDriver != nullptr ) {
+		if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() ){
+			return true;
+		}
 	}
+	return false;
 #else
 	return false;
 #endif	
@@ -4036,13 +4036,14 @@ bool Hydrogen::haveJackAudioDriver() const {
 
 bool Hydrogen::haveJackTransport() const {
 #ifdef H2CORE_HAVE_JACK
-	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() &&
-		 Preferences::get_instance()->m_bJackTransportMode ==
-	     Preferences::USE_JACK_TRANSPORT ){
-		return true;
-	} else {
-		return false;
+	if ( m_pAudioDriver != nullptr ) {
+		if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name() &&
+			 Preferences::get_instance()->m_bJackTransportMode ==
+			 Preferences::USE_JACK_TRANSPORT ){
+			return true;
+		}
 	}
+	return false;
 #else
 	return false;
 #endif	

--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -553,14 +553,14 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 			continue;
 		}
 
-		int noteStartInFrames = ( int ) ( pNote->get_position() * audio_output->m_transport.m_nTickSize ) + pNote->get_humanize_delay();
+		int noteStartInFrames = ( int ) ( pNote->get_position() * audio_output->m_transport.m_fTickSize ) + pNote->get_humanize_delay();
 
 		int nInitialSilence = 0;
 		if ( noteStartInFrames > ( int ) nFramepos ) {	// scrivo silenzio prima dell'inizio della nota
 			nInitialSilence = noteStartInFrames - nFramepos;
 			int nFrames = nBufferSize - nInitialSilence;
 			if ( nFrames < 0 ) {
-				int noteStartInFramesNoHumanize = ( int )pNote->get_position() * audio_output->m_transport.m_nTickSize;
+				int noteStartInFramesNoHumanize = ( int )pNote->get_position() * audio_output->m_transport.m_fTickSize;
 				if ( noteStartInFramesNoHumanize > ( int )( nFramepos + nBufferSize ) ) {
 					// this note is not valid. it's in the future...let's skip it....
 					ERRORLOG( QString( "Note pos in the future?? Current frames: %1, note frame pos: %2" ).arg( nFramepos ).arg(noteStartInFramesNoHumanize ) );
@@ -852,7 +852,7 @@ bool Sampler::__render_note_no_resample(
 
 	int nNoteLength = -1;
 	if ( pNote->get_length() != -1 ) {
-		nNoteLength = ( int )( pNote->get_length() * pAudioOutput->m_transport.m_nTickSize );
+		nNoteLength = ( int )( pNote->get_length() * pAudioOutput->m_transport.m_fTickSize );
 	}
 
 	int nAvail_bytes = pSample->get_frames() - ( int )pSelectedLayerInfo->SamplePosition;	// verifico il numero di frame disponibili ancora da eseguire
@@ -1000,7 +1000,7 @@ bool Sampler::__render_note_resample(
 	int nNoteLength = -1;
 	if ( pNote->get_length() != -1 ) {
 		float resampledTickSize = AudioEngine::compute_tick_size( pSample->get_sample_rate(),
-		                                                          pAudioOutput->m_transport.m_nBPM,
+		                                                          pAudioOutput->m_transport.m_fBPM,
 		                                                          pSong->__resolution );
 		
 		nNoteLength = ( int )( pNote->get_length() * resampledTickSize);

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -581,7 +581,7 @@ void PlayerControl::updatePlayerControl()
 #ifdef H2CORE_HAVE_JACK
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( p_Driver && strncmp(p_Driver->class_name(), "JackAudioDriver", 10) == 0){
+	if ( m_pEngine->haveJackAudioDriver() ) {
 		m_pJackTransportBtn->show();
 		switch ( pPref->m_bJackTransportMode ) {
 			case Preferences::NO_JACK_TRANSPORT:
@@ -887,7 +887,7 @@ void PlayerControl::jackTransportBtnClicked( Button* )
 	Preferences *pPref = Preferences::get_instance();
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( ! ( p_Driver && strncmp(p_Driver->class_name(), "JackAudioDriver", 10) == 0 ) ){
+	if ( !m_pEngine->haveJackAudioDriver() ) {
 		QMessageBox::warning( this, "Hydrogen", tr( "JACK-transport will work only with JACK driver." ) );
 		return;
 	}
@@ -916,7 +916,7 @@ void PlayerControl::jackMasterBtnClicked( Button* )
 	Preferences *pPref = Preferences::get_instance();
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( ! ( p_Driver && strncmp(p_Driver->class_name(), "JackAudioDriver", 10) == 0 ) ){
+	if ( !m_pEngine->haveJackAudioDriver() ) {
 		QMessageBox::warning( this, "Hydrogen", tr( "JACK-transport will work only with JACK driver." ) );
 		return;
 	}
@@ -952,7 +952,7 @@ void PlayerControl::bpmClicked()
 		m_pEngine->getSong()->set_is_modified( true );
 
 		AudioEngine::get_instance()->lock( RIGHT_HERE );
-		
+
 		m_pEngine->setBPM( fNewVal );
 		AudioEngine::get_instance()->unlock();
 	}

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -605,7 +605,6 @@ void PlayerControl::updatePlayerControl()
 				m_pJackTransportBtn->setPressed(true);
 				
 				if ( static_cast<JackAudioDriver*>(p_Driver)->getIsTimebaseMaster() > 0 ) {
-					std::cout << "That guy is master!" << std::endl;
 					m_pJackMasterBtn->setPressed( true );
 				} else {
 					m_pJackMasterBtn->setPressed( false );

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -929,7 +929,7 @@ void PlayerControl::jackMasterBtnClicked( Button* )
 	Preferences *pPref = Preferences::get_instance();
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( !m_pEngine->haveJackAudioDriver() ) {
+	if ( !m_pEngine->haveJackTransport() ) {
 		QMessageBox::warning( this, "Hydrogen", tr( "JACK-transport will work only with JACK driver." ) );
 		return;
 	}

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -597,7 +597,7 @@ void PlayerControl::updatePlayerControl()
 
 
 		m_pJackMasterBtn->show();
-		if ( static_cast<JackAudioDriver*>(p_Driver)->getIsTimebaseMaster() ) {
+		if ( static_cast<JackAudioDriver*>(p_Driver)->getIsTimebaseMaster() > 0 ) {
 			m_pJackMasterBtn->setPressed( true );
 		} else {
 			m_pJackMasterBtn->setPressed( false );
@@ -611,13 +611,6 @@ void PlayerControl::updatePlayerControl()
 
 	// time
 	float fFrames = m_pEngine->getAudioOutput()->m_transport.m_nFrames;
-
-#ifdef H2CORE_HAVE_JACK
-	if ( pPref->m_sAudioDriver == "Jack"  && Preferences::get_instance()->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT )
-	{
-		fFrames =  m_pEngine->getHumantimeFrames();
-	}
-#endif
 
 	float fSampleRate = m_pEngine->getAudioOutput()->getSampleRate();
 	if ( fSampleRate != 0 ) {
@@ -959,6 +952,7 @@ void PlayerControl::bpmClicked()
 		m_pEngine->getSong()->set_is_modified( true );
 
 		AudioEngine::get_instance()->lock( RIGHT_HERE );
+		
 		m_pEngine->setBPM( fNewVal );
 		AudioEngine::get_instance()->unlock();
 	}

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -597,22 +597,10 @@ void PlayerControl::updatePlayerControl()
 
 
 		m_pJackMasterBtn->show();
-		switch ( pPref->m_bJackMasterMode ) {
-			case Preferences::NO_JACK_TIME_MASTER:
-				m_pJackMasterBtn->setPressed(false);
-				break;
-
-			case Preferences::USE_JACK_TIME_MASTER:
-				if ( m_pJackTransportBtn->isPressed()){
-					m_pJackMasterBtn->setPressed(true);
-				}
-				else
-				{
-					m_pJackMasterBtn->setPressed(false);
-					Hydrogen::get_instance()->offJackMaster();
-					pPref->m_bJackMasterMode = Preferences::NO_JACK_TIME_MASTER;
-				}
-				break;
+		if ( static_cast<JackAudioDriver*>(p_Driver)->getIsTimebaseMaster() ) {
+			m_pJackMasterBtn->setPressed( true );
+		} else {
+			m_pJackMasterBtn->setPressed( false );
 		}
 	}
 	else {

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -35,6 +35,7 @@
 #include <hydrogen/basics/instrument.h>
 #include <hydrogen/LocalFileMng.h>
 #include <hydrogen/timeline.h>
+#include <hydrogen/IO/jack_audio_driver.h>
 using namespace H2Core;
 
 #include "UndoActions.h"
@@ -996,17 +997,30 @@ void SongEditorPatternList::patternChangedEvent() {
 
 	createBackground();
 	update();
+	
 	///here we check the timeline  && m_pSong->get_mode() == Song::SONG_MODE
-	Hydrogen *engine = Hydrogen::get_instance();
-	Timeline *pTimeline = engine->getTimeline();
-		if ( ( Preferences::get_instance()->getUseTimelineBpm() ) && ( engine->getSong()->get_mode() == Song::SONG_MODE ) ){
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	
+#ifdef H2CORE_HAVE_JACK
+	AudioOutput* pDriver = pHydrogen->getAudioOutput();
+	if ( pDriver->class_name() == JackAudioDriver::class_name() ){
+		return;
+	}
+#endif
+	
+	Timeline* pTimeline = pHydrogen->getTimeline();
+	if ( ( Preferences::get_instance()->getUseTimelineBpm() ) &&
+		 ( pHydrogen->getSong()->get_mode() == Song::SONG_MODE ) ){
+		
 		for ( int i = 0; i < static_cast<int>(pTimeline->m_timelinevector.size()); i++){
-			if ( ( pTimeline->m_timelinevector[i].m_htimelinebeat == engine->getPatternPos() )
-				&& ( engine->getNewBpmJTM() != pTimeline->m_timelinevector[i].m_htimelinebpm ) ){
-				engine->setBPM( pTimeline->m_timelinevector[i].m_htimelinebpm );
-			}//if
-		}//for
-	}//if
+			
+			if ( ( pTimeline->m_timelinevector[i].m_htimelinebeat == pHydrogen->getPatternPos() )
+				&& ( pHydrogen->getNewBpmJTM() != pTimeline->m_timelinevector[i].m_htimelinebpm ) ){
+				
+				pHydrogen->setBPM( pTimeline->m_timelinevector[i].m_htimelinebpm );
+			}
+		}
+	}
 }
 
 

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2171,6 +2171,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 
 void SongEditorPositionRuler::updatePosition()
 {
+	HydrogenApp::get_instance()->getSongEditorPanel()->updateTimelineUsage();
 	update();
 }
 

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1002,8 +1002,7 @@ void SongEditorPatternList::patternChangedEvent() {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	
 #ifdef H2CORE_HAVE_JACK
-	AudioOutput* pDriver = pHydrogen->getAudioOutput();
-	if ( pDriver->class_name() == JackAudioDriver::class_name() ){
+	if ( pHydrogen->haveJackTransport() ) {
 		return;
 	}
 #endif
@@ -2026,64 +2025,61 @@ void SongEditorPositionRuler::mouseMoveEvent(QMouseEvent *ev)
 
 void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 {
+	auto pHydrogen = Hydrogen::get_instance();
+	
 	if (ev->button() == Qt::LeftButton && ev->y() >= 26) {
 		int column = (ev->x() / m_nGridWidth);
 		m_bRightBtnPressed = false;
 
-		if ( column > (int)Hydrogen::get_instance()->getSong()->get_pattern_group_vector()->size() ) {
+		if ( column > (int)pHydrogen->getSong()->get_pattern_group_vector()->size() ) {
 			return;
 		}
 
 		// disabling son relocates while in pattern mode as it causes weird behaviour. (jakob lund)
-		if ( Hydrogen::get_instance()->getSong()->get_mode() == Song::PATTERN_MODE ) {
+		if ( pHydrogen->getSong()->get_mode() == Song::PATTERN_MODE ) {
 			return;
 		}
-		AudioOutput* pDriver = Hydrogen::get_instance()->getAudioOutput();
+		AudioOutput* pDriver = pHydrogen->getAudioOutput();
 
-		int nPatternPos = Hydrogen::get_instance()->getPatternPos();
+		int nPatternPos = pHydrogen->getPatternPos();
 		if ( nPatternPos != column ) {
 			WARNINGLOG( "relocate via mouse click" );
-			Hydrogen::get_instance()->setPatternPos( column );
+			pHydrogen->setPatternPos( column );
 			update();
 
-			long totalTick = Hydrogen::get_instance()->getTickForPosition( column );
-			if ( totalTick < 0 && Hydrogen::get_instance()->getState() != STATE_PLAYING ) {
-				
-			}
-			
 #ifdef H2CORE_HAVE_JACK
-			static_cast<JackAudioDriver*>(pDriver)->m_currentPos = 
-				totalTick * pDriver->m_transport.m_fTickSize;
+			if ( pHydrogen->haveJackTransport() ) {
+				long totalTick = pHydrogen->getTickForPosition( column );
+				static_cast<JackAudioDriver*>(pDriver)->m_currentPos = 
+					totalTick * pDriver->m_transport.m_fTickSize;
+			}
 #endif
 		}
 
 		//time line test
 	
 #ifdef H2CORE_HAVE_JACK
-		if ( pDriver->class_name() == JackAudioDriver::class_name() &&
-			 static_cast<JackAudioDriver*>(pDriver)->getIsTimebaseMaster() != 0 ){
-			Hydrogen::get_instance()->setTimelineBpm();
+		if ( !pHydrogen->haveJackTimebaseClient() ) {
+			pHydrogen->setTimelineBpm();
 		}
 #else
-		Hydrogen::get_instance()->setTimelineBpm();
+		pHydrogen->setTimelineBpm();
 #endif
 
-	}
-	else if (ev->button() == Qt::MidButton && ev->y() >= 26) {
+	} else if (ev->button() == Qt::MidButton && ev->y() >= 26) {
 		int column = (ev->x() / m_nGridWidth);
 		SongEditorPanelTagWidget dialog( this , column );
 		if (dialog.exec() == QDialog::Accepted) {
 			//createBackground();
 		}
-	}
-	else if (ev->button() == Qt::RightButton && ev->y() >= 26) {
+	} else if (ev->button() == Qt::RightButton && ev->y() >= 26) {
 		int column = (ev->x() / m_nGridWidth);
 		Preferences* pPref = Preferences::get_instance();
-		if ( column >= (int)Hydrogen::get_instance()->getSong()->get_pattern_group_vector()->size() ) {
+		if ( column >= (int)pHydrogen->getSong()->get_pattern_group_vector()->size() ) {
 			pPref->unsetPunchArea();
 			return;
 		}
-		if ( Hydrogen::get_instance()->getSong()->get_mode() == Song::PATTERN_MODE ) {
+		if ( pHydrogen->getSong()->get_mode() == Song::PATTERN_MODE ) {
 			return;
 		}
 		m_bRightBtnPressed = true;
@@ -2091,8 +2087,7 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 		pPref->setPunchInPos(column);
 		pPref->setPunchOutPos(-1);
 		update();
-	}
-		else if( ( ev->button() == Qt::LeftButton || ev->button() == Qt::RightButton ) && ev->y() <= 25 && Preferences::get_instance()->getUseTimelineBpm() ){
+	} else if( ( ev->button() == Qt::LeftButton || ev->button() == Qt::RightButton ) && ev->y() <= 25 && Preferences::get_instance()->getUseTimelineBpm() ){
 		int column = (ev->x() / m_nGridWidth);
 		SongEditorPanelBpmWidget dialog( this , column );
 		if (dialog.exec() == QDialog::Accepted) {

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -83,6 +83,11 @@ class SongEditorPanel : public QWidget, public EventListener, public H2Core::Obj
 		///< pattern at idx within pattern list will be destroyed
 		void deletePattern( int idx );
 
+		/** Disables and deactivates the Timeline when an external
+		 * JACK timebase master is detected and enables it when it's
+		 * gone or Hydrogen itself becomes the timebase master.
+		 */
+		void updateTimelineUsage();
 	private slots:
 		void vScrollTo( int value );
 		void hScrollTo( int value );


### PR DESCRIPTION
1. the *beat*, *bar*, and *tick* information got misinterpreted as the
   current transport position propagated by the external JACK timebase
   master. But a "tick" is an arbitrary quantization of the beat and
   the last one passed at the current transport position will be
   provided by the BBT information of the JACK server. Therefore it
   almost always lags behind current transport and thus triggering a
   warning described in issue #602 .

   I rewrote the code in such a way the if clause probing for a
   discrepancy between the current transport position + the
   `bbt_frame_offset` and the JACK server transport position is only
   entered after relocations of the JACK transport position. It will
   set the current transport position to the one of the server and
   resets `bbt_frame_offset` to zero. The corner case of an external
   JACK timebase master changing the tempo using the BBT information
   and some relocations taking place afterwards will be covered by
   keeping track of the tick size upon during tempo change and
   remapping the position of the relocation to our internal version
   with a different speed.

   I'm not 100% sure what the *beat*, *bar*, *tick* information are
   actually provided for. Everything works flawless at my end and no
   one of the jack-devel mailing list could/wanted to give me any
   example or use case my implementation would not be able to handle.

2. The internal transport position and the `bbt_frame_offset` variable
   were not properly reset after a relocation by the user took place.