### PR TITLE
Multiple osc instances

### DIFF
--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -80,7 +80,7 @@ class OscServer : public H2Core::Object
 		 * \param pPreferences Pointer to the Preferences
 		 * singleton.
 		 */
-		static void create_instance(H2Core::Preferences* pPreferences);
+		static void create_instance(H2Core::Preferences* pPref);
 		/**
 		 * Returns a pointer to the current OscServer
 		 * singleton stored in #__instance.
@@ -138,8 +138,8 @@ class OscServer : public H2Core::Object
 	private:
 		OscServer(H2Core::Preferences* pPreferences);
 
-		lo::ServerThread*				m_pServerThread;
-		H2Core::Preferences*			m_pPreferences;
+		lo::ServerThread*		m_pServerThread;
+		H2Core::Preferences*		m_pPref;
 		static std::list<lo_address>	m_pClientRegistry;
 };
 

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -59,7 +59,6 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	setMinimumSize( width(), height() );
 
 	Preferences *pPref = Preferences::get_instance();
-	pPref->loadPreferences( false );	// reload user's preferences
 
 	driverComboBox->clear();
 	driverComboBox->addItem( "Auto" );
@@ -305,6 +304,10 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 PreferencesDialog::~PreferencesDialog()
 {
 	INFOLOG("~PREFERENCES_DIALOG");
+	
+	// Store the current state of Preferences including all the
+	// changes done by the user.
+	Preferences::get_instance()->savePreferences();
 }
 
 


### PR DESCRIPTION
This fixes #723.

Beforehand it was not possible to start two instances of H2 at the same time since both of them tried to start up an OSC server using the same port. This caused the starting of the second one to result in a segmentation fault.

Now, whenever H2 is about to start up the OSC it uses the port specified in the preferences. If this, however, is not possible, it will let the **liblo** library, which provides the implementation of the OSC server, choose an available port number by itself. This way arbitrary many instances of H2 can be started.

In order to let the `PreferencesDialog` know about the new port, I had to make some changes: 
In `PreferencesDialog::PreferencesDialog()` the settings of the user were reloaded from her ~/.hydrogen/hydrogen.conf file before setting up the PreferencesDialog. But this will discard all the changes to the `Preferences` singleton, which are not saved yet, like the port of the OSC server.

The only reason I could think of why this behavior would be desired is that it ensures consistency between the values shown and the ones in the config file. But I think overwriting the current state with a historic one is the wrong approach of ensuring this.

A way more convenient (and also a more timely one) would be to store the changes in the Preferences as soon as the `PreferencesDialog` gets closed by the user. I am actually surprised myself I have to press ctrl-s to store these changes. But I really like the fact that the dialog is created anew each time it is called. I implemented the automatic save of `Preferences` in the destructor of `PreferencesDialog`.

Apart from the general benefits I think this setting is most convenient for the OSC server itself: If the port is occupied and the user does not care about the actual number, she does not have a look at the PreferencesDialog and the new number will not be changed (if not done expicitly). But if she takes a look at it, the H2 will use the same port number she starts it up again.

Two notes:
- I will add the documentation to all stuff related to OSC in a separate pull request
- This does not allow H2 to run perfectly with many different instances in parallel yet. E.g. the Osc port number should be moved to the Song to ensure reproducible sessions and all instances should use individual temporary folders instead of sharing */tmp/hydrogen*. But I do not plan to pursue this topic any further.