### PR TITLE
Adding documentation and tweaks to OSC server

### DIFF
--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -290,11 +290,11 @@ public:
 	 * Whether to send the current state of Hydrogen to the OSC
 	 * clients.
 	 *
-	 * If set to true, each time an OSC message arrives from an
-	 * address previously unknown to Hydrogen, its current state will
-	 * be send to \e all known OSC clients using
+	 * If set to true, the current state of Hydrogen will be sent to
+	 * \e all known OSC clients using
 	 * CoreActionController::initExternalControlInterfaces() and
-	 * OscServer::handleAction() via OSC messages.
+	 * OscServer::handleAction() via OSC messages each time it gets
+	 * udpated..
 	 
 	 * Set by setOscFeedbackEnabled() and queried by
 	 * getOscFeedbackEnabled().

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -273,8 +273,39 @@ public:
 	bool				m_bEnableMidiFeedback;
 	
 	// OSC Server properties
+	/**
+	 * Whether to start the OscServer thread.
+	 *
+	 * If set to true, the OscServer::start() function of the
+	 * OscServer singleton will be called in
+	 * Hydrogen::Hydrogen(). This will register all OSC message
+	 * handlers and makes the server listen to port
+	 * #m_nOscServerPort.
+	 *
+	 * Set by setOscServerEnabled() and queried by
+	 * getOscServerEnabled().
+	 */
 	bool				m_bOscServerEnabled;
+	/**
+	 * Whether to send the current state of Hydrogen to the OSC
+	 * clients.
+	 *
+	 * If set to true, each time an OSC message arrives from an
+	 * address previously unknown to Hydrogen, its current state will
+	 * be send to \e all known OSC clients using
+	 * CoreActionController::initExternalControlInterfaces() and
+	 * OscServer::handleAction() via OSC messages.
+	 
+	 * Set by setOscFeedbackEnabled() and queried by
+	 * getOscFeedbackEnabled().
+	 */
 	bool				m_bOscFeedbackEnabled;
+	/**
+	 * Port number the OscServer will be started at.
+	 
+	 * Set by setOscServerPort() and queried by
+	 * getOscServerPort().
+	 */
 	int					m_nOscServerPort;
 
 	//	alsa audio driver properties ___
@@ -490,13 +521,17 @@ public:
 	QString			getNsmSongName(void);
 #endif
 
+	/** \return #m_bOscServerEnabled*/
 	bool			getOscServerEnabled();
+	/** \param val Sets #m_bOscServerEnabled*/
 	void			setOscServerEnabled( bool val );
-	
+	/** \return #m_bOscFeedbackEnabled*/
 	bool			getOscFeedbackEnabled();
+	/** \param val Sets #m_bOscFeedbackEnabled*/
 	void			setOscFeedbackEnabled( bool val );
-	
+	/** \return #m_nOscServerPort*/
 	int				getOscServerPort();
+	/** \param oscPort Sets #m_nOscServerPort*/
 	void			setOscServerPort( int oscPort );
 
 	/** Whether to use the bpm of the timeline.

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -71,10 +71,10 @@ namespace lo
 * will start to listen for incoming messages. But this will only
 * happen if H2Core::Preferences::m_bOscServerEnabled is set to
 * true. In addition, Hydrogen will send OSC messages about its current
-* state to all clients each time a new client is contacting the OSC
-* server if H2Core::Preferences::m_bOscFeedbackEnabled is set to
-* true. H2Core::Preferences::m_nOscServerPort contains the port number the OSC
-* server will be started at.
+* state to all clients each time its state changes if
+* H2Core::Preferences::m_bOscFeedbackEnabled is set to
+* true. H2Core::Preferences::m_nOscServerPort contains the port number
+* the OSC server will be started at.
 *
 * @author Sebastian Moors
 *
@@ -162,14 +162,15 @@ class OscServer : public H2Core::Object
 		 * and types.
 		 *
 		 * In addition, a lambda function will be registered to match
-		 * all types and paths too. It will take care of registering
-		 * all clients communicating with Hydrogen to the
-		 * #m_pClientRegistry using the address of the received OSC
-		 * message. After a successful registration it will call
-		 * H2Core::CoreActionController::initExternalControlInterfaces()
-		 * and returns 1. The latter function will, apart from MIDI
-		 * related stuff, use handleAction() to push the current state
-		 * of Hydrogen to the registered OSC clients.
+		 * all types and paths too. If the client has not sent any
+		 * message to Hydrogen yet, it will take care of its
+		 * registration to #m_pClientRegistry using the address of the
+		 * received OSC message. More importantly, it also will call
+		 * H2Core::CoreActionController::initExternalControlInterfaces(),
+		 * which, apart from MIDI related stuff, use handleAction() to
+		 * push the current state of Hydrogen to the registered OSC
+		 * clients. This will happen each time the state of Hydrogen
+		 * does change.
 		 *
 		 * This function will only be processed if the created server
 		 * thread #m_pServerThread is valid.
@@ -178,10 +179,8 @@ class OscServer : public H2Core::Object
 		/**
 		 * Function called by
 		 * H2Core::CoreActionController::initExternalControlInterfaces()
-		 * after successfully registering a new client to
-		 * #m_pClientRegistry to inform all clients about the current
-		 * state of Hydrogen using OSC messages send by Hydrogen
-		 * itself.
+		 * to inform all clients about the current state of Hydrogen
+		 * using OSC messages send by Hydrogen itself.
 		 *
 		 * The following feedback functions will be used to describe
 		 * the aforementioned state:

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -33,113 +33,593 @@
 #include <cassert>
 
 
-/**
-* @class OscServer
-*
-* @brief Osc Server implementation
-*
-* @author Sebastian Moors
-*
-*/
+
 
 namespace lo
 {
 	class ServerThread;
 }
 
-class OscClientInfo : public H2Core::Object
-{
-	H2_OBJECT
-	public:
-		int port;
-		QString address;
-		QString protocol;
-};
-
-
+/**
+* @class OscServer
+*
+* @brief OSC Server implementation
+*
+* Open Sound Control (OSC) is a protocol for communication among
+* programs, computers, and hardware, like synthesizers or multimedia
+* devices, via networking protocols such as UDP or TCP. It can be
+* thought of as a replacement for the MIDI protocol with rich
+* benefits, like supporting symbolic and high-resolution numerical
+* argument data, providing an URL-style naming scheme in combination
+* with a pattern matching language, and allowing to bundle messages
+* for a better handling of timing and simultaneous processing.
+*
+* The OscServer class provides an implementation of an OSC server
+* running in a separate thread and handling all incoming and outgoing
+* OSC messages send to or from Hydrogen. Its naming scheme starts with
+* the prefix \e /Hydrogen/ followed by the name of one of the handler
+* functions implemented as members of this class without the \e
+* _Handler() prefix. Sending an OSC message to the path \e
+* /Hydrogen/PAUSE will thus trigger the PAUSE_Handler() to pause the
+* playback. You can play with these features using the command line
+* program \b oscsend on UNIX-based systems.
+*
+* Internally, the OscServer is implemented as a singleton and will be
+* created using create_instance() and queried using
+* get_instance(). Using start() all handler functions will be
+* registered to their corresponding paths and the OSC server thread
+* will start to listen for incoming messages. But this will only
+* happen if H2Core::Preferences::m_bOscServerEnabled is set to
+* true. In addition, Hydrogen will send OSC messages about its current
+* state to all clients each time a new client is contacting the OSC
+* server if H2Core::Preferences::m_bOscFeedbackEnabled is set to
+* true. H2Core::Preferences::m_nOscServerPort contains the port number the OSC
+* server will be started at.
+*
+* @author Sebastian Moors
+*
+*/
 class OscServer : public H2Core::Object
 {
 	H2_OBJECT
 	public:
 		/**
-		 * Object holding the current OscServer singleton. It
-		 * is initialized with NULL, set with
-		 * create_instance(), and accessed with
-		 * get_instance().
+		 * Object holding the current OscServer singleton. It is
+		 * initialized with nullptr, set with create_instance(), and
+		 * accessed with get_instance().
 		 */
 		static OscServer* __instance;
+		/**
+		 * Destructor freeing all addresses in #m_pClientRegistry and
+		 * setting #__instance to nullptr.
+		 */
 		~OscServer();
 	
 		/**		 
-		 * If #__instance equals 0, a new OscServer singleton
-		 * will be created and stored in it.
+		 * If #__instance equals nullptr, a new OscServer singleton
+		 * will be created by calling the OscServer() constructor and
+		 * stored in #__instance.
 		 *
 		 * It is called in
 		 * H2Core::Hydrogen::create_instance().
-		 *
-		 * \param pPreferences Pointer to the Preferences
-		 * singleton.
 		 */
-		static void create_instance(H2Core::Preferences* pPreferences);
+		static void create_instance();
 		/**
 		 * Returns a pointer to the current OscServer
 		 * singleton stored in #__instance.
 		 */
 		static OscServer* get_instance() { assert(__instance); return __instance; }
 
+		/**
+		 * Converts a data @a data of type @a type into a printable
+		 * QString.
+		 * 
+		 * Apart from the basic OSC types LO_INT32, LO_FLOAT, and
+		 * LO_STRING the following extended OSC types are supported:
+		 * - LO_INT64
+		 * - LO_TIMETAG
+		 * - LO_DOUBLE
+		 * - LO_SYMBOL
+		 * - LO_CHAR
+		 * - LO_TRUE
+		 * - LO_FALSE
+		 * - LO_NIL
+		 * - LO_INFINITUM
+		 *
+		 * LO_BLOB and LO_MIDI are, however, NOT supported.
+		 *
+		 * \param type Liblo class @a data will be cast to. 
+		 * \param data Data to be converted to string.
+		 *
+		 * \return QString representation of @a data.
+		 */
 		static QString qPrettyPrint(lo_type type,void * data);
 		
-
+		/**
+		 * Registers all handler functions defined for this class
+		 * starts the OscServer.
+		 *
+		 * The path the handlers will be registered at always starts
+		 * with \e /Hydrogen/ followed by the name of the handler
+		 * function without the suffix \e _Handler. PLAY_Handler()
+		 * will thus be registered to \e /Hydrogen/PLAY.
+		 *
+		 * Most handler will be registered for both types "" and "f"
+		 * (floats). But the following handlers will be registered fro
+		 * floats only:
+		 * - BPM_DECR_Handler()
+		 * - BPM_INCR_Handler()
+		 * - MASTER_VOLUME_ABSOLUTE_Handler()
+		 * - MASTER_VOLUME_RELATIVE_Handler()
+		 * - STRIP_VOLUME_RELATIVE_Handler()
+		 * - SELECT_NEXT_PATTERN_Handler()
+		 * - SELECT_NEXT_PATTERN_PROMPTLY_Handler()
+		 * - SELECT_AND_PLAY_PATTERN_Handler() 
+		 * - PLAYLIST_SONG_Handler()
+		 * - SELECT_INSTRUMENT_Handler()
+		 *
+		 * The generic_handler() will be registered to match all paths
+		 * and types.
+		 *
+		 * In addition, a lambda function will be registered to match
+		 * all types and paths too. It will take care of registering
+		 * all clients communicating with Hydrogen to the
+		 * #m_pClientRegistry using the address of the received OSC
+		 * message. After a successful registration it will call
+		 * H2Core::CoreActionController::initExternalControlInterfaces()
+		 * and returns 1. The latter function will, apart from MIDI
+		 * related stuff, use handleAction() to push the current state
+		 * of Hydrogen to the registered OSC clients.
+		 *
+		 * This function will only be processed if the created server
+		 * thread #m_pServerThread is valid.
+		 */
 		void start();
+		/**
+		 * Function called by
+		 * H2Core::CoreActionController::initExternalControlInterfaces()
+		 * after successfully registering a new client to
+		 * #m_pClientRegistry to inform all clients about the current
+		 * state of Hydrogen using OSC messages send by Hydrogen
+		 * itself.
+		 *
+		 * The following feedback functions will be used to describe
+		 * the aforementioned state:
+		 * - H2Core::CoreActionController::setMasterVolume()
+		 * - H2Core::CoreActionController::setMetronomeIsActive()
+		 * - H2Core::CoreActionController::setMasterIsMuted()
+		 * - H2Core::CoreActionController::setStripVolume() [*]
+		 * - H2Core::CoreActionController::setStripPan() [*]
+		 * - H2Core::CoreActionController::setStripIsMuted() [*]
+		 * - H2Core::CoreActionController::setStripIsSoloed() [*]
+		 *
+		 * [*] Function will be called for all Instruments in
+		 * H2Core::Song::__instrument_list.
+		 *
+		 * The constructed messages will contain the
+		 * Action::parameter2 of @a pAction as float types (or
+		 * Action::parameter1 for the actions @b TOGGLE_METRONOME and
+		 * @b MUTE_TOGGLE) and will be associated with one of the
+		 * following paths:
+		 * - \e /Hydrogen/MASTER_VOLUME_ABSOLUTE
+		 * - \e /Hydrogen/TOGGLE_METRONOME
+		 * - \e /Hydrogen/MUTE_TOGGLE
+		 * - \e /Hydrogen/STRIP_VOLUME_ABSOLUTE/[x]
+		 * - \e /Hydrogen/PAN_ABSOLUTE/[x]
+		 * - \e /Hydrogen/STRIP_MUTE_TOGGLE/[x]
+		 * - \e /Hydrogen/STRIP_SOLO_TOGGLE/[x]
+		 *
+		 * [x] The last part of the URI is determined by
+		 * Action::parameter1 and specifies an individual strip.
+		 *
+		 * Only called if H2Core::Preferences::m_bOscServerEnabled is
+		 * true.
+		 *
+		 * \param pAction Action to be sent to all registered
+		 * clients. 
+		 */
 		static void handleAction(Action* pAction);
 
+		/**
+		 * Creates an Action of type @b PLAY and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PLAY_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PLAY/STOP_TOGGLE and passes
+		 * its references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PLAY_STOP_TOGGLE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PLAY/PAUSE_TOGGLE and passes
+		 * its references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PLAY_PAUSE_TOGGLE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b STOP and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void STOP_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PAUSE and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PAUSE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b RECORD_READY and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void RECORD_READY_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b RECORD/STROBE_TOGGLE and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void RECORD_STROBE_TOGGLE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b RECORD_STROBE and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void RECORD_STROBE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b EXIT and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void RECORD_EXIT_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b MUTE and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void MUTE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b UNMUTE and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void UNMUTE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b MUTE_TOGGLE and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void MUTE_TOGGLE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b >>_NEXT_BAR and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void NEXT_BAR_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b <<_PREVIOUS_BAR and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PREVIOUS_BAR_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b BPM_INCR and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void BPM_INCR_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b BPM_DECR and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void BPM_DECR_Handler(lo_arg **argv, int i);
-		static void BPM_CC_RELATIVE_Handler(lo_arg **argv, int i);
-		static void BPM_FINE_CC_RELATIVE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b MASTER_VOLUME_RELATIVE and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter2.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void MASTER_VOLUME_RELATIVE_Handler(lo_arg **argv, int i);
+		/**
+		 * Calls H2Core::CoreActionController::setMasterVolume() with
+		 * the first argument in @a argv.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void MASTER_VOLUME_ABSOLUTE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b STRIP_VOLUME_RELATIVE and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter2.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void STRIP_VOLUME_RELATIVE_Handler(lo_arg **argv, int i);
+		/**
+		 * Calls H2Core::CoreActionController::setStripVolume() with
+		 * both @a param1 and @a param2.
+		 *
+		 * \param param1 Passed as first argument to
+		 * H2Core::CoreActionController::setStripVolume().
+		 * \param param2 Passed as second argument to
+		 * H2Core::CoreActionController::setStripVolume().*/
 		static void STRIP_VOLUME_ABSOLUTE_Handler(int param1, float param2);
+		/**
+		 * Creates an Action of type @b SELECT_NEXT_PATTERN and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void SELECT_NEXT_PATTERN_Handler(lo_arg **argv, int i);
-		static void SELECT_NEXT_PATTERN_CC_ABSOLUTE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SELECT_NEXT_PATTERN_PROMPTLY
+		 * and passes its references to
+		 * MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void SELECT_NEXT_PATTERN_PROMPTLY_Handler(lo_arg **argv, int i);
-		static void SELECT_NEXT_PATTERN_RELATIVE_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SELECT_AND_PLAY_PATTERN and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void SELECT_AND_PLAY_PATTERN_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PAN_RELATIVE and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * \param param1 Sets Action::parameter1 of the newly created
+		 * Action.
+		 * \param param2 Sets Action::parameter2 of the newly created
+		 * Action.*/
 		static void PAN_RELATIVE_Handler(QString param1, QString param2);
+		/**
+		 * Creates an Action of type @b PAN_ABSOLTUE and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * \param param1 Sets Action::parameter1 of the newly created
+		 * Action.
+		 * \param param2 Sets Action::parameter2 of the newly created
+		 * Action.*/
 		static void PAN_ABSOLUTE_Handler(QString param1, QString param2);
+		/**
+		 * Creates an Action of type @b FILTER_CUTOFF_LEVEL_ABSOLUTE
+		 * and passes its references to
+		 * MidiActionManager::handleAction().
+		 *
+		 * \param param1 Sets Action::parameter1 of the newly created
+		 * Action.
+		 * \param param2 Sets Action::parameter2 of the newly created
+		 * Action.*/
 		static void FILTER_CUTOFF_LEVEL_ABSOLUTE_Handler(QString param1, QString param2);
+		/**
+		 * Creates an Action of type @b BEATCOUNTER and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void BEATCOUNTER_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b TAP_TEMPO and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void TAP_TEMPO_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PLAYLIST_SONG and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PLAYLIST_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PLAYLIST_NEXT_SONG and passes
+		 * its references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PLAYLIST_NEXT_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b PLAYLIST_PREV_SONG and passes
+		 * its references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void PLAYLIST_PREV_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b TOGGLE_METRONOME and passes
+		 * its references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void TOGGLE_METRONOME_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SELECT_INSTRUMENT and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter2.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void SELECT_INSTRUMENT_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b UNDO_ACTION and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void UNDO_ACTION_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b REDO_ACTION and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
 		static void REDO_ACTION_Handler(lo_arg **argv, int i);
+		/** 
+		 * Catches any incoming messages and display them. 
+		 *
+		 * It is also responsible for catching OSC messages at the
+		 * following paths and invoking the corresponding functions
+		 * (if only a single argument is present.)
+		 * - \e /Hydrogen/STRIP_VOLUME_ABSOLUTE/[x]
+		 * - \e /Hydrogen/PAN_ABSOLUTE/[x]
+		 * - \e /Hydrogen/PAN_RELATIVE/[x]
+		 * - \e /Hydrogen/FILTER_CUTOFF_LEVEL_ABSOLUTE/[x]
+		 * - \e /Hydrogen/STRIP_MUTE_TOGGLE/[x]
+		 * - \e /Hydrogen/STRIP_SOLO_TOGGLE/[x]
+		 *
+		 * [x] Digit specifying a particular instrument.
+		 *
+		 * \param path The OSC path to register the method to. If NULL
+		 * is passed the method will match all paths.
+		 * \param types The typespec the method accepts. In Hydrogen
+		 * handler functions are registered to listen for floats.
+		 * \param argv Pointer to a vector of arguments passed by the
+		 * OSC message.
+		 * \param argc Number of arguments passed by the OSC message.
+		 * \param data Unused.
+		 * \param user_data Unused.
+		 *
+		 * \return 1 - means that the message has not been fully
+		 * handled and the server should try other methods */
 		static int  generic_handler(const char *path, const char *types, lo_arg ** argv,
 								int argc, void *data, void *user_data);
 
 	private:
-		OscServer(H2Core::Preferences* pPreferences);
+		/**
+		 * Private constructor creating a new OSC server thread using
+		 * the port H2Core::Preferences::m_nOscServerPort and
+		 * assigning the object to #m_pServerThread.
+		 */
+		OscServer();
 
+		/**
+		 * Object containing the actual thread with an OSC server
+		 * running in.
+		 *
+		 * It is created in OscServer() and both assigned handlers and
+		 * started in start().
+		 */
 		lo::ServerThread*				m_pServerThread;
-		H2Core::Preferences*			m_pPreferences;
+		/**
+		 * List of all OSC clients known to Hydrogen.
+		 *
+		 * Whenever an OSC client sends a message to the started OSC
+		 * server of Hydrogen, a lambda handler registered in start()
+		 * will check whether the address of this client is already
+		 * present in #m_pClientRegistry. If this is not the case it
+		 * will be added to it and the current state Hydrogen will be
+		 * propagated to all registered clients.
+		 */
 		static std::list<lo_address>	m_pClientRegistry;
 };
 

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -102,8 +102,13 @@ class OscServer : public H2Core::Object
 		 *
 		 * It is called in
 		 * H2Core::Hydrogen::create_instance().
+		 *
+		 * \param pPreferences Pointer to the H2Core::Preferences
+		 * singleton. Although it could be accessed internally using
+		 * H2Core::Preferences::get_instance(), this is an appetizer
+		 * for internal changes happening after the 1.0 release.
 		 */
-		static void create_instance();
+		static void create_instance( H2Core::Preferences* pPreferences );
 		/**
 		 * Returns a pointer to the current OscServer
 		 * singleton stored in #__instance.
@@ -598,9 +603,20 @@ class OscServer : public H2Core::Object
 		 * Private constructor creating a new OSC server thread using
 		 * the port H2Core::Preferences::m_nOscServerPort and
 		 * assigning the object to #m_pServerThread.
+		 *
+		 * \param pPreferences Pointer to the H2Core::Preferences
+		 * singleton. Although it could be accessed internally using
+		 * H2Core::Preferences::get_instance(), this is an appetizer
+		 * for internal changes happening after the 1.0 release.
 		 */
-		OscServer();
-
+		OscServer( H2Core::Preferences* pPreferences );
+	
+		/** Pointer to the H2Core::Preferences singleton. Although it
+		 * could be accessed internally using
+		 * H2Core::Preferences::get_instance(), this is an appetizer
+		 * for internal changes happening after the 1.0 release.*/
+		H2Core::Preferences*			m_pPreferences;
+		
 		/**
 		 * Object containing the actual thread with an OSC server
 		 * running in.

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2246,7 +2246,7 @@ void Hydrogen::create_instance()
 
 #ifdef H2CORE_HAVE_OSC
 	NsmClient::create_instance();
-	OscServer::create_instance();
+	OscServer::create_instance( Preferences::get_instance() );
 #endif
 
 	if ( __instance == 0 ) {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2246,7 +2246,7 @@ void Hydrogen::create_instance()
 
 #ifdef H2CORE_HAVE_OSC
 	NsmClient::create_instance();
-	OscServer::create_instance( Preferences::get_instance() );
+	OscServer::create_instance();
 #endif
 
 	if ( __instance == 0 ) {

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -827,7 +827,7 @@ void OscServer::start()
 	m_pServerThread->start();
 
 
-	INFOLOG(QString("Osc server started. Listening on port %1").arg( m_pPreferences->get_instance()->getOscServerPort() ));
+	INFOLOG(QString("Osc server started. Listening on port %1").arg( m_pPreferences->getOscServerPort() ));
 }
 
 OscServer::~OscServer()

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -246,17 +246,18 @@ int OscServer::generic_handler(const char *	path,
 
 
 
-OscServer::OscServer() : Object( __class_name )
+OscServer::OscServer( H2Core::Preferences* pPreferences ) : Object( __class_name )
 {
-	int port = H2Core::Preferences::get_instance()->getOscServerPort();
+	m_pPreferences = pPreferences;
+	int port = m_pPreferences->getOscServerPort();
 
 	m_pServerThread = new lo::ServerThread( port );
 }
 
-void OscServer::create_instance()
+void OscServer::create_instance( H2Core::Preferences* pPreferences )
 {
 	if( __instance == nullptr ) {
-		__instance = new OscServer();
+		__instance = new OscServer( pPreferences );
 	}
 }
 
@@ -826,7 +827,7 @@ void OscServer::start()
 	m_pServerThread->start();
 
 
-	INFOLOG(QString("Osc server started. Listening on port %1").arg( H2Core::Preferences::get_instance()->getOscServerPort() ));
+	INFOLOG(QString("Osc server started. Listening on port %1").arg( m_pPreferences->get_instance()->getOscServerPort() ));
 }
 
 OscServer::~OscServer()

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -39,7 +39,7 @@
 #include "hydrogen/basics/song.h"
 #include "hydrogen/midi_action.h"
 
-OscServer * OscServer::__instance = 0;
+OscServer * OscServer::__instance = nullptr;
 const char* OscServer::__class_name = "OscServer";
 std::list<lo_address> OscServer::m_pClientRegistry;
 
@@ -239,24 +239,24 @@ int OscServer::generic_handler(const char *	path,
 		INFOLOG(QString("Argument %1: %2 %3").arg(i).arg(types[i]).arg(formattedArgument));
 	}
 	
+	// Returning 1 means that the message has not been fully handled
+	// and the server should try other methods.
 	return 1;
 }
 
 
 
-OscServer::OscServer( H2Core::Preferences * pPreferences )
-	: Object( __class_name )
+OscServer::OscServer() : Object( __class_name )
 {
-	m_pPreferences = pPreferences;
-	int port = m_pPreferences->getOscServerPort();
+	int port = H2Core::Preferences::get_instance()->getOscServerPort();
 
 	m_pServerThread = new lo::ServerThread( port );
 }
 
-void OscServer::create_instance( H2Core::Preferences* pPreferences )
+void OscServer::create_instance()
 {
 	if( __instance == nullptr ) {
-		__instance = new OscServer( pPreferences );
+		__instance = new OscServer();
 	}
 }
 
@@ -570,7 +570,7 @@ bool IsLoAddressEqual( lo_address first, lo_address second )
 
 void OscServer::handleAction( Action* pAction )
 {
-	H2Core::Preferences * pPref = H2Core::Preferences::get_instance();
+	H2Core::Preferences *pPref = H2Core::Preferences::get_instance();
 	
 	if( !pPref->getOscFeedbackEnabled() ){
 		return;
@@ -732,7 +732,11 @@ void OscServer::start()
 										
 										pController->initExternalControlInterfaces();
 									}
-
+									
+									// Returning 1 means that the
+									// message has not been fully
+									// handled and the server should
+									// try other methods.
 									return 1;
 								});
 
@@ -822,7 +826,7 @@ void OscServer::start()
 	m_pServerThread->start();
 
 
-	INFOLOG(QString("Osc server started. Listening on port %1").arg( m_pPreferences->getOscServerPort() ));
+	INFOLOG(QString("Osc server started. Listening on port %1").arg( H2Core::Preferences::get_instance()->getOscServerPort() ));
 }
 
 OscServer::~OscServer()


### PR DESCRIPTION
I added a bunch of doumentation to the OscServer class and its members.

In addition, removed the argument from the Constructor and `create_instance()` function as well as the `m_pPreferences` member. The former is used to pass a fresh copy of the `Preferences` instance and the latter is used to access `Preferencs::m_nOscServerPort`. Both can be done more readable and consistent with the overall code base by using direct calls to `Preferences::get_instance()`.

I also remove some member functions which were neither implemented nor used
- `BPM_CC_RELATIVE_Handler()`
- `BPM_FINE_CC_RELATIVE_Handler()`
- `SELECT_NEXT_PATTERN_CC_ABSOLUTE_Handler()`
- `SELECT_NEXT_PATTERN_RELATIVE_Handler()`

as well as the unused `OscClientInfo` class.