### PR TITLE
Adding documentation in audioEngine

### DIFF
--- a/src/core/include/hydrogen/IO/TransportInfo.h
+++ b/src/core/include/hydrogen/IO/TransportInfo.h
@@ -69,12 +69,17 @@ public:
 	long long m_nFrames;
 	/** 
 	 * Number of frames that make up one tick.
+	 *
+	 * A tick is the most fine-grained time scale handled by the
+	 * AudioEngine. The notes won't be processed frame by frame but,
+	 * instead, tick by tick. Therefore, #m_nTickSize represents the
+	 * minimum duration of a Note as well as the minimum distance
+	 * between two of them.
 	 * 
-	 * It will only be used by the JackAudioDriver and is
-	 * calculated by the sample rate * 60.0 / ( #m_nBPM *
+	 * It is calculated by the sample rate * 60.0 / ( #m_nBPM *
 	 * Song::__resolution ). The factor 60.0 will be used to convert
-	 * the sample rate, which is given in second, into minutes (as
-	 * the #m_nBPM).
+	 * the sample rate, which is given in second, into minutes (as the
+	 * #m_nBPM).
 	 */
 	float m_nTickSize;
 	/** Current tempo in beats per minute. */

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -230,9 +230,14 @@ public:
 	 * - "Fake" : createDriver() will create a FakeDriver.
 	 */
 	QString				m_sAudioDriver;
-	bool				m_bUseMetronome;		///< Use metronome?
-	float				m_fMetronomeVolume;	///< Metronome volume FIXME: remove this volume!!
-	unsigned			m_nMaxNotes;		///< max notes
+	/** If set to true, samples of the metronome will be added to
+	 * #m_songNoteQueue in audioEngine_updateNoteQueue() and thus
+	 * played back on a regular basis.*/
+	bool				m_bUseMetronome;
+	/// Metronome volume FIXME: remove this volume!!
+	float				m_fMetronomeVolume;
+	/// max notes
+	unsigned			m_nMaxNotes;
 	/** 
 	 * Buffer size of the audio.
 	 *
@@ -455,7 +460,9 @@ public:
 
 	UIStyle*		getDefaultUIStyle();
 
+	/** \return #m_bPatternModePlaysSelected*/
 	bool			patternModePlaysSelected();
+	/** \param b Sets #m_bPatternModePlaysSelected*/
 	void			setPatternModePlaysSelected( bool b );
 	bool			useLash();
 	void			setUseLash( bool b );
@@ -546,13 +553,25 @@ private:
 	//___ General properties ___
 	QString				m_sH2ProcessName; //Name of hydrogen's main process
 	int					__rubberBandCalcTime;
-	bool				m_useTheRubberbandBpmChangeEvent; ///rubberband bpm change queue
-	bool				m_bPatternModePlaysSelected; /// Behaviour of Pattern Mode
-	bool				m_brestoreLastSong;		///< Restore last song?
+	 ///rubberband bpm change queue
+	bool				m_useTheRubberbandBpmChangeEvent;
+	/**
+	 * When transport is in Song::PATTERN_MODE and this variable is
+	 * set to true, the currently focused Pattern will be used for
+	 * playback.
+	 *
+	 * It is set by setPatternModePlaysSelected() and queried by
+	 * patternModePlaysSelected().
+	 */
+	bool				m_bPatternModePlaysSelected;
+	///< Restore last song?
+	bool				m_brestoreLastSong;
 	bool				m_brestoreLastPlaylist;
 	bool				m_bUseLash;
-	bool				m_bShowDevelWarning;	///< Show development version warning?
-	QString				m_lastSongFilename;	///< Last song used
+	///< Show development version warning?
+	bool				m_bShowDevelWarning;
+	///< Last song used
+	QString				m_lastSongFilename;
 	QString				m_lastPlaylistFilename;
 
 	bool				quantizeEvents;

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -40,8 +40,22 @@ enum EventType {
 	/** Fallback event*/
 	EVENT_NONE,
 	EVENT_STATE,
+	/** The current pattern changed during the processing of the
+	 * AudioEngine with respect to the previous process cycle.
+	 *
+	 * It is handled by EventListener::patternChangedEvent().
+	 */
 	EVENT_PATTERN_CHANGED,
 	EVENT_PATTERN_MODIFIED,
+	/** Another pattern was selected via MIDI or the GUI without
+	 * affecting the audio transport (e.g in Song::PATTERN_MODE when
+	 * Preferences::m_bPatternModePlaysSelected is set to true). While
+	 * the selection in the former case already happens in the GUI,
+	 * this event will be used to tell it the selection was successful
+	 * and had been done.
+	 *
+	 * Handled by EventListener::selectedPatternChangedEvent().
+	 */
 	EVENT_SELECTED_PATTERN_CHANGED,
 	EVENT_SELECTED_INSTRUMENT_CHANGED,
 	EVENT_PARAMETERS_INSTRUMENT_CHANGED,
@@ -49,6 +63,27 @@ enum EventType {
 	EVENT_XRUN,
 	EVENT_NOTEON,
 	EVENT_ERROR,
+	/** Event indicating the triggering of the
+	 * #m_pMetronomeInstrument.
+	 *
+	 * In audioEngine_updateNoteQueue() the pushing of this Event is
+	 * decoupled from the creation and queuing of the corresponding
+	 * Note itself.
+	 *
+	 * The associated values do correspond to the following actions:
+	 * - 0: Beat at the beginning of a Pattern in
+	 *      audioEngine_updateNoteQueue(). The corresponding Note will
+	 *      be created with a pitch of 3 and velocity of 1.0.
+	 * - 1: Beat in the remainder of a Pattern in
+	 *      audioEngine_updateNoteQueue(). The corresponding Note will
+	 *      be created with a pitch of 0 and velocity of 0.8. In
+	 *      addition, it will be also pushed by
+	 *      Hydrogen::setPatternPos() without creating a Note.
+	 * - 2:
+	 * - 3:
+	 *
+	 * Handled by EventListener::metronomeEvent().
+	 */
 	EVENT_METRONOME,
 	EVENT_RECALCULATERUBBERBAND,
 	EVENT_PROGRESS,

--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -1297,7 +1297,7 @@ void Sampler::setPlayingNotelength( Instrument* instrument, unsigned long ticks,
 	if ( instrument ) { // stop all notes using this instrument
 		Hydrogen *pEngine = Hydrogen::get_instance();
 		Song* pSong = pEngine->getSong();
-		int selectedpattern = pEngine->__get_selected_PatterNumber();
+		int selectedpattern = pEngine->getSelectedPatternNumber();
 		Pattern* pCurrentPattern = NULL;
 
 


### PR DESCRIPTION
Most of the new parts focus on the `audioEngine_updateNoteQueue()` function.

In addition, I removed the `Hydrogen::__get_selected_PatternNumber()` since it was doing exactly the same as `Hydrogen::getSelectedPatternNumber()`