### PR TITLE
Fixing bug in config recreation

### DIFF
--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -460,11 +460,15 @@ public:
 	bool				useLash();
 	void				setUseLash( bool b );
 
-	void				setMaxBars( int bars );
-	int				getMaxBars();
+	/** @param bars Sets #m_iMaxBars.*/
+	void				setMaxBars( const int bars );
+	/** @return #m_iMaxBars.*/
+	int				getMaxBars() const;
 
-	void				setMaxLayers( int layers );
-	int				getMaxLayers();
+	/** @param layers Sets #m_iMaxLayers.*/
+	void				setMaxLayers( const int layers );
+	/** @return #m_iMaxLayers.*/
+	int				getMaxLayers() const;
 
 	void				setWaitForSessionHandler(bool value);
 	bool				getWaitForSessionHandler();
@@ -557,8 +561,24 @@ private:
 	bool				readPrefFileforotherplaces;
 	int				punchInPos;
 	int				punchOutPos;
-	int				maxBars;
-	int				maxLayers;
+	/** Maximum number of bars shown in the Song Editor at
+	 * once. 
+	 *
+	 * It is set by setMaxBars() and queried by
+	 * getMaxBars(). In order to change this value, you have to
+	 * manually edit the \<maxBars\> tag in the configuration file
+	 * of Hydrogen in your home folder. Default value assigned in
+	 * constructor: 400.*/
+	int				m_iMaxBars;
+	/** Maximum number of layers to be used in the Instrument
+	 *  editor. 
+	 *
+	 * It is set by setMaxLayers() and queried by
+	 * getMaxLayers(). It is setIn order to change this value, you
+	 * have to manually edit the \<maxLayers\> tag in the
+	 * configuration file of Hydrogen in your home folder. Default
+	 * value assigned in constructor: 16. */
+	int				m_iMaxLayers;
 	bool				hearNewNotes;
 
 	QStringList			m_recentFX;
@@ -984,20 +1004,20 @@ inline void Preferences::setUseLash( bool b ){
 	m_bUseLash = b;
 }
 
-inline void Preferences::setMaxBars( int bars ){
-	maxBars = bars;
+inline void Preferences::setMaxBars( const int bars ){
+	m_iMaxBars = bars;
 }
 
-inline int Preferences::getMaxBars(){
-	return maxBars;
+inline int Preferences::getMaxBars() const {
+	return m_iMaxBars;
 }
 
-inline void Preferences::setMaxLayers( int layers ){
-	maxLayers = layers;
+inline void Preferences::setMaxLayers( const int layers ){
+	m_iMaxLayers = layers;
 }
 
-inline int Preferences::getMaxLayers(){
-	return maxLayers;
+inline int Preferences::getMaxLayers() const {
+	return m_iMaxLayers;
 }
 
 inline void Preferences::setWaitForSessionHandler(bool value){

--- a/src/core/include/hydrogen/basics/instrument_component.h
+++ b/src/core/include/hydrogen/basics/instrument_component.h
@@ -45,29 +45,39 @@ class InstrumentComponent : public H2Core::Object
 		InstrumentComponent( InstrumentComponent* other );
 		~InstrumentComponent();
 
-		void						save_to( XMLNode* node, int component_id );
-		static InstrumentComponent* load_from( XMLNode* node, const QString& dk_path );
+		void				save_to( XMLNode* node, int component_id );
+		static InstrumentComponent* 	load_from( XMLNode* node, const QString& dk_path );
 
-		InstrumentLayer*			operator[]( int idx );
-		InstrumentLayer*			get_layer( int idx );
-		void						set_layer( InstrumentLayer* layer, int idx );
+		InstrumentLayer*		operator[]( int ix );
+		InstrumentLayer*		get_layer( int idx );
+		void				set_layer( InstrumentLayer* layer, int idx );
 
-		void						set_drumkit_componentID( int related_drumkit_componentID );
-		int							get_drumkit_componentID();
+		void				set_drumkit_componentID( int related_drumkit_componentID );
+		int				get_drumkit_componentID();
 
-		void						set_gain( float gain );
-		float						get_gain() const;
+		void				set_gain( float gain );
+		float				get_gain() const;
 
-		static int					getMaxLayers( );
-		static void					setMaxLayers( int layers );
+		/**  @return #m_iMaxLayers.*/
+		static int			getMaxLayers();
+		/** @param layers Sets #m_iMaxLayers.*/
+		static void			setMaxLayers( int layers );
 
 	private:
-	        /** Component ID of the drumkit. It is set by
+		/** Component ID of the drumkit. It is set by
 		    set_drumkit_componentID() and
 		    accessed via get_drumkit_componentID(). */
 		int				__related_drumkit_componentID;
-		float							__gain;
-		static int						maxLayers;
+		float				__gain;
+		
+		/** Maximum number of layers to be used in the
+		 *  Instrument editor.
+		 *
+		 * It is set by setMaxLayers(), queried by
+		 * getMaxLayers(), and inferred from
+		 * Preferences::m_iMaxLayers. Default value assigned in
+		 * Preferences::Preferences(): 16. */
+		static int			m_iMaxLayers;
 		std::vector<InstrumentLayer*>	__layers;
 };
 
@@ -97,13 +107,13 @@ inline float InstrumentComponent::get_gain() const
 
 inline InstrumentLayer* InstrumentComponent::operator[]( int idx )
 {
-	assert( idx >= 0 && idx < maxLayers );
+	assert( idx >= 0 && idx < m_iMaxLayers );
 	return __layers[ idx ];
 }
 
 inline InstrumentLayer* InstrumentComponent::get_layer( int idx )
 {
-	assert( idx >= 0 && idx < maxLayers );
+	assert( idx >= 0 && idx < m_iMaxLayers );
 	return __layers[ idx ];
 }
 

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -564,8 +564,8 @@ private:
 	 *   #m_pCoreActionController, 
 	 * - Calls initBeatcounter(), audioEngine_init(), and
 	 *   audioEngine_startAudioDrivers() 
-	 * - Sets InstrumentComponent::maxLayers to
-	 *   Preferences::maxLayers via
+	 * - Sets InstrumentComponent::m_iMaxLayers to
+	 *   Preferences::m_iMaxLayers via
 	 *   InstrumentComponent::setMaxLayers() and
 	 *   Preferences::getMaxLayers() 
 	 * - Starts the OscServer using OscServer::start() if

--- a/src/core/include/hydrogen/sampler/Sampler.h
+++ b/src/core/include/hydrogen/sampler/Sampler.h
@@ -108,8 +108,12 @@ private:
 	std::vector<Note*> __playing_notes_queue;
 	std::vector<Note*> __queuedNoteOffs;
 
-
-	int __maxLayers;
+	/** Maximum number of layers to be used in the Instrument
+	    editor. It will be inferred from
+	    InstrumentComponent::m_iMaxLayers, which itself is
+	    inferred from Preferences::m_iMaxLayers. Default value
+	    assigned in Preferences::Preferences(): 16.*/
+	int m_iMaxLayers;
 
 	bool processPlaybackTrack(int nBufferSize);
 

--- a/src/core/src/basics/instrument_component.cpp
+++ b/src/core/src/basics/instrument_component.cpp
@@ -41,15 +41,15 @@ namespace H2Core
 
 const char* InstrumentComponent::__class_name = "InstrumentComponent";
 
-int InstrumentComponent::maxLayers;
+int InstrumentComponent::m_iMaxLayers;
 
 InstrumentComponent::InstrumentComponent( int related_drumkit_componentID )
 	: Object( __class_name )
 	, __related_drumkit_componentID( related_drumkit_componentID )
 	, __gain( 1.0 )
 {
-	__layers.resize( maxLayers );
-	for ( int i = 0; i < maxLayers; i++ ) {
+	__layers.resize( m_iMaxLayers );
+	for ( int i = 0; i < m_iMaxLayers; i++ ) {
 		__layers[i] = nullptr;
 	}
 }
@@ -59,8 +59,8 @@ InstrumentComponent::InstrumentComponent( InstrumentComponent* other )
 	, __related_drumkit_componentID( other->__related_drumkit_componentID )
 	, __gain( other->__gain )
 {
-	__layers.resize( maxLayers );
-	for ( int i = 0; i < maxLayers; i++ ) {
+	__layers.resize( m_iMaxLayers );
+	for ( int i = 0; i < m_iMaxLayers; i++ ) {
 		InstrumentLayer* other_layer = other->get_layer( i );
 		if ( other_layer ) {
 			__layers[i] = new InstrumentLayer( other_layer, other_layer->get_sample());
@@ -72,7 +72,7 @@ InstrumentComponent::InstrumentComponent( InstrumentComponent* other )
 
 InstrumentComponent::~InstrumentComponent()
 {
-	for ( int i = 0; i < maxLayers; i++ ) {
+	for ( int i = 0; i < m_iMaxLayers; i++ ) {
 		delete __layers[i];
 		__layers[i] = nullptr;
 	}
@@ -80,7 +80,7 @@ InstrumentComponent::~InstrumentComponent()
 
 void InstrumentComponent::set_layer( InstrumentLayer* layer, int idx )
 {
-	assert( idx >= 0 && idx < maxLayers );
+	assert( idx >= 0 && idx < m_iMaxLayers );
 	if ( __layers[ idx ] ) {
 		delete __layers[ idx ];
 	}
@@ -89,12 +89,12 @@ void InstrumentComponent::set_layer( InstrumentLayer* layer, int idx )
 
 void InstrumentComponent::setMaxLayers( int layers )
 {
-	maxLayers = layers;
+	m_iMaxLayers = layers;
 }
 
 int InstrumentComponent::getMaxLayers()
 {
-	return maxLayers;
+	return m_iMaxLayers;
 }
 
 InstrumentComponent* InstrumentComponent::load_from( XMLNode* node, const QString& dk_path )
@@ -109,8 +109,8 @@ InstrumentComponent* InstrumentComponent::load_from( XMLNode* node, const QStrin
 	XMLNode layer_node = node->firstChildElement( "layer" );
 	int n = 0;
 	while ( !layer_node.isNull() ) {
-		if ( n >= maxLayers ) {
-			ERRORLOG( QString( "n (%1) >= maxLayers (%2)" ).arg( n ).arg( maxLayers ) );
+		if ( n >= m_iMaxLayers ) {
+			ERRORLOG( QString( "n (%1) >= m_iMaxLayers (%2)" ).arg( n ).arg( m_iMaxLayers ) );
 			break;
 		}
 		pInstrumentComponent->set_layer( InstrumentLayer::load_from( &layer_node, dk_path ), n );
@@ -128,7 +128,7 @@ void InstrumentComponent::save_to( XMLNode* node, int component_id )
 		component_node.write_int( "component_id", __related_drumkit_componentID );
 		component_node.write_float( "gain", __gain );
 	}
-	for ( int n = 0; n < maxLayers; n++ ) {
+	for ( int n = 0; n < m_iMaxLayers; n++ ) {
 		InstrumentLayer* pLayer = get_layer( n );
 		if( pLayer ) {
 			if( component_id == -1 ) {

--- a/src/core/src/basics/song.cpp
+++ b/src/core/src/basics/song.cpp
@@ -819,7 +819,7 @@ Song* SongReader::readSong( const QString& filename )
 					QDomNode layerNode = componentNode.firstChildElement( "layer" );
 					while (  ! layerNode.isNull()  ) {
 						if ( nLayer >= InstrumentComponent::getMaxLayers() ) {
-							ERRORLOG( QString( "nLayer (%1) > maxLayers (%2)" ).arg ( nLayer ).arg( InstrumentComponent::getMaxLayers() ) );
+							ERRORLOG( QString( "nLayer (%1) > m_iMaxLayers (%2)" ).arg ( nLayer ).arg( InstrumentComponent::getMaxLayers() ) );
 							continue;
 						}
 						//bool sIsModified = false;
@@ -906,7 +906,7 @@ Song* SongReader::readSong( const QString& filename )
 					QDomNode layerNode = instrumentNode.firstChildElement( "layer" );
 					while (  ! layerNode.isNull()  ) {
 						if ( nLayer >= InstrumentComponent::getMaxLayers() ) {
-							ERRORLOG( QString( "nLayer (%1) > maxLayers (%2)" ).arg ( nLayer ).arg( InstrumentComponent::getMaxLayers() ) );
+							ERRORLOG( QString( "nLayer (%1) > m_iMaxLayers (%2)" ).arg ( nLayer ).arg( InstrumentComponent::getMaxLayers() ) );
 							continue;
 						}
 						QString sFilename = LocalFileMng::readXmlString( layerNode, "filename", "" );

--- a/src/core/src/helpers/legacy.cpp
+++ b/src/core/src/helpers/legacy.cpp
@@ -152,7 +152,7 @@ Drumkit* Legacy::load_drumkit( const QString& dk_path ) {
 					XMLNode layer_node = instrument_node.firstChildElement( "layer" );
 					while ( !layer_node.isNull() ) {
 						if ( n >= InstrumentComponent::getMaxLayers() ) {
-							ERRORLOG( QString( "n (%1) > maxLayers (%2)" ).arg ( n ).arg( InstrumentComponent::getMaxLayers() ) );
+							ERRORLOG( QString( "n (%1) > m_iMaxLayers (%2)" ).arg ( n ).arg( InstrumentComponent::getMaxLayers() ) );
 							break;
 						}
 						Sample* pSample = new Sample( dk_path+"/"+layer_node.read_string( "filename", "" ) );

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -213,6 +213,8 @@ Preferences::Preferences()
 	m_ladspaProperties[1].set(2, 20, 0, 0, false);
 	m_ladspaProperties[2].set(2, 20, 0, 0, false);
 	m_ladspaProperties[3].set(2, 20, 0, 0, false);
+	m_iMaxBars = 400;
+	m_iMaxLayers = 16;
 
 	m_nColoringMethod = 2;
 	m_nColoringMethodAuxValue = 213;
@@ -296,8 +298,8 @@ void Preferences::loadPreferences( bool bGlobal )
 			m_bPatternModePlaysSelected = LocalFileMng::readXmlBool( rootNode, "patternModePlaysSelected", true );
 			m_bUseLash = LocalFileMng::readXmlBool( rootNode, "useLash", false );
 			__useTimelineBpm = LocalFileMng::readXmlBool( rootNode, "useTimeLine", __useTimelineBpm );
-			maxBars = LocalFileMng::readXmlInt( rootNode, "maxBars", 400 );
-			maxLayers = LocalFileMng::readXmlInt( rootNode, "maxLayers", 16 );
+			m_iMaxBars = LocalFileMng::readXmlInt( rootNode, "maxBars", 400 );
+			m_iMaxLayers = LocalFileMng::readXmlInt( rootNode, "maxLayers", 16 );
 			m_nDefaultUILayout =  LocalFileMng::readXmlInt( rootNode, "defaultUILayout", UI_LAYOUT_SINGLE_PANE );
 			m_nLastOpenTab =  LocalFileMng::readXmlInt( rootNode, "lastOpenTab", 0 );
 			m_bUseRelativeFilenamesForPlaylists = LocalFileMng::readXmlBool( rootNode, "useRelativeFilenamesForPlaylists", false );
@@ -643,8 +645,8 @@ void Preferences::loadPreferences( bool bGlobal )
 		}
 	}
 
-	if ( maxLayers < 16 ) {
-		maxLayers = 16;
+	if ( m_iMaxLayers < 16 ) {
+		m_iMaxLayers = 16;
 	}
 
 	// The preferences file should be recreated?
@@ -681,8 +683,8 @@ void Preferences::savePreferences()
 	LocalFileMng::writeXmlString( rootNode, "useLash", m_bsetLash ? "true": "false" );
 	LocalFileMng::writeXmlString( rootNode, "useTimeLine", __useTimelineBpm ? "true": "false" );
 
-	LocalFileMng::writeXmlString( rootNode, "maxBars", QString::number( maxBars ) );
-	LocalFileMng::writeXmlString( rootNode, "maxLayers", QString::number( maxLayers ) );
+	LocalFileMng::writeXmlString( rootNode, "maxBars", QString::number( m_iMaxBars ) );
+	LocalFileMng::writeXmlString( rootNode, "maxLayers", QString::number( m_iMaxLayers ) );
 
 	LocalFileMng::writeXmlString( rootNode, "defaultUILayout", QString::number( m_nDefaultUILayout ) );
 	LocalFileMng::writeXmlString( rootNode, "lastOpenTab", QString::number( m_nLastOpenTab ) );

--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -79,7 +79,7 @@ Sampler::Sampler()
 	__main_out_L = new float[ MAX_BUFFER_SIZE ];
 	__main_out_R = new float[ MAX_BUFFER_SIZE ];
 
-	__maxLayers = InstrumentComponent::getMaxLayers();
+	m_iMaxLayers = InstrumentComponent::getMaxLayers();
 
 	QString sEmptySampleFilename = Filesystem::empty_sample_path();
 
@@ -318,7 +318,7 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 		else {
 			switch ( pInstr->sample_selection_alg() ) {
 				case Instrument::VELOCITY:
-					for ( unsigned nLayer = 0; nLayer < __maxLayers; ++nLayer ) {
+					for ( unsigned nLayer = 0; nLayer < m_iMaxLayers; ++nLayer ) {
 						InstrumentLayer *pLayer = pCompo->get_layer( nLayer );
 						if ( pLayer == NULL ) continue;
 
@@ -342,7 +342,7 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 						// for the nearest layer and use its sample.
 						float shortestDistance = 1.0f;
 						int nearestLayer = -1;
-						for ( unsigned nLayer = 0; nLayer < __maxLayers; ++nLayer ){
+						for ( unsigned nLayer = 0; nLayer < m_iMaxLayers; ++nLayer ){
 							InstrumentLayer *pLayer = pCompo->get_layer( nLayer );
 							if ( pLayer == NULL ) continue;
 							
@@ -379,9 +379,9 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 						}
 					}
 					if( pSample == NULL ) {
-						int __possibleIndex[ __maxLayers ];
+						int __possibleIndex[ m_iMaxLayers ];
 						int __foundSamples = 0;
-						for ( unsigned nLayer = 0; nLayer < __maxLayers; ++nLayer ) {
+						for ( unsigned nLayer = 0; nLayer < m_iMaxLayers; ++nLayer ) {
 							InstrumentLayer *pLayer = pCompo->get_layer( nLayer );
 							if ( pLayer == NULL ) continue;
 
@@ -405,7 +405,7 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 							WARNINGLOG( "Velocity did fall into a hole between the instrument layers." );
 							float shortestDistance = 1.0f;
 							int nearestLayer = -1;
-							for ( unsigned nLayer = 0; nLayer < __maxLayers; ++nLayer ){
+							for ( unsigned nLayer = 0; nLayer < m_iMaxLayers; ++nLayer ){
 								InstrumentLayer *pLayer = pCompo->get_layer( nLayer );
 								if ( pLayer == NULL ) continue;
 								
@@ -459,10 +459,10 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 						}
 					}
 					if( !pSample ) {
-						int __possibleIndex[ __maxLayers ];
+						int __possibleIndex[ m_iMaxLayers ];
 						int __foundSamples = 0;
 						float __roundRobinID;
-						for ( unsigned nLayer = 0; nLayer < __maxLayers; ++nLayer ) {
+						for ( unsigned nLayer = 0; nLayer < m_iMaxLayers; ++nLayer ) {
 							InstrumentLayer *pLayer = pCompo->get_layer( nLayer );
 							if ( pLayer == NULL ) continue;
 
@@ -485,7 +485,7 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 							WARNINGLOG( "Velocity did fall into a hole between the instrument layers." );
 							float shortestDistance = 1.0f;
 							int nearestLayer = -1;
-							for ( unsigned nLayer = 0; nLayer < __maxLayers; ++nLayer ){
+							for ( unsigned nLayer = 0; nLayer < m_iMaxLayers; ++nLayer ){
 								InstrumentLayer *pLayer = pCompo->get_layer( nLayer );
 								if ( pLayer == NULL ) continue;
 								


### PR DESCRIPTION
As reported in issue #682 the rendering of H2 does not work properly if the hydrogen.default.conf file was not properly installed.

If neither the system-level config file nor the one in the user directory are not present, H2 will recreate the user config using the default parameters set in the `Preferences::Preferences()` constructor. Since the parameters `maxLayers` and `maxBars` are not set in there, they will be initialized with `0`. This causes H2 to not be properly displayed and the user has no way of changing it but to manually rewrite her config file.

In addition introduced some documentation and made the naming of the `m_iMaxLayers` variable consistent throughout the code base.

It is possible that other parameters, which are not present in the Preferences constructor either might cause additional bugs? Should we/I do some preventive measures and set ALL private parameters in the constructors or would this be an overkill?