### PR TITLE
validate drumkits containing loads of instruments

### DIFF
--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -116,7 +116,7 @@
 			<xsd:element name="instrumentList">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element ref="h2:instrument" maxOccurs="1000"/>
+						<xsd:element ref="h2:instrument" maxOccurs="unbounded"/>
 					</xsd:sequence>
 				</xsd:complexType>
 			</xsd:element>


### PR DESCRIPTION
As encountered in issue #694 the validation of the drumkit by QXmlSchemaValidator does not work for more than 102 instruments in a drumkit.

I do not know why since 102 is obviously less than 1000, increasing the number does solve anything, and other XML Schema validators, like `xmllint`, do not show this problem. It may be a bug in the underlying Qt5 implementation.

Setting the maximum number of occurrence to `unbounded` resolves the issue.

In addition, I would advocate the change regardless of the behavior of QXmlSchemaValidator since the user is allowed to set `MAX_INSTRUMENTS` to a number bigger than 1000, which would not be noticed by the XSD file.