### PR TITLE
Doc structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,14 +231,19 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 #set(CMAKE_AUTOMOC ON)
 
 
+# Building the developer/API documentation.
 find_package(Doxygen)
 if(DOXYGEN_FOUND)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
-	add_custom_target(doc_dir ALL COMMAND ${CMAKE_COMMAND}
-		-E make_directory ${CMAKE_CURRENT_BINARY_DIR}/docs)
+	add_custom_target(doc_dir
+	  ALL
+	  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/docs)
+	add_custom_target(doxygen_dir
+	  ALL
+	  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/doxygen ${CMAKE_CURRENT_BINARY_DIR}/doxygen)
 	add_custom_target(doc
 		${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-		DEPENDS doc_dir
+		DEPENDS doc_dir doxygen_dir
 		WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/docs
 		COMMENT "Generating API documentation with Doxygen"
 		VERBATIM)

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -557,7 +557,8 @@ WARN_LOGFILE           =
 # with spaces.
 
 INPUT                  = "@CMAKE_SOURCE_DIR@/src/gui/" \
-                         "@CMAKE_SOURCE_DIR@/src/core/"
+                         "@CMAKE_SOURCE_DIR@/src/core/"\
+			 "@CMAKE_SOURCE_DIR@/doxygen/"
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -397,11 +397,11 @@ SORT_MEMBER_DOCS       = YES
 # by member name. If set to NO (the default) the members will appear in
 # declaration order.
 
-SORT_BRIEF_DOCS        = NO
+SORT_BRIEF_DOCS        = YES
 
 # If the SORT_MEMBERS_CTORS_1ST tag is set to YES then doxygen will sort the (brief and detailed) documentation of class members so that constructors and destructors are listed first. If set to NO (the default) the constructors will appear in the respective orders defined by SORT_MEMBER_DOCS and SORT_BRIEF_DOCS. This tag will be ignored for brief docs if SORT_BRIEF_DOCS is set to NO and ignored for detailed docs if SORT_MEMBER_DOCS is set to NO.
 
-SORT_MEMBERS_CTORS_1ST = NO
+SORT_MEMBERS_CTORS_1ST = YES
 
 # If the SORT_GROUP_NAMES tag is set to YES then doxygen will sort the
 # hierarchy of group names into alphabetical order. If set to NO (the default)
@@ -423,7 +423,7 @@ SORT_BY_SCOPE_NAME     = NO
 # disable (NO) the todo list. This list is created by putting \todo
 # commands in the documentation.
 
-GENERATE_TODOLIST      = YES
+GENERATE_TODOLIST      = NO
 
 # The GENERATE_TESTLIST tag can be used to enable (YES) or
 # disable (NO) the test list. This list is created by putting \test

--- a/doxygen/grouping.hpp
+++ b/doxygen/grouping.hpp
@@ -1,0 +1,16 @@
+/** \defgroup h2core Core of Hydrogen
+*/
+
+/** \defgroup h2audiooEngine Parts of the source code belonging to the
+	audio engine and coping with the actual audio processing 
+* Ladida
+*/
+
+/** \page introduction A general overview
+ * \tableofcontents
+ * \section general
+ * \subsection gui Wraps \ref core
+ * \subsection core Blub
+ */
+
+/** \page advanced Some advanced pages.*/

--- a/doxygen/grouping.hpp
+++ b/doxygen/grouping.hpp
@@ -1,16 +1,57 @@
-/** \defgroup h2core Core of Hydrogen
+/** \defgroup docCore Core of hydrogen
+ * All major classes of the part of hydrogen.
 */
 
-/** \defgroup h2audiooEngine Parts of the source code belonging to the
-	audio engine and coping with the actual audio processing 
-* Ladida
-*/
-
-/** \page introduction A general overview
- * \tableofcontents
- * \section general
- * \subsection gui Wraps \ref core
- * \subsection core Blub
+/** \defgroup docAudioEngine Audio engine
+ *
+ * Parts of the source code belonging to the audio engine and coping
+ * with the actual audio processing.
  */
 
-/** \page advanced Some advanced pages.*/
+/** \defgroup docAudioDriver Audio driver
+ *
+ * These classes handle the communication with the sound card of your
+ * computer.
+ */
+/** \defgroup docDataStructure Data structures
+ *
+ * Basic data structures hydrogen uses to store/handle individual
+ * instruments, samples, whole drumkits etc.
+ */
+/** \defgroup docConfiguration Configuration
+ *
+ * Classes and functions allowing for customizing both the behavior
+ * and the appearance of hydrogen.
+ */
+/** \defgroup docDebugging Debugging
+ *
+ * Classes, functions, and macros making the debugging hydrogen more
+ * convenient.
+ */
+/** \defgroup docEvent Events
+ *
+ * Basic classes for communication of the core part of hydrogen with
+ * its GUI.
+ */
+/** \defgroup docMIDI MIDI 
+ *
+ * Various MIDI-related classes and functions.
+ */
+/** \defgroup docSound Sound generation
+ *
+ * Classes handling both the generation of sound either using a
+ * synthesizer or samples and their modification and shaping.
+ */
+/** \defgroup docAutomatization Automatization
+ *
+ * Various classes for controlling hydrogen from outside the program itself.
+ */
+
+/** \defgroup docGUI GUI of hydrogen
+ *
+ * All major classes of the GUI of hydrogen.
+ */
+/** \defgroup docWidgets Basic components of the GUI
+ *
+ * Fundamental classes the GUI is constructed with.
+ */

--- a/src/core/include/hydrogen/IO/AlsaAudioDriver.h
+++ b/src/core/include/hydrogen/IO/AlsaAudioDriver.h
@@ -35,6 +35,7 @@ namespace H2Core
 
 typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
+/** \ingroup docCore docAudioDriver */
 class AlsaAudioDriver : public AudioOutput
 {
 public:
@@ -81,6 +82,7 @@ private:
 
 namespace H2Core {
 
+/** \ingroup docCore docAudioDriver */
 class AlsaAudioDriver : public NullDriver
 {
 public:

--- a/src/core/include/hydrogen/IO/AlsaAudioDriver.h
+++ b/src/core/include/hydrogen/IO/AlsaAudioDriver.h
@@ -37,8 +37,9 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
 class AlsaAudioDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	snd_pcm_t *m_pPlayback_handle;
 	bool m_bIsRunning;
 	unsigned long m_nBufferSize;
@@ -66,6 +67,12 @@ public:
 	virtual void setBpm( float fBPM );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 	unsigned int m_nSampleRate;
 };
@@ -76,9 +83,17 @@ namespace H2Core {
 
 class AlsaAudioDriver : public NullDriver
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	AlsaAudioDriver( audioProcessCallback processCallback ) : NullDriver( processCallback ) {}
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 };
 

--- a/src/core/include/hydrogen/IO/AlsaMidiDriver.h
+++ b/src/core/include/hydrogen/IO/AlsaMidiDriver.h
@@ -35,10 +35,12 @@
 namespace H2Core
 {
 
-///
-/// Alsa Midi Driver
-/// Based on Matthias Nagorni alsa sequencer example
-///
+/**
+ * Alsa Midi Driver
+ *
+ * Based on Matthias Nagorni alsa sequencer example
+ * \ingroup docCore docAudioDriver docMIDI
+ */
 class AlsaMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
 public:

--- a/src/core/include/hydrogen/IO/AlsaMidiDriver.h
+++ b/src/core/include/hydrogen/IO/AlsaMidiDriver.h
@@ -41,8 +41,9 @@ namespace H2Core
 ///
 class AlsaMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	AlsaMidiDriver();
 	virtual ~AlsaMidiDriver();
 
@@ -59,6 +60,12 @@ public:
 	virtual void handleOutgoingControlChange( int param, int value, int channel );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/IO/AudioOutput.h
+++ b/src/core/include/hydrogen/IO/AudioOutput.h
@@ -30,9 +30,10 @@
 namespace H2Core
 {
 
-///
-/// Base abstract class for audio output classes.
-///
+/**
+ * Base abstract class for audio output classes.
+ * \ingroup docCore docAudioDriver
+ */
 class AudioOutput : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/IO/CoreAudioDriver.h
+++ b/src/core/include/hydrogen/IO/CoreAudioDriver.h
@@ -49,6 +49,7 @@ namespace H2Core
 
 #if defined(H2CORE_HAVE_COREAUDIO) || _DOXYGEN_
 
+/** \ingroup docCore docAudioDriver */
 class CoreAudioDriver : public AudioOutput
 {
 public:
@@ -106,6 +107,7 @@ private:
 
 #else
 
+/** \ingroup docCore docAudioDriver */
 class CoreAudioDriver : public NullDriver
 {
 public:

--- a/src/core/include/hydrogen/IO/CoreAudioDriver.h
+++ b/src/core/include/hydrogen/IO/CoreAudioDriver.h
@@ -51,8 +51,9 @@ namespace H2Core
 
 class CoreAudioDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 
 	audioProcessCallback mProcessCallback;
 	UInt32 m_nBufferSize;
@@ -87,6 +88,12 @@ public:
 
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	void retrieveDefaultDevice(void);
 	void retrieveBufferSize(void);
 	void printStreamInfo(void);
@@ -101,10 +108,18 @@ private:
 
 class CoreAudioDriver : public NullDriver
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	CoreAudioDriver( audioProcessCallback processCallback ) : NullDriver ( processCallback ) {}
 
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 #endif // H2CORE_HAVE_COREAUDIO

--- a/src/core/include/hydrogen/IO/CoreMidiDriver.h
+++ b/src/core/include/hydrogen/IO/CoreMidiDriver.h
@@ -38,6 +38,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore docAudioDriver docMIDI*/
 class CoreMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
 public:

--- a/src/core/include/hydrogen/IO/CoreMidiDriver.h
+++ b/src/core/include/hydrogen/IO/CoreMidiDriver.h
@@ -40,8 +40,9 @@ namespace H2Core
 
 class CoreMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	CoreMidiDriver();
 	~CoreMidiDriver();
 
@@ -67,6 +68,12 @@ public:
 	MIDIEndpointRef h2VirtualOut;
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	void sendMidiPacket (MIDIPacketList *packetList);
 };
 

--- a/src/core/include/hydrogen/IO/DiskWriterDriver.h
+++ b/src/core/include/hydrogen/IO/DiskWriterDriver.h
@@ -40,8 +40,9 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
 ///
 class DiskWriterDriver : public AudioOutput
 {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 
 		unsigned				m_nSampleRate;
 		QString					m_sFilename;
@@ -90,6 +91,12 @@ class DiskWriterDriver : public AudioOutput
 		
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 
 };

--- a/src/core/include/hydrogen/IO/DiskWriterDriver.h
+++ b/src/core/include/hydrogen/IO/DiskWriterDriver.h
@@ -35,9 +35,10 @@ namespace H2Core
 
 typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
-///
-/// Driver for export audio to disk
-///
+/**
+ * Driver for export audio to disk
+ * \ingroup docCore docAudioDriver
+ */
 class DiskWriterDriver : public AudioOutput
 {
 	public:

--- a/src/core/include/hydrogen/IO/FakeDriver.h
+++ b/src/core/include/hydrogen/IO/FakeDriver.h
@@ -36,8 +36,9 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
  */
 class FakeDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	FakeDriver( audioProcessCallback processCallback );
 	~FakeDriver();
 
@@ -59,6 +60,12 @@ public:
 	virtual void setBpm( float fBPM );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	audioProcessCallback m_processCallback;
 	unsigned m_nBufferSize;
 	float* m_pOut_L;

--- a/src/core/include/hydrogen/IO/FakeDriver.h
+++ b/src/core/include/hydrogen/IO/FakeDriver.h
@@ -33,6 +33,8 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
 /**
  * Fake audio driver. Used only for profiling.
+ *
+ * \ingroup docCore docAudioDriver
  */
 class FakeDriver : public AudioOutput
 {

--- a/src/core/include/hydrogen/IO/JackMidiDriver.h
+++ b/src/core/include/hydrogen/IO/JackMidiDriver.h
@@ -48,8 +48,9 @@ namespace H2Core
 
 class JackMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	JackMidiDriver();
 	virtual ~JackMidiDriver();
 
@@ -67,6 +68,12 @@ public:
 	virtual void handleOutgoingControlChange( int param, int value, int channel );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	void JackMidiOutEvent(uint8_t *buf, uint8_t len);
 
 	void lock();

--- a/src/core/include/hydrogen/IO/JackMidiDriver.h
+++ b/src/core/include/hydrogen/IO/JackMidiDriver.h
@@ -46,6 +46,9 @@
 namespace H2Core
 {
 
+/**
+ * \ingroup docCore docAudioDriver docMIDI
+ */
 class JackMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
 public:

--- a/src/core/include/hydrogen/IO/MidiCommon.h
+++ b/src/core/include/hydrogen/IO/MidiCommon.h
@@ -31,6 +31,9 @@
 namespace H2Core
 {
 
+/**
+ * \ingroup docCore docMIDI
+ */
 class MidiMessage
 {
 public:

--- a/src/core/include/hydrogen/IO/MidiInput.h
+++ b/src/core/include/hydrogen/IO/MidiInput.h
@@ -33,6 +33,7 @@ namespace H2Core
 
 /**
  * MIDI input base class
+ * \ingroup docCore docAudioDriver docMIDI
  */
 class MidiInput : public virtual Object
 {

--- a/src/core/include/hydrogen/IO/MidiOutput.h
+++ b/src/core/include/hydrogen/IO/MidiOutput.h
@@ -34,7 +34,8 @@ class Note;
 
 
 /**
- * MIDI input base class
+ * MIDI output base class
+ * \ingroup docCore docAudioDriver docMIDI
  */
 class MidiOutput : public virtual Object
 {

--- a/src/core/include/hydrogen/IO/NullDriver.h
+++ b/src/core/include/hydrogen/IO/NullDriver.h
@@ -35,8 +35,9 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
 class NullDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	NullDriver( audioProcessCallback processCallback );
 	~NullDriver();
 
@@ -55,6 +56,13 @@ public:
 	virtual void updateTransportInfo();
 	virtual void setBpm( float fBPM );
 
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/IO/NullDriver.h
+++ b/src/core/include/hydrogen/IO/NullDriver.h
@@ -33,6 +33,7 @@ namespace H2Core
 
 typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
+/** \ingroup docCore docAudioDriver */
 class NullDriver : public AudioOutput
 {
 public:

--- a/src/core/include/hydrogen/IO/OssDriver.h
+++ b/src/core/include/hydrogen/IO/OssDriver.h
@@ -59,9 +59,10 @@ namespace H2Core
 
 typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
-///
-/// OSS Audio Driver
-///
+/**
+ * OSS Audio Driver
+ * \ingroup docCore docAudioDriver
+ */
 class OssDriver : public AudioOutput
 {
 public:
@@ -110,6 +111,7 @@ private:
 
 namespace H2Core {
 
+/** \ingroup docCore docAudioDriver */
 class OssDriver : public NullDriver
 {
 public:

--- a/src/core/include/hydrogen/IO/OssDriver.h
+++ b/src/core/include/hydrogen/IO/OssDriver.h
@@ -64,8 +64,10 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
 ///
 class OssDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+	
 	OssDriver( audioProcessCallback processCallback );
 	~OssDriver();
 
@@ -86,6 +88,12 @@ public:
 	virtual void setBpm( float fBPM );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	/** file descriptor, for writing to /dev/dsp */
 	int fd;
 
@@ -104,9 +112,17 @@ namespace H2Core {
 
 class OssDriver : public NullDriver
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	OssDriver( audioProcessCallback processCallback ) : NullDriver( processCallback ) {}
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 };
 

--- a/src/core/include/hydrogen/IO/PortAudioDriver.h
+++ b/src/core/include/hydrogen/IO/PortAudioDriver.h
@@ -38,6 +38,7 @@ namespace H2Core
 
 typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
+/** \ingroup docCore docAudioDriver */
 class PortAudioDriver : public AudioOutput
 {
 public:
@@ -84,6 +85,7 @@ private:
 namespace H2Core
 {
 
+/** \ingroup docCore docAudioDriver */
 class PortAudioDriver : public NullDriver
 {
 public:

--- a/src/core/include/hydrogen/IO/PortAudioDriver.h
+++ b/src/core/include/hydrogen/IO/PortAudioDriver.h
@@ -40,8 +40,9 @@ typedef int  ( *audioProcessCallback )( uint32_t, void * );
 
 class PortAudioDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	audioProcessCallback m_processCallback;
 	float* m_pOut_L;
 	float* m_pOut_R;
@@ -65,6 +66,12 @@ public:
 	virtual void setBpm( float fBPM );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	PaStream *m_pStream;
 	unsigned m_nSampleRate;
 
@@ -79,10 +86,18 @@ namespace H2Core
 
 class PortAudioDriver : public NullDriver
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	PortAudioDriver( audioProcessCallback processCallback ) : NullDriver( processCallback ) {}
 
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/IO/PortMidiDriver.h
+++ b/src/core/include/hydrogen/IO/PortMidiDriver.h
@@ -32,6 +32,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore docAudioDriver docMIDI*/
 class PortMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
 public:

--- a/src/core/include/hydrogen/IO/PortMidiDriver.h
+++ b/src/core/include/hydrogen/IO/PortMidiDriver.h
@@ -34,8 +34,9 @@ namespace H2Core
 
 class PortMidiDriver : public virtual MidiInput, public virtual MidiOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	PmStream *m_pMidiIn;
 	PmStream *m_pMidiOut;
 	bool m_bRunning;
@@ -53,6 +54,12 @@ public:
 	virtual void handleOutgoingControlChange( int param, int value, int channel );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 };
 

--- a/src/core/include/hydrogen/IO/PulseAudioDriver.h
+++ b/src/core/include/hydrogen/IO/PulseAudioDriver.h
@@ -35,9 +35,11 @@ namespace H2Core
 {
 
 
-///
-/// PulseAudio driver.
-///
+/**
+ * PulseAudio driver.
+ *
+ * \ingroup docCore docAudioDriver
+ */
 class PulseAudioDriver : public AudioOutput
 {
 public:
@@ -101,6 +103,7 @@ private:
 #include <hydrogen/IO/NullDriver.h>
 
 namespace H2Core {
+	/** \ingroup docCore docAudioDriver */
 	class PulseAudioDriver : public NullDriver
 	{
 	public:

--- a/src/core/include/hydrogen/IO/PulseAudioDriver.h
+++ b/src/core/include/hydrogen/IO/PulseAudioDriver.h
@@ -40,8 +40,9 @@ namespace H2Core
 ///
 class PulseAudioDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	typedef int (*audioProcessCallback)(uint32_t, void *);
 
 	PulseAudioDriver(audioProcessCallback processCallback);
@@ -62,6 +63,12 @@ public:
 	virtual void setBpm( float fBPM );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	pthread_t				m_thread;
 	pthread_mutex_t			m_mutex;
 	pthread_cond_t			m_cond;
@@ -96,10 +103,18 @@ private:
 namespace H2Core {
 	class PulseAudioDriver : public NullDriver
 	{
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PulseAudioDriver( audioProcessCallback processCallback ) : NullDriver( processCallback ) {}
 
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 	};
 }
 

--- a/src/core/include/hydrogen/IO/TransportInfo.h
+++ b/src/core/include/hydrogen/IO/TransportInfo.h
@@ -34,8 +34,9 @@ namespace H2Core
  */
 class TransportInfo : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	enum {
 	      /** The audio engine is playing back or processing audio
 		  and the transport is stopped. */
@@ -101,6 +102,13 @@ public:
 	  * Prints out #m_status, #m_nFrames, and #m_nTickSize.
 	  */
 	void printInfo();
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/IO/TransportInfo.h
+++ b/src/core/include/hydrogen/IO/TransportInfo.h
@@ -31,6 +31,8 @@ namespace H2Core
  * Object holding most of the information about the transport state of
  * the AudioEngine, like if it is playing or stopped or its current
  * transport position and speed.
+ *
+ * \ingroup docCore docAudioDriver docAudioEngine
  */
 class TransportInfo : public H2Core::Object
 {

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -106,6 +106,8 @@ class InstrumentComponent;
  * This object will only be accessible if #H2CORE_HAVE_JACK was defined
  * during the configuration and the user enables the support of the
  * JACK server.
+ *
+ * \ingroup docCore docAudioDriver
  */
 class JackAudioDriver : public AudioOutput
 {
@@ -930,6 +932,9 @@ private:
 // JACK is disabled
 
 namespace H2Core {
+/**
+ * \ingroup docCore docAudioDriver
+ */
 class JackAudioDriver : public NullDriver {
 public:
 	/** \return #m_sClassName*/

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -109,8 +109,9 @@ class InstrumentComponent;
  */
 class JackAudioDriver : public AudioOutput
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	/** 
 	 * Object holding the external client session with the JACK
 	 * server. 
@@ -714,6 +715,12 @@ protected:
 #endif
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	/**
 	 * Updates the tick size TransportInfo::m_nTickSize and frame
 	 * position TransportInfo::m_nFrames using the transport
@@ -924,8 +931,9 @@ private:
 
 namespace H2Core {
 class JackAudioDriver : public NullDriver {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	/**
 	 * Fallback version of the JackAudioDriver in case
 	 * #H2CORE_HAVE_JACK was not defined during the configuration
@@ -933,6 +941,13 @@ public:
 	 * the user.
 	 */
 	JackAudioDriver( audioProcessCallback processCallback ) : NullDriver( processCallback ) {}
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 };
 

--- a/src/core/include/hydrogen/LashClient.h
+++ b/src/core/include/hydrogen/LashClient.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <cassert>
 
+/** \ingroup docCore docAutomatization*/
 class LashClient
 {
 public:

--- a/src/core/include/hydrogen/LocalFileMng.h
+++ b/src/core/include/hydrogen/LocalFileMng.h
@@ -49,8 +49,9 @@ class Drumkit;
  */
 class LocalFileMng : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	LocalFileMng();
 	~LocalFileMng();
 
@@ -68,6 +69,12 @@ public:
 	static QDomDocument openXmlDocument( const QString& filename );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	static QString processNode( QDomNode node, const QString& nodeName, bool bCanBeEmpty, bool bShouldExists );
 };
 
@@ -78,13 +85,21 @@ private:
  */
 class SongWriter : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SongWriter();
 	~SongWriter();
 
 	// Returns 0 on success.
 	int writeSong( Song *song, const QString& filename );
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/LocalFileMng.h
+++ b/src/core/include/hydrogen/LocalFileMng.h
@@ -45,7 +45,7 @@ class Song;
 class Drumkit;
 
 /**
- *
+ * \ingroup docCore
  */
 class LocalFileMng : public H2Core::Object
 {
@@ -82,6 +82,8 @@ private:
 
 /**
  * Write XML file of a song
+ *
+ * \ingroup docCore
  */
 class SongWriter : public H2Core::Object
 {

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -47,8 +47,10 @@ const float FALLOFF_FAST =	1.5f;
 */
 class WindowProperties : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+	
 	int x;
 	int y;
 	int width;
@@ -63,6 +65,13 @@ public:
 		width = _width; height = _height;
 		visible = _visible;
 	}
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 };
 
@@ -72,8 +81,9 @@ public:
 */
 class H2RGBColor : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	H2RGBColor( int r = -1, int g = -1, int b = -1 );
 	H2RGBColor( const QString& sColor );
 	~H2RGBColor();
@@ -91,6 +101,12 @@ public:
 	}
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	int m_red;
 	int m_green;
 	int m_blue;
@@ -104,8 +120,9 @@ private:
 */
 class UIStyle : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	UIStyle();
 	H2RGBColor m_songEditor_backgroundColor;
 	H2RGBColor m_songEditor_alternateRowColor;
@@ -126,6 +143,13 @@ public:
 	H2RGBColor m_patternEditor_line3Color;
 	H2RGBColor m_patternEditor_line4Color;
 	H2RGBColor m_patternEditor_line5Color;
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
@@ -136,8 +160,9 @@ public:
 */
 class Preferences : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	enum {
 	      /** 
 	       * Specifies whether or not to use JACK transport
@@ -578,6 +603,12 @@ public:
 	void			setExportTemplate( int nExportTemplate );
 	
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	/**
 	 * Object holding the current Preferences singleton. It is
 	 * initialized with NULL, set with create_instance(), and

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -41,10 +41,9 @@ const float FALLOFF_SLOW = 	1.08f;
 const float FALLOFF_NORMAL=	1.1f;
 const float FALLOFF_FAST =	1.5f;
 
-
 /**
-\ingroup H2CORE
-*/
+ * \ingroup docCore docConfiguration
+ */
 class WindowProperties : public H2Core::Object
 {
 public:
@@ -75,10 +74,9 @@ private:
 
 };
 
-
 /**
-\ingroup H2CORE
-*/
+ * \ingroup docCore docConfiguration
+ */
 class H2RGBColor : public H2Core::Object
 {
 public:
@@ -115,9 +113,9 @@ private:
 
 
 /**
-\ingroup H2CORE
-\brief	Colors for hydrogen
-*/
+ * \ingroup docCore docConfiguration
+ * \brief	Colors for hydrogen
+ */
 class UIStyle : public H2Core::Object
 {
 public:
@@ -155,9 +153,9 @@ private:
 
 
 /**
-\ingroup H2CORE
-\brief	Manager for User Preferences File (singleton)
-*/
+ * \ingroup docCore docConfiguration
+ * \brief	Manager for User Preferences File (singleton)
+ */
 class Preferences : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/audio_engine.h
+++ b/src/core/include/hydrogen/audio_engine.h
@@ -60,8 +60,10 @@ namespace H2Core
  */ 
 class AudioEngine : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+
 	/**
 	 * If #__instance equals 0, a new AudioEngine singleton will
 	 * be created and stored in it.
@@ -152,6 +154,13 @@ public:
 	Synth* get_synth();
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
+
 	/**
 	 * Object holding the current AudioEngine singleton. It is
 	 * initialized with NULL, set with create_instance(), and

--- a/src/core/include/hydrogen/audio_engine.h
+++ b/src/core/include/hydrogen/audio_engine.h
@@ -45,6 +45,7 @@
 #define RIGHT_HERE __FILE__, __LINE__, __PRETTY_FUNCTION__
 #endif
 
+
 namespace H2Core
 {
 
@@ -57,6 +58,8 @@ namespace H2Core
  * Song object and the AudioEngine itself. lock() and try_lock() can
  * be called by a thread to lock the engine and unlock() to make it
  * accessible for other threads once again.
+ *
+ * \ingroup docCore docAudioEngine
  */ 
 class AudioEngine : public H2Core::Object
 {
@@ -212,7 +215,6 @@ private:
 	 */
 	AudioEngine();
 };
-
 };
 
 

--- a/src/core/include/hydrogen/automation_path_serializer.h
+++ b/src/core/include/hydrogen/automation_path_serializer.h
@@ -32,14 +32,23 @@ namespace H2Core
 
 class AutomationPathSerializer : private Object
 {
-	H2_OBJECT
 
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+
 	AutomationPathSerializer();
 
 	void read_automation_path(const QDomNode &node, AutomationPath &path);
 	void write_automation_path(QDomNode &node, const AutomationPath &path);
 
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 

--- a/src/core/include/hydrogen/automation_path_serializer.h
+++ b/src/core/include/hydrogen/automation_path_serializer.h
@@ -30,6 +30,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore */
 class AutomationPathSerializer : private Object
 {
 

--- a/src/core/include/hydrogen/basics/adsr.h
+++ b/src/core/include/hydrogen/basics/adsr.h
@@ -30,6 +30,8 @@ namespace H2Core
 
 /**
  * Attack Decay Sustain Release envelope.
+ *
+ * \ingroup docCore docSound
  */
 class ADSR : private Object
 {

--- a/src/core/include/hydrogen/basics/adsr.h
+++ b/src/core/include/hydrogen/basics/adsr.h
@@ -33,8 +33,9 @@ namespace H2Core
  */
 class ADSR : private Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 
 		/**
 		 * constructor
@@ -98,6 +99,13 @@ class ADSR : private Object
 		float release();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		unsigned int __attack;		///< Attack tick count
 		unsigned int __decay;		///< Decay tick count
 		float __sustain;			///< Sustain level

--- a/src/core/include/hydrogen/basics/automation_path.h
+++ b/src/core/include/hydrogen/basics/automation_path.h
@@ -35,21 +35,12 @@ namespace H2Core
 
 class AutomationPath : private Object
 {
-	H2_OBJECT
+public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 
-	public:
 	typedef std::map<float,float>::iterator iterator;
 	typedef std::map<float,float>::const_iterator const_iterator;
-
-	private:
-	
-	float _min;
-	float _max;
-	float _def;
-
-	std::map<float,float> _points;
-
-	public:
 	
 	AutomationPath(float min, float max, float def);
 
@@ -73,6 +64,20 @@ class AutomationPath : private Object
 
 	iterator find(float x);
 	iterator move(iterator &in, float x, float y);
+
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
+	
+	float _min;
+	float _max;
+	float _def;
+
+	std::map<float,float> _points;
 };
 
 std::ostream &operator<< (std::ostream &o, const AutomationPath &p);

--- a/src/core/include/hydrogen/basics/drumkit.h
+++ b/src/core/include/hydrogen/basics/drumkit.h
@@ -34,7 +34,9 @@ class DrumkitComponent;
 
 /**
  * Drumkit info
-*/
+ *
+ * \ingroup docCore docDataStructure
+ */
 class Drumkit : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/basics/drumkit.h
+++ b/src/core/include/hydrogen/basics/drumkit.h
@@ -37,8 +37,10 @@ class DrumkitComponent;
 */
 class Drumkit : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+
 		/** drumkit constructor, does nothing */
 		Drumkit();
 		/** copy constructor */
@@ -219,6 +221,13 @@ class Drumkit : public H2Core::Object
 		void set_components( std::vector<DrumkitComponent*>* components );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		QString __path;					///< absolute drumkit path
 		QString __name;					///< drumkit name
 		QString __author;				///< drumkit author

--- a/src/core/include/hydrogen/basics/drumkit_component.h
+++ b/src/core/include/hydrogen/basics/drumkit_component.h
@@ -38,8 +38,10 @@ class InstrumentLayer;
 
 class DrumkitComponent : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+
 		DrumkitComponent( const int id, const QString& name );
 		DrumkitComponent( DrumkitComponent* other );
 		~DrumkitComponent();
@@ -75,6 +77,13 @@ class DrumkitComponent : public H2Core::Object
 		float						get_out_R( int nBufferPos );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		int		__id;
 	        /** Name of the DrumkitComponent. It is set by
 		    set_name() and accessed via get_name().*/

--- a/src/core/include/hydrogen/basics/drumkit_component.h
+++ b/src/core/include/hydrogen/basics/drumkit_component.h
@@ -36,6 +36,7 @@ class ADSR;
 class Drumkit;
 class InstrumentLayer;
 
+/** \ingroup docCore docDataStructure */
 class DrumkitComponent : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/basics/instrument.h
+++ b/src/core/include/hydrogen/basics/instrument.h
@@ -49,8 +49,10 @@ Instrument class
 */
 class Instrument : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		enum SampleSelectionAlgo {
 			VELOCITY,
 			ROUND_ROBIN,
@@ -270,6 +272,13 @@ class Instrument : public H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 	        /** Identifier of an instrument, which should be
 		    unique. It is set by set_id() and accessed via
 	        get_id().*/

--- a/src/core/include/hydrogen/basics/instrument.h
+++ b/src/core/include/hydrogen/basics/instrument.h
@@ -45,8 +45,9 @@ class InstrumentComponent;
 
 
 /**
-Instrument class
-*/
+ *Instrument class
+ * \ingroup docCore docDataStructure
+ */
 class Instrument : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/basics/instrument_component.h
+++ b/src/core/include/hydrogen/basics/instrument_component.h
@@ -37,6 +37,7 @@ class Drumkit;
 class InstrumentLayer;
 class DrumkitComponent;
 
+/** \ingroup docCore docDataStructure */
 class InstrumentComponent : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/basics/instrument_component.h
+++ b/src/core/include/hydrogen/basics/instrument_component.h
@@ -39,8 +39,10 @@ class DrumkitComponent;
 
 class InstrumentComponent : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		InstrumentComponent( int related_drumkit_componentID );
 		InstrumentComponent( InstrumentComponent* other );
 		~InstrumentComponent();
@@ -64,6 +66,13 @@ class InstrumentComponent : public H2Core::Object
 		static void			setMaxLayers( int layers );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		/** Component ID of the drumkit. It is set by
 		    set_drumkit_componentID() and
 		    accessed via get_drumkit_componentID(). */

--- a/src/core/include/hydrogen/basics/instrument_layer.h
+++ b/src/core/include/hydrogen/basics/instrument_layer.h
@@ -37,7 +37,10 @@ namespace H2Core
 	 * <br><b>gain</b> which is the ration between the input sample and the output signal,
 	 * <br><b>pitch</b> wich allows you to play the sample at a faster or lower frequency,
 	 * <br><b>start velocity</b> and <b>end velocity</b> which allows you to chose between a layer or another within an instrument
-	 * by changing the velocity of the played note. so the only layer of an instrument should start at 0.0 and end at 1.0.
+	 * by changing the velocity of the played note. so the only layer
+	 * of an instrument should start at 0.0 and end at 1.0.
+	 *
+	 * \ingroup docCore docDataStructure
 	 */
 	class InstrumentLayer : public H2Core::Object
 	{

--- a/src/core/include/hydrogen/basics/instrument_layer.h
+++ b/src/core/include/hydrogen/basics/instrument_layer.h
@@ -41,8 +41,10 @@ namespace H2Core
 	 */
 	class InstrumentLayer : public H2Core::Object
 	{
-		H2_OBJECT
-		public:
+	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+		
 		/** constructor
 		 * \param sample the sample to use
 		 * */
@@ -105,6 +107,13 @@ namespace H2Core
 		static InstrumentLayer* load_from( XMLNode* node, const QString& dk_path );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+		
 		float __gain;               ///< ratio between the input sample and the output signal, 1.0 by default
 		float __pitch;              ///< the frequency of the sample, 0.0 by default which means output pitch is the same as input pitch
 		float __start_velocity;     ///< the start velocity of the sample, 0.0 by default

--- a/src/core/include/hydrogen/basics/instrument_list.h
+++ b/src/core/include/hydrogen/basics/instrument_list.h
@@ -35,6 +35,8 @@ class Instrument;
 
 /**
  * InstrumentList is a collection of instruments used within a song, a drumkit, ...
+ *
+ * \ingroup docCore docDataStructure
 */
 class InstrumentList : public H2Core::Object
 {

--- a/src/core/include/hydrogen/basics/instrument_list.h
+++ b/src/core/include/hydrogen/basics/instrument_list.h
@@ -38,8 +38,10 @@ class Instrument;
 */
 class InstrumentList : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		/** constructor */
 		InstrumentList();
 		/** destructor */
@@ -175,6 +177,13 @@ class InstrumentList : public H2Core::Object
 		void set_default_midi_out_notes();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		std::vector<Instrument*> __instruments;            ///< the list of instruments
 };
 

--- a/src/core/include/hydrogen/basics/note.h
+++ b/src/core/include/hydrogen/basics/note.h
@@ -65,8 +65,10 @@ struct SelectedLayerInfo {
  */
 class Note : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		/** possible keys */
 		enum Key { C=KEY_MIN, Cs, D, Ef, E, F, Fs, G, Af, A, Bf, B };
 		/** possible octaves */
@@ -298,6 +300,13 @@ class Note : public H2Core::Object
 		void compute_lr_values( float* val_l, float* val_r );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		Instrument*		__instrument;   ///< the instrument to be played by this note
 		int				__instrument_id;        ///< the id of the instrument played by this note
 		int				__specific_compo_id;    ///< play a specific component, -1 if playing all

--- a/src/core/include/hydrogen/basics/note.h
+++ b/src/core/include/hydrogen/basics/note.h
@@ -62,6 +62,8 @@ struct SelectedLayerInfo {
 
 /**
  * A note plays an associated instrument with a velocity left and right pan
+ *
+ * \ingroup docCore docDataStructure
  */
 class Note : public H2Core::Object
 {

--- a/src/core/include/hydrogen/basics/pattern.h
+++ b/src/core/include/hydrogen/basics/pattern.h
@@ -41,8 +41,10 @@ Pattern class is a Note container
 */
 class Pattern : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		///< multimap note type
 		typedef std::multimap <int, Note*> notes_t;
 		///< multimap note iterator type
@@ -191,6 +193,13 @@ class Pattern : public H2Core::Object
 		void save_to( XMLNode* node, const Instrument* instrumentOnly = 0 ) const;
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		int __length;                                           ///< the length of the pattern
 		QString __name;                                         ///< the name of thepattern
 		QString __category;                                     ///< the category of the pattern

--- a/src/core/include/hydrogen/basics/pattern.h
+++ b/src/core/include/hydrogen/basics/pattern.h
@@ -37,8 +37,10 @@ class InstrumentList;
 class PatternList;
 
 /**
-Pattern class is a Note container
-*/
+ * Pattern class is a Note container
+ *
+ * \ingroup docCore docDataStructure
+ */
 class Pattern : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/basics/pattern_list.h
+++ b/src/core/include/hydrogen/basics/pattern_list.h
@@ -34,7 +34,9 @@ class Pattern;
 
 /**
  * PatternList is a collection of patterns
-*/
+ *
+ * \ingroup docCore docDataStructure
+ */
 class PatternList : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/basics/pattern_list.h
+++ b/src/core/include/hydrogen/basics/pattern_list.h
@@ -37,8 +37,10 @@ class Pattern;
 */
 class PatternList : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		/** constructor */
 		PatternList();
 		/** destructor */
@@ -151,6 +153,13 @@ class PatternList : public H2Core::Object
 		QString find_unused_pattern_name( QString sourceName );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		std::vector<Pattern*> __patterns;            ///< the list of patterns
 };
 

--- a/src/core/include/hydrogen/basics/playlist.h
+++ b/src/core/include/hydrogen/basics/playlist.h
@@ -29,8 +29,8 @@ namespace H2Core
 {
 
 /**
- * Drumkit info
-*/
+ * \ingroup docCore docDataStructure
+ */
 class Playlist : public H2Core::Object
 
 {

--- a/src/core/include/hydrogen/basics/playlist.h
+++ b/src/core/include/hydrogen/basics/playlist.h
@@ -34,9 +34,10 @@ namespace H2Core
 class Playlist : public H2Core::Object
 
 {
-		H2_OBJECT
-
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		struct Entry
 		{
 			QString filePath;
@@ -85,6 +86,13 @@ class Playlist : public H2Core::Object
 		bool save_file( const QString& pl_path, const QString& name, bool overwrite, bool useRelativePaths );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		/**
 		 * Object holding the current Playlist singleton. It is
 		 * initialized with NULL, set with create_instance(), and

--- a/src/core/include/hydrogen/basics/sample.h
+++ b/src/core/include/hydrogen/basics/sample.h
@@ -33,6 +33,8 @@ namespace H2Core
 
 /**
  * A container for a sample, beeing able to apply modifications on it
+ *
+ * \ingroup docCore docDataStructure docSound
  */
 class Sample : public H2Core::Object
 {

--- a/src/core/include/hydrogen/basics/sample.h
+++ b/src/core/include/hydrogen/basics/sample.h
@@ -36,8 +36,10 @@ namespace H2Core
  */
 class Sample : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		/** an envelope point within a frame */
 		class EnvelopePoint
 		{
@@ -318,6 +320,13 @@ class Sample : public H2Core::Object
 		QString get_loop_mode_string() const;
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		QString __filepath;                     ///< filepath of the sample
 		int __frames;                           ///< number of frames in this sample
 		int __sample_rate;                      ///< samplerate for this sample
@@ -359,7 +368,7 @@ inline const QString Sample::get_filename() const
 	return __filepath.section( "/", -1 );
 }
 
-inline void Sample::Sample::set_frames( int frames )
+inline void Sample::set_frames( int frames )
 {
 	__frames = frames;
 }

--- a/src/core/include/hydrogen/basics/song.h
+++ b/src/core/include/hydrogen/basics/song.h
@@ -53,8 +53,10 @@ class AutomationPath;
 */
 class Song : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		enum SongMode {
 			PATTERN_MODE,
 			SONG_MODE
@@ -201,6 +203,13 @@ class Song : public H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		///< volume of the song (0.0..1.0)
 		float			__volume;
 		///< Metronome volume
@@ -413,14 +422,23 @@ inline void Song::set_playback_track_volume( const float volume )
 */
 class SongReader : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		SongReader();
 		~SongReader();
 		const QString getPath( const QString& filename );
 		Song* readSong( const QString& filename );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		QString m_sSongVersion;
 
 		/// Dato un XmlNode restituisce un oggetto Pattern

--- a/src/core/include/hydrogen/basics/song.h
+++ b/src/core/include/hydrogen/basics/song.h
@@ -48,8 +48,9 @@ class PatternList;
 class AutomationPath;
 
 /**
-\ingroup H2CORE
-\brief	Song class
+ * \brief	Song class
+ *
+ * \ingroup docCore docDataStructure
 */
 class Song : public H2Core::Object
 {

--- a/src/core/include/hydrogen/config.dox
+++ b/src/core/include/hydrogen/config.dox
@@ -1,3 +1,7 @@
+/** \addtogroup docConfiguration
+ * @{
+ */
+
 /*! \file config.h.in
  * Documentation for the macros defined in the config.h.in file (which
    is not properly read by Doxygen).
@@ -150,5 +154,6 @@
     could be found in the rubberband library. */
 #define H2CORE_HAVE_RUBBERBAND
 
-
-
+/**
+ * @}
+ */

--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -29,9 +29,10 @@ namespace H2Core
 {
 
 class CoreActionController : public H2Core::Object {
-	H2_OBJECT
-	
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		CoreActionController();
 		~CoreActionController();
 	
@@ -47,6 +48,12 @@ class CoreActionController : public H2Core::Object {
 		void handleOutgoingControlChange( int param, int value);
 		
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		
 		const int m_nDefaultMidiFeedbackChannel;
 };

--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -28,6 +28,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore docMIDI docAutomatization*/
 class CoreActionController : public H2Core::Object {
 	public:
 		/** \return #m_sClassName*/

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -34,8 +34,12 @@
 namespace H2Core
 {
 	
-/** Basic types of communication between the core part of Hydrogen and
-    its GUI.*/
+/** 
+ * Basic types of communication between the core part of Hydrogen and
+ * its GUI.
+ *
+ * \ingroup docEvent
+*/
 enum EventType {
 	/** Fallback event*/
 	EVENT_NONE,
@@ -95,8 +99,13 @@ enum EventType {
 };
 
 /** Basic building block for the communication between the core of
- * Hydrogen and its GUI.  The individual Events will be enlisted in
- * the EventQueue singleton.*/
+ * Hydrogen and its GUI.  
+ *
+ * The individual Events will be enlisted in the EventQueue
+ * singleton.
+ *
+ * \ingroup docCore docEvent
+ */
 class Event
 {
 public:
@@ -120,7 +129,10 @@ public:
  * is encountered, the corresponding function in the EventListener
  * will be invoked to respond to the condition of the engine. For
  * details about the mapping of EventTypes to functions please see the
- * documentation of HydrogenApp::onEventQueueTimer().*/
+ * documentation of HydrogenApp::onEventQueueTimer().
+ *
+ * \ingroup docCore docEvent
+ */
 class EventQueue : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -123,9 +123,11 @@ public:
  * documentation of HydrogenApp::onEventQueueTimer().*/
 class EventQueue : public H2Core::Object
 {
-	H2_OBJECT
-public:/**
-	* If #__instance equals 0, a new EventQueue singleton will be
+public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+	/**
+	 * If #__instance equals 0, a new EventQueue singleton will be
 	 * created and stored in it.
 	 *
 	 * It is called in Hydrogen::create_instance().
@@ -190,6 +192,12 @@ public:/**
 	std::vector<AddMidiNoteVector> m_addMidiNoteVector;
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	/**
 	 * Constructor of the EventQueue class.
 	 *

--- a/src/core/include/hydrogen/fx/Effects.h
+++ b/src/core/include/hydrogen/fx/Effects.h
@@ -37,8 +37,10 @@ namespace H2Core
 {
 class Effects : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+	
 	/**
 	 * If #__instance equals 0, a new Effects
 	 * singleton will be created and stored in it.
@@ -61,6 +63,12 @@ public:
 
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	/**
 	 * Object holding the current Effects singleton. It is
 	 * initialized with NULL, set with create_instance(), and

--- a/src/core/include/hydrogen/fx/Effects.h
+++ b/src/core/include/hydrogen/fx/Effects.h
@@ -35,6 +35,7 @@
 
 namespace H2Core
 {
+/** \ingroup docCore docSound*/
 class Effects : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/fx/LadspaFX.h
+++ b/src/core/include/hydrogen/fx/LadspaFX.h
@@ -35,6 +35,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore docSound*/
 class LadspaFXInfo : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/fx/LadspaFX.h
+++ b/src/core/include/hydrogen/fx/LadspaFX.h
@@ -37,8 +37,9 @@ namespace H2Core
 
 class LadspaFXInfo : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	LadspaFXInfo( const QString& sName );
 	~LadspaFXInfo();
 
@@ -53,14 +54,22 @@ public:
 	unsigned m_nIAPorts;	///< input audio port
 	unsigned m_nOAPorts;	///< output audio port
 	static bool alphabeticOrder( LadspaFXInfo* a, LadspaFXInfo* b );
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
 
 class LadspaFXGroup : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	LadspaFXGroup( const QString& sName );
 	~LadspaFXGroup();
 
@@ -88,6 +97,12 @@ public:
 
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	QString m_sName;
 	std::vector<LadspaFXInfo*> m_ladspaList;
 	std::vector<LadspaFXGroup*> m_childGroups;
@@ -97,8 +112,9 @@ private:
 
 class LadspaControlPort : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	QString sName;
 	bool isToggle;
 	bool m_bIsInteger;
@@ -108,14 +124,22 @@ public:
 	LADSPA_Data fUpperBound;
 
 	LadspaControlPort() : Object( "LadspaControlPort" ) { }
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
 
 class LadspaFX : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	enum {
 		MONO_FX,
 		STEREO_FX,
@@ -173,6 +197,12 @@ public:
 
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	bool m_pluginType;
 	bool m_bEnabled;
 	bool m_bActivated;	// Guard against plugins that can't be deactivated before being activated (

--- a/src/core/include/hydrogen/globals.h
+++ b/src/core/include/hydrogen/globals.h
@@ -22,6 +22,10 @@
 #ifndef H2C_GLOBALS_H
 #define H2C_GLOBALS_H
 
+/** \addtogroup docConfiguration
+ * @{
+ */
+
 #define MIDI_OUT_NOTE_MIN       0
 #define MIDI_OUT_NOTE_MAX       127
 #define MIDI_OUT_CHANNEL_MIN    -1
@@ -41,5 +45,6 @@
 #define                         US_DIVIDER .000001
 // ~m_nBeatCounter
 
+/** @} */
 
 #endif // H2C_GLOBALS_H

--- a/src/core/include/hydrogen/h2_exception.h
+++ b/src/core/include/hydrogen/h2_exception.h
@@ -30,6 +30,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore docDebugging */
 class H2Exception : public std::runtime_error
 {
 public:

--- a/src/core/include/hydrogen/helpers/files.h
+++ b/src/core/include/hydrogen/helpers/files.h
@@ -13,7 +13,11 @@ class Playlist;
 class Song;
 
 /**
- * Files is in charge of writing and reading Patterns, Drumkits, Songs to the filesystem
+ * Files is in charge of writing and reading Patterns, Drumkits, Songs
+ * to the filesystem
+ *
+ *
+ * \ingroup docCore
  */
 class Files : public H2Core::Object
 {

--- a/src/core/include/hydrogen/helpers/files.h
+++ b/src/core/include/hydrogen/helpers/files.h
@@ -17,8 +17,10 @@ class Song;
  */
 class Files : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		enum SaveMode {
 			SAVE_NEW,				// construct regular path, do not overwrite
 			SAVE_OVERWRITE,			// construct regular path, overwrite existing file
@@ -96,6 +98,13 @@ class Files : public H2Core::Object
 		}
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
+	
 		static QString savePattern( SaveMode mode, const QString& fileName, const Pattern* pattern, Song* song, const QString& drumkitName );
 		static QString savePlaylist( SaveMode mode, const QString& fileName, Playlist* playlist, bool relativePaths );
 };

--- a/src/core/include/hydrogen/helpers/filesystem.h
+++ b/src/core/include/hydrogen/helpers/filesystem.h
@@ -13,8 +13,9 @@ namespace H2Core
  */
 class Filesystem : public H2Core::Object
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		/** flags available for check_permissions() */
 		enum file_perms {
 			is_dir =0x01,
@@ -264,6 +265,12 @@ class Filesystem : public H2Core::Object
 		static bool mkdir( const QString& path );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static Logger* __logger;                    ///< a pointer to the logger
 		static bool check_sys_paths();              ///< returns true if the system path is consistent
 		static bool check_usr_paths();              ///< returns true if the user path is consistent

--- a/src/core/include/hydrogen/helpers/filesystem.h
+++ b/src/core/include/hydrogen/helpers/filesystem.h
@@ -10,6 +10,8 @@ namespace H2Core
 
 /**
  * Filesystem is a thin layer over QDir, QFile and QFileInfo
+ *
+ * \ingroup docCore
  */
 class Filesystem : public H2Core::Object
 {

--- a/src/core/include/hydrogen/helpers/legacy.h
+++ b/src/core/include/hydrogen/helpers/legacy.h
@@ -13,6 +13,8 @@ class InstrumentList;
 
 /**
  * Legacy is a container for legacy code which should be once removed
+ *
+ * \ingroup docCore
  */
 class Legacy : public H2Core::Object {
 	public:

--- a/src/core/include/hydrogen/helpers/legacy.h
+++ b/src/core/include/hydrogen/helpers/legacy.h
@@ -15,8 +15,9 @@ class InstrumentList;
  * Legacy is a container for legacy code which should be once removed
  */
 class Legacy : public H2Core::Object {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		/**
 		 * load drumkit information from a file
 		 * \param dk_path is a path to an xml file
@@ -37,6 +38,13 @@ class Legacy : public H2Core::Object {
 		 * \return a Playlist on success, 0 otherwise
 		 */
 		static Playlist* load_playlist( Playlist* pl, const QString& pl_path );
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/helpers/xml.h
+++ b/src/core/include/hydrogen/helpers/xml.h
@@ -14,8 +14,9 @@ namespace H2Core
 */
 class XMLNode : public H2Core::Object, public QDomNode
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		/** basic constructor */
 		XMLNode( );
 		/** to wrap a QDomNode */
@@ -108,6 +109,12 @@ class XMLNode : public H2Core::Object, public QDomNode
 		 */
 		void write_attribute( const QString& attribute, const QString& value );
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		/**
 		 * reads a string stored into a child node
 		 * \param node the name of the child node to read into
@@ -128,8 +135,9 @@ class XMLNode : public H2Core::Object, public QDomNode
 */
 class XMLDoc : public H2Core::Object, public QDomDocument
 {
-		H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		/** basic constructor */
 		XMLDoc( );
 		/**
@@ -149,6 +157,13 @@ class XMLDoc : public H2Core::Object, public QDomDocument
 		 * \param xmlns the xml namespace prefix to add after XMLNS_BASE
 		 */
 		XMLNode set_root( const QString& node_name, const QString& xmlns = 0 );
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 };
 
 };

--- a/src/core/include/hydrogen/helpers/xml.h
+++ b/src/core/include/hydrogen/helpers/xml.h
@@ -11,7 +11,9 @@ namespace H2Core
 
 /**
  * XMLNode is a subclass of QDomNode with read and write values methods
-*/
+ *
+ * \ingroup docCore
+ */
 class XMLNode : public H2Core::Object, public QDomNode
 {
 	public:

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -66,9 +66,11 @@ inline int randomValue( int max );
 
 namespace H2Core
 {
-///
-/// Hydrogen Audio Engine.
-///
+/**
+ * Hydrogen Audio Engine.
+ *
+ * \ingroup docCore docAudioEngine
+ */
 class Hydrogen : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -71,8 +71,9 @@ namespace H2Core
 ///
 class Hydrogen : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	/**
 	 * Creates all the instances used within Hydrogen in the right
 	 * order. 
@@ -580,6 +581,12 @@ void			previewSample( Sample *pSample );
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	/**
 	 * Static reference to the Hydrogen singleton. 
 	 *

--- a/src/core/include/hydrogen/lilypond/lilypond.h
+++ b/src/core/include/hydrogen/lilypond/lilypond.h
@@ -35,7 +35,11 @@ class Pattern;
 class PatternList;
 class Song;
 
-/// A class to convert a Hydrogen song to LilyPond format
+/** 
+ * A class to convert a Hydrogen song to LilyPond format
+ *
+ * \ingroup docCore docSound
+ */
 class LilyPond {
 public:
 	LilyPond();

--- a/src/core/include/hydrogen/logger.h
+++ b/src/core/include/hydrogen/logger.h
@@ -36,6 +36,8 @@ namespace H2Core {
 
 /**
  * Class for writing logs to the console
+ *
+ * \ingroup docCore docDebugging
  */
 class Logger {
 	public:

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -28,7 +28,7 @@
 
 using namespace std;
 
-
+/** \ingroup docCore docMIDI */
 class Action : public H2Core::Object {
 	public:
 		/** \return #m_sClassName*/
@@ -72,6 +72,7 @@ namespace H2Core
 	class Hydrogen;
 }
 
+/** \ingroup docCore docMIDI */
 class MidiActionManager : public H2Core::Object
 {
 	private:

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -30,8 +30,9 @@ using namespace std;
 
 
 class Action : public H2Core::Object {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		Action( QString );
 
 		void setParameter1( QString text ){
@@ -55,6 +56,12 @@ class Action : public H2Core::Object {
 		}
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QString type;
 		QString parameter1;
 		QString parameter2;
@@ -67,8 +74,13 @@ namespace H2Core
 
 class MidiActionManager : public H2Core::Object
 {
-	H2_OBJECT
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		/**
 		 * Object holding the current MidiActionManager
 		 * singleton. It is initialized with NULL, set with
@@ -136,6 +148,9 @@ class MidiActionManager : public H2Core::Object
 		int m_nLastBpmChangeCCParameter;
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
+	
 		bool handleAction( Action * );
 		/**
 		 * If #__instance equals 0, a new MidiActionManager

--- a/src/core/include/hydrogen/midi_map.h
+++ b/src/core/include/hydrogen/midi_map.h
@@ -31,6 +31,7 @@
 
 class Action;
 
+/** \ingroup docCore docMIDI */
 class MidiMap : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/midi_map.h
+++ b/src/core/include/hydrogen/midi_map.h
@@ -33,8 +33,9 @@ class Action;
 
 class MidiMap : public H2Core::Object
 {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		typedef std::map< QString, Action* > map_t;
 		/**
 		 * Object holding the current MidiMap singleton. It is
@@ -81,6 +82,12 @@ class MidiMap : public H2Core::Object
 
 		void setupNoteArray();
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		MidiMap();
 
 		Action* __note_array[ 128 ];

--- a/src/core/include/hydrogen/nsm_client.h
+++ b/src/core/include/hydrogen/nsm_client.h
@@ -37,8 +37,8 @@
 *
 * @author Sebastian Moors
 *
+* \ingroup docCore docAutomatization
 */
-
 class NsmClient : public H2Core::Object
 {
 	public:

--- a/src/core/include/hydrogen/nsm_client.h
+++ b/src/core/include/hydrogen/nsm_client.h
@@ -41,8 +41,9 @@
 
 class NsmClient : public H2Core::Object
 {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		/**
 		 * Object holding the current NsmClient singleton. It
 		 * is initialized with NULL, set with
@@ -72,6 +73,12 @@ class NsmClient : public H2Core::Object
 		void shutdown();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		NsmClient();
 
 };

--- a/src/core/include/hydrogen/object.h
+++ b/src/core/include/hydrogen/object.h
@@ -51,6 +51,7 @@ namespace H2Core {
 * Before any Object or a derived class can be created, the Logger has
 * to be initialized and the static bootstrap() member be called first.
 *
+* \ingroup docCore
 */
 class Object {
 	public:
@@ -248,7 +249,6 @@ class Object {
 		static Logger* __logger;
 };
 
-
 //////////////////////////////////////////////////////////////////////
 // LOG MACROS
 
@@ -277,6 +277,7 @@ class Object {
  * H2Core::Logger::Info, H2Core::Logger::Warning, and
  * H2Core::Logger::Error.
  * \param msg User message.
+ * \ingroup docDebugging
  */
 #define __LOG_METHOD(   lvl, msg )  if( __logger->should_log( (lvl) ) )                 { __logger->log( (lvl), className(), __FUNCTION__, msg ); }
 
@@ -305,6 +306,7 @@ class Object {
  * H2Core::Logger::Info, H2Core::Logger::Warning, and
  * H2Core::Logger::Error.
  * \param msg User message.
+ * \ingroup docDebugging
  */
 #define __LOG_CLASS(    lvl, msg )  if( logger()->should_log( (lvl) ) )                 { logger()->log( (lvl), className(), __FUNCTION__, msg ); }
 
@@ -334,6 +336,7 @@ class Object {
  * H2Core::Logger::Info, H2Core::Logger::Warning, and
  * H2Core::Logger::Error.
  * \param msg User message.
+ * \ingroup docDebugging
  */
 #define __LOG_OBJ(      lvl, msg )  if( __object->logger()->should_log( (lvl) ) )       { __object->logger()->log( (lvl), 0, __PRETTY_FUNCTION__, msg ); }
 
@@ -361,6 +364,7 @@ class Object {
  * H2Core::Logger::Info, H2Core::Logger::Warning, and
  * H2Core::Logger::Error.
  * \param msg User message.
+ * \ingroup docDebugging
  */
 #define __LOG_STATIC(   lvl, msg )  if( H2Core::Logger::get_instance()->should_log( (lvl) ) )   { H2Core::Logger::get_instance()->log( (lvl), 0, __PRETTY_FUNCTION__, msg ); }
 
@@ -368,70 +372,86 @@ class Object {
 
 /** Wrapper around __LOG_METHOD() using H2Core::Logger::Debug as log
  *	level. 
- * \param x User message.*/ 
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define DEBUGLOG(x)     __LOG_METHOD( H2Core::Logger::Debug,   (x) );
 /** Wrapper around __LOG_METHOD() using H2Core::Logger::Info as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define INFOLOG(x)      __LOG_METHOD( H2Core::Logger::Info,    (x) );
 /** Wrapper around __LOG_METHOD() using H2Core::Logger::Warning as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define WARNINGLOG(x)   __LOG_METHOD( H2Core::Logger::Warning, (x) );
 /** Wrapper around __LOG_METHOD() using H2Core::Logger::Error as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define ERRORLOG(x)     __LOG_METHOD( H2Core::Logger::Error,   (x) );
 
 /** Wrapper around __LOG_CLASS() using H2Core::Logger::Debug as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define _DEBUGLOG(x)    __LOG_CLASS( H2Core::Logger::Debug,   (x) );
 /** Wrapper around __LOG_CLASS() using H2Core::Logger::Info as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define _INFOLOG(x)     __LOG_CLASS( H2Core::Logger::Info,    (x) );
 /** Wrapper around __LOG_CLASS() using H2Core::Logger::Warning as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define _WARNINGLOG(x)  __LOG_CLASS( H2Core::Logger::Warning, (x) );
 /** Wrapper around __LOG_CLASS() using H2Core::Logger::Error as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define _ERRORLOG(x)    __LOG_CLASS( H2Core::Logger::Error,   (x) );
 
 /** Wrapper around __LOG_OBJ() using H2Core::Logger::Debug as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define __DEBUGLOG(x)   __LOG_OBJ( H2Core::Logger::Debug,      (x) );
 /** Wrapper around __LOG_OBJ() using H2Core::Logger::Info as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define __INFOLOG(x)    __LOG_OBJ( H2Core::Logger::Info,       (x) );
 /** Wrapper around __LOG_OBJ() using H2Core::Logger::Warning as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define __WARNINGLOG(x) __LOG_OBJ( H2Core::Logger::Warning,    (x) );
 /** Wrapper around __LOG_OBJ() using H2Core::Logger::Error as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define __ERRORLOG(x)   __LOG_OBJ( H2Core::Logger::Error,      (x) );
 
 /** Wrapper around __LOG_STATIC() using H2Core::Logger::Debug as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define ___DEBUGLOG(x)  __LOG_STATIC( H2Core::Logger::Debug,    (x) );
 /** Wrapper around __LOG_STATIC() using H2Core::Logger::Info as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define ___INFOLOG(x)   __LOG_STATIC( H2Core::Logger::Info,     (x) );
 /** Wrapper around __LOG_STATIC() using H2Core::Logger::Warning as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define ___WARNINGLOG(x) __LOG_STATIC(H2Core::Logger::Warning,  (x) );
 /** Wrapper around __LOG_STATIC() using H2Core::Logger::Error as log
  *	level. 
- * \param x User message.*/
+ * \param x User message.
+ * \ingroup docDebugging*/
 #define ___ERRORLOG(x)  __LOG_STATIC( H2Core::Logger::Error,    (x) );
 
 };

--- a/src/core/include/hydrogen/object.h
+++ b/src/core/include/hydrogen/object.h
@@ -43,9 +43,9 @@ class Object {
 		/** copy constructor */
 		Object( const Object& obj );
 		/** constructor */
-		Object( const char* class_name );
-
-		const char* class_name( ) const         { return __class_name; }        ///< return the class name
+		Object( const char* m_sClassName );
+		/** \return #m_sClassName*/
+		const char* className() { return m_sClassName; }
 		/**
 		 * enable/disable class instances counting
 		 * \param flag the counting status to set
@@ -90,7 +90,12 @@ class Object {
 		/** the objects class map type */
 		typedef std::map<const char*, obj_cpt_t> object_map_t;
 
-		const char* __class_name;               ///< the object class name
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		const char* m_sClassName;
 		static bool __count;                    ///< should we count class instances
 		static unsigned __objects_count;        ///< total objects count
 		static object_map_t __objects_map;      ///< objects classes and instances count structure
@@ -100,14 +105,9 @@ class Object {
 		static Logger* __logger;                ///< logger instance pointer
 };
 
-// Object inherited class declaration macro
-#define H2_OBJECT                                                       \
-	public: static const char* class_name() { return __class_name; }    \
-	private: static const char* __class_name;                           \
-
 // LOG MACROS
-#define __LOG_METHOD(   lvl, msg )  if( __logger->should_log( (lvl) ) )                 { __logger->log( (lvl), class_name(), __FUNCTION__, msg ); }
-#define __LOG_CLASS(    lvl, msg )  if( logger()->should_log( (lvl) ) )                 { logger()->log( (lvl), class_name(), __FUNCTION__, msg ); }
+#define __LOG_METHOD(   lvl, msg )  if( __logger->should_log( (lvl) ) )                 { __logger->log( (lvl), className(), __FUNCTION__, msg ); }
+#define __LOG_CLASS(    lvl, msg )  if( logger()->should_log( (lvl) ) )                 { logger()->log( (lvl), className(), __FUNCTION__, msg ); }
 #define __LOG_OBJ(      lvl, msg )  if( __object->logger()->should_log( (lvl) ) )       { __object->logger()->log( (lvl), 0, __PRETTY_FUNCTION__, msg ); }
 #define __LOG_STATIC(   lvl, msg )  if( H2Core::Logger::get_instance()->should_log( (lvl) ) )   { H2Core::Logger::get_instance()->log( (lvl), 0, __PRETTY_FUNCTION__, msg ); }
 #define __LOG( logger,  lvl, msg )  if( (logger)->should_log( (lvl) ) )                 { (logger)->log( (lvl), 0, 0, msg ); }

--- a/src/core/include/hydrogen/object.h
+++ b/src/core/include/hydrogen/object.h
@@ -33,61 +33,154 @@
 
 namespace H2Core {
 
+
 /**
- * Base class.
- */
+* @class Object
+*
+* @brief Base class of most classes in hydrogen.
+*
+* Most components of hydrogen do inherit from the Object class. Each
+* object has a qualified name (#m_sClassName), which is set prior to
+* the creation of the first instance of the corresponding class, and
+* gets registered in a memory map at creation (#__objects_map).  This
+* map helps to debug memory leaks and can be printed at any time using
+* write_objects_map_to(). In addition, the inheritance from Object
+* allows for more informative log messages in the member functions
+* using INFOLOG() or _INFOLOG()
+*
+* Before any Object or a derived class can be created, the Logger has
+* to be initialized and the static bootstrap() member be called first.
+*
+*/
 class Object {
 	public:
-		/** destructor */
+		/** Destructor
+		 *
+		 * If Hydrogen was compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set, del_object() with the current
+		 * object as argument will be called whenever #__count is
+		 * `true`.*/
 		~Object();
-		/** copy constructor */
+		/** Copy constructor
+		 *
+		 * If Hydrogen was compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set, add_object() with the current
+		 * object as first and `true` as second argument will be
+		 * called whenever #__count is `true`.*/
 		Object( const Object& obj );
-		/** constructor */
+		/** Constructor
+		 *
+		 * If Hydrogen was compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set, add_object() with the current
+		 * object as first and `false` as second argument will be
+		 * called whenever #__count is `true`.*/
 		Object( const char* m_sClassName );
 		/** \return #m_sClassName*/
 		const char* className() { return m_sClassName; }
 		/**
-		 * enable/disable class instances counting
-		 * \param flag the counting status to set
+		 * Whether the number and the specific types of the created
+		 * objects should be tracked.
+		 *
+		 * If Hydrogen was compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set, @a flag enables or disables
+		 * the counting of the instances created for a specific
+		 * class. If, however, debugging was not enabled, an error
+		 * messages will be printed using the Logger.
+		 *
+		 * \param flag Enables (`true`) or disable the counting.
 		 */
 		static void set_count( bool flag );
-		static bool count_active()              { return __count; }             ///< return true if class instances counting is enabled
-		static unsigned objects_count()         { return __objects_count; }     ///< return the number of objects
+		
+		/**\return #__count*/
+		static bool count_active()              { return __count; }
+		/**\return #__objects_count*/
+		static unsigned objects_count()         { return __objects_count; }
 
 		/**
-		 * output the full objects map to a given ostream
-		 * \param out the ostream to write to
+		 * Prints #__objects_map to the ostream @a out.
+		 *
+		 * This action will only be performed if Hydrogen was
+		 * compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set and #__count is set to
+		 * `true`. In addition #__mutex will be locked during the
+		 * operation.
+		 *
+		 * \param out The ostream to write to
 		 */
 		static void write_objects_map_to( std::ostream& out );
-		static void write_objects_map_to_cerr() { Object::write_objects_map_to( std::cerr ); }  ///< ouput objects map to stderr
+		/** 
+		 * Prints #__objects_map to stderr.
+		 *
+		 * Wrapper around write_objects_map_to() passing `std::cerr`
+		 * as argument.*/
+		static void write_objects_map_to_cerr() { Object::write_objects_map_to( std::cerr ); }
 
 		/**
-		 * must be called before any Object instanciation !
-		 * \param logger the logger instance used to send messages to
-		 * \param count should we count objects instances or not
+		 * Must be called before any Object instantiating!
+		 *
+		 * It assigns @a logger to #__logger, @a count to #__count,
+		 * and initializes #__mutex by calling `pthread_mutex_init()`.
+		 *
+		 * \param logger The logger instance used to send messages to.
+		 * \param count Should we count objects instances or not.
+		 *
+		 * \return `0` if everything worked fine and `1` if either
+		 * #__logger or @a logger is a `nullptr`.
 		 */
 		static int bootstrap( Logger* logger, bool count=false );
-		static Logger* logger()                 { return __logger; }            ///< return the logger instance
+		/**\return #__logger*/
+		static Logger* logger()                 { return __logger; }
 
 	private:
 		/**
-		 * search for the class name within __objects_map, decrease class and global counts
-		 * \param obj the object to be taken into account
+		 * Decrements #__objects_count and increments the
+		 * obj_cpt_t::destructed member of #__objects_map.
+		 *
+		 * After locking #__mutex a key in #__objects_map
+		 * corresponding to the class name of @a obj will be
+		 * searched. If found, #__objects_count will be decremented
+		 * and the value of the obj_cpt_t::destructed member of #__objects_map
+		 * matching the class name of @a obj will be incremented.
+		 *
+		 * These actions will only be performed if Hydrogen was
+		 * compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set.
+		 *
+		 * \param obj The Object to be taken into account.
 		 */
 		static void del_object( const Object* obj );
 		/**
-		 * search for the clas name within __objects_map, create it if doesn't exists, increase class and global counts
-		 * \param obj the object to be taken into account
-		 * \param copy is it called from a copy constructor
+		 * Increments #__objects_count and the obj_cpt_t::constructed
+		 * member of #__objects_map.
+		 *
+		 * After locking #__mutex both #__objects_count and the value
+		 * of the obj_cpt_t::constructed member of the key in
+		 * #__objects_map matching the class name of @a obj will be
+		 * incremented. If such a key does not exist yet, it will be
+		 * created.
+		 *
+		 * These actions will only be performed if Hydrogen was
+		 * compiled with the `WANT_DEBUG` flag causing
+		 * #H2CORE_HAVE_DEBUG to be set.
+		 *
+		 * \param obj The Object to be taken into account.
+		 * \param copy Specifies whether the function is called from a
+		 * copy constructor. It only affects the debugging messages
+		 * printed by the Logger.
 		 */
 		static void add_object( const Object* obj, bool copy );
 
-		/** an objects class map item type */
+		/** Struct used in #__objects_map to keep track of the number
+		 * of constructed and destroyed instances of each individual
+		 * class.*/
 		typedef struct {
+			/** Number of constructed instances of a particular class.*/
 			unsigned constructed;
+			/** Number of destroyed instances of a particular class.*/
 			unsigned destructed;
 		} obj_cpt_t;
-		/** the objects class map type */
+	
+		/** Map class used by #__objects_map.*/
 		typedef std::map<const char*, obj_cpt_t> object_map_t;
 
 		/** Contains the name of the class.
@@ -96,44 +189,249 @@ class Object {
 		 * with the name of the class the message is generated in
 		 * being displayed as well. Queried using className().*/
 		const char* m_sClassName;
-		static bool __count;                    ///< should we count class instances
-		static unsigned __objects_count;        ///< total objects count
-		static object_map_t __objects_map;      ///< objects classes and instances count structure
-		static pthread_mutex_t __mutex;         ///< yeah this has to be thread safe
+		/**
+		 * Specifies whether the creation and destruction of each
+		 * class derived from Object should be counted using
+		 * add_object() and del_object().
+		 *
+		 * It is globally initialized to `false` and locally in
+		 * bootstrap(). In addition it is set by set_count() and
+		 * queried using count_active().
+		 */
+		static bool __count;
+		/**
+		 * Number of objects, which are either of class Object itself
+		 * or derived from it.
+		 *
+		 * It is globally initialized to `0`, incremented in
+		 * add_object(), decremented in del_object(), and queried
+		 * using objects_count().
+		 */
+		static unsigned __objects_count;
+		/**
+		 * A map keeping track of the number of constructed and
+		 * destroyed instances per individual class.
+		 *
+		 * The keys of the map correspond to the individual names of
+		 * the classes encountered and the value to a struct counting
+		 * both the number of created instances obj_cpt_t::constructed
+		 * and destroyed instances obj_cpt_t::destructed. When
+		 * hydrogen is started in debugging mode (with command line
+		 * argument `-VDebug`) the content of the map will be
+		 * displayed using write_objects_map_to() after telling the
+		 * application to shut down.
+		 *
+		 * It is globally initialized to an empty obj_cpt_t and
+		 * modified by add_object() and del_object().
+		 */
+		static object_map_t __objects_map;
+		/**
+		 * Mutex ensuring writing to #__objects_map and
+		 * #__objects_count will be thread safe.
+		 *
+		 * It is globally initialized to a `pthread_mutex_t` object
+		 * and initialized in bootstrap().
+		 */
+		static pthread_mutex_t __mutex;
 
 	protected:
-		static Logger* __logger;                ///< logger instance pointer
+		/**
+		 * Pointer to the Logger singleton.
+		 *
+		 * Using this object all classes derived from Object are able
+		 * to print more informative messages using the various log
+		 * macros.
+		 *
+		 * It is initialized globally to a `nullptr`, set in
+		 * bootstrap(), and queried using logger().
+		 */
+		static Logger* __logger;
 };
 
+
+//////////////////////////////////////////////////////////////////////
 // LOG MACROS
+
+/**
+ * Print a log message using the private H2Core::Object::__logger
+ * member of the particular class.
+ *
+ * To create log messages, please use the more user-friendly wrappers,
+ * like INFOLOG(), instead.
+ *
+ * If H2Core::Logger::should_log() returns `true`, this macro will
+ * call H2Core::Logger::log() of the private H2Core::Object::__logger
+ * member of the class the macro is placed in. It will provide the log
+ * level @a lvl, the return value of H2Core::Object::className(), the
+ * implicitly declared identifier `__FUNCTION__` (which contains the
+ * name of the calling function), and @a msg as input arguments. Since
+ * the H2Core::Object::m_sClassName is a static variable and set
+ * before the actual class is constructed, also static member
+ * functions without its corresponding class being created can be
+ * logged.
+ *
+ * Please keep in mind that only objects inherited from H2Core::Object
+ * can use this logging macro!
+ *
+ * \param lvl Log level. Has to be one of H2Core::Logger::Debug,
+ * H2Core::Logger::Info, H2Core::Logger::Warning, and
+ * H2Core::Logger::Error.
+ * \param msg User message.
+ */
 #define __LOG_METHOD(   lvl, msg )  if( __logger->should_log( (lvl) ) )                 { __logger->log( (lvl), className(), __FUNCTION__, msg ); }
+
+/**
+ * Print a log message using the public H2Core::Object::logger()
+ * member of the particular class.
+ *
+ * To create log messages, please use the more user-friendly wrappers,
+ * like _INFOLOG(), instead.
+ *
+ * If H2Core::Logger::should_log() returns `true`, this macro will
+ * call H2Core::Logger::log() of the public H2Core::Object::logger()
+ * member of the class the macro is placed in. It will provide the log
+ * level @a lvl, the return value of H2Core::Object::className(), the
+ * implicitly declared identifier `__FUNCTION__` (which contains the
+ * name of the calling function), and @a msg as input arguments. Since
+ * the H2Core::Object::m_sClassName is a static variable and set
+ * before the actual class is constructed, also static member
+ * functions without its corresponding class being created can be
+ * logged.
+ *
+ * Please keep in mind that only objects inherited from H2Core::Object
+ * can use this logging macro!
+ *
+ * \param lvl Log level. Has to be one of H2Core::Logger::Debug,
+ * H2Core::Logger::Info, H2Core::Logger::Warning, and
+ * H2Core::Logger::Error.
+ * \param msg User message.
+ */
 #define __LOG_CLASS(    lvl, msg )  if( logger()->should_log( (lvl) ) )                 { logger()->log( (lvl), className(), __FUNCTION__, msg ); }
+
+/**
+ * Print a log message using the public H2Core::Object::logger()
+ * member of the object stored in `__object`.
+ *
+ * This particular version of the logging it used in the callback
+ * functions of the audio drivers. To those functions an object
+ * derived from the H2Core::Object class will be provided as an
+ * argument, which will internally assigned to a variable named
+ * `__object`. This enables also those functions living outside of the
+ * classes of hydrogen to use the same logging style.
+ *
+ * To create log messages, please use the more user-friendly wrappers,
+ * like __INFOLOG(), instead.
+ *
+ * If H2Core::Logger::should_log() returns `true`, this macro will
+ * call H2Core::Logger::log() of the public H2Core::Object::logger()
+ * member of the `__object` variable. It will provide the log level @a
+ * lvl, `0`, the implicitly declared identifier `__PRETTY_FUNCTION__`
+ * (which contains the name of the calling function), and @a msg as
+ * input arguments. Since those functions are called outside of any
+ * hydrogen classes, no class name can be provided.
+ *
+ * \param lvl Log level. Has to be one of H2Core::Logger::Debug,
+ * H2Core::Logger::Info, H2Core::Logger::Warning, and
+ * H2Core::Logger::Error.
+ * \param msg User message.
+ */
 #define __LOG_OBJ(      lvl, msg )  if( __object->logger()->should_log( (lvl) ) )       { __object->logger()->log( (lvl), 0, __PRETTY_FUNCTION__, msg ); }
+
+/**
+ * Print a log message using the global instance of the Logger
+ * singleton.
+ *
+ * This particular version of the logging is a fallback version that
+ * should always work. It is mainly used in global functions, like
+ * the `audioEngine_*` ones in `hydrogen.cpp`.
+ *
+ * To create log messages, please use the more user-friendly wrappers,
+ * like ___INFOLOG(), instead.
+ *
+ * If H2Core::Logger::should_log() returns `true`, this macro will
+ * call H2Core::Logger::log() of the global instance of the
+ * H2Core::Logger singleton retrieved using
+ * H2Core::Logger::get_instance(). It will provide the log level @a
+ * lvl, `0`, the implicitly declared identifier `__PRETTY_FUNCTION__`
+ * (which contains the name of the calling function), and @a msg as
+ * input arguments. Since those functions are called outside of any
+ * hydrogen classes, no class name can be provided.
+ *
+ * \param lvl Log level. Has to be one of H2Core::Logger::Debug,
+ * H2Core::Logger::Info, H2Core::Logger::Warning, and
+ * H2Core::Logger::Error.
+ * \param msg User message.
+ */
 #define __LOG_STATIC(   lvl, msg )  if( H2Core::Logger::get_instance()->should_log( (lvl) ) )   { H2Core::Logger::get_instance()->log( (lvl), 0, __PRETTY_FUNCTION__, msg ); }
-#define __LOG( logger,  lvl, msg )  if( (logger)->should_log( (lvl) ) )                 { (logger)->log( (lvl), 0, 0, msg ); }
 
 // Object instance method logging macros
+
+/** Wrapper around __LOG_METHOD() using H2Core::Logger::Debug as log
+ *	level. 
+ * \param x User message.*/ 
 #define DEBUGLOG(x)     __LOG_METHOD( H2Core::Logger::Debug,   (x) );
+/** Wrapper around __LOG_METHOD() using H2Core::Logger::Info as log
+ *	level. 
+ * \param x User message.*/
 #define INFOLOG(x)      __LOG_METHOD( H2Core::Logger::Info,    (x) );
+/** Wrapper around __LOG_METHOD() using H2Core::Logger::Warning as log
+ *	level. 
+ * \param x User message.*/
 #define WARNINGLOG(x)   __LOG_METHOD( H2Core::Logger::Warning, (x) );
+/** Wrapper around __LOG_METHOD() using H2Core::Logger::Error as log
+ *	level. 
+ * \param x User message.*/
 #define ERRORLOG(x)     __LOG_METHOD( H2Core::Logger::Error,   (x) );
 
-// Object class method logging macros
+/** Wrapper around __LOG_CLASS() using H2Core::Logger::Debug as log
+ *	level. 
+ * \param x User message.*/
 #define _DEBUGLOG(x)    __LOG_CLASS( H2Core::Logger::Debug,   (x) );
+/** Wrapper around __LOG_CLASS() using H2Core::Logger::Info as log
+ *	level. 
+ * \param x User message.*/
 #define _INFOLOG(x)     __LOG_CLASS( H2Core::Logger::Info,    (x) );
+/** Wrapper around __LOG_CLASS() using H2Core::Logger::Warning as log
+ *	level. 
+ * \param x User message.*/
 #define _WARNINGLOG(x)  __LOG_CLASS( H2Core::Logger::Warning, (x) );
+/** Wrapper around __LOG_CLASS() using H2Core::Logger::Error as log
+ *	level. 
+ * \param x User message.*/
 #define _ERRORLOG(x)    __LOG_CLASS( H2Core::Logger::Error,   (x) );
 
-// logging macros using an Object *__object ( thread :  Object* __object = ( Object* )param; )
+/** Wrapper around __LOG_OBJ() using H2Core::Logger::Debug as log
+ *	level. 
+ * \param x User message.*/
 #define __DEBUGLOG(x)   __LOG_OBJ( H2Core::Logger::Debug,      (x) );
+/** Wrapper around __LOG_OBJ() using H2Core::Logger::Info as log
+ *	level. 
+ * \param x User message.*/
 #define __INFOLOG(x)    __LOG_OBJ( H2Core::Logger::Info,       (x) );
+/** Wrapper around __LOG_OBJ() using H2Core::Logger::Warning as log
+ *	level. 
+ * \param x User message.*/
 #define __WARNINGLOG(x) __LOG_OBJ( H2Core::Logger::Warning,    (x) );
+/** Wrapper around __LOG_OBJ() using H2Core::Logger::Error as log
+ *	level. 
+ * \param x User message.*/
 #define __ERRORLOG(x)   __LOG_OBJ( H2Core::Logger::Error,      (x) );
 
-// logging macros using  ( thread :  Object* __object = ( Object* )param; )
+/** Wrapper around __LOG_STATIC() using H2Core::Logger::Debug as log
+ *	level. 
+ * \param x User message.*/
 #define ___DEBUGLOG(x)  __LOG_STATIC( H2Core::Logger::Debug,    (x) );
+/** Wrapper around __LOG_STATIC() using H2Core::Logger::Info as log
+ *	level. 
+ * \param x User message.*/
 #define ___INFOLOG(x)   __LOG_STATIC( H2Core::Logger::Info,     (x) );
+/** Wrapper around __LOG_STATIC() using H2Core::Logger::Warning as log
+ *	level. 
+ * \param x User message.*/
 #define ___WARNINGLOG(x) __LOG_STATIC(H2Core::Logger::Warning,  (x) );
+/** Wrapper around __LOG_STATIC() using H2Core::Logger::Error as log
+ *	level. 
+ * \param x User message.*/
 #define ___ERRORLOG(x)  __LOG_STATIC( H2Core::Logger::Error,    (x) );
 
 };

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -81,8 +81,9 @@ namespace lo
 */
 class OscServer : public H2Core::Object
 {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		/**
 		 * Object holding the current OscServer singleton. It is
 		 * initialized with nullptr, set with create_instance(), and
@@ -599,6 +600,12 @@ class OscServer : public H2Core::Object
 								int argc, void *data, void *user_data);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		/**
 		 * Private constructor creating a new OSC server thread using
 		 * the port H2Core::Preferences::m_nOscServerPort and

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -77,7 +77,7 @@ namespace lo
 * the OSC server will be started at.
 *
 * @author Sebastian Moors
-*
+* \ingroup docCore docAutomatization
 */
 class OscServer : public H2Core::Object
 {

--- a/src/core/include/hydrogen/sampler/Sampler.h
+++ b/src/core/include/hydrogen/sampler/Sampler.h
@@ -48,8 +48,9 @@ class AudioOutput;
 ///
 class Sampler : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	float *__main_out_L;	///< sampler main out (left channel)
 	float *__main_out_R;	///< sampler main out (right channel)
 
@@ -114,6 +115,12 @@ public:
 		void reinitialize_playback_track();
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	std::vector<Note*> __playing_notes_queue;
 	std::vector<Note*> __queuedNoteOffs;
 

--- a/src/core/include/hydrogen/sampler/Sampler.h
+++ b/src/core/include/hydrogen/sampler/Sampler.h
@@ -43,9 +43,11 @@ struct SelectedLayerInfo;
 class InstrumentComponent;
 class AudioOutput;
 
-///
-/// Waveform based sampler.
-///
+/**
+ * Waveform based sampler.
+ *
+ * \ingroup docCore docSound
+ */
 class Sampler : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/smf/SMF.h
+++ b/src/core/include/hydrogen/smf/SMF.h
@@ -34,7 +34,7 @@
 
 namespace H2Core
 {
-
+/** \ingroup docCore docSound */
 class SMFHeader : public SMFBase, public H2Core::Object
 {
 public:
@@ -58,7 +58,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFTrack : public SMFBase, public H2Core::Object
 {
 public:
@@ -83,7 +83,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMF : public SMFBase, public H2Core::Object
 {
 public:
@@ -109,7 +109,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFWriter : Object
 {
 public:

--- a/src/core/include/hydrogen/smf/SMF.h
+++ b/src/core/include/hydrogen/smf/SMF.h
@@ -37,8 +37,9 @@ namespace H2Core
 
 class SMFHeader : public SMFBase, public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFHeader( int nFormat, int nTracks, int nTPQN );
 	~SMFHeader();
 
@@ -47,14 +48,22 @@ public:
 	int m_nTPQN;		///< ticks per quarter note
 
 	virtual std::vector<char> getBuffer();
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
 
 class SMFTrack : public SMFBase, public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 
 	SMFTrack();
 	~SMFTrack();
@@ -64,6 +73,12 @@ public:
 	virtual std::vector<char> getBuffer();
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	std::vector<SMFEvent*> m_eventList;
 };
 
@@ -71,8 +86,9 @@ private:
 
 class SMF : public SMFBase, public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMF();
 	~SMF();
 
@@ -80,6 +96,12 @@ public:
 	virtual std::vector<char> getBuffer();
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	std::vector<SMFTrack*> m_trackList;
 
 	SMFHeader* m_pHeader;
@@ -90,14 +112,21 @@ private:
 
 class SMFWriter : Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFWriter();
 	~SMFWriter();
 
 	void save( const QString& sFilename, Song *pSong );
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	FILE *m_file;
 
 };

--- a/src/core/include/hydrogen/smf/SMFEvent.h
+++ b/src/core/include/hydrogen/smf/SMFEvent.h
@@ -31,8 +31,9 @@ namespace H2Core
 
 class SMFBuffer : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	std::vector<char> getBuffer() {
 		return m_buffer;
 	}
@@ -46,6 +47,13 @@ public:
 	std::vector<char> m_buffer;
 
 	SMFBuffer();
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
@@ -84,25 +92,40 @@ public:
 
 class SMFEvent : public SMFBase, public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFEvent( const char* sEventName, unsigned nTicks );
 	virtual ~SMFEvent();
 
 	int m_nTicks;
 	int m_nDeltaTime;
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
 
 class SMFTrackNameMetaEvent : public SMFEvent
 {
-	H2_OBJECT
 public:
 	SMFTrackNameMetaEvent( const QString& sTrackName, unsigned nDeltaTime );
 	virtual std::vector<char> getBuffer();
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	QString m_sTrackName;
 
 };
@@ -111,12 +134,19 @@ private:
 
 class SMFSetTempoMetaEvent : public SMFEvent
 {
-	H2_OBJECT
 public:
 	SMFSetTempoMetaEvent( float fBPM, unsigned nDeltaTime );
 	virtual std::vector<char> getBuffer();
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	unsigned m_fBPM;
 
 };
@@ -125,12 +155,19 @@ private:
 
 class SMFCopyRightNoticeMetaEvent : public SMFEvent
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFCopyRightNoticeMetaEvent( const QString& sAuthor, unsigned nDeltaTime );
 	virtual std::vector<char> getBuffer();
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	QString m_sAuthor;
 
 };
@@ -139,13 +176,20 @@ private:
 
 class SMFTimeSignatureMetaEvent : public SMFEvent
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFTimeSignatureMetaEvent( unsigned nBeats, unsigned nNote , unsigned nMTPMC , unsigned nTSNP24 , unsigned nTicks );
 	virtual std::vector<char> getBuffer();
 	// MTPMC = MIDI ticks per metronome click
 	// TSNP24 = Thirty Second Notes Per 24 MIDI Ticks.
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	unsigned m_nBeats, m_nNote, m_nMTPMC , m_nTSNP24 , m_nTicks;
 };
 
@@ -153,11 +197,19 @@ private:
 
 class SMFNoteOnEvent : public SMFEvent
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFNoteOnEvent( unsigned nTicks, int nChannel, int nPitch, int nVelocity );
 
 	virtual std::vector<char> getBuffer();
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 protected:
 	unsigned m_nChannel;
@@ -169,11 +221,19 @@ protected:
 
 class SMFNoteOffEvent : public SMFEvent
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SMFNoteOffEvent(  unsigned nTicks, int nChannel, int nPitch, int nVelocity );
 
 	virtual std::vector<char> getBuffer();
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 protected:
 	unsigned m_nChannel;

--- a/src/core/include/hydrogen/smf/SMFEvent.h
+++ b/src/core/include/hydrogen/smf/SMFEvent.h
@@ -29,6 +29,7 @@
 namespace H2Core
 {
 
+/** \ingroup docCore docSound */
 class SMFBuffer : public H2Core::Object
 {
 public:
@@ -57,14 +58,14 @@ private:
 };
 
 
-
+/** \ingroup docSound */
 enum SMFEventType {
 	NOTE_OFF = 128,
 	NOTE_ON = 144
 };
 
 
-
+/** \ingroup docSound */
 enum SMFMetaEventType {
 	SEQUENCE_NUMBER = 0,
 	TEXT_EVENT,
@@ -80,7 +81,7 @@ enum SMFMetaEventType {
 	KEY_SIGNATURE
 };
 
-
+/** \ingroup docCore docSound */
 class SMFBase
 {
 public:
@@ -89,7 +90,7 @@ public:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFEvent : public SMFBase, public H2Core::Object
 {
 public:
@@ -110,7 +111,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFTrackNameMetaEvent : public SMFEvent
 {
 public:
@@ -131,7 +132,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFSetTempoMetaEvent : public SMFEvent
 {
 public:
@@ -152,7 +153,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFCopyRightNoticeMetaEvent : public SMFEvent
 {
 public:
@@ -173,7 +174,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFTimeSignatureMetaEvent : public SMFEvent
 {
 public:
@@ -194,7 +195,7 @@ private:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFNoteOnEvent : public SMFEvent
 {
 public:
@@ -218,7 +219,7 @@ protected:
 };
 
 
-
+/** \ingroup docCore docSound */
 class SMFNoteOffEvent : public SMFEvent
 {
 public:

--- a/src/core/include/hydrogen/synth/Synth.h
+++ b/src/core/include/hydrogen/synth/Synth.h
@@ -39,9 +39,11 @@ namespace H2Core
 
 
 
-///
-/// A simple synthetizer...
-///
+/**
+ * A simple synthetizer...
+ *
+ * \ingroup docCore docSound
+ */
 class Synth : public H2Core::Object
 {
 public:

--- a/src/core/include/hydrogen/synth/Synth.h
+++ b/src/core/include/hydrogen/synth/Synth.h
@@ -44,8 +44,9 @@ namespace H2Core
 ///
 class Synth : public H2Core::Object
 {
-	H2_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	float *m_pOut_L;
 	float *m_pOut_R;
 
@@ -73,6 +74,12 @@ public:
 
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	std::vector<Note*> m_playingNotesQueue;
 
 	float m_fTheta;

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -27,6 +27,7 @@
 
 namespace H2Core
 {
+	/** \ingroup docCore*/
 	class Timeline : public H2Core::Object
 	{
 		public:

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -29,10 +29,11 @@ namespace H2Core
 {
 	class Timeline : public H2Core::Object
 	{
-		H2_OBJECT
-
 		public:
 			Timeline();
+
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 
 			///sample editor vectors
 			void		sortTimelineVector();
@@ -71,9 +72,13 @@ namespace H2Core
 					return lhs.m_htimelinetagbeat < rhs.m_htimelinetagbeat;
 				}
 			};
-
-
 		private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 	};
 };

--- a/src/core/include/hydrogen/version.h
+++ b/src/core/include/hydrogen/version.h
@@ -5,7 +5,9 @@
 #include <string>
 
 namespace H2Core {
-
+/** \addtogroup docDebugging
+ * @{
+ */
 /// Returns the current Hydrogen version string
 std::string get_version();
 
@@ -13,7 +15,7 @@ std::string get_version();
  * return true of the current version is older than the given values
  */
 bool version_older_than( int major, int minor, int patch );
-
+/** @}*/
 #endif // H2C_VERSION
 
 };

--- a/src/core/src/IO/alsa_audio_driver.cpp
+++ b/src/core/src/IO/alsa_audio_driver.cpp
@@ -109,10 +109,10 @@ void* alsaAudioDriver_processCaller( void* param )
 }
 
 
-const char* AlsaAudioDriver::__class_name = "AlsaAudioDriver";
+const char* AlsaAudioDriver::m_sClassName = "AlsaAudioDriver";
 
 AlsaAudioDriver::AlsaAudioDriver( audioProcessCallback processCallback )
-		: AudioOutput( __class_name )
+		: AudioOutput( m_sClassName )
 		, m_bIsRunning( false )
 		, m_pOut_L( NULL )
 		, m_pOut_R( NULL )

--- a/src/core/src/IO/alsa_midi_driver.cpp
+++ b/src/core/src/IO/alsa_midi_driver.cpp
@@ -165,10 +165,10 @@ void* alsaMidiDriver_thread( void* param )
 
 
 
-const char* AlsaMidiDriver::__class_name = "AlsaMidiDriver";
+const char* AlsaMidiDriver::m_sClassName = "AlsaMidiDriver";
 
 AlsaMidiDriver::AlsaMidiDriver()
-		: MidiInput( __class_name ), MidiOutput( __class_name ), Object( __class_name )
+		: MidiInput( m_sClassName ), MidiOutput( m_sClassName ), Object( m_sClassName )
 {
 //	infoLog("INIT");
 }

--- a/src/core/src/IO/coreaudio_driver.cpp
+++ b/src/core/src/IO/coreaudio_driver.cpp
@@ -69,7 +69,7 @@ static OSStatus renderProc(
 namespace H2Core
 {
 
-const char* CoreAudioDriver::__class_name = "CoreAudioDriver";
+const char* CoreAudioDriver::m_sClassName = "CoreAudioDriver";
 
 
 void CoreAudioDriver::retrieveDefaultDevice(void)
@@ -157,7 +157,7 @@ void CoreAudioDriver::printStreamInfo(void)
 
 
 CoreAudioDriver::CoreAudioDriver( audioProcessCallback processCallback )
-		: H2Core::AudioOutput( __class_name )
+		: H2Core::AudioOutput( m_sClassName )
 		, m_bIsRunning( false )
 		, mProcessCallback( processCallback )
 		, m_pOut_L( NULL )

--- a/src/core/src/IO/coremidi_driver.cpp
+++ b/src/core/src/IO/coremidi_driver.cpp
@@ -98,10 +98,10 @@ static void midiProc ( const MIDIPacketList * pktlist,
 }
 
 
-const char* CoreMidiDriver::__class_name = "CoreMidiDriver";
+const char* CoreMidiDriver::m_sClassName = "CoreMidiDriver";
 
 CoreMidiDriver::CoreMidiDriver()
-		: MidiInput( __class_name ) ,MidiOutput( __class_name ), Object( __class_name )
+		: MidiInput( m_sClassName ) ,MidiOutput( m_sClassName ), Object( m_sClassName )
 		, m_bRunning( false )
 {
 	INFOLOG( "INIT" );

--- a/src/core/src/IO/disk_writer_driver.cpp
+++ b/src/core/src/IO/disk_writer_driver.cpp
@@ -272,10 +272,10 @@ void* diskWriterDriver_thread( void* param )
 
 
 
-const char* DiskWriterDriver::__class_name = "DiskWriterDriver";
+const char* DiskWriterDriver::m_sClassName = "DiskWriterDriver";
 
 DiskWriterDriver::DiskWriterDriver( audioProcessCallback processCallback, unsigned nSamplerate, int nSampleDepth )
-		: AudioOutput( __class_name )
+		: AudioOutput( m_sClassName )
 		, m_nSampleRate( nSamplerate )
 		, m_nSampleDepth ( nSampleDepth )
 		, m_processCallback( processCallback )

--- a/src/core/src/IO/fake_driver.cpp
+++ b/src/core/src/IO/fake_driver.cpp
@@ -25,10 +25,10 @@
 namespace H2Core
 {
 
-const char* FakeDriver::__class_name = "FakeDiskDriver";
+const char* FakeDriver::m_sClassName = "FakeDiskDriver";
 
 FakeDriver::FakeDriver( audioProcessCallback processCallback )
-		: AudioOutput( __class_name )
+		: AudioOutput( m_sClassName )
 		, m_processCallback( processCallback )
 		, m_pOut_L( NULL )
 		, m_pOut_R( NULL )

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -152,10 +152,10 @@ void jackDriverShutdown( void* arg )
 }
 
 
-const char* JackAudioDriver::__class_name = "JackAudioDriver";
+const char* JackAudioDriver::m_sClassName = "JackAudioDriver";
 
 JackAudioDriver::JackAudioDriver( JackProcessCallback processCallback )
-	: AudioOutput( __class_name )
+	: AudioOutput( m_sClassName )
 {
 	INFOLOG( "INIT" );
 	// __track_out_enabled is inherited from AudioOutput and

--- a/src/core/src/IO/jack_midi_driver.cpp
+++ b/src/core/src/IO/jack_midi_driver.cpp
@@ -45,7 +45,7 @@ using namespace std;
 namespace H2Core
 {
 
-const char* JackMidiDriver::__class_name = "JackMidiDriver";
+const char* JackMidiDriver::m_sClassName = "JackMidiDriver";
 
 void
 JackMidiDriver::lock(void)
@@ -323,7 +323,7 @@ JackMidiShutdown(void *arg)
 }
 
 JackMidiDriver::JackMidiDriver()
-	: MidiInput( __class_name ), MidiOutput( __class_name ), Object( __class_name )
+	: MidiInput( m_sClassName ), MidiOutput( m_sClassName ), Object( m_sClassName )
 {
 	pthread_mutex_init(&mtx, NULL);
 

--- a/src/core/src/IO/null_driver.cpp
+++ b/src/core/src/IO/null_driver.cpp
@@ -27,10 +27,10 @@
 namespace H2Core
 {
 
-const char* NullDriver::__class_name = "NullDriver";
+const char* NullDriver::m_sClassName = "NullDriver";
 
 NullDriver::NullDriver( audioProcessCallback processCallback )
-		: AudioOutput( __class_name )
+		: AudioOutput( m_sClassName )
 {
 	UNUSED( processCallback );
 //	INFOLOG( "INIT" );

--- a/src/core/src/IO/oss_driver.cpp
+++ b/src/core/src/IO/oss_driver.cpp
@@ -68,10 +68,10 @@ void* ossDriver_processCaller( void* param )
 
 
 
-const char* OssDriver::__class_name = "OssDriver";
+const char* OssDriver::m_sClassName = "OssDriver";
 
 OssDriver::OssDriver( audioProcessCallback processCallback )
-		: AudioOutput( __class_name )
+		: AudioOutput( m_sClassName )
 {
 	INFOLOG( "INIT" );
 	audioBuffer = NULL;

--- a/src/core/src/IO/portaudio_driver.cpp
+++ b/src/core/src/IO/portaudio_driver.cpp
@@ -30,10 +30,10 @@ int portAudioCallback(
 }
 
 
-const char* PortAudioDriver::__class_name = "PortAudioDriver";
+const char* PortAudioDriver::m_sClassName = "PortAudioDriver";
 
 PortAudioDriver::PortAudioDriver( audioProcessCallback processCallback )
-		: AudioOutput( __class_name )
+		: AudioOutput( m_sClassName )
 		, m_processCallback( processCallback )
 		, m_pOut_L( NULL )
 		, m_pOut_R( NULL )

--- a/src/core/src/IO/portmidi_driver.cpp
+++ b/src/core/src/IO/portmidi_driver.cpp
@@ -118,10 +118,10 @@ void* PortMidiDriver_thread( void* param )
 	return NULL;
 }
 
-const char* PortMidiDriver::__class_name = "PortMidiDriver";
+const char* PortMidiDriver::m_sClassName = "PortMidiDriver";
 
 PortMidiDriver::PortMidiDriver()
-		: MidiInput( __class_name ), MidiOutput( __class_name ), Object( __class_name )
+		: MidiInput( m_sClassName ), MidiOutput( m_sClassName ), Object( m_sClassName )
 		, m_bRunning( false )
 		, m_pMidiIn( nullptr )
 		, m_pMidiOut( nullptr )

--- a/src/core/src/IO/transport_info.cpp
+++ b/src/core/src/IO/transport_info.cpp
@@ -25,10 +25,10 @@
 namespace H2Core
 {
 
-const char* TransportInfo::__class_name = "TransportInfo";
+const char* TransportInfo::m_sClassName = "TransportInfo";
 
 TransportInfo::TransportInfo()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 //	INFOLOG( "INIT" );
 	m_status = STOPPED;

--- a/src/core/src/audio_engine.cpp
+++ b/src/core/src/audio_engine.cpp
@@ -33,7 +33,7 @@ namespace H2Core
 
 
 AudioEngine* AudioEngine::__instance = NULL;
-const char* AudioEngine::__class_name = "AudioEngine";
+const char* AudioEngine::m_sClassName = "AudioEngine";
 
 
 void AudioEngine::create_instance()
@@ -44,7 +44,7 @@ void AudioEngine::create_instance()
 }
 
 AudioEngine::AudioEngine()
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, __sampler( NULL )
 		, __synth( NULL )
 {

--- a/src/core/src/automation_path_serializer.cpp
+++ b/src/core/src/automation_path_serializer.cpp
@@ -24,11 +24,11 @@
 namespace H2Core
 {
 
-const char* AutomationPathSerializer::__class_name = "AutomationPathSerializer";
+const char* AutomationPathSerializer::m_sClassName = "AutomationPathSerializer";
 
 
 AutomationPathSerializer::AutomationPathSerializer()
-	: Object(__class_name)
+	: Object(m_sClassName)
 {
 }
 

--- a/src/core/src/basics/adsr.cpp
+++ b/src/core/src/basics/adsr.cpp
@@ -27,7 +27,7 @@
 namespace H2Core
 {
 
-const char* ADSR::__class_name = "ADSR";
+const char* ADSR::m_sClassName = "ADSR";
 
 inline static float linear_interpolation( float fVal_A, float fVal_B, double fVal )
 {
@@ -64,7 +64,7 @@ void ADSR::normalise()
 	}
 }
 
-ADSR::ADSR( unsigned int attack, unsigned int decay, float sustain, unsigned int release ) : Object( __class_name ),
+ADSR::ADSR( unsigned int attack, unsigned int decay, float sustain, unsigned int release ) : Object( m_sClassName ),
 	__attack( attack ),
 	__decay( decay ),
 	__sustain( sustain ),
@@ -77,7 +77,7 @@ ADSR::ADSR( unsigned int attack, unsigned int decay, float sustain, unsigned int
 	normalise();
 }
 
-ADSR::ADSR( const ADSR* other ) : Object( __class_name ),
+ADSR::ADSR( const ADSR* other ) : Object( m_sClassName ),
 	__attack( other->__attack ),
 	__decay( other->__decay ),
 	__sustain( other->__sustain ),

--- a/src/core/src/basics/automation_path.cpp
+++ b/src/core/src/basics/automation_path.cpp
@@ -24,10 +24,10 @@
 namespace H2Core
 {
 
-const char* AutomationPath::__class_name = "AutomationPath";
+const char* AutomationPath::m_sClassName = "AutomationPath";
 
 AutomationPath::AutomationPath(float min, float max, float def)
-	: Object(__class_name),
+	: Object(m_sClassName),
 	  _min(min),
 	  _max(max),
 	  _def(def)

--- a/src/core/src/basics/drumkit.cpp
+++ b/src/core/src/basics/drumkit.cpp
@@ -48,15 +48,15 @@
 namespace H2Core
 {
 
-const char* Drumkit::__class_name = "Drumkit";
+const char* Drumkit::m_sClassName = "Drumkit";
 
-Drumkit::Drumkit() : Object( __class_name ), __samples_loaded( false ), __instruments( nullptr ), __components( nullptr )
+Drumkit::Drumkit() : Object( m_sClassName ), __samples_loaded( false ), __instruments( nullptr ), __components( nullptr )
 {
 	__components = new std::vector<DrumkitComponent*> ();
 }
 
 Drumkit::Drumkit( Drumkit* other ) :
-	Object( __class_name ),
+	Object( m_sClassName ),
 	__path( other->get_path() ),
 	__name( other->get_name() ),
 	__author( other->get_author() ),

--- a/src/core/src/basics/drumkit_component.cpp
+++ b/src/core/src/basics/drumkit_component.cpp
@@ -38,10 +38,10 @@
 namespace H2Core
 {
 
-const char* DrumkitComponent::__class_name = "DrumkitComponent";
+const char* DrumkitComponent::m_sClassName = "DrumkitComponent";
 
 DrumkitComponent::DrumkitComponent( const int id, const QString& name )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __id( id )
 	, __name( name )
 	, __volume( 1.0 )
@@ -57,7 +57,7 @@ DrumkitComponent::DrumkitComponent( const int id, const QString& name )
 }
 
 DrumkitComponent::DrumkitComponent( DrumkitComponent* other )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __id( other->get_id() )
 	, __name( other->get_name() )
 	, __volume( other->__volume )

--- a/src/core/src/basics/instrument.cpp
+++ b/src/core/src/basics/instrument.cpp
@@ -40,10 +40,10 @@
 namespace H2Core
 {
 
-const char* Instrument::__class_name = "Instrument";
+const char* Instrument::m_sClassName = "Instrument";
 
 Instrument::Instrument( const int id, const QString& name, ADSR* adsr )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __id( id )
 	, __name( name )
 	, __gain( 1.0 )
@@ -94,7 +94,7 @@ Instrument::Instrument( const int id, const QString& name, ADSR* adsr )
 }
 
 Instrument::Instrument( Instrument* other )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __id( other->get_id() )
 	, __name( other->get_name() )
 	, __gain( other->__gain )

--- a/src/core/src/basics/instrument_component.cpp
+++ b/src/core/src/basics/instrument_component.cpp
@@ -39,12 +39,12 @@
 namespace H2Core
 {
 
-const char* InstrumentComponent::__class_name = "InstrumentComponent";
+const char* InstrumentComponent::m_sClassName = "InstrumentComponent";
 
 int InstrumentComponent::m_nMaxLayers;
 
 InstrumentComponent::InstrumentComponent( int related_drumkit_componentID )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __related_drumkit_componentID( related_drumkit_componentID )
 	, __gain( 1.0 )
 {
@@ -55,7 +55,7 @@ InstrumentComponent::InstrumentComponent( int related_drumkit_componentID )
 }
 
 InstrumentComponent::InstrumentComponent( InstrumentComponent* other )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __related_drumkit_componentID( other->__related_drumkit_componentID )
 	, __gain( other->__gain )
 {

--- a/src/core/src/basics/instrument_layer.cpp
+++ b/src/core/src/basics/instrument_layer.cpp
@@ -28,9 +28,9 @@
 namespace H2Core
 {
 
-const char* InstrumentLayer::__class_name = "InstrumentLayer";
+const char* InstrumentLayer::m_sClassName = "InstrumentLayer";
 
-InstrumentLayer::InstrumentLayer( Sample* sample ) : Object( __class_name ),
+InstrumentLayer::InstrumentLayer( Sample* sample ) : Object( m_sClassName ),
 	__start_velocity( 0.0 ),
 	__end_velocity( 1.0 ),
 	__pitch( 0.0 ),
@@ -39,7 +39,7 @@ InstrumentLayer::InstrumentLayer( Sample* sample ) : Object( __class_name ),
 {
 }
 
-InstrumentLayer::InstrumentLayer( InstrumentLayer* other ) : Object( __class_name ),
+InstrumentLayer::InstrumentLayer( InstrumentLayer* other ) : Object( m_sClassName ),
 	__start_velocity( other->get_start_velocity() ),
 	__end_velocity( other->get_end_velocity() ),
 	__pitch( other->get_pitch() ),
@@ -48,7 +48,7 @@ InstrumentLayer::InstrumentLayer( InstrumentLayer* other ) : Object( __class_nam
 {
 }
 
-InstrumentLayer::InstrumentLayer( InstrumentLayer* other, Sample* sample ) : Object( __class_name ),
+InstrumentLayer::InstrumentLayer( InstrumentLayer* other, Sample* sample ) : Object( m_sClassName ),
 	__start_velocity( other->get_start_velocity() ),
 	__end_velocity( other->get_end_velocity() ),
 	__pitch( other->get_pitch() ),

--- a/src/core/src/basics/instrument_list.cpp
+++ b/src/core/src/basics/instrument_list.cpp
@@ -30,13 +30,13 @@
 namespace H2Core
 {
 
-const char* InstrumentList::__class_name = "InstrumentList";
+const char* InstrumentList::m_sClassName = "InstrumentList";
 
-InstrumentList::InstrumentList() : Object( __class_name )
+InstrumentList::InstrumentList() : Object( m_sClassName )
 {
 }
 
-InstrumentList::InstrumentList( InstrumentList* other ) : Object( __class_name )
+InstrumentList::InstrumentList( InstrumentList* other ) : Object( m_sClassName )
 {
 	assert( __instruments.size() == 0 );
 	for ( int i=0; i<other->size(); i++ ) {

--- a/src/core/src/basics/note.cpp
+++ b/src/core/src/basics/note.cpp
@@ -34,11 +34,11 @@
 namespace H2Core
 {
 
-const char* Note::__class_name = "Note";
+const char* Note::m_sClassName = "Note";
 const char* Note::__key_str[] = { "C", "Cs", "D", "Ef", "E", "F", "Fs", "G", "Af", "A", "Bf", "B" };
 
 Note::Note( Instrument* instrument, int position, float velocity, float pan_l, float pan_r, int length, float pitch )
-	: Object( __class_name ),
+	: Object( m_sClassName ),
 	  __instrument( instrument ),
 	  __instrument_id( 0 ),
 	  __specific_compo_id( -1 ),
@@ -85,7 +85,7 @@ Note::Note( Instrument* instrument, int position, float velocity, float pan_l, f
 }
 
 Note::Note( Note* other, Instrument* instrument )
-	: Object( __class_name ),
+	: Object( m_sClassName ),
 	  __instrument( other->get_instrument() ),
 	  __instrument_id( 0 ),
 	  __specific_compo_id( -1 ),

--- a/src/core/src/basics/pattern.cpp
+++ b/src/core/src/basics/pattern.cpp
@@ -35,10 +35,10 @@
 namespace H2Core
 {
 
-const char* Pattern::__class_name = "Pattern";
+const char* Pattern::m_sClassName = "Pattern";
 
 Pattern::Pattern( const QString& name, const QString& info, const QString& category, int length )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __length( length )
 	, __name( name )
 	, __info( info )
@@ -47,7 +47,7 @@ Pattern::Pattern( const QString& name, const QString& info, const QString& categ
 }
 
 Pattern::Pattern( Pattern* other )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __length( other->get_length() )
 	, __name( other->get_name() )
 	, __info( other->get_info() )

--- a/src/core/src/basics/pattern_list.cpp
+++ b/src/core/src/basics/pattern_list.cpp
@@ -28,13 +28,13 @@
 namespace H2Core
 {
 
-const char* PatternList::__class_name = "PatternList";
+const char* PatternList::m_sClassName = "PatternList";
 
-PatternList::PatternList() : Object( __class_name )
+PatternList::PatternList() : Object( m_sClassName )
 {
 }
 
-PatternList::PatternList( PatternList* other ) : Object( __class_name )
+PatternList::PatternList( PatternList* other ) : Object( m_sClassName )
 {
 	assert( __patterns.size() == 0 );
 	for ( int i=0; i<other->size(); i++ ) {

--- a/src/core/src/basics/playlist.cpp
+++ b/src/core/src/basics/playlist.cpp
@@ -33,10 +33,10 @@ namespace H2Core
 
 Playlist* Playlist::__instance = NULL;
 
-const char* Playlist::__class_name = "Playlist";
+const char* Playlist::m_sClassName = "Playlist";
 
 Playlist::Playlist()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 	__filename = "";
 	m_nSelectedSongNumber = -1;

--- a/src/core/src/basics/sample.cpp
+++ b/src/core/src/basics/sample.cpp
@@ -38,7 +38,7 @@
 namespace H2Core
 {
 
-const char* Sample::__class_name = "Sample";
+const char* Sample::m_sClassName = "Sample";
 const char* Sample::__loop_modes[] = { "forward", "reverse", "pingpong" };
 
 #if defined(H2CORE_HAVE_RUBBERBAND) || _DOXYGEN_
@@ -46,7 +46,7 @@ static double compute_pitch_scale( const Sample::Rubberband& r );
 static RubberBand::RubberBandStretcher::Options compute_rubberband_options( const Sample::Rubberband& r );
 #endif
 
-Sample::Sample( const QString& filepath,  int frames, int sample_rate, float* data_l, float* data_r ) : Object( __class_name ),
+Sample::Sample( const QString& filepath,  int frames, int sample_rate, float* data_l, float* data_r ) : Object( m_sClassName ),
 	__filepath( filepath ),
 	__frames( frames ),
 	__sample_rate( sample_rate ),
@@ -57,7 +57,7 @@ Sample::Sample( const QString& filepath,  int frames, int sample_rate, float* da
 	assert( filepath.lastIndexOf( "/" ) >0 );
 }
 
-Sample::Sample( Sample* pOther ): Object( __class_name ),
+Sample::Sample( Sample* pOther ): Object( m_sClassName ),
 	__filepath( pOther->get_filepath() ),
 	__frames( pOther->get_frames() ),
 	__sample_rate( pOther->get_sample_rate() ),

--- a/src/core/src/basics/song.cpp
+++ b/src/core/src/basics/song.cpp
@@ -57,10 +57,10 @@ namespace
 namespace H2Core
 {
 
-const char* Song::__class_name = "Song";
+const char* Song::m_sClassName = "Song";
 
 Song::Song( const QString& name, const QString& author, float bpm, float volume )
-	: Object( __class_name )
+	: Object( m_sClassName )
 	, __is_muted( false )
 	, __resolution( 48 )
 	, __bpm( bpm )
@@ -558,10 +558,10 @@ bool Song::pasteInstrumentLineFromString( const QString& serialized, int selecte
 //	Implementation of SongReader class
 //-----------------------------------------------------------------------------
 
-const char* SongReader::__class_name = "SongReader";
+const char* SongReader::m_sClassName = "SongReader";
 
 SongReader::SongReader()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 //	infoLog("init");
 }

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -35,10 +35,10 @@
 namespace H2Core
 {
 
-const char* CoreActionController::__class_name = "CoreActionController";
+const char* CoreActionController::m_sClassName = "CoreActionController";
 
 
-CoreActionController::CoreActionController() : Object( __class_name ),
+CoreActionController::CoreActionController() : Object( m_sClassName ),
 												m_nDefaultMidiFeedbackChannel(0)
 {
 	//nothing

--- a/src/core/src/event_queue.cpp
+++ b/src/core/src/event_queue.cpp
@@ -34,10 +34,10 @@ void EventQueue::create_instance()
 	}
 }
 
-const char* EventQueue::__class_name = "EventQueue";
+const char* EventQueue::m_sClassName = "EventQueue";
 
 EventQueue::EventQueue()
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, __read_index( 0 )
 		, __write_index( 0 )
 {

--- a/src/core/src/fx/effects.cpp
+++ b/src/core/src/fx/effects.cpp
@@ -44,10 +44,10 @@ namespace H2Core
 
 // static data
 Effects* Effects::__instance = NULL;
-const char* Effects::__class_name = "Effects";
+const char* Effects::m_sClassName = "Effects";
 
 Effects::Effects()
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, m_pRootGroup( NULL )
 		, m_pRecentGroup( NULL )
 {

--- a/src/core/src/fx/ladspa_fx.cpp
+++ b/src/core/src/fx/ladspa_fx.cpp
@@ -41,10 +41,10 @@ using namespace std;
 namespace H2Core
 {
 
-const char* LadspaFXGroup::__class_name = "LadspaFXGroup";
+const char* LadspaFXGroup::m_sClassName = "LadspaFXGroup";
 
 LadspaFXGroup::LadspaFXGroup( const QString& sName )
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 //	infoLog( "INIT - " + sName );
 	m_sName = sName;
@@ -88,10 +88,10 @@ void LadspaFXGroup::sort()
 
 ////////////////
 
-const char* LadspaFXInfo::__class_name = "LadspaFXInfo";
+const char* LadspaFXInfo::m_sClassName = "LadspaFXInfo";
 
 LadspaFXInfo::LadspaFXInfo( const QString& sName )
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 //	infoLog( "INIT - " + sName );
 	m_sFilename = "";
@@ -118,11 +118,11 @@ bool LadspaFXInfo::alphabeticOrder( LadspaFXInfo* a, LadspaFXInfo* b )
 ///////////////////
 
 
-const char* LadspaFX::__class_name = "LadspaFX";
+const char* LadspaFX::m_sClassName = "LadspaFX";
 
 // ctor
 LadspaFX::LadspaFX( const QString& sLibraryPath, const QString& sPluginLabel )
-		: Object( __class_name )
+		: Object( m_sClassName )
 //, m_nBufferSize( 0 )
 		, m_pBuffer_L( NULL )
 		, m_pBuffer_R( NULL )

--- a/src/core/src/helpers/files.cpp
+++ b/src/core/src/helpers/files.cpp
@@ -9,7 +9,7 @@
 namespace H2Core
 {
 
-	const char* Files::__class_name = "Files";
+	const char* Files::m_sClassName = "Files";
 
 	QString Files::savePattern( SaveMode mode, const QString& fileName, const Pattern* pPattern, Song* pSong, const QString& drumkitName )
 	{

--- a/src/core/src/helpers/filesystem.cpp
+++ b/src/core/src/helpers/filesystem.cpp
@@ -51,7 +51,7 @@ namespace H2Core
 {
 
 Logger* Filesystem::__logger = 0;
-const char* Filesystem::__class_name = "Filesystem";
+const char* Filesystem::m_sClassName = "Filesystem";
 
 const QString Filesystem::scripts_ext = ".sh";
 const QString Filesystem::songs_ext = ".h2song";

--- a/src/core/src/helpers/legacy.cpp
+++ b/src/core/src/helpers/legacy.cpp
@@ -19,7 +19,7 @@
 
 namespace H2Core {
 
-const char* Legacy::__class_name = "Legacy";
+const char* Legacy::m_sClassName = "Legacy";
 
 Drumkit* Legacy::load_drumkit( const QString& dk_path ) {
 	if ( version_older_than( 0, 9, 8 ) ) {

--- a/src/core/src/helpers/xml.cpp
+++ b/src/core/src/helpers/xml.cpp
@@ -34,10 +34,10 @@ protected:
 };
 
 
-const char* XMLNode::__class_name ="XMLNode";
+const char* XMLNode::m_sClassName ="XMLNode";
 
-XMLNode::XMLNode() : Object( __class_name ) { }
-XMLNode::XMLNode( QDomNode node ) : Object( __class_name ), QDomNode( node ) { }
+XMLNode::XMLNode() : Object( m_sClassName ) { }
+XMLNode::XMLNode( QDomNode node ) : Object( m_sClassName ), QDomNode( node ) { }
 
 XMLNode XMLNode::createNode( const QString& name )
 {
@@ -165,9 +165,9 @@ void XMLNode::write_bool( const QString& name, const bool value )
 	write_child_node( name, QString( ( value ? "true" : "false" ) ) );
 }
 
-const char* XMLDoc::__class_name ="XMLDoc";
+const char* XMLDoc::m_sClassName ="XMLDoc";
 
-XMLDoc::XMLDoc( ) : Object( __class_name ) { }
+XMLDoc::XMLDoc( ) : Object( m_sClassName ) { }
 
 bool XMLDoc::read( const QString& filepath, const QString& schemapath )
 {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -92,7 +92,9 @@
 
 namespace H2Core
 {
-
+/** \addtogroup docAudioEngine
+ * @{
+ */ 
 // GLOBALS
 
 // info
@@ -382,7 +384,7 @@ void				audioEngine_destroy();
  * this function will
  * - sets #m_fMasterPeak_L and #m_fMasterPeak_R to 0.0f
  * - sets TransportInfo::m_nFrames to @a nTotalFrames
- * - sets m_nSongPos and m_nPatternStartTick to -1
+ * - sets #m_nSongPos and #m_nPatternStartTick to -1
  * - m_nPatternTickPosition to 0
  * - calls updateTickSize()
  * - sets #m_audioEngineState to #STATE_PLAYING
@@ -393,6 +395,7 @@ void				audioEngine_destroy();
  *   option should only be used, if the process calling this function
  *   did already locked it.
  * \param nTotalFrames New value of the transport position.
+ *
  * \return 0 regardless what happens inside the function.
  */
 int				audioEngine_start( bool bLockEngine = false, unsigned nTotalFrames = 0 );
@@ -668,7 +671,8 @@ void				audioEngine_startAudioDrivers();
  * #STATE_READY, the function returns before deleting anything.
  */
 void				audioEngine_stopAudioDrivers();
-
+	
+/** @}*/ // Adding audio engine related stuff to h2audioEngine group.
 /** Gets the current time.
  * \return Current time obtained by gettimeofday()*/
 inline timeval currentTime2()

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -916,7 +916,7 @@ inline void audioEngine_process_checkBPMChanged(Song* pSong)
 	m_pAudioDriver->m_transport.m_nFrames = ceil(fTickNumber) * fNewTickSize;
 
 #ifdef H2CORE_HAVE_JACK
-	if ( JackAudioDriver::class_name() == m_pAudioDriver->class_name()
+	if ( JackAudioDriver::className() == m_pAudioDriver->className()
 		&& m_audioEngineState == STATE_PLAYING )
 	{
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->calculateFrameOffset();
@@ -1303,15 +1303,15 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 		m_pAudioDriver->stop();
 		m_pAudioDriver->locate( 0 ); // locate 0, reposition from start of the song
 
-		if ( ( m_pAudioDriver->class_name() == DiskWriterDriver::class_name() )
-			 || ( m_pAudioDriver->class_name() == FakeDriver::class_name() )
+		if ( ( m_pAudioDriver->className() == DiskWriterDriver::className() )
+			 || ( m_pAudioDriver->className() == FakeDriver::className() )
 			 ) {
 			___INFOLOG( "End of song." );
 			return 1;	// kill the audio AudioDriver thread
 		}
 
 #ifdef H2CORE_HAVE_JACK
-		else if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() )
+		else if ( m_pAudioDriver->className() == JackAudioDriver::className() )
 		{
 			// Do something clever :-s ... Jakob Lund
 			// Mainly to keep sync with Ardour.
@@ -1494,7 +1494,7 @@ void audioEngine_renameJackPorts(Song * pSong)
 	// renames jack ports
 	if ( ! pSong ) return;
 
-	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
+	if ( m_pAudioDriver->className() == JackAudioDriver::className() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->makeTrackOutputs( pSong );
 	}
 #endif
@@ -2037,13 +2037,13 @@ AudioOutput* createDriver( const QString& sDriver )
 
 	if ( sDriver == "Oss" ) {
 		pDriver = new OssDriver( audioEngine_process );
-		if ( pDriver->class_name() == NullDriver::class_name() ) {
+		if ( pDriver->className() == NullDriver::className() ) {
 			delete pDriver;
 			pDriver = NULL;
 		}
 	} else if ( sDriver == "Jack" ) {
 		pDriver = new JackAudioDriver( audioEngine_process );
-		if ( pDriver->class_name() == NullDriver::class_name() ) {
+		if ( pDriver->className() == NullDriver::className() ) {
 			delete pDriver;
 			pDriver = NULL;
 		} else {
@@ -2055,13 +2055,13 @@ AudioOutput* createDriver( const QString& sDriver )
 		}
 	} else if ( sDriver == "Alsa" ) {
 		pDriver = new AlsaAudioDriver( audioEngine_process );
-		if ( pDriver->class_name() == NullDriver::class_name() ) {
+		if ( pDriver->className() == NullDriver::className() ) {
 			delete pDriver;
 			pDriver = NULL;
 		}
 	} else if ( sDriver == "PortAudio" ) {
 		pDriver = new PortAudioDriver( audioEngine_process );
-		if ( pDriver->class_name() == NullDriver::class_name() ) {
+		if ( pDriver->className() == NullDriver::className() ) {
 			delete pDriver;
 			pDriver = NULL;
 		}
@@ -2070,7 +2070,7 @@ AudioOutput* createDriver( const QString& sDriver )
 	else if ( sDriver == "CoreAudio" ) {
 		___INFOLOG( "Creating CoreAudioDriver" );
 		pDriver = new CoreAudioDriver( audioEngine_process );
-		if ( pDriver->class_name() == NullDriver::class_name() ) {
+		if ( pDriver->className() == NullDriver::className() ) {
 			delete pDriver;
 			pDriver = NULL;
 		}
@@ -2078,7 +2078,7 @@ AudioOutput* createDriver( const QString& sDriver )
 	//#endif
 	else if ( sDriver == "PulseAudio" ) {
 		pDriver = new PulseAudioDriver( audioEngine_process );
-		if ( pDriver->class_name() == NullDriver::class_name() ) {
+		if ( pDriver->className() == NullDriver::className() ) {
 			delete pDriver;
 			pDriver = NULL;
 		}
@@ -2337,10 +2337,10 @@ void audioEngine_restartAudioDrivers()
 //----------------------------------------------------------------------------
 
 Hydrogen* Hydrogen::__instance = NULL;
-const char* Hydrogen::__class_name = "Hydrogen";
+const char* Hydrogen::m_sClassName = "Hydrogen";
 
 Hydrogen::Hydrogen()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 	if ( __instance ) {
 		ERRORLOG( "Hydrogen audio engine is already running" );
@@ -3113,7 +3113,7 @@ void Hydrogen::startExportSong( const QString& filename)
 
 void Hydrogen::stopExportSong()
 {
-	if ( m_pAudioDriver->class_name() != DiskWriterDriver::class_name() ) {
+	if ( m_pAudioDriver->className() != DiskWriterDriver::className() ) {
 		return;
 	}
 
@@ -3829,14 +3829,14 @@ void Hydrogen::setHumantimeFrames(unsigned long hframes)
 #ifdef H2CORE_HAVE_JACK
 void Hydrogen::offJackMaster()
 {
-	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
+	if ( m_pAudioDriver->className() == JackAudioDriver::className() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->com_release();
 	}
 }
 
 void Hydrogen::onJackMaster()
 {
-	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
+	if ( m_pAudioDriver->className() == JackAudioDriver::className() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->initTimeMaster();
 	}
 }

--- a/src/core/src/local_file_mgr.cpp
+++ b/src/core/src/local_file_mgr.cpp
@@ -58,10 +58,10 @@
 namespace H2Core
 {
 
-const char* LocalFileMng::__class_name = "LocalFileMng";
+const char* LocalFileMng::m_sClassName = "LocalFileMng";
 
 LocalFileMng::LocalFileMng()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 	//	infoLog("INIT");
 }
@@ -308,10 +308,10 @@ QDomDocument LocalFileMng::openXmlDocument( const QString& filename )
 //	Implementation of SongWriter class
 //-----------------------------------------------------------------------------
 
-const char* SongWriter::__class_name = "SongWriter";
+const char* SongWriter::m_sClassName = "SongWriter";
 
 SongWriter::SongWriter()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 	//	infoLog("init");
 }

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -62,9 +62,9 @@ using namespace H2Core;
 *
 */
 
-const char* Action::__class_name = "MidiAction";
+const char* Action::m_sClassName = "MidiAction";
 
-Action::Action( QString typeString ) : Object( __class_name ) {
+Action::Action( QString typeString ) : Object( m_sClassName ) {
 	type = typeString;
 	QString parameter1 = "0";
 	QString parameter2 = "0" ;
@@ -84,9 +84,9 @@ Action::Action( QString typeString ) : Object( __class_name ) {
 *
 */
 MidiActionManager* MidiActionManager::__instance = NULL;
-const char* MidiActionManager::__class_name = "ActionManager";
+const char* MidiActionManager::m_sClassName = "ActionManager";
 
-MidiActionManager::MidiActionManager() : Object( __class_name ) {
+MidiActionManager::MidiActionManager() : Object( m_sClassName ) {
 	__instance = this;
 
 	m_nLastBpmChangeCCParameter = -1;

--- a/src/core/src/midi_map.cpp
+++ b/src/core/src/midi_map.cpp
@@ -42,10 +42,10 @@
 */
 
 MidiMap * MidiMap::__instance = 0;
-const char* MidiMap::__class_name = "MidiMap";
+const char* MidiMap::m_sClassName = "MidiMap";
 
 MidiMap::MidiMap()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 	__instance = this;
 	QMutexLocker mx(&__mutex);

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -38,7 +38,7 @@
 
 
 NsmClient * NsmClient::__instance = 0;
-const char* NsmClient::__class_name = "NsmClient";
+const char* NsmClient::m_sClassName = "NsmClient";
 bool NsmShutdown = false;
 
 
@@ -94,7 +94,7 @@ void* nsm_processEvent(void* data)
 }
 
 NsmClient::NsmClient()
-	: Object( __class_name )
+	: Object( m_sClassName )
 {
 	m_NsmThread = 0;
 }

--- a/src/core/src/object.cpp
+++ b/src/core/src/object.cpp
@@ -27,30 +27,16 @@
 #include <iomanip>
 #include <cstdlib>
 
-
-/**
-* @class Object
-*
-* @brief Base class of all components of hydrogen.
-*
-* Every component of hydrogen is inherited from the
-* Object class. Each object has a qualified name
-* and gets registered in a memory map at creation.
-* This memory map helps to debug memory leaks and
-* can be printed at any time.
-*
-*/
-
 namespace H2Core {
 
-Logger* Object::__logger = 0;
+Logger* Object::__logger = nullptr;
 bool Object::__count = false;
 unsigned Object::__objects_count = 0;
 pthread_mutex_t Object::__mutex;
 Object::object_map_t Object::__objects_map;
 
 int Object::bootstrap( Logger* logger, bool count ) {
-	if( __logger==0 && logger!=0 ) {
+	if( __logger == nullptr && logger != nullptr ) {
 		__logger = logger;
 		__count = count;
 		pthread_mutex_init( &__mutex, 0 );
@@ -71,7 +57,7 @@ Object::Object( const Object& obj ) : m_sClassName( obj.m_sClassName ) {
 #endif
 }
 
-Object::Object( const char* className ) :m_sClassName( className ) {
+Object::Object( const char* className ) : m_sClassName( className ) {
 #ifdef H2CORE_HAVE_DEBUG
 	if( __count ) add_object( this, false );
 #endif
@@ -90,9 +76,10 @@ void Object::set_count( bool flag ) {
 inline void Object::add_object( const Object* obj, bool copy ) {
 #ifdef H2CORE_HAVE_DEBUG
 	const char* className = ( ( Object* )obj )->className();
-	if( __logger && __logger->should_log( Logger::Constructors ) ) __logger->log( Logger::Debug, 0, className, ( copy ? "Copy Constructor" : "Constructor" ) );
+	if( __logger && __logger->should_log( Logger::Constructors ) ) {
+		__logger->log( Logger::Debug, 0, className, ( copy ? "Copy Constructor" : "Constructor" ) );
+	}
 	pthread_mutex_lock( &__mutex );
-	//if( __objects_map.size()==0) atexit( Object::write_objects_map_to_cerr );
 	__objects_count++;
 	__objects_map[ className ].constructed++;
 	pthread_mutex_unlock( &__mutex );
@@ -102,7 +89,10 @@ inline void Object::add_object( const Object* obj, bool copy ) {
 inline void Object::del_object( const Object* obj ) {
 #ifdef H2CORE_HAVE_DEBUG
 	const char* className = ( ( Object* )obj )->className();
-	if( __logger && __logger->should_log( Logger::Constructors ) ) __logger->log( Logger::Debug, 0, className, "Destructor" );
+	if( __logger && __logger->should_log( Logger::Constructors ) ) {
+		__logger->log( Logger::Debug, 0, className, "Destructor" );
+	}
+	
 	object_map_t::iterator it_count = __objects_map.find( className );
 	if ( it_count==__objects_map.end() ) {
 		if( __logger!=0 && __logger->should_log( Logger::Error ) ) {
@@ -154,7 +144,7 @@ void Object::write_objects_map_to( std::ostream& out ) {
 #else
 	out << "\033[35mObject::write_objects_map_to :: \033[31mnot compiled with H2CORE_HAVE_DEBUG flag set\033[0m" << std::endl;
 #endif
-#endif
+#endif //H2CORE_HAVE_DEBUG
 }
 
 };

--- a/src/core/src/object.cpp
+++ b/src/core/src/object.cpp
@@ -65,13 +65,13 @@ Object::~Object( ) {
 #endif
 }
 
-Object::Object( const Object& obj ) : __class_name( obj.__class_name ) {
+Object::Object( const Object& obj ) : m_sClassName( obj.m_sClassName ) {
 #ifdef H2CORE_HAVE_DEBUG
 	if( __count ) add_object( this, true );
 #endif
 }
 
-Object::Object( const char* class_name ) :__class_name( class_name ) {
+Object::Object( const char* className ) :m_sClassName( className ) {
 #ifdef H2CORE_HAVE_DEBUG
 	if( __count ) add_object( this, false );
 #endif
@@ -89,32 +89,32 @@ void Object::set_count( bool flag ) {
 
 inline void Object::add_object( const Object* obj, bool copy ) {
 #ifdef H2CORE_HAVE_DEBUG
-	const char* class_name = ( ( Object* )obj )->class_name();
-	if( __logger && __logger->should_log( Logger::Constructors ) ) __logger->log( Logger::Debug, 0, class_name, ( copy ? "Copy Constructor" : "Constructor" ) );
+	const char* className = ( ( Object* )obj )->className();
+	if( __logger && __logger->should_log( Logger::Constructors ) ) __logger->log( Logger::Debug, 0, className, ( copy ? "Copy Constructor" : "Constructor" ) );
 	pthread_mutex_lock( &__mutex );
 	//if( __objects_map.size()==0) atexit( Object::write_objects_map_to_cerr );
 	__objects_count++;
-	__objects_map[ class_name ].constructed++;
+	__objects_map[ className ].constructed++;
 	pthread_mutex_unlock( &__mutex );
 #endif
 }
 
 inline void Object::del_object( const Object* obj ) {
 #ifdef H2CORE_HAVE_DEBUG
-	const char* class_name = ( ( Object* )obj )->class_name();
-	if( __logger && __logger->should_log( Logger::Constructors ) ) __logger->log( Logger::Debug, 0, class_name, "Destructor" );
-	object_map_t::iterator it_count = __objects_map.find( class_name );
+	const char* className = ( ( Object* )obj )->className();
+	if( __logger && __logger->should_log( Logger::Constructors ) ) __logger->log( Logger::Debug, 0, className, "Destructor" );
+	object_map_t::iterator it_count = __objects_map.find( className );
 	if ( it_count==__objects_map.end() ) {
 		if( __logger!=0 && __logger->should_log( Logger::Error ) ) {
 			std::stringstream msg;
-			msg << "the class " <<  class_name << " is not registered ! [" << obj << "]";
+			msg << "the class " <<  className << " is not registered ! [" << obj << "]";
 			__logger->log( Logger::Error,"del_object", "Object", QString::fromStdString( msg.str() ) );
 		}
 		return;
 	}
-	assert( ( *it_count ).first == class_name );
+	assert( ( *it_count ).first == className );
 	pthread_mutex_lock( &__mutex );
-	assert( __objects_map[class_name].constructed > ( __objects_map[class_name].destructed ) );
+	assert( __objects_map[className].constructed > ( __objects_map[className].destructed ) );
 	__objects_count--;
 	assert( __objects_count>=0 );
 	__objects_map[ ( *it_count ).first ].destructed++;

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -40,7 +40,7 @@
 #include "hydrogen/midi_action.h"
 
 OscServer * OscServer::__instance = nullptr;
-const char* OscServer::__class_name = "OscServer";
+const char* OscServer::m_sClassName = "OscServer";
 std::list<lo_address> OscServer::m_pClientRegistry;
 
 QString OscServer::qPrettyPrint(lo_type type,void * data)
@@ -246,7 +246,7 @@ int OscServer::generic_handler(const char *	path,
 
 
 
-OscServer::OscServer( H2Core::Preferences* pPreferences ) : Object( __class_name )
+OscServer::OscServer( H2Core::Preferences* pPreferences ) : Object( m_sClassName )
 {
 	m_pPreferences = pPreferences;
 	int port = m_pPreferences->getOscServerPort();

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -56,10 +56,10 @@ void Preferences::create_instance()
 	}
 }
 
-const char* Preferences::__class_name = "Preferences";
+const char* Preferences::m_sClassName = "Preferences";
 
 Preferences::Preferences()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 	__instance = this;
 	INFOLOG( "INIT" );
@@ -1203,10 +1203,10 @@ void Preferences::readUIStyle( QDomNode parent )
 
 
 
-const char* WindowProperties::__class_name = "WindowProperties";
+const char* WindowProperties::m_sClassName = "WindowProperties";
 
 WindowProperties::WindowProperties()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 //	infoLog( "INIT" );
 	x = 0;
@@ -1229,10 +1229,10 @@ WindowProperties::~WindowProperties()
 // :::::::::::::::::::::::::::::::
 
 
-const char* UIStyle::__class_name = "UIStyle";
+const char* UIStyle::m_sClassName = "UIStyle";
 
 UIStyle::UIStyle()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 //	infoLog( "INIT" );
 }
@@ -1242,10 +1242,10 @@ UIStyle::UIStyle()
 // ::::::::::::::::::::::::::::::::::::::
 
 
-const char* H2RGBColor::__class_name = "H2RGBColor";
+const char* H2RGBColor::m_sClassName = "H2RGBColor";
 
 H2RGBColor::H2RGBColor( int r, int g, int b )
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, m_red( r )
 		, m_green( g )
 		, m_blue( b )
@@ -1265,7 +1265,7 @@ H2RGBColor::~H2RGBColor()
 
 
 H2RGBColor::H2RGBColor( const QString& sColor )
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 //	infoLog( "INIT " + sColor );
 	QString temp = sColor;

--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -54,7 +54,7 @@
 namespace H2Core
 {
 
-const char* Sampler::__class_name = "Sampler";
+const char* Sampler::m_sClassName = "Sampler";
 
 
 static Instrument* create_instrument(int id, const QString& filepath, float volume )
@@ -69,7 +69,7 @@ static Instrument* create_instrument(int id, const QString& filepath, float volu
 }
 
 Sampler::Sampler()
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, __main_out_L( NULL )
 		, __main_out_R( NULL )
 		, __preview_instrument( NULL )

--- a/src/core/src/smf/smf.cpp
+++ b/src/core/src/smf/smf.cpp
@@ -35,10 +35,10 @@ using std::vector;
 namespace H2Core
 {
 
-const char* SMFHeader::__class_name = "SMFHeader";
+const char* SMFHeader::m_sClassName = "SMFHeader";
 
 SMFHeader::SMFHeader( int nFormat, int nTracks, int nTPQN )
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, m_nFormat( nFormat )
 		, m_nTracks( nTracks )
 		, m_nTPQN( nTPQN )
@@ -73,11 +73,11 @@ vector<char> SMFHeader::getBuffer()
 // :::::::::::::::
 
 
-const char* SMFTrack::__class_name = "SMFTrack";
+const char* SMFTrack::m_sClassName = "SMFTrack";
 
 //SMFTrack::SMFTrack( const QString& sTrackName )
 SMFTrack::SMFTrack()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 }
@@ -147,10 +147,10 @@ void SMFTrack::addEvent( SMFEvent *pEvent )
 
 
 
-const char* SMF::__class_name = "SMF";
+const char* SMF::m_sClassName = "SMF";
 
 SMF::SMF()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 
@@ -208,10 +208,10 @@ vector<char> SMF::getBuffer()
 // :::::::::::::::::::...
 
 
-const char* SMFWriter::__class_name = "SMFWriter";
+const char* SMFWriter::m_sClassName = "SMFWriter";
 
 SMFWriter::SMFWriter()
-		: Object( __class_name )
+		: Object( m_sClassName )
 		, m_file( NULL )
 {
 	INFOLOG( "INIT" );

--- a/src/core/src/smf/smf_event.cpp
+++ b/src/core/src/smf/smf_event.cpp
@@ -26,9 +26,9 @@
 namespace H2Core
 {
 
-const char* SMFBuffer::__class_name = "SMFBuffer";
+const char* SMFBuffer::m_sClassName = "SMFBuffer";
 
-SMFBuffer::SMFBuffer() : Object( __class_name ) { }
+SMFBuffer::SMFBuffer() : Object( m_sClassName ) { }
 
 void SMFBuffer::writeByte( short int nByte )
 {
@@ -95,10 +95,10 @@ void SMFBuffer::writeVarLen( long value )
 
 // ::::::::::::::::::
 
-const char* SMFTrackNameMetaEvent::__class_name = "SMFTrackNameMetaEvent";
+const char* SMFTrackNameMetaEvent::m_sClassName = "SMFTrackNameMetaEvent";
 
 SMFTrackNameMetaEvent::SMFTrackNameMetaEvent( const QString& sTrackName, unsigned nTicks )
-		: SMFEvent( __class_name, nTicks )
+		: SMFEvent( m_sClassName, nTicks )
 		, m_sTrackName( sTrackName )
 {
 	// it's always at the start of the song
@@ -119,10 +119,10 @@ std::vector<char> SMFTrackNameMetaEvent::getBuffer()
 
 // ::::::::::::::::::
 
-const char* SMFSetTempoMetaEvent::__class_name = "SMFSetTempoMetaEvent";
+const char* SMFSetTempoMetaEvent::m_sClassName = "SMFSetTempoMetaEvent";
 
 SMFSetTempoMetaEvent::SMFSetTempoMetaEvent( float fBPM, unsigned nTicks )
-		: SMFEvent( __class_name, nTicks )
+		: SMFEvent( m_sClassName, nTicks )
 		, m_fBPM( fBPM )
 {
 	// it's always at the start of the song
@@ -151,10 +151,10 @@ std::vector<char> SMFSetTempoMetaEvent::getBuffer()
 
 // ::::::::::::::::::
 
-const char* SMFCopyRightNoticeMetaEvent::__class_name = "SMFCopyRightNoticeMetaEvent";
+const char* SMFCopyRightNoticeMetaEvent::m_sClassName = "SMFCopyRightNoticeMetaEvent";
 
 SMFCopyRightNoticeMetaEvent::SMFCopyRightNoticeMetaEvent( const QString& sAuthor, unsigned nTicks )
-		: SMFEvent( __class_name, nTicks )
+		: SMFEvent( m_sClassName, nTicks )
 		, m_sAuthor( sAuthor )
 {
 	// it's always at the start of the song
@@ -186,10 +186,10 @@ std::vector<char> SMFCopyRightNoticeMetaEvent::getBuffer()
 
 // ::::::::::::::::::
 		
-const char* SMFTimeSignatureMetaEvent::__class_name = "SMFTimeSignatureMetaEvent";
+const char* SMFTimeSignatureMetaEvent::m_sClassName = "SMFTimeSignatureMetaEvent";
 
 SMFTimeSignatureMetaEvent::SMFTimeSignatureMetaEvent( unsigned nBeats, unsigned nNote , unsigned nMTPMC , unsigned nTSNP24 , unsigned nTicks )
-		: SMFEvent( __class_name, nTicks )
+		: SMFEvent( m_sClassName, nTicks )
 		, m_nBeats( nBeats )
 		, m_nNote( nNote )
 		, m_nMTPMC( nMTPMC )
@@ -243,10 +243,10 @@ SMFEvent::~SMFEvent()
 
 // ::::::::::::::
 
-const char* SMFNoteOnEvent::__class_name = "SMFNoteOnEvent";
+const char* SMFNoteOnEvent::m_sClassName = "SMFNoteOnEvent";
 
 SMFNoteOnEvent::SMFNoteOnEvent( unsigned nTicks, int nChannel, int nPitch, int nVelocity )
-		: SMFEvent( __class_name, nTicks )
+		: SMFEvent( m_sClassName, nTicks )
 		, m_nChannel( nChannel )
 		, m_nPitch( nPitch )
 		, m_nVelocity( nVelocity )
@@ -273,10 +273,10 @@ std::vector<char> SMFNoteOnEvent::getBuffer()
 // :::::::::::
 
 
-const char* SMFNoteOffEvent::__class_name = "SMFNoteOffEvent";
+const char* SMFNoteOffEvent::m_sClassName = "SMFNoteOffEvent";
 
 SMFNoteOffEvent::SMFNoteOffEvent( unsigned nTicks, int nChannel, int nPitch, int nVelocity )
-		: SMFEvent( __class_name, nTicks )
+		: SMFEvent( m_sClassName, nTicks )
 		, m_nChannel( nChannel )
 		, m_nPitch( nPitch )
 		, m_nVelocity( nVelocity )

--- a/src/core/src/synth/synth.cpp
+++ b/src/core/src/synth/synth.cpp
@@ -28,10 +28,10 @@
 namespace H2Core
 {
 
-const char* Synth::__class_name = "Synth";
+const char* Synth::m_sClassName = "Synth";
 
 Synth::Synth()
-		: Object( __class_name )
+		: Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -26,9 +26,9 @@
 
 namespace H2Core
 {
-	const char* Timeline::__class_name = "Timeline";
+	const char* Timeline::m_sClassName = "Timeline";
 
-	Timeline::Timeline() : Object( __class_name )
+	Timeline::Timeline() : Object( m_sClassName )
 	{
 	}
 

--- a/src/gui/src/AboutDialog.h
+++ b/src/gui/src/AboutDialog.h
@@ -31,6 +31,7 @@
 
 #include "ui_about_dialog.h"
 
+/** \ingroup docGUI */
 class AboutDialog : public QDialog, public Ui_AboutDialog_UI
 {
 Q_OBJECT

--- a/src/gui/src/AudioEngineInfoForm.cpp
+++ b/src/gui/src/AudioEngineInfoForm.cpp
@@ -41,11 +41,11 @@ using namespace H2Core;
 
 #include "Skin.h"
 
-const char* AudioEngineInfoForm::__class_name = "AudioEngineInfoForm";
+const char* AudioEngineInfoForm::m_sClassName = "AudioEngineInfoForm";
 
 AudioEngineInfoForm::AudioEngineInfoForm(QWidget* parent)
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 
@@ -138,7 +138,7 @@ void AudioEngineInfoForm::updateInfo()
 	// Audio driver info
 	AudioOutput *driver = pEngine->getAudioOutput();
 	if (driver) {
-		QString audioDriverName = driver->class_name();
+		QString audioDriverName = driver->className();
 		driverLbl->setText(audioDriverName);
 
 		// Audio driver buffer size
@@ -165,7 +165,7 @@ void AudioEngineInfoForm::updateInfo()
 	// Midi driver info
 	MidiInput *pMidiDriver = pEngine->getMidiInput();
 	if (pMidiDriver) {
-		midiDriverName->setText( pMidiDriver->class_name() );
+		midiDriverName->setText( pMidiDriver->className() );
 	}
 	else {
 		midiDriverName->setText("No MIDI driver support");

--- a/src/gui/src/AudioEngineInfoForm.h
+++ b/src/gui/src/AudioEngineInfoForm.h
@@ -36,6 +36,8 @@
 
 /**
  * Audio Engine information form
+ *
+ * \ingroup docGUI
  */
 class AudioEngineInfoForm : public QWidget, public Ui_AudioEngineInfoForm_UI, public EventListener, public H2Core::Object
 {

--- a/src/gui/src/AudioEngineInfoForm.h
+++ b/src/gui/src/AudioEngineInfoForm.h
@@ -39,9 +39,14 @@
  */
 class AudioEngineInfoForm : public QWidget, public Ui_AudioEngineInfoForm_UI, public EventListener, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QTimer *timer;
 
 		virtual void updateAudioEngineState();
@@ -52,6 +57,8 @@ class AudioEngineInfoForm : public QWidget, public Ui_AudioEngineInfoForm_UI, pu
 		//~ EventListener implementation
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		AudioEngineInfoForm(QWidget* parent);
 		~AudioEngineInfoForm();
 

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
@@ -38,11 +38,11 @@
 using namespace H2Core;
 using namespace std;
 
-const char* AudioFileBrowser::__class_name = "AudioFileBrowser";
+const char* AudioFileBrowser::m_sClassName = "AudioFileBrowser";
 
 AudioFileBrowser::AudioFileBrowser ( QWidget* pParent )
 		: QDialog ( pParent )
-		, Object ( __class_name )
+		, Object ( m_sClassName )
 {
 	setupUi ( this );
 	INFOLOG ( "INIT" );

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
@@ -34,9 +34,11 @@
 class Button;
 class SampleWaveDisplay;
 
-///
-/// This dialog is used to preview audiofiles
-///
+/**
+ * This dialog is used to preview audiofiles
+ *
+ * \ingroup docGUI
+ */
 class AudioFileBrowser : public QDialog, public Ui_AudioFileBrowser_UI, public H2Core::Object
 
 {

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
@@ -40,9 +40,10 @@ class SampleWaveDisplay;
 class AudioFileBrowser : public QDialog, public Ui_AudioFileBrowser_UI, public H2Core::Object
 
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		
 		AudioFileBrowser( QWidget* pParent );
 		~AudioFileBrowser();
@@ -69,6 +70,12 @@ class AudioFileBrowser : public QDialog, public Ui_AudioFileBrowser_UI, public H
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		InstrumentEditor* m_pInstrumentEditor;
 		QString m_pSampleFilename;
 		QStringList m_pSelectedFile;

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
@@ -28,11 +28,11 @@ using namespace H2Core;
 #include "SampleWaveDisplay.h"
 #include "../Skin.h"
 
-const char* SampleWaveDisplay::__class_name = "SampleWaveDisplay";
+const char* SampleWaveDisplay::m_sClassName = "SampleWaveDisplay";
 
 SampleWaveDisplay::SampleWaveDisplay(QWidget* pParent)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_sSampleName( "" )
 {
 //	setAttribute(Qt::WA_NoBackground);

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
@@ -29,8 +29,7 @@
 #endif
 #include <hydrogen/object.h>
 
-
-
+/** \ingroup docGUI */
 class SampleWaveDisplay : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
@@ -33,10 +33,11 @@
 
 class SampleWaveDisplay : public QWidget, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SampleWaveDisplay( QWidget* pParent );
 		~SampleWaveDisplay();
 
@@ -45,6 +46,12 @@ class SampleWaveDisplay : public QWidget, public H2Core::Object
 		void paintEvent(QPaintEvent *ev);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QPixmap m_Background;
 		QString m_sSampleName;
 		int *	m_pPeakData;

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -33,6 +33,7 @@
 #include "EventListener.h"
 
 
+/** \ingroup docGUI */
 class Director : public QDialog, public Ui_Director_UI, public H2Core::Object, public EventListener
 
 {

--- a/src/gui/src/DonationDialog.h
+++ b/src/gui/src/DonationDialog.h
@@ -31,6 +31,7 @@
 
 #include "ui_DonationDialog.h"
 
+/** \ingroup docGUI */
 class DonationDialog : public QDialog, public Ui_DonationDialog_UI
 {
 Q_OBJECT

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -23,6 +23,7 @@
 #define EVENT_LISTENER
 
 #include <hydrogen/globals.h>
+/** \ingroup docGUI docEvent*/
 class EventListener
 {
 	public:

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -54,13 +54,13 @@
 
 using namespace H2Core;
 
-const char* ExportSongDialog::__class_name = "ExportSongDialog";
+const char* ExportSongDialog::m_sClassName = "ExportSongDialog";
 
 enum ExportModes { EXPORT_TO_SINGLE_TRACK, EXPORT_TO_SEPARATE_TRACKS, EXPORT_TO_BOTH};
 
 ExportSongDialog::ExportSongDialog(QWidget* parent)
 	: QDialog(parent)
-	, Object( __class_name )
+	, Object( m_sClassName )
 	, m_bExporting( false )
 	, m_pEngine( Hydrogen::get_instance() )
 	, m_pPreferences( Preferences::get_instance() )

--- a/src/gui/src/ExportSongDialog.h
+++ b/src/gui/src/ExportSongDialog.h
@@ -35,9 +35,11 @@ namespace H2Core {
 	class Preferences;
 }
 
-///
-/// Dialog for exporting song
-///
+/**
+ * Dialog for exporting song
+ *
+ * \ingroup docGUI
+ */
 class ExportSongDialog : public QDialog, public Ui_ExportSongDialog_UI, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/ExportSongDialog.h
+++ b/src/gui/src/ExportSongDialog.h
@@ -40,14 +40,15 @@ namespace H2Core {
 ///
 class ExportSongDialog : public QDialog, public Ui_ExportSongDialog_UI, public EventListener, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 
-	public:
-		ExportSongDialog(QWidget* parent);
-		~ExportSongDialog();
+public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+	ExportSongDialog(QWidget* parent);
+	~ExportSongDialog();
 
-		virtual void progressEvent( int nValue );
+	virtual void progressEvent( int nValue );
 
 
 private slots:
@@ -61,6 +62,12 @@ private slots:
 	void		resampleComboBoIndexChanged(int index);
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 
 	void		setResamplerMode(int index);
 	void		calculateRubberbandTime();

--- a/src/gui/src/HelpBrowser.cpp
+++ b/src/gui/src/HelpBrowser.cpp
@@ -30,11 +30,11 @@
 #endif
 #include <hydrogen/globals.h>
 
-const char* SimpleHTMLBrowser::__class_name = "SimpleHTMLBrowser";
+const char* SimpleHTMLBrowser::m_sClassName = "SimpleHTMLBrowser";
 
 SimpleHTMLBrowser::SimpleHTMLBrowser( QWidget *pParent, const QString& sDataPath, const QString& sFilename, SimpleHTMLBrowserType type )
  : QDialog( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_type( type )
  , m_sDataPath( sDataPath )
  , m_sFilename( sFilename )

--- a/src/gui/src/HelpBrowser.h
+++ b/src/gui/src/HelpBrowser.h
@@ -36,9 +36,10 @@
 
 class SimpleHTMLBrowser : public QDialog, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		enum SimpleHTMLBrowserType {
 			WELCOME,
 			MANUAL
@@ -53,6 +54,12 @@ class SimpleHTMLBrowser : public QDialog, public H2Core::Object
 		void docIndex();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		SimpleHTMLBrowserType m_type;
 		QTextBrowser *m_pBrowser;
 		QPushButton *m_pDontShowAnymoreBtn;

--- a/src/gui/src/HelpBrowser.h
+++ b/src/gui/src/HelpBrowser.h
@@ -34,6 +34,7 @@
 
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI */
 class SimpleHTMLBrowser : public QDialog, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -62,10 +62,10 @@ using namespace H2Core;
 
 
 HydrogenApp* HydrogenApp::m_pInstance = NULL;
-const char* HydrogenApp::__class_name = "HydrogenApp";
+const char* HydrogenApp::m_sClassName = "HydrogenApp";
 
 HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
- : Object( __class_name )
+ : Object( m_sClassName )
  , m_pMainForm( pMainForm )
  , m_pMixer( NULL )
  , m_pPatternEditorPanel( NULL )

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -42,7 +42,10 @@
 /** Amount of time to pass between successive calls to
  * HydrogenApp::onEventQueueTimer() in milliseconds.
  *
- * This causes the GUI to update at 20 frames per second.*/
+ * This causes the GUI to update at 20 frames per second.
+ *
+ * \ingroup docConfiguration
+ */
 #define QUEUE_TIMER_PERIOD 50
 
 
@@ -69,6 +72,7 @@ class SampleEditor;
 class Director;
 class InfoBar;
 
+/** \ingroup docGUI */
 class HydrogenApp : public QObject, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -71,9 +71,10 @@ class InfoBar;
 
 class HydrogenApp : public QObject, public H2Core::Object
 {
-		H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		HydrogenApp( MainForm* pMainForm, H2Core::Song *pFirstSong );
 
 		/// Returns the instance of HydrogenApp class
@@ -181,6 +182,12 @@ class HydrogenApp : public QObject, public H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static HydrogenApp *		m_pInstance;	///< HydrogenApp instance
 
 #ifdef H2CORE_HAVE_LADSPA

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -56,11 +56,11 @@ using namespace H2Core;
 #include "LayerPreview.h"
 #include "AudioFileBrowser/AudioFileBrowser.h"
 
-const char* InstrumentEditor::__class_name = "InstrumentEditor";
+const char* InstrumentEditor::m_sClassName = "InstrumentEditor";
 
 InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	: QWidget( pParent )
-	, Object( __class_name )
+	, Object( m_sClassName )
 	, m_pInstrument( nullptr )
 	, m_nSelectedLayer( 0 )
 {

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -51,10 +51,11 @@ class LayerPreview;
 ///
 class InstrumentEditor : public QWidget, public H2Core::Object, public EventListener
 {
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		InstrumentEditor( QWidget* parent );
 		~InstrumentEditor();
 
@@ -95,6 +96,12 @@ class InstrumentEditor : public QWidget, public H2Core::Object, public EventList
 		void waveDisplayDoubleClicked( QWidget *pRef );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		H2Core::Instrument *m_pInstrument;
 		int m_nSelectedLayer;
 		int m_nSelectedComponent;

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -46,9 +46,11 @@ class WaveDisplay;
 class LayerPreview;
 
 
-///
-/// Instrument Editor
-///
+/**
+ * Instrument Editor
+ *
+ * \ingroup docGUI
+ */
 class InstrumentEditor : public QWidget, public H2Core::Object, public EventListener
 {
 	Q_OBJECT

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -33,7 +33,7 @@
 
 
 InstrumentEditorPanel* InstrumentEditorPanel::m_pInstance = NULL;
-const char* InstrumentEditorPanel::__class_name = "InstrumentEditorPanel";
+const char* InstrumentEditorPanel::m_sClassName = "InstrumentEditorPanel";
 
 InstrumentEditorPanel* InstrumentEditorPanel::get_instance()
 {
@@ -46,7 +46,7 @@ InstrumentEditorPanel* InstrumentEditorPanel::get_instance()
 
 
 InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent )
- : Object( __class_name )
+ : Object( m_sClassName )
 {
 	UNUSED( pParent );
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
@@ -36,9 +36,10 @@
 ///
 class InstrumentEditorPanel : public QWidget, private H2Core::Object, public EventListener
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		static InstrumentEditorPanel* get_instance();
 		~InstrumentEditorPanel();
 
@@ -54,6 +55,12 @@ class InstrumentEditorPanel : public QWidget, private H2Core::Object, public Eve
 		void notifyOfDrumkitChange();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static InstrumentEditorPanel* m_pInstance;
 		InstrumentEditor* m_pInstrumentEditor;
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
@@ -31,9 +31,11 @@
 #include "InstrumentEditor.h"
 #include "../EventListener.h"
 
-///
-/// Container for the Instrument Editor (Singleton).
-///
+/**
+ * Container for the Instrument Editor (Singleton).
+ *
+ * \ingroup docGUI
+ */
 class InstrumentEditorPanel : public QWidget, private H2Core::Object, public EventListener
 {
 	Q_OBJECT

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -41,11 +41,11 @@ using namespace H2Core;
 #include "InstrumentEditorPanel.h"
 #include "LayerPreview.h"
 
-const char* LayerPreview::__class_name = "LayerPreview";
+const char* LayerPreview::m_sClassName = "LayerPreview";
 
 LayerPreview::LayerPreview( QWidget* pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_pInstrument( NULL )
  , m_nSelectedComponent( 0 )
  , m_nSelectedLayer( 0 )

--- a/src/gui/src/InstrumentEditor/LayerPreview.h
+++ b/src/gui/src/InstrumentEditor/LayerPreview.h
@@ -38,7 +38,7 @@ class InstrumentLayer;
 
 using H2Core::InstrumentLayer;
 
-
+/** \ingroup docGUI */
 class LayerPreview : public QWidget, public H2Core::Object, public EventListener
 {
 	Q_OBJECT

--- a/src/gui/src/InstrumentEditor/LayerPreview.h
+++ b/src/gui/src/InstrumentEditor/LayerPreview.h
@@ -41,10 +41,11 @@ using H2Core::InstrumentLayer;
 
 class LayerPreview : public QWidget, public H2Core::Object, public EventListener
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		LayerPreview(QWidget* pParent);
 		~LayerPreview();
 
@@ -58,6 +59,12 @@ class LayerPreview : public QWidget, public H2Core::Object, public EventListener
 		void set_selected_component( int SelectedComponent );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static const int m_nLayerHeight = 10;
 		QPixmap m_speakerPixmap;
 		H2Core::Instrument *m_pInstrument;

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -29,11 +29,11 @@ using namespace H2Core;
 #include "WaveDisplay.h"
 #include "../Skin.h"
 
-const char* WaveDisplay::__class_name = "WaveDisplay";
+const char* WaveDisplay::m_sClassName = "WaveDisplay";
 
 WaveDisplay::WaveDisplay(QWidget* pParent)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_nCurrentWidth( 0 )
  , m_sSampleName( "-" )
  , m_pLayer( nullptr )

--- a/src/gui/src/InstrumentEditor/WaveDisplay.h
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.h
@@ -34,6 +34,7 @@ namespace H2Core
 	class InstrumentLayer;
 }
 
+/** \ingroup docGUI */
 class WaveDisplay : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/InstrumentEditor/WaveDisplay.h
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.h
@@ -36,10 +36,11 @@ namespace H2Core
 
 class WaveDisplay : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		WaveDisplay(QWidget* pParent);
 		~WaveDisplay();
 
@@ -55,6 +56,12 @@ class WaveDisplay : public QWidget, public H2Core::Object
 		void doubleClicked(QWidget *pWidget);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		Qt::AlignmentFlag			m_SampleNameAlignment;
 		QPixmap						m_Background;
 		QString						m_sSampleName;

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -28,11 +28,11 @@
 
 #include <QGridLayout>
 
-const char* InstrumentRack::__class_name = "InstrumentRack";
+const char* InstrumentRack::m_sClassName = "InstrumentRack";
 
 InstrumentRack::InstrumentRack( QWidget *pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 

--- a/src/gui/src/InstrumentRack.h
+++ b/src/gui/src/InstrumentRack.h
@@ -34,6 +34,7 @@
 class ToggleButton;
 class SoundLibraryPanel;
 
+/** \ingroup docGUI */
 class InstrumentRack : public QWidget, private H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/InstrumentRack.h
+++ b/src/gui/src/InstrumentRack.h
@@ -36,9 +36,10 @@ class SoundLibraryPanel;
 
 class InstrumentRack : public QWidget, private H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		InstrumentRack( QWidget *pParent );
 		~InstrumentRack();
 
@@ -50,6 +51,12 @@ class InstrumentRack : public QWidget, private H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		/// button for showing the Sound Library
 		ToggleButton *m_pShowSoundLibraryBtn;
 

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -41,11 +41,11 @@
 using namespace std;
 using namespace H2Core;
 
-const char* LadspaFXProperties::__class_name = "LadspaFXProperties";
+const char* LadspaFXProperties::m_sClassName = "LadspaFXProperties";
 
 LadspaFXProperties::LadspaFXProperties(QWidget* parent, uint nLadspaFX)
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 //	INFOLOG( "INIT" );
 

--- a/src/gui/src/LadspaFXProperties.h
+++ b/src/gui/src/LadspaFXProperties.h
@@ -35,6 +35,7 @@ class Fader;
 class LCDDisplay;
 class InstrumentNameWidget;
 
+/** \ingroup docGUI */
 class LadspaFXProperties : public QWidget, public H2Core::Object {
 	Q_OBJECT
 

--- a/src/gui/src/LadspaFXProperties.h
+++ b/src/gui/src/LadspaFXProperties.h
@@ -36,10 +36,11 @@ class LCDDisplay;
 class InstrumentNameWidget;
 
 class LadspaFXProperties : public QWidget, public H2Core::Object {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		LadspaFXProperties(QWidget* parent, uint nLadspaFX);
 		~LadspaFXProperties();
 
@@ -56,6 +57,12 @@ class LadspaFXProperties : public QWidget, public H2Core::Object {
 		void updateOutputControls();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		uint m_nLadspaFX;
 
 		QLabel *m_pNameLbl;

--- a/src/gui/src/LadspaFXSelector.cpp
+++ b/src/gui/src/LadspaFXSelector.cpp
@@ -33,11 +33,11 @@
 using namespace std;
 using namespace H2Core;
 
-const char* LadspaFXSelector::__class_name = "LadspaFXSelector";
+const char* LadspaFXSelector::m_sClassName = "LadspaFXSelector";
 
 LadspaFXSelector::LadspaFXSelector(int nLadspaFX)
  : QDialog( NULL )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_pCurrentItem( NULL )
 {
 	//INFOLOG( "INIT" );

--- a/src/gui/src/LadspaFXSelector.h
+++ b/src/gui/src/LadspaFXSelector.h
@@ -43,10 +43,11 @@ namespace H2Core {
 
 class LadspaFXSelector : public QDialog, public Ui_LadspaFXSelector_UI, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		LadspaFXSelector(int nLadspaFX);
 		~LadspaFXSelector();
 
@@ -57,6 +58,12 @@ class LadspaFXSelector : public QDialog, public Ui_LadspaFXSelector_UI, public H
 		void pluginSelected();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QTreeWidgetItem* m_pCurrentItem;
 		QString m_sSelectedPluginName;
 		void buildLadspaGroups();

--- a/src/gui/src/LadspaFXSelector.h
+++ b/src/gui/src/LadspaFXSelector.h
@@ -41,6 +41,7 @@ namespace H2Core {
 	class LadspaFXGroup;
 }
 
+/** \ingroup docGUI */
 class LadspaFXSelector : public QDialog, public Ui_LadspaFXSelector_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -88,11 +88,11 @@ using namespace H2Core;
 
 int MainForm::sigusr1Fd[2];
 
-const char* MainForm::__class_name = "MainForm";
+const char* MainForm::m_sClassName = "MainForm";
 
 MainForm::MainForm( QApplication *app, const QString& songFilename )
 	: QMainWindow( 0, 0 )
-	, Object( __class_name )
+	, Object( m_sClassName )
 {
 	setMinimumSize( QSize( 1000, 500 ) );
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -40,9 +40,11 @@
 class HydrogenApp;
 class QUndoView;///debug only
 
-///
-/// Main window
-///
+/**
+ * Main window
+ *
+ * \ingroup docGUI
+ */
 class MainForm : public QMainWindow, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -45,10 +45,11 @@ class QUndoView;///debug only
 ///
 class MainForm : public QMainWindow, public EventListener, public H2Core::Object
 {
-		H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		QApplication* m_pQApp;
 
 		MainForm( QApplication *app, const QString& songFilename );
@@ -149,6 +150,12 @@ public slots:
 		bool handleUnsavedChanges();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		HydrogenApp*	h2app;
 
 		static int sigusr1Fd[2];

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -47,11 +47,11 @@ using namespace H2Core;
 #define MIXER_STRIP_WIDTH	56
 #define MASTERMIXER_STRIP_WIDTH	126
 
-const char* Mixer::__class_name = "Mixer";
+const char* Mixer::m_sClassName = "Mixer";
 
 Mixer::Mixer( QWidget* pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setWindowTitle( trUtf8( "Mixer" ) );
 	setMaximumHeight( 284 );

--- a/src/gui/src/Mixer/Mixer.h
+++ b/src/gui/src/Mixer/Mixer.h
@@ -43,6 +43,7 @@ class MasterMixerLine;
 class LadspaFXMixerLine;
 class PixmapWidget;
 
+/** \ingroup docGUI */
 class Mixer : public QWidget, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/Mixer/Mixer.h
+++ b/src/gui/src/Mixer/Mixer.h
@@ -45,9 +45,10 @@ class PixmapWidget;
 
 class Mixer : public QWidget, public EventListener, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		Mixer(QWidget* parent);
 		~Mixer();
 
@@ -84,6 +85,12 @@ class Mixer : public QWidget, public EventListener, public H2Core::Object
 		void closeEvent(QCloseEvent *event);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QHBoxLayout *			m_pFaderHBox;
 		LadspaFXMixerLine *		m_pLadspaFXLine[MAX_FX];
 

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -49,10 +49,10 @@ using namespace H2Core;
 
 using namespace H2Core;
 
-const char* MixerLine::__class_name = "MixerLine";
+const char* MixerLine::m_sClassName = "MixerLine";
 
 MixerLine::MixerLine(QWidget* parent, int nInstr)
- : PixmapWidget( parent, __class_name )
+ : PixmapWidget( parent, m_sClassName )
 {
 //	INFOLOG( "INIT" );
 
@@ -428,10 +428,10 @@ void MixerLine::setSelected( bool bIsSelected )
 // ::::::::::::::::::::::::::::
 
 
-const char* ComponentMixerLine::__class_name = "ComponentMixerLine";
+const char* ComponentMixerLine::m_sClassName = "ComponentMixerLine";
 
 ComponentMixerLine::ComponentMixerLine(QWidget* parent, int CompoID)
- : PixmapWidget( parent, __class_name )
+ : PixmapWidget( parent, m_sClassName )
 {
 //	INFOLOG( "INIT" );
 
@@ -644,10 +644,10 @@ float ComponentMixerLine::getPeak_R() {
 
 
 // ::::::::::::::::::::::::::::
-const char* MasterMixerLine::__class_name = "MasterMixerLine";
+const char* MasterMixerLine::m_sClassName = "MasterMixerLine";
 
 MasterMixerLine::MasterMixerLine(QWidget* parent)
- : PixmapWidget( parent, __class_name )
+ : PixmapWidget( parent, m_sClassName )
 {
 	m_nWidth = MASTERMIXERLINE_WIDTH;
 	m_nHeight = MASTERMIXERLINE_HEIGHT;

--- a/src/gui/src/Mixer/MixerLine.h
+++ b/src/gui/src/Mixer/MixerLine.h
@@ -44,7 +44,7 @@ class Rotary;
 
 #include "../Widgets/PixmapWidget.h"
 
-
+/** \ingroup docGUI */
 class InstrumentNameWidget : public PixmapWidget
 {
 	Q_OBJECT
@@ -83,9 +83,11 @@ class InstrumentNameWidget : public PixmapWidget
 
 
 
-///
-/// A mixer strip
-///
+/**
+ * A mixer strip
+ *
+ * \ingroup docGUI
+ */
 class MixerLine: public PixmapWidget
 {
 	Q_OBJECT
@@ -176,6 +178,7 @@ class MixerLine: public PixmapWidget
 		LCDDisplay *			m_pPeakLCD;
 };
 
+/** \ingroup docGUI */
 class ComponentMixerLine: public PixmapWidget
 {
 	Q_OBJECT
@@ -241,11 +244,7 @@ class ComponentMixerLine: public PixmapWidget
 		LCDDisplay *			m_pPeakLCD;
 };
 
-
-
-
-
-
+/** \ingroup docGUI */
 class MasterMixerLine: public PixmapWidget
 {
 	Q_OBJECT
@@ -305,9 +304,11 @@ class MasterMixerLine: public PixmapWidget
 
 
 
-///
-/// Mixer strip for FX
-///
+/**
+ * Mixer strip for FX
+ *
+ * \ingroup docGUI
+ */
 class FxMixerLine: public PixmapWidget
 {
 	Q_OBJECT
@@ -358,9 +359,7 @@ class FxMixerLine: public PixmapWidget
 		LCDDisplay *			m_pPeakLCD;
 };
 
-
-
-
+/** \ingroup docGUI */
 class LadspaFXMixerLine : public PixmapWidget
 {
 	Q_OBJECT

--- a/src/gui/src/Mixer/MixerLine.h
+++ b/src/gui/src/Mixer/MixerLine.h
@@ -47,9 +47,10 @@ class Rotary;
 
 class InstrumentNameWidget : public PixmapWidget
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		InstrumentNameWidget(QWidget* parent);
 		~InstrumentNameWidget();
 
@@ -67,6 +68,12 @@ class InstrumentNameWidget : public PixmapWidget
 		virtual void paintEvent(QPaintEvent *ev);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		int			m_nWidgetWidth;
 		int			m_nWidgetHeight;
 		QString		m_sInstrName;
@@ -81,9 +88,10 @@ class InstrumentNameWidget : public PixmapWidget
 ///
 class MixerLine: public PixmapWidget
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MixerLine(QWidget* parent, int nInstr);
 		~MixerLine();
 
@@ -141,6 +149,12 @@ class MixerLine: public PixmapWidget
 		void	nameSelected();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		uint	m_nWidth;
 		uint	m_nHeight;
 		bool	m_bIsSelected;
@@ -164,9 +178,10 @@ class MixerLine: public PixmapWidget
 
 class ComponentMixerLine: public PixmapWidget
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		ComponentMixerLine(QWidget* parent, int CompoID);
 		~ComponentMixerLine();
 
@@ -203,6 +218,12 @@ class ComponentMixerLine: public PixmapWidget
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		int		__compoID;
 		uint	m_nWidth;
 		uint	m_nHeight;
@@ -227,9 +248,10 @@ class ComponentMixerLine: public PixmapWidget
 
 class MasterMixerLine: public PixmapWidget
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MasterMixerLine(QWidget* parent);
 		~MasterMixerLine();
 
@@ -255,6 +277,12 @@ class MasterMixerLine: public PixmapWidget
 		void	muteClicked(Button*);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		uint	m_nWidth;
 		uint	m_nHeight;
 
@@ -282,9 +310,10 @@ class MasterMixerLine: public PixmapWidget
 ///
 class FxMixerLine: public PixmapWidget
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		FxMixerLine(QWidget* parent);
 		~FxMixerLine();
 
@@ -313,6 +342,12 @@ class FxMixerLine: public PixmapWidget
 		void	faderChanged(Fader * ref);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		uint	m_nWidth;
 		uint	m_nHeight;
 		float	m_fMaxPeak;
@@ -328,9 +363,10 @@ class FxMixerLine: public PixmapWidget
 
 class LadspaFXMixerLine : public PixmapWidget
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		LadspaFXMixerLine(QWidget* parent);
 		~LadspaFXMixerLine();
 
@@ -354,6 +390,12 @@ class LadspaFXMixerLine : public PixmapWidget
 		void volumeChanged( LadspaFXMixerLine *ref);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		float			m_fMaxPeak;
 		ToggleButton *	m_pActiveBtn;
 		Button *		m_pEditBtn;

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -51,11 +51,11 @@
 using namespace std;
 using namespace H2Core;
 
-const char* DrumPatternEditor::__class_name = "DrumPatternEditor";
+const char* DrumPatternEditor::m_sClassName = "DrumPatternEditor";
 
 DrumPatternEditor::DrumPatternEditor(QWidget* parent, PatternEditorPanel *panel)
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_nResolution( 8 )
  , m_bUseTriplets( false )
  , m_bRightBtnPressed( false )

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -41,9 +41,11 @@ namespace H2Core
 
 class PatternEditorInstrumentList;
 class PatternEditorPanel;
-///
-/// Drum pattern editor
-///
+/**
+ * Drum pattern editor
+ *
+ * \ingroup docGUI
+ */
 class DrumPatternEditor : public QWidget, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -46,10 +46,11 @@ class PatternEditorPanel;
 ///
 class DrumPatternEditor : public QWidget, public EventListener, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		DrumPatternEditor(QWidget* parent, PatternEditorPanel *panel);
 		~DrumPatternEditor();
 
@@ -112,6 +113,12 @@ class DrumPatternEditor : public QWidget, public EventListener, public H2Core::O
 		void updateEditor();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		float m_nGridWidth;
 		uint m_nGridHeight;
 		int m_nEditorHeight;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -39,11 +39,11 @@ using namespace H2Core;
 #include "DrumPatternEditor.h"
 #include "PianoRollEditor.h"
 
-const char* NotePropertiesRuler::__class_name = "NotePropertiesRuler";
+const char* NotePropertiesRuler::m_sClassName = "NotePropertiesRuler";
 
 NotePropertiesRuler::NotePropertiesRuler( QWidget *parent, PatternEditorPanel *pPatternEditorPanel, NotePropertiesMode mode )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_Mode( mode )
  , m_pPatternEditorPanel( pPatternEditorPanel )
  , m_pPattern( NULL )

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -40,6 +40,7 @@ namespace H2Core
 
 class PatternEditorPanel;
 
+/** \ingroup docGUI */
 class NotePropertiesRuler : public QWidget, public H2Core::Object, public EventListener
 {
 	Q_OBJECT

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -42,9 +42,10 @@ class PatternEditorPanel;
 
 class NotePropertiesRuler : public QWidget, public H2Core::Object, public EventListener
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		enum NotePropertiesMode {
 			VELOCITY,
 			PAN,
@@ -63,6 +64,12 @@ class NotePropertiesRuler : public QWidget, public H2Core::Object, public EventL
 		void updateEditor();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static const int m_nKeys = 24;
 		static const int m_nBasePitch = 12;
 

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -53,10 +53,10 @@ using namespace H2Core;
 
 using namespace std;
 
-const char* InstrumentLine::__class_name = "InstrumentLine";
+const char* InstrumentLine::m_sClassName = "InstrumentLine";
 
 InstrumentLine::InstrumentLine(QWidget* pParent)
-	: PixmapWidget(pParent, __class_name)
+	: PixmapWidget(pParent, m_sClassName)
 	, m_bIsSelected(false)
 {
 	int h = Preferences::get_instance()->getPatternEditorGridHeight();
@@ -509,11 +509,11 @@ void InstrumentLine::functionDeleteInstrument()
 
 //////
 
-const char* PatternEditorInstrumentList::__class_name = "PatternEditorInstrumentList";
+const char* PatternEditorInstrumentList::m_sClassName = "PatternEditorInstrumentList";
 
 PatternEditorInstrumentList::PatternEditorInstrumentList( QWidget *parent, PatternEditorPanel *pPatternEditorPanel )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	//INFOLOG("INIT");
 	m_pPattern = NULL;

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -45,10 +45,11 @@ class ToggleButton;
 
 class InstrumentLine : public PixmapWidget
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		InstrumentLine(QWidget* pParent);
 
 		void setName(const QString& sName);
@@ -83,6 +84,12 @@ class InstrumentLine : public PixmapWidget
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QMenu *m_pFunctionPopup;
 		QMenu *m_pFunctionPopupSub;
 		QMenu *m_pCopyPopupSub;
@@ -99,10 +106,11 @@ class InstrumentLine : public PixmapWidget
 
 
 class PatternEditorInstrumentList : public QWidget, public H2Core::Object {
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PatternEditorInstrumentList( QWidget *parent, PatternEditorPanel *pPatternEditorPanel );
 		~PatternEditorInstrumentList();
 
@@ -130,6 +138,13 @@ class PatternEditorInstrumentList : public QWidget, public H2Core::Object {
 		QPoint __drag_start_position;
 
 		InstrumentLine* createInstrumentLine();
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 };
 

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -43,6 +43,7 @@ namespace H2Core
 class PatternEditorPanel;
 class ToggleButton;
 
+/** \ingroup docGUI */
 class InstrumentLine : public PixmapWidget
 {
 	Q_OBJECT

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -59,12 +59,12 @@ void PatternEditorPanel::updateSLnameLabel( )
 	pSLlabel->setText( Hydrogen::get_instance()->m_currentDrumkit  );
 }
 
-const char* PatternEditorPanel::__class_name = "PatternEditorPanel";
+const char* PatternEditorPanel::m_sClassName = "PatternEditorPanel";
 
 
 PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_pPattern( NULL )
  , m_bEnablePatternResize( true )
 {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -48,9 +48,11 @@ namespace H2Core
 	class Pattern;
 }
 
-///
-/// Pattern Editor Panel
-///
+/**
+ * Pattern Editor Panel
+ *
+ * \ingroup docGUI
+ */
 class PatternEditorPanel : public QWidget, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -53,10 +53,11 @@ namespace H2Core
 ///
 class PatternEditorPanel : public QWidget, public EventListener, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PatternEditorPanel(QWidget *parent);
 		~PatternEditorPanel();
 
@@ -105,6 +106,12 @@ class PatternEditorPanel : public QWidget, public EventListener, public H2Core::
 		void recPostDeleteSelect( int index );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		H2Core::Pattern *	m_pPattern;
 		QPixmap				m_backgroundPixmap;
 		QLabel *			pSLlabel;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -36,11 +36,11 @@ using namespace H2Core;
 #include "../Skin.h"
 
 
-const char* PatternEditorRuler::__class_name = "PatternEditorRuler";
+const char* PatternEditorRuler::m_sClassName = "PatternEditorRuler";
 
 PatternEditorRuler::PatternEditorRuler( QWidget* parent )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setAttribute(Qt::WA_NoBackground);
 

--- a/src/gui/src/PatternEditor/PatternEditorRuler.h
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.h
@@ -37,6 +37,7 @@ namespace H2Core
 	class Pattern;
 }
 
+/** \ingroup docGUI */
 class PatternEditorRuler : public QWidget, public H2Core::Object, public EventListener
 {
 	Q_OBJECT

--- a/src/gui/src/PatternEditor/PatternEditorRuler.h
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.h
@@ -39,10 +39,11 @@ namespace H2Core
 
 class PatternEditorRuler : public QWidget, public H2Core::Object, public EventListener
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PatternEditorRuler( QWidget* parent );
 		~PatternEditorRuler();
 
@@ -62,6 +63,12 @@ class PatternEditorRuler : public QWidget, public H2Core::Object, public EventLi
 		void updateEditor( bool bRedrawAll = false );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		uint m_nRulerWidth;
 		uint m_nRulerHeight;
 		float m_nGridWidth;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -39,11 +39,11 @@ using namespace H2Core;
 #include "../HydrogenApp.h"
 
 
-const char* PianoRollEditor::__class_name = "PianoRollEditor";
+const char* PianoRollEditor::m_sClassName = "PianoRollEditor";
 
 PianoRollEditor::PianoRollEditor( QWidget *pParent, PatternEditorPanel *panel )
 	: QWidget( pParent )
-	, Object( __class_name )
+	, Object( m_sClassName )
 	, m_nResolution( 8 )
 	, m_bRightBtnPressed( false )
 	, m_bUseTriplets( false )

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -41,9 +41,10 @@ class PatternEditorPanel;
 
 class PianoRollEditor: public QWidget, public EventListener, public H2Core::Object
 {
-    H2_OBJECT
     Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PianoRollEditor( QWidget *pParent, PatternEditorPanel *panel );
 		~PianoRollEditor();
 
@@ -85,6 +86,12 @@ class PianoRollEditor: public QWidget, public EventListener, public H2Core::Obje
 		void updateEditor();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 		unsigned m_nRowHeight;
 		unsigned m_nOctaves;

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -39,6 +39,7 @@ namespace H2Core
 
 class PatternEditorPanel;
 
+/** \ingroup docGUI */
 class PianoRollEditor: public QWidget, public EventListener, public H2Core::Object
 {
     Q_OBJECT

--- a/src/gui/src/PatternPropertiesDialog.h
+++ b/src/gui/src/PatternPropertiesDialog.h
@@ -35,9 +35,11 @@ namespace H2Core
 	class Pattern;
 }
 
-///
-///Pattern Properties Dialog
-///
+/**
+ * Pattern Properties Dialog
+ *
+ * \ingroup docGUI
+ */
 class PatternPropertiesDialog : public QDialog, public Ui_PatternPropertiesDialog_UI
 {
 	Q_OBJECT

--- a/src/gui/src/PatternPropertiesDialog.h
+++ b/src/gui/src/PatternPropertiesDialog.h
@@ -42,6 +42,8 @@ class PatternPropertiesDialog : public QDialog, public Ui_PatternPropertiesDialo
 {
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PatternPropertiesDialog( QWidget* parent, H2Core::Pattern* pattern, int nselectedPattern, bool save );
 
 		~PatternPropertiesDialog();
@@ -57,6 +59,12 @@ class PatternPropertiesDialog : public QDialog, public Ui_PatternPropertiesDialo
 		void on_categoryComboBox_editTextChanged();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		H2Core::Pattern *pattern;
 		int __nselectedPattern;
 		bool __savepattern;

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -49,11 +49,11 @@ using namespace H2Core;
 int bcDisplaystatus = 0;
 //~ beatcounter
 
-const char* PlayerControl::__class_name = "PlayerControl";
+const char* PlayerControl::m_sClassName = "PlayerControl";
 
 PlayerControl::PlayerControl(QWidget *parent)
  : QLabel(parent)
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	HydrogenApp::get_instance()->addEventListener( this );
 	
@@ -581,7 +581,7 @@ void PlayerControl::updatePlayerControl()
 #ifdef H2CORE_HAVE_JACK
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( p_Driver && strncmp(p_Driver->class_name(), "JackAudioDriver", 10) == 0){
+	if ( p_Driver && strncmp(p_Driver->className(), "JackAudioDriver", 10) == 0){
 		m_pJackTransportBtn->show();
 		switch ( pPref->m_bJackTransportMode ) {
 			case Preferences::NO_JACK_TRANSPORT:
@@ -906,7 +906,7 @@ void PlayerControl::jackTransportBtnClicked( Button* )
 	Preferences *pPref = Preferences::get_instance();
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( ! ( p_Driver && strncmp(p_Driver->class_name(), "JackAudioDriver", 10) == 0 ) ){
+	if ( ! ( p_Driver && strncmp(p_Driver->className(), "JackAudioDriver", 10) == 0 ) ){
 		QMessageBox::warning( this, "Hydrogen", trUtf8( "JACK-transport will work only with JACK driver." ) );
 		return;
 	}
@@ -935,7 +935,7 @@ void PlayerControl::jackMasterBtnClicked( Button* )
 	Preferences *pPref = Preferences::get_instance();
 	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
 
-	if ( ! ( p_Driver && strncmp(p_Driver->class_name(), "JackAudioDriver", 10) == 0 ) ){
+	if ( ! ( p_Driver && strncmp(p_Driver->className(), "JackAudioDriver", 10) == 0 ) ){
 		QMessageBox::warning( this, "Hydrogen", trUtf8( "JACK-transport will work only with JACK driver." ) );
 		return;
 	}
@@ -1118,11 +1118,11 @@ void PlayerControl::tempoChangedEvent( int nValue )
 
 //::::::::::::::::::::::::::::::::::::::::::::::::
 
-const char* MetronomeWidget::__class_name = "MetronomeWidget";
+const char* MetronomeWidget::m_sClassName = "MetronomeWidget";
 
 MetronomeWidget::MetronomeWidget(QWidget *pParent)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_nValue( 0 )
  , m_state( METRO_OFF )
 {

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -49,9 +49,10 @@ class PixmapWidget;
 ///
 class MetronomeWidget : public QWidget,public EventListener, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MetronomeWidget(QWidget *pParent);
 		~MetronomeWidget();
 
@@ -64,6 +65,12 @@ class MetronomeWidget : public QWidget,public EventListener, public H2Core::Obje
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		enum m_state {
 			METRO_FIRST,
 			METRO_ON,
@@ -85,9 +92,10 @@ class MetronomeWidget : public QWidget,public EventListener, public H2Core::Obje
 ///
 class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PlayerControl(QWidget *parent);
 		~PlayerControl();
 
@@ -131,6 +139,12 @@ class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 		void rubberbandButtonToggle(Button* ref);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		H2Core::Hydrogen *m_pEngine;
 		QPixmap m_background;
 

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -44,9 +44,7 @@ class CpuLoadWidget;
 class MidiActivityWidget;
 class PixmapWidget;
 
-///
-///
-///
+/** \ingroup docGUI */
 class MetronomeWidget : public QWidget,public EventListener, public H2Core::Object
 {
 	Q_OBJECT
@@ -87,9 +85,11 @@ class MetronomeWidget : public QWidget,public EventListener, public H2Core::Obje
 };
 
 
-///
-/// Player control panel
-///
+/**
+ * Player control panel
+ *
+ * \ingroup docGUI
+ */
 class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -53,11 +53,11 @@
 using namespace H2Core;
 using namespace std;
 
-const char* PlaylistDialog::__class_name = "PlaylistDialog";
+const char* PlaylistDialog::m_sClassName = "PlaylistDialog";
 
 PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 		: QDialog ( pParent )
-		, Object ( __class_name )
+		, Object ( m_sClassName )
 {
 
 	setupUi ( this );

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.h
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.h
@@ -42,9 +42,10 @@ class PixmapWidget;
 class PlaylistDialog : public QDialog, public Ui_PlaylistDialog_UI, public H2Core::Object
 
 {
-		H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 
 		PlaylistDialog( QWidget* pParent );
 		~PlaylistDialog();
@@ -79,6 +80,12 @@ class PlaylistDialog : public QDialog, public Ui_PlaylistDialog_UI, public H2Cor
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 		void updatePlayListNode( QString file );
 		void updatePlayListVector();

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.h
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.h
@@ -36,9 +36,11 @@ class Button;
 class ToggleButton;
 class PixmapWidget;
 
-///
-/// This dialog is used to use the H2PlayList
-///
+/**
+ * This dialog is used to use the H2PlayList
+ *
+ * \ingroup docGUI
+ */
 class PlaylistDialog : public QDialog, public Ui_PlaylistDialog_UI, public H2Core::Object
 
 {

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -46,11 +46,11 @@
 
 using namespace H2Core;
 
-const char* PreferencesDialog::__class_name = "PreferencesDialog";
+const char* PreferencesDialog::m_sClassName = "PreferencesDialog";
 
 PreferencesDialog::PreferencesDialog(QWidget* parent)
  : QDialog( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 

--- a/src/gui/src/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog.h
@@ -28,9 +28,11 @@
 
 #include <hydrogen/object.h>
 
-///
-/// Preferences Dialog
-///
+/**
+ * Preferences Dialog
+ *
+ * \ingroup docGUI docConfiguration
+ */
 class PreferencesDialog : public QDialog, private Ui_PreferencesDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog.h
@@ -33,9 +33,10 @@
 ///
 class PreferencesDialog : public QDialog, private Ui_PreferencesDialog_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PreferencesDialog( QWidget* parent );
 		~PreferencesDialog();
 
@@ -59,6 +60,12 @@ class PreferencesDialog : public QDialog, private Ui_PreferencesDialog_UI, publi
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		bool m_bNeedDriverRestart;
 
 		void updateDriverInfo();

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.cpp
@@ -28,11 +28,11 @@ using namespace H2Core;
 #include "DetailWaveDisplay.h"
 #include "../Skin.h"
 
-const char* DetailWaveDisplay::__class_name = "DetailWaveDisplay";
+const char* DetailWaveDisplay::m_sClassName = "DetailWaveDisplay";
 
 DetailWaveDisplay::DetailWaveDisplay(QWidget* pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_sSampleName( "" )
 {
 //	setAttribute(Qt::WA_NoBackground);

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.h
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.h
@@ -36,10 +36,11 @@ namespace H2Core
 
 class DetailWaveDisplay : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		DetailWaveDisplay(QWidget* pParent);
 		~DetailWaveDisplay();
 
@@ -49,6 +50,12 @@ class DetailWaveDisplay : public QWidget, public H2Core::Object
 		void setDetailSamplePosition( unsigned posi, float zoomfactor, QString type);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QPixmap m_background;
 		QString m_sSampleName;
 		int *m_pPeakDatal;

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.h
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.h
@@ -34,6 +34,7 @@ namespace H2Core
 	class Sample;
 }
 
+/** \ingroup docGUI */
 class DetailWaveDisplay : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
@@ -30,11 +30,11 @@ using namespace H2Core;
 #include "MainSampleWaveDisplay.h"
 #include "../Skin.h"
 
-const char* MainSampleWaveDisplay::__class_name = "MainSampleWaveDisplay";
+const char* MainSampleWaveDisplay::m_sClassName = "MainSampleWaveDisplay";
 
 MainSampleWaveDisplay::MainSampleWaveDisplay(QWidget* pParent)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 //	setAttribute(Qt::WA_NoBackground);
 

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
@@ -33,10 +33,11 @@ class SampleEditor;
 
 class MainSampleWaveDisplay : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MainSampleWaveDisplay(QWidget* pParent);
 		~MainSampleWaveDisplay();
 
@@ -56,6 +57,12 @@ class MainSampleWaveDisplay : public QWidget, public H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QPixmap m_background;
 		int *m_pPeakDatal;
 		int *m_pPeakDatar;

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
@@ -31,6 +31,7 @@
 #include "SampleEditor.h"
 class SampleEditor;
 
+/** \ingroup docGUI */
 class MainSampleWaveDisplay : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -47,11 +47,11 @@
 using namespace H2Core;
 using namespace std;
 
-const char* SampleEditor::__class_name = "SampleEditor";
+const char* SampleEditor::m_sClassName = "SampleEditor";
 
 SampleEditor::SampleEditor ( QWidget* pParent, int nSelectedComponent, int nSelectedLayer, QString mSamplefilename )
 		: QDialog ( pParent )
-		, Object ( __class_name )
+		, Object ( m_sClassName )
 {
 	setupUi ( this );
 	INFOLOG ( "INIT" );

--- a/src/gui/src/SampleEditor/SampleEditor.h
+++ b/src/gui/src/SampleEditor/SampleEditor.h
@@ -39,9 +39,11 @@ class 	MainSampleWaveDisplay;
 class	TargetWaveDisplay;
 class	DetailWaveDisplay;
 
-///
-/// This dialog is used to preview audiofiles
-///
+/**
+ * This dialog is used to preview audiofiles
+ *
+ * \ingroup docGUI
+ */
 class SampleEditor : public QDialog, public Ui_SampleEditor_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SampleEditor/SampleEditor.h
+++ b/src/gui/src/SampleEditor/SampleEditor.h
@@ -44,9 +44,10 @@ class	DetailWaveDisplay;
 ///
 class SampleEditor : public QDialog, public Ui_SampleEditor_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		
 		SampleEditor( QWidget* pParent, int nSelectedComponent, int nSelectedLayer, QString nSampleFilename );
 		~SampleEditor();
@@ -81,6 +82,12 @@ class SampleEditor : public QDialog, public Ui_SampleEditor_UI, public H2Core::O
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 		H2Core::Sample *m_pSampleFromFile;
 		int m_pSelectedLayer;

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -38,11 +38,11 @@ using namespace H2Core;
 #include "TargetWaveDisplay.h"
 #include "../Skin.h"
 
-const char* TargetWaveDisplay::__class_name = "TargetWaveDisplay";
+const char* TargetWaveDisplay::m_sClassName = "TargetWaveDisplay";
 
 TargetWaveDisplay::TargetWaveDisplay(QWidget* pParent)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_sSampleName( "" )
 {
 //	setAttribute(Qt::WA_NoBackground);

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.h
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.h
@@ -37,6 +37,7 @@ namespace H2Core
 	class InstrumentLayer;
 }
 
+/** \ingroup docGUI */
 class TargetWaveDisplay : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.h
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.h
@@ -39,10 +39,11 @@ namespace H2Core
 
 class TargetWaveDisplay : public QWidget, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		TargetWaveDisplay(QWidget* pParent);
 		~TargetWaveDisplay();
 
@@ -54,6 +55,12 @@ class TargetWaveDisplay : public QWidget, public H2Core::Object
 		H2Core::Sample::VelocityEnvelope* get_velocity() { return &__velocity; }
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QPixmap m_Background;
 
 		QString m_sSampleName;

--- a/src/gui/src/Skin.h
+++ b/src/gui/src/Skin.h
@@ -25,9 +25,11 @@
 #include <QString>
 #include <hydrogen/helpers/filesystem.h>
 
-///
-/// Skin support
-///
+/**
+ * Skin support
+ *
+ * \ingroup docGUI
+ */
 class Skin
 {
 	public:

--- a/src/gui/src/SongEditor/PatternFillDialog.cpp
+++ b/src/gui/src/SongEditor/PatternFillDialog.cpp
@@ -29,11 +29,11 @@
 
 #include "Skin.h"
 
-const char* PatternFillDialog::__class_name = "PatternFillDialog";
+const char* PatternFillDialog::m_sClassName = "PatternFillDialog";
 
 PatternFillDialog::PatternFillDialog(QWidget* parent, FillRange* pRange)
  : QDialog(parent)
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 

--- a/src/gui/src/SongEditor/PatternFillDialog.h
+++ b/src/gui/src/SongEditor/PatternFillDialog.h
@@ -50,9 +50,10 @@ struct FillRange {
 ///
 class PatternFillDialog : public QDialog, public Ui_PatternFillDialog_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PatternFillDialog( QWidget* parent, FillRange* range );
 		~PatternFillDialog();
 
@@ -63,6 +64,12 @@ class PatternFillDialog : public QDialog, public Ui_PatternFillDialog_UI, public
 		void on_toText_textChanged(const QString & text);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		FillRange* __fill_range;
 
 		/// Does some name check

--- a/src/gui/src/SongEditor/PatternFillDialog.h
+++ b/src/gui/src/SongEditor/PatternFillDialog.h
@@ -45,9 +45,11 @@ struct FillRange {
 };
 
 
-///
-/// Pattern Fill Dialog
-///
+/**
+ * Pattern Fill Dialog
+ *
+ * \ingroup docGUI
+ */
 class PatternFillDialog : public QDialog, public Ui_PatternFillDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -65,7 +65,7 @@ using namespace H2Core;
 
 using namespace std;
 
-const char* SongEditor::__class_name = "SongEditor";
+const char* SongEditor::m_sClassName = "SongEditor";
 
 
 SongEditorGridRepresentationItem::SongEditorGridRepresentationItem(int x, int y, bool value)
@@ -78,7 +78,7 @@ SongEditorGridRepresentationItem::SongEditorGridRepresentationItem(int x, int y,
 
 SongEditor::SongEditor( QWidget *parent )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bSequenceChanged( true )
  , m_bIsMoving( false )
  , m_bShowLasso( false )
@@ -931,11 +931,11 @@ void SongEditor::updateEditorandSetTrue()
 // :::::::::::::::::::
 
 
-const char* SongEditorPatternList::__class_name = "SongEditorPatternList";
+const char* SongEditorPatternList::m_sClassName = "SongEditorPatternList";
 
 SongEditorPatternList::SongEditorPatternList( QWidget *parent )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , EventListener()
  , m_pBackgroundPixmap( NULL )
 {
@@ -1835,11 +1835,11 @@ void SongEditorPatternList::mouseMoveEvent(QMouseEvent *event)
 
 // ::::::::::::::::::::::::::
 
-const char* SongEditorPositionRuler::__class_name = "SongEditorPositionRuler";
+const char* SongEditorPositionRuler::m_sClassName = "SongEditorPositionRuler";
 
 SongEditorPositionRuler::SongEditorPositionRuler( QWidget *parent )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bRightBtnPressed( false )
 {
 	setAttribute(Qt::WA_NoBackground);

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -61,10 +61,11 @@ class SongEditorGridRepresentationItem
 ///
 class SongEditor : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongEditor( QWidget *parent );
 		~SongEditor();
 
@@ -82,6 +83,12 @@ class SongEditor : public QWidget, public H2Core::Object
                 void movePatternCellAction( std::vector<QPoint> movingCells, std::vector<QPoint> selectedCells, std::vector<QPoint> m_existingCells, bool bIsCtrlPressed, bool undo);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
                 //holds a list for active patterns for each pattern
                 QList<SongEditorGridRepresentationItem*> gridRepresentation;
 
@@ -121,10 +128,11 @@ class SongEditor : public QWidget, public H2Core::Object
 ///
 class SongEditorPatternList : public QWidget, public H2Core::Object, public EventListener
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongEditorPatternList( QWidget *parent );
 		~SongEditorPatternList();
 
@@ -156,6 +164,12 @@ class SongEditorPatternList : public QWidget, public H2Core::Object, public Even
 		virtual void dropEvent(QDropEvent *event);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		uint m_nGridHeight;
 		uint m_nWidth;
 		static const uint m_nInitialHeight = 10;
@@ -193,10 +207,11 @@ class SongEditorPatternList : public QWidget, public H2Core::Object, public Even
 
 class SongEditorPositionRuler : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongEditorPositionRuler( QWidget *parent );
 		~SongEditorPositionRuler();	
 
@@ -213,6 +228,12 @@ class SongEditorPositionRuler : public QWidget, public H2Core::Object
 		void updatePosition();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QTimer *			m_pTimer;
 		uint				m_nGridWidth;
 		uint				m_nMaxPatternSequence;

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -47,6 +47,7 @@ static const uint SONG_EDITOR_MIN_GRID_WIDTH = 8;
 static const uint SONG_EDITOR_MAX_GRID_WIDTH = 16;
 
 
+/** \ingroup docGUI */
 class SongEditorGridRepresentationItem
 {
     public:
@@ -56,9 +57,11 @@ class SongEditorGridRepresentationItem
             bool value;
 };
 
-///
-/// Song editor
-///
+/**
+ * Song editor
+ *
+ * \ingroup docGUI
+ */
 class SongEditor : public QWidget, public H2Core::Object
 {
 	Q_OBJECT
@@ -123,9 +126,11 @@ class SongEditor : public QWidget, public H2Core::Object
 
 
 
-///
-/// Song editor pattern list
-///
+/**
+ * Song editor pattern list
+ *
+ * \ingroup docGUI
+ */
 class SongEditorPatternList : public QWidget, public H2Core::Object, public EventListener
 {
 	Q_OBJECT
@@ -205,6 +210,7 @@ class SongEditorPatternList : public QWidget, public H2Core::Object, public Even
 // }
 //
 
+/** \ingroup docGUI */
 class SongEditorPositionRuler : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -45,12 +45,12 @@
 using namespace H2Core;
 using namespace std;
 
-const char* SongEditorPanel::__class_name = "SongEditorPanel";
+const char* SongEditorPanel::m_sClassName = "SongEditorPanel";
 
 
 SongEditorPanel::SongEditorPanel(QWidget *pParent)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_actionMode( DRAW_ACTION )
 {
 	m_nInitialWidth = 600;

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -52,10 +52,11 @@ enum SongEditorActionMode
 
 class SongEditorPanel : public QWidget, public EventListener, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongEditorPanel( QWidget *parent );
 		~SongEditorPanel();
 
@@ -115,6 +116,12 @@ class SongEditorPanel : public QWidget, public EventListener, public H2Core::Obj
 		void automationPathPointMoved(float ox, float oy, float tx, float ty);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		SongEditorActionMode	m_actionMode;
 
 		uint					m_nInitialWidth;

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -50,6 +50,7 @@ enum SongEditorActionMode
 };
 
 
+/** \ingroup docGUI */
 class SongEditorPanel : public QWidget, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -36,11 +36,11 @@
 namespace H2Core
 {
 
-const char* SongEditorPanelBpmWidget::__class_name = "SongEditorPanelBpmWidget";
+const char* SongEditorPanelBpmWidget::m_sClassName = "SongEditorPanelBpmWidget";
 
 SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int beat )
 	: QDialog( pParent )
-	, Object( __class_name )
+	, Object( m_sClassName )
 	, m_stimelineposition ( beat )
 {
 	setupUi( this );

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.h
@@ -32,7 +32,7 @@
 namespace H2Core
 {
 
-
+/** \ingroup docGUI */
 class SongEditorPanelBpmWidget : public QDialog, public Ui_SongEditorPanelBpmWidget_UI, public H2Core::Object
 {
 

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.h
@@ -35,7 +35,6 @@ namespace H2Core
 
 class SongEditorPanelBpmWidget : public QDialog, public Ui_SongEditorPanelBpmWidget_UI, public H2Core::Object
 {
-    H2_OBJECT
 
 //lineEditBEAT
 //lineEditBPM
@@ -43,6 +42,8 @@ class SongEditorPanelBpmWidget : public QDialog, public Ui_SongEditorPanelBpmWid
 
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongEditorPanelBpmWidget( QWidget* pParent, int beat );
 		~SongEditorPanelBpmWidget();
 
@@ -53,6 +54,12 @@ class SongEditorPanelBpmWidget : public QDialog, public Ui_SongEditorPanelBpmWid
 		void on_deleteBtn_clicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		int m_stimelineposition;
 };
 

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -37,11 +37,11 @@
 namespace H2Core
 {
 
-const char* SongEditorPanelTagWidget::__class_name = "SongEditorPanelTagWidget";
+const char* SongEditorPanelTagWidget::m_sClassName = "SongEditorPanelTagWidget";
 
 SongEditorPanelTagWidget::SongEditorPanelTagWidget( QWidget* pParent, int beat )
 	: QDialog( pParent )
-	, Object( __class_name )
+	, Object( m_sClassName )
 	, m_stimelineposition ( beat )
 {
 	setupUi( this );

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
@@ -32,7 +32,7 @@
 namespace H2Core
 {
 
-
+/** \ingroup docGUI */
 class SongEditorPanelTagWidget : public QDialog, public Ui_SongEditorPanelTagWidget_UI, public H2Core::Object
 {
 //lineEditBEAT

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
@@ -35,14 +35,14 @@ namespace H2Core
 
 class SongEditorPanelTagWidget : public QDialog, public Ui_SongEditorPanelTagWidget_UI, public H2Core::Object
 {
-    H2_OBJECT
-
 //lineEditBEAT
 //lineEditBPM
 //deleteBtn
 
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongEditorPanelTagWidget( QWidget* pParent, int beat );
 		~SongEditorPanelTagWidget();
 
@@ -54,6 +54,12 @@ class SongEditorPanelTagWidget : public QDialog, public Ui_SongEditorPanelTagWid
 		void  a_itemIsChanged(QTableWidgetItem *item);
 		
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		int m_stimelineposition;
 		void createTheTagTableWidget();
 		QStringList __theChangedItems;

--- a/src/gui/src/SongEditor/VirtualPatternDialog.cpp
+++ b/src/gui/src/SongEditor/VirtualPatternDialog.cpp
@@ -30,11 +30,11 @@
 
 #include "Skin.h"
 
-const char* VirtualPatternDialog::__class_name = "VirtualPatternDialog";
+const char* VirtualPatternDialog::m_sClassName = "VirtualPatternDialog";
 
 VirtualPatternDialog::VirtualPatternDialog(QWidget* parent)
     : QDialog(parent)
-    , Object( __class_name )
+    , Object( m_sClassName )
 {
     setupUi( this );
     setFixedSize( width(), height() );

--- a/src/gui/src/SongEditor/VirtualPatternDialog.h
+++ b/src/gui/src/SongEditor/VirtualPatternDialog.h
@@ -39,9 +39,11 @@ namespace H2Core
 }
 
 
-///
-/// Virtual Pattern Dialog
-///
+/**
+ * Virtual Pattern Dialog
+ *
+ * \ingroup docGUI
+ */
 class VirtualPatternDialog : public QDialog, public Ui_VirtualPatternDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SongEditor/VirtualPatternDialog.h
+++ b/src/gui/src/SongEditor/VirtualPatternDialog.h
@@ -44,9 +44,10 @@ namespace H2Core
 ///
 class VirtualPatternDialog : public QDialog, public Ui_VirtualPatternDialog_UI, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		VirtualPatternDialog( QWidget* parent );
 		~VirtualPatternDialog();
 
@@ -55,6 +56,12 @@ class VirtualPatternDialog : public QDialog, public Ui_VirtualPatternDialog_UI, 
 		void on_okBtn_clicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 
 

--- a/src/gui/src/SongPropertiesDialog.h
+++ b/src/gui/src/SongPropertiesDialog.h
@@ -32,16 +32,24 @@
  */
 class SongPropertiesDialog : public QDialog, private Ui_SongPropertiesDialog_UI
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SongPropertiesDialog(QWidget* parent);
 		~SongPropertiesDialog();
 
 	private slots:
 		void on_cancelBtn_clicked();
 		void on_okBtn_clicked();
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 
 };
 

--- a/src/gui/src/SongPropertiesDialog.h
+++ b/src/gui/src/SongPropertiesDialog.h
@@ -29,6 +29,8 @@
 
 /**
  * Song Properties Dialog
+ *
+ * \ingroup docGUI
  */
 class SongPropertiesDialog : public QDialog, private Ui_SongPropertiesDialog_UI
 {

--- a/src/gui/src/SoundLibrary/FileBrowser.cpp
+++ b/src/gui/src/SoundLibrary/FileBrowser.cpp
@@ -33,11 +33,11 @@
 #include <hydrogen/audio_engine.h>
 using namespace H2Core;
 
-const char* FileBrowser::__class_name = "FileBrowser";
+const char* FileBrowser::m_sClassName = "FileBrowser";
 
 FileBrowser::FileBrowser( QWidget* pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	INFOLOG( "[FileBrowser]" );
 

--- a/src/gui/src/SoundLibrary/FileBrowser.h
+++ b/src/gui/src/SoundLibrary/FileBrowser.h
@@ -31,6 +31,7 @@
 #  include <QtWidgets>
 #endif
 
+/** \ingroup docGUI */
 class FileBrowser : public QWidget, private H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/FileBrowser.h
+++ b/src/gui/src/SoundLibrary/FileBrowser.h
@@ -33,9 +33,10 @@
 
 class FileBrowser : public QWidget, private H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		FileBrowser( QWidget* pParent );
 		~FileBrowser();
 
@@ -48,6 +49,12 @@ class FileBrowser : public QWidget, private H2Core::Object
 		void on_playBtnClicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QLabel *m_pDirectoryLabel;
 		QPushButton* m_pUpBtn;
 		QLabel *m_pFileInfo;

--- a/src/gui/src/SoundLibrary/SoundLibraryDatastructures.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryDatastructures.cpp
@@ -23,9 +23,9 @@ using namespace H2Core;
 
 SoundLibraryDatabase* SoundLibraryDatabase::__instance = NULL;
 
-const char* SoundLibraryDatabase::__class_name = "SoundLibraryDatabase";
+const char* SoundLibraryDatabase::m_sClassName = "SoundLibraryDatabase";
 
-SoundLibraryDatabase::SoundLibraryDatabase() : Object( __class_name )
+SoundLibraryDatabase::SoundLibraryDatabase() : Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 	patternVector = new soundLibraryInfoVector();
@@ -116,13 +116,13 @@ soundLibraryInfoVector* SoundLibraryDatabase::getAllPatterns() const
 
 
 
-const char* SoundLibraryInfo::__class_name = "SoundLibraryInfo";
-SoundLibraryInfo::SoundLibraryInfo() : Object( __class_name )
+const char* SoundLibraryInfo::m_sClassName = "SoundLibraryInfo";
+SoundLibraryInfo::SoundLibraryInfo() : Object( m_sClassName )
 {
 	//default constructor
 }
 
-SoundLibraryInfo::SoundLibraryInfo(const QString &path) : Object( __class_name )
+SoundLibraryInfo::SoundLibraryInfo(const QString &path) : Object( m_sClassName )
 {
 	/*
 	 *Use the provided file instantiate this object with the corresponding meta

--- a/src/gui/src/SoundLibrary/SoundLibraryDatastructures.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryDatastructures.h
@@ -14,6 +14,8 @@ class SoundLibraryInfo;
 * This class organizes the metadata of all locally installed soundlibrary items.
 *
 * @author Sebastian Moors
+ *
+ * \ingroup docGUI
 *
 */
 
@@ -65,6 +67,8 @@ class SoundLibraryDatabase:  public H2Core::Object
 * the metadata for songs, pattern and drumkits.
 *
 * @author Sebastian Moors
+ *
+ * \ingroup docGUI
 *
 */
 

--- a/src/gui/src/SoundLibrary/SoundLibraryDatastructures.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryDatastructures.h
@@ -21,8 +21,9 @@ typedef std::vector<SoundLibraryInfo*> soundLibraryInfoVector;
 
 class SoundLibraryDatabase:  public H2Core::Object
 {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryDatabase();
 		~SoundLibraryDatabase();
 
@@ -43,6 +44,12 @@ class SoundLibraryDatabase:  public H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static SoundLibraryDatabase *__instance;
 		soundLibraryInfoVector* patternVector;
 		QStringList patternCategories;
@@ -63,8 +70,9 @@ class SoundLibraryDatabase:  public H2Core::Object
 
 class SoundLibraryInfo :  public H2Core::Object
 {
-	H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryInfo();
 		SoundLibraryInfo( const QString& path);
 		~SoundLibraryInfo();
@@ -151,6 +159,12 @@ class SoundLibraryInfo :  public H2Core::Object
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QString m_sName;
 		QString m_sURL;
 		QString m_sInfo;

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -49,11 +49,11 @@
 
 using namespace H2Core;
 
-const char* SoundLibraryExportDialog::__class_name = "SoundLibraryExportDialog";
+const char* SoundLibraryExportDialog::m_sClassName = "SoundLibraryExportDialog";
 
 SoundLibraryExportDialog::SoundLibraryExportDialog( QWidget* pParent,  const QString& selectedKit )
 	: QDialog( pParent )
-	, Object( __class_name )
+	, Object( m_sClassName )
 {
 	setupUi( this );
 	INFOLOG( "INIT" );

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.h
@@ -36,11 +36,12 @@
 ///
 class SoundLibraryExportDialog : public QDialog, public Ui_SoundLibraryExportDialog_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
-	public:
-		SoundLibraryExportDialog( QWidget* pParent, const QString&);
-		~SoundLibraryExportDialog();
+public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
+	SoundLibraryExportDialog( QWidget* pParent, const QString&);
+	~SoundLibraryExportDialog();
 
 private slots:
 	void on_exportBtn_clicked();
@@ -51,6 +52,12 @@ private slots:
 	void on_drumkitPathTxt_textChanged( QString str );
 	void updateDrumkitList();
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	std::vector<H2Core::Drumkit*> drumkitInfoList;
 	QString preselectedKit;
 	QHash<QString, QStringList> kit_components;

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.h
@@ -31,9 +31,7 @@
 
 #include <vector>
 
-///
-///
-///
+/** \ingroup docGUI */
 class SoundLibraryExportDialog : public QDialog, public Ui_SoundLibraryExportDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
@@ -44,12 +44,12 @@
 
 #include <memory>
 
-const char* SoundLibraryImportDialog::__class_name = "SoundLibraryImportDialog";
+const char* SoundLibraryImportDialog::m_sClassName = "SoundLibraryImportDialog";
 const int max_redirects = 30;
 
 SoundLibraryImportDialog::SoundLibraryImportDialog( QWidget* pParent, bool bOnlineImport )
  : QDialog( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 	INFOLOG( "INIT" );

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.h
@@ -31,9 +31,12 @@
 #include <hydrogen/Preferences.h>
 #include "SoundLibraryDatastructures.h"
 
-///
-/// This dialog is used to import a SoundLibrary file from a local file or via HTTP.
-///
+/**
+ * This dialog is used to import a SoundLibrary file from a local file
+ * or via HTTP.
+ *
+ * \ingroup docGUI
+ */
 class SoundLibraryImportDialog : public QDialog, public Ui_SoundLibraryImportDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.h
@@ -36,9 +36,10 @@
 ///
 class SoundLibraryImportDialog : public QDialog, public Ui_SoundLibraryImportDialog_UI, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryImportDialog( QWidget* pParent, bool bOnlineImport );
 		~SoundLibraryImportDialog();
 
@@ -59,6 +60,12 @@ class SoundLibraryImportDialog : public QDialog, public Ui_SoundLibraryImportDia
 
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		std::vector<SoundLibraryInfo> m_soundLibraryList;
 
 		QTreeWidgetItem* m_pDrumkitsItem;

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
@@ -26,11 +26,11 @@
 
 using namespace H2Core;
 
-const char* SoundLibraryOpenDialog::__class_name = "SoundLibraryOpenDialog";
+const char* SoundLibraryOpenDialog::m_sClassName = "SoundLibraryOpenDialog";
 
 SoundLibraryOpenDialog::SoundLibraryOpenDialog( QWidget* pParent )
 	: QDialog( pParent )
-	, Object( __class_name )
+	, Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 	setWindowTitle( trUtf8( "Open Sound Library" ) );

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.h
@@ -32,6 +32,7 @@
 
 class SoundLibraryPanel;
 
+/** \ingroup docGUI */
 class SoundLibraryOpenDialog : public QDialog, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.h
@@ -34,9 +34,10 @@ class SoundLibraryPanel;
 
 class SoundLibraryOpenDialog : public QDialog, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryOpenDialog( QWidget* pParent );
 		~SoundLibraryOpenDialog();
 
@@ -47,6 +48,12 @@ class SoundLibraryOpenDialog : public QDialog, public H2Core::Object
 		void on_open_btn_clicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		SoundLibraryPanel*	m_pSoundLibraryPanel;
 		QPushButton*		m_pOkBtn;
 		QPushButton*		m_pCancelBtn;

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -64,11 +64,11 @@ using namespace H2Core;
 
 #include <cassert>
 
-const char* SoundLibraryPanel::__class_name = "SoundLibraryPanel";
+const char* SoundLibraryPanel::m_sClassName = "SoundLibraryPanel";
 
 SoundLibraryPanel::SoundLibraryPanel( QWidget *pParent, bool bInItsOwnDialog )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , __sound_library_tree( NULL )
  , __drumkit_menu( NULL )
  , __instrument_menu( NULL )

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.h
@@ -45,9 +45,10 @@ class ToggleButton;
 
 class SoundLibraryPanel : public QWidget, private H2Core::Object
 {
-	H2_OBJECT
 Q_OBJECT
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	SoundLibraryPanel( QWidget* parent, bool bInItsOwnDialog );
 	~SoundLibraryPanel();
 
@@ -77,6 +78,12 @@ signals:
 	void item_changed(bool bDrumkitSelected);
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	SoundLibraryTree *__sound_library_tree;
 	//FileBrowser *m_pFileBrowser;
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.h
@@ -43,6 +43,7 @@ namespace H2Core
 class SoundLibraryTree;
 class ToggleButton;
 
+/** \ingroup docGUI */
 class SoundLibraryPanel : public QWidget, private H2Core::Object
 {
 Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
@@ -41,11 +41,11 @@ Drumkit *pGlobalDrumkitInfo = nullptr;
 Drumkit *pGlobalPreDrumkit = nullptr;
 QString oldName;
 
-const char* SoundLibraryPropertiesDialog::__class_name = "SoundLibraryPropertiesDialog";
+const char* SoundLibraryPropertiesDialog::m_sClassName = "SoundLibraryPropertiesDialog";
 
 SoundLibraryPropertiesDialog::SoundLibraryPropertiesDialog( QWidget* pParent, Drumkit *pDrumkitInfo, Drumkit *pPreDrumKit )
  : QDialog( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 	INFOLOG( "INIT" );

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
@@ -33,6 +33,7 @@ namespace H2Core
 
 class Drumkit;
 
+/** \ingroup docGUI */
 class SoundLibraryPropertiesDialog : public QDialog, public Ui_SoundLibraryPropertiesDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
@@ -35,9 +35,10 @@ class Drumkit;
 
 class SoundLibraryPropertiesDialog : public QDialog, public Ui_SoundLibraryPropertiesDialog_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryPropertiesDialog(QWidget* pParent , Drumkit *pDrumkitInfo, Drumkit *pPreDrumKit );
 		~SoundLibraryPropertiesDialog();
 
@@ -46,6 +47,12 @@ class SoundLibraryPropertiesDialog : public QDialog, public Ui_SoundLibraryPrope
 		void on_imageBrowsePushButton_clicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		void updateImage( QString& filename );
 };
 

--- a/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.cpp
@@ -28,11 +28,11 @@
 #include <QInputDialog>
 #include <QListWidgetItem>
 
-const char* SoundLibraryRepositoryDialog::__class_name = "SoundLibraryRepositoryDialog";
+const char* SoundLibraryRepositoryDialog::m_sClassName = "SoundLibraryRepositoryDialog";
 
 SoundLibraryRepositoryDialog::SoundLibraryRepositoryDialog( QWidget* pParent )
  : QDialog( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 	INFOLOG( "INIT" );

--- a/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.h
@@ -26,9 +26,7 @@
 #include "ui_SoundLibraryRepositoryDialog_UI.h"
 #include <hydrogen/object.h>
 
-///
-///
-///
+/** \ingroup docGUI */
 class SoundLibraryRepositoryDialog : public QDialog, public Ui_SoundLibraryRepositoryDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.h
@@ -31,9 +31,10 @@
 ///
 class SoundLibraryRepositoryDialog : public QDialog, public Ui_SoundLibraryRepositoryDialog_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryRepositoryDialog( QWidget* pParent );
 		~SoundLibraryRepositoryDialog();
 
@@ -42,6 +43,12 @@ class SoundLibraryRepositoryDialog : public QDialog, public Ui_SoundLibraryRepos
 		void on_DeleteBtn_clicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		void updateDialog();
 };
 

--- a/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.cpp
@@ -28,11 +28,11 @@
 #include "../HydrogenApp.h"
 #include "../Skin.h"
 
-const char* SoundLibrarySaveDialog::__class_name = "SoundLibrarySaveDialog";
+const char* SoundLibrarySaveDialog::m_sClassName = "SoundLibrarySaveDialog";
 
 SoundLibrarySaveDialog::SoundLibrarySaveDialog( QWidget* pParent )
  : QDialog( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setupUi( this );
 	INFOLOG( "INIT" );

--- a/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.h
@@ -31,9 +31,10 @@
 ///
 class SoundLibrarySaveDialog : public QDialog, public Ui_SoundLibrarySaveDialog_UI, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibrarySaveDialog( QWidget* pParent );
 		~SoundLibrarySaveDialog();
 
@@ -42,6 +43,12 @@ class SoundLibrarySaveDialog : public QDialog, public Ui_SoundLibrarySaveDialog_
 		void on_imageBrowsePushButton_clicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		void updateImage( QString& filename );
 
 };

--- a/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.h
@@ -26,9 +26,7 @@
 #include "ui_SoundLibrarySaveDialog_UI.h"
 #include <hydrogen/object.h>
 
-///
-///
-///
+/** \ingroup docGUI */
 class SoundLibrarySaveDialog : public QDialog, public Ui_SoundLibrarySaveDialog_UI, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryTree.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryTree.cpp
@@ -23,11 +23,11 @@
 #include "SoundLibraryTree.h"
 #include <QMimeData>
 
-const char* SoundLibraryTree::__class_name = "SoundLibraryTree";
+const char* SoundLibraryTree::m_sClassName = "SoundLibraryTree";
 
 SoundLibraryTree::SoundLibraryTree( QWidget *pParent )
  : QTreeWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setHeaderLabels( QStringList( trUtf8( "Sound library" ) ) );
 	setAlternatingRowColors(true);

--- a/src/gui/src/SoundLibrary/SoundLibraryTree.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryTree.h
@@ -31,6 +31,7 @@
 
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI */
 class SoundLibraryTree : public QTreeWidget, private H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/SoundLibrary/SoundLibraryTree.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryTree.h
@@ -33,9 +33,10 @@
 
 class SoundLibraryTree : public QTreeWidget, private H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SoundLibraryTree( QWidget *pParent );
 
 	signals:
@@ -53,6 +54,13 @@ class SoundLibraryTree : public QTreeWidget, private H2Core::Object
 		virtual void mouseMoveEvent(QMouseEvent *event);
 
 
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 };
 
 

--- a/src/gui/src/SplashScreen.cpp
+++ b/src/gui/src/SplashScreen.cpp
@@ -29,11 +29,11 @@
 
 #include "Skin.h"
 
-const char* SplashScreen::__class_name = "SplashScreen";
+const char* SplashScreen::m_sClassName = "SplashScreen";
 
 SplashScreen::SplashScreen()
  : QSplashScreen( NULL )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	//INFOLOG( "SplashScreen" );
 

--- a/src/gui/src/SplashScreen.h
+++ b/src/gui/src/SplashScreen.h
@@ -32,9 +32,10 @@
 
 class SplashScreen : public QSplashScreen, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		SplashScreen();
 		~SplashScreen();
 
@@ -42,6 +43,12 @@ class SplashScreen : public QSplashScreen, public H2Core::Object
 		void onCloseTimer();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QPixmap *			m_pBackground;
 		static const uint	width = 400;
 		static const uint	height = 300;

--- a/src/gui/src/SplashScreen.h
+++ b/src/gui/src/SplashScreen.h
@@ -30,6 +30,7 @@
 
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI */
 class SplashScreen : public QSplashScreen, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -26,6 +26,7 @@
 
 //=====================================================================================================================================
 //song editor commands
+/** \ingroup docGUI */
 class SE_addPatternAction : public QUndoCommand
 {
 public:
@@ -54,6 +55,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_deletePatternAction : public QUndoCommand
 {
 public:
@@ -82,6 +84,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_movePatternListItemAction : public QUndoCommand
 {
 public:
@@ -108,6 +111,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_deletePatternSequenceAction : public QUndoCommand
 {
 public:
@@ -132,6 +136,7 @@ private:
 	QString __pFilename;
 };
 
+/** \ingroup docGUI */
 class SE_deletePatternFromListAction : public QUndoCommand
 {
 public:
@@ -162,6 +167,7 @@ private:
 	int __patternPosition;
 };
 
+/** \ingroup docGUI */
 class SE_modifyPatternPropertiesAction : public QUndoCommand
 {
 public:
@@ -200,6 +206,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_copyPatternAction : public QUndoCommand
 {
 public:
@@ -226,6 +233,7 @@ private:
 	int __patternPosition;
 };
 
+/** \ingroup docGUI */
 class SE_insertPatternAction : public QUndoCommand
 {
 public:
@@ -257,6 +265,7 @@ private:
 	int __patternPosition;
 };
 
+/** \ingroup docGUI */
 class SE_loadPatternAction : public QUndoCommand
 {
 public:
@@ -301,6 +310,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_fillRangePatternAction : public QUndoCommand
 {
 public:
@@ -346,6 +356,7 @@ private:
 	int __nPattern;
 };
 
+/** \ingroup docGUI */
 class SE_movePatternCellAction : public QUndoCommand
 {
 public:
@@ -377,6 +388,7 @@ private:
 	bool __bIsCtrlPressed;
 };
 
+/** \ingroup docGUI */
 class SE_editTimeLineAction : public QUndoCommand
 {
 public:
@@ -415,6 +427,7 @@ private:
 //=====================================================================================================================================
 //time line commands
 
+/** \ingroup docGUI */
 class SE_deleteTimeLineAction : public QUndoCommand
 {
 public:
@@ -444,6 +457,7 @@ private:
 	float __newBpm;
 };
 
+/** \ingroup docGUI */
 class SE_editTagAction : public QUndoCommand
 {
 public:
@@ -488,6 +502,7 @@ private:
 //=====================================================================================================================================
 //pattern editor commands
 
+/** \ingroup docGUI */
 class SE_addNoteAction : public QUndoCommand
 {
 public:
@@ -581,6 +596,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_addNoteRightClickAction : public QUndoCommand
 {
 public:
@@ -608,6 +624,7 @@ private:
 	int __selectedPatternNumber;
 };
 
+/** \ingroup docGUI */
 class SE_editNoteLenghtAction : public QUndoCommand
 {
 public:
@@ -642,6 +659,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_clearNotesPatternEditorAction : public QUndoCommand
 {
 public:
@@ -687,6 +705,7 @@ private:
 	int __selectedPatternNumber;
 };
 
+/** \ingroup docGUI */
 class SE_pasteNotesPatternEditorAction : public QUndoCommand
 {
 public:
@@ -739,6 +758,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_fillNotesRightClickAction : public QUndoCommand
 {
 public:
@@ -767,6 +787,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_randomVelocityRightClickAction : public QUndoCommand
 {
 public:
@@ -798,6 +819,7 @@ private:
 
 
 
+/** \ingroup docGUI */
 class SE_moveInstrumentAction : public QUndoCommand
 {
 public:
@@ -823,6 +845,7 @@ private:
 	int __nTargetInstrument;
 };
 
+/** \ingroup docGUI */
 class SE_dragInstrumentAction : public QUndoCommand
 {
 public:
@@ -853,6 +876,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_deleteInstrumentAction : public QUndoCommand
 {
 public:
@@ -902,6 +926,7 @@ private:
 
 
 
+/** \ingroup docGUI */
 class SE_mainMenuAddInstrumentAction : public QUndoCommand
 {
 public:
@@ -928,6 +953,7 @@ private:
 //piano roll editor commands
 
 
+/** \ingroup docGUI */
 class SE_addNotePianoRollAction : public QUndoCommand
 {
 public:
@@ -1004,6 +1030,7 @@ private:
 	int __oldOctaveKeyVal;
 };
 
+/** \ingroup docGUI */
 class SE_addPianoRollNoteOffAction : public QUndoCommand
 {
 public:
@@ -1035,6 +1062,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_editPianoRollNoteLengthAction : public QUndoCommand
 {
 public:
@@ -1075,6 +1103,7 @@ private:
 	int __pressedLine;
 };
 
+/** \ingroup docGUI */
 class SE_editNotePropertiesPianoRollAction : public QUndoCommand
 {
 public:
@@ -1155,6 +1184,7 @@ private:
 //=====================================================================================================================================
 //Note Properties Ruler commands
 
+/** \ingroup docGUI */
 class SE_editNotePropertiesVolumeAction : public QUndoCommand
 {
 public:
@@ -1264,6 +1294,7 @@ private:
 
 
 
+/** \ingroup docGUI */
 class SE_automationPathAddPointAction : public QUndoCommand
 {
 public:
@@ -1297,6 +1328,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_automationPathRemovePointAction : public QUndoCommand
 {
 public:
@@ -1330,6 +1362,7 @@ private:
 };
 
 
+/** \ingroup docGUI */
 class SE_automationPathMovePointAction : public QUndoCommand
 {
 public:

--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -23,13 +23,13 @@
 #include <hydrogen/Preferences.h>
 #include "../SongEditor/SongEditor.h"
 
-const char* AutomationPathView::__class_name = "AutomationPathView";
+const char* AutomationPathView::m_sClassName = "AutomationPathView";
 
 using namespace H2Core;
 
 AutomationPathView::AutomationPathView(QWidget *parent)
 	: QWidget(parent),
-	  H2Core::Object(__class_name),
+	  H2Core::Object(m_sClassName),
 	  m_nGridWidth(16),
 	  m_nMarginWidth(10),
 	  m_nMarginHeight(4),

--- a/src/gui/src/Widgets/AutomationPathView.h
+++ b/src/gui/src/Widgets/AutomationPathView.h
@@ -30,6 +30,7 @@
 #  include <QtWidgets>
 #endif
 
+/** \ingroup docGUI docWidgets */
 class AutomationPathView : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/AutomationPathView.h
+++ b/src/gui/src/Widgets/AutomationPathView.h
@@ -33,7 +33,6 @@
 class AutomationPathView : public QWidget, public H2Core::Object
 {
 	Q_OBJECT
-	H2_OBJECT
 
 	H2Core::AutomationPath *_path;
 	int m_nGridWidth;   /** < Width of song grid cell size - in order to properly align AutomationPathView and SongEditor */
@@ -48,6 +47,8 @@ class AutomationPathView : public QWidget, public H2Core::Object
 	H2Core::AutomationPath::iterator _selectedPoint; /** < Point that is being dragged */
 
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	AutomationPathView(QWidget *parent = 0);
 
 	H2Core::AutomationPath *getAutomationPath() const noexcept { return _path; }
@@ -77,6 +78,13 @@ signals:
 	void pointAdded(float x, float y);
 	void pointRemoved(float x, float y);
 	void pointMoved(float ox, float oy, float tx, float ty);
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 #endif

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -34,11 +34,11 @@
 
 #include <hydrogen/globals.h>
 
-const char* Button::__class_name = "Button";
+const char* Button::m_sClassName = "Button";
 
 Button::Button( QWidget * pParent, const QString& sOnImage, const QString& sOffImage, const QString& sOverImage, QSize size, bool use_skin_style, bool enable_press_hold )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bPressed( false )
  , m_onPixmap( size )
  , m_offPixmap( size )

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -42,10 +42,11 @@ class PixmapWidget;
  */
 class Button : public QWidget, public H2Core::Object, public MidiLearnable
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		Button(
 				QWidget *pParent,
 				const QString& sOnImg,
@@ -82,6 +83,12 @@ class Button : public QWidget, public H2Core::Object, public MidiLearnable
 		QPixmap m_overPixmap;
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		bool m_bMouseOver;
 		bool __use_skin_style;
 		bool __enable_press_hold;

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -39,6 +39,8 @@ class PixmapWidget;
 
 /**
  * Generic Button with pixmaps and text.
+ *
+ * \ingroup docGUI docWidgets
  */
 class Button : public QWidget, public H2Core::Object, public MidiLearnable
 {
@@ -110,6 +112,8 @@ class Button : public QWidget, public H2Core::Object, public MidiLearnable
 
 /**
  * A ToggleButton (On/Off).
+ *
+ * \ingroup docGUI docWidgets
  */
 class ToggleButton : public Button
 {

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -28,7 +28,7 @@
 #  include <QtWidgets>
 #endif
 
-
+/** \ingroup docGUI docWidgets */
 class ClickableLabel : public QLabel
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/CpuLoadWidget.cpp
+++ b/src/gui/src/Widgets/CpuLoadWidget.cpp
@@ -32,11 +32,11 @@
 #include <QPaintEvent>
 #include <QPainter>
 
-const char* CpuLoadWidget::__class_name = "CpuLoadWidget";
+const char* CpuLoadWidget::m_sClassName = "CpuLoadWidget";
 
 CpuLoadWidget::CpuLoadWidget( QWidget *pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_fValue( 0 )
 {
 	setAttribute(Qt::WA_NoBackground);

--- a/src/gui/src/Widgets/CpuLoadWidget.h
+++ b/src/gui/src/Widgets/CpuLoadWidget.h
@@ -39,10 +39,11 @@
 ///
 class CpuLoadWidget : public QWidget, public EventListener, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		CpuLoadWidget(QWidget *pParent );
 		~CpuLoadWidget();
 
@@ -58,6 +59,12 @@ class CpuLoadWidget : public QWidget, public EventListener, public H2Core::Objec
 		void updateCpuLoadWidget();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		float m_fValue;
 		uint m_nXRunValue;
 

--- a/src/gui/src/Widgets/CpuLoadWidget.h
+++ b/src/gui/src/Widgets/CpuLoadWidget.h
@@ -34,9 +34,11 @@
 #  include <QtWidgets>
 #endif
 
-///
-/// Shows CPU load
-///
+/**
+ * Shows CPU load
+ *
+ * \ingroup docGUI docWidgets
+ */
 class CpuLoadWidget : public QWidget, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/DownloadWidget.cpp
+++ b/src/gui/src/Widgets/DownloadWidget.cpp
@@ -26,11 +26,11 @@
 #include <cstdlib>
 #include <QNetworkReply>
 
-const char* Download::__class_name = "Download";
+const char* Download::m_sClassName = "Download";
 
 Download::Download( QWidget* pParent, const QString& download_url, const QString& local_file )
 		: QDialog( pParent )
-		, Object( __class_name )
+		, Object( m_sClassName )
 		, __download_percent( 0 )
 		, __eta( 0 )
 		, __bytes_current( 0 )

--- a/src/gui/src/Widgets/DownloadWidget.h
+++ b/src/gui/src/Widgets/DownloadWidget.h
@@ -34,10 +34,11 @@
 
 class Download : public QDialog, public H2Core::Object
 {
-	H2_OBJECT
 	Q_OBJECT
 
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	Download( QWidget* parent, const QString& download_url, const QString& local_file );
 	~Download();
 
@@ -68,16 +69,24 @@ protected:
 	QString					__feed_xml_string;
 
 	bool					__error;
+private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 };
 
 
 
 class DownloadWidget : public Download
 {
-	H2_OBJECT
 	Q_OBJECT
 
 public:
+	/** \return #m_sClassName*/
+	static const char* className() { return m_sClassName; }
 	DownloadWidget( QWidget* parent, const QString& title, const QString& download_url, const QString& local_file = "" );
 	~DownloadWidget();
 
@@ -87,6 +96,12 @@ private slots:
 	void updateStats();
 
 private:
+	/** Contains the name of the class.
+	 *
+	 * This variable allows from more informative log messages
+	 * with the name of the class the message is generated in
+	 * being displayed as well. Queried using className().*/
+	static const char* m_sClassName;
 	QTimer* __update_timer;
 	QTimer* __close_timer;
 	QLabel* __url_label;

--- a/src/gui/src/Widgets/DownloadWidget.h
+++ b/src/gui/src/Widgets/DownloadWidget.h
@@ -32,6 +32,7 @@
 
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI docWidgets */
 class Download : public QDialog, public H2Core::Object
 {
 	Q_OBJECT
@@ -78,8 +79,7 @@ private:
 	static const char* m_sClassName;
 };
 
-
-
+/** \ingroup docGUI docWidgets */
 class DownloadWidget : public Download
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -32,11 +32,11 @@
 #endif
 #include <hydrogen/globals.h>
 
-const char* Fader::__class_name = "Fader";
+const char* Fader::m_sClassName = "Fader";
 
 Fader::Fader( QWidget *pParent, bool bUseIntSteps, bool bWithoutKnob)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bWithoutKnob( bWithoutKnob )
  , m_bUseIntSteps( bUseIntSteps )
  , m_fPeakValue_L( 0.0 )
@@ -442,11 +442,11 @@ void VerticalFader::paintEvent( QPaintEvent *ev)
 
 //////////////////////////////////
 
-const char* MasterFader::__class_name = "MasterFader";
+const char* MasterFader::m_sClassName = "MasterFader";
 
 MasterFader::MasterFader(QWidget *pParent, bool bWithoutKnob)
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bWithoutKnob( bWithoutKnob )
  , m_fPeakValue_L( 0.0 )
  , m_fPeakValue_R( 0.0 )
@@ -694,14 +694,14 @@ void MasterFader::setMax( float fMax )
 
 QPixmap* Knob::m_background = NULL;
 
-const char* Knob::__class_name = "Knob";
+const char* Knob::m_sClassName = "Knob";
 
 ///
 /// Constructor
 ///
 Knob::Knob( QWidget* pParent )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	setAttribute(Qt::WA_NoBackground);
 

--- a/src/gui/src/Widgets/Fader.h
+++ b/src/gui/src/Widgets/Fader.h
@@ -33,9 +33,11 @@
 #include <hydrogen/object.h>
 #include "MidiLearnable.h"
 
-///
-/// Fader and VuMeter widget
-///
+/**
+ * Fader and VuMeter widget
+ *
+ * \ingroup docGUI docWidgets
+ */
 class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 {
 	Q_OBJECT
@@ -103,6 +105,7 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 		static const char* m_sClassName;
 };
 
+/** \ingroup docGUI docWidgets */
 class VerticalFader : public Fader
 {
 	Q_OBJECT
@@ -119,6 +122,7 @@ public:
 };
 
 
+/** \ingroup docGUI docWidgets */
 class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 {
 	Q_OBJECT
@@ -183,6 +187,7 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 
 
 
+/** \ingroup docGUI docWidgets */
 class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/Fader.h
+++ b/src/gui/src/Widgets/Fader.h
@@ -38,10 +38,11 @@
 ///
 class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		Fader(QWidget *pParent, bool bUseIntSteps, bool bWithoutKnob );
 		~Fader();
 
@@ -93,6 +94,13 @@ class Fader : public QWidget, public H2Core::Object, public MidiLearnable
 		QPixmap m_back;
 		QPixmap m_leds;
 		QPixmap m_knob;
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 };
 
 class VerticalFader : public Fader
@@ -113,10 +121,11 @@ public:
 
 class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 {
-    H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MasterFader(QWidget *pParent, bool bWithoutKnob = false);
 		~MasterFader();
 
@@ -148,6 +157,12 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 		void valueChanged( MasterFader *ref );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		bool m_bWithoutKnob;
 		bool m_bIgnoreMouseMove;
 
@@ -170,9 +185,10 @@ class MasterFader : public QWidget, public H2Core::Object, public MidiLearnable
 
 class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		Knob( QWidget* parent );
 		~Knob();
 
@@ -188,6 +204,12 @@ class Knob : public QWidget, public H2Core::Object, public MidiLearnable
 		void valueChanged( Knob *ref );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static QPixmap *m_background;
 		bool m_bIgnoreMouseMove;
 

--- a/src/gui/src/Widgets/InfoBar.h
+++ b/src/gui/src/Widgets/InfoBar.h
@@ -30,6 +30,7 @@ class QHBoxLayout;
 class QLabel;
 class QPushButton;
 
+/** \ingroup docGUI docWidgets */
 class InfoBar : public QWidget
 {
 	QHBoxLayout *m_pLayout;

--- a/src/gui/src/Widgets/LCD.cpp
+++ b/src/gui/src/Widgets/LCD.cpp
@@ -36,11 +36,11 @@ QPixmap* LCDDigit::m_pSmallRedFontSet = NULL;
 QPixmap* LCDDigit::m_pLargeGrayFontSet = NULL;
 QPixmap* LCDDigit::m_pSmallGrayFontSet = NULL;
 
-const char* LCDDigit::__class_name = "LCDDigit";
+const char* LCDDigit::m_sClassName = "LCDDigit";
 
 LCDDigit::LCDDigit( QWidget * pParent, LCDType type )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_type( type )
 {
 	setAttribute(Qt::WA_NoBackground);
@@ -202,11 +202,11 @@ void LCDDigit::setSmallBlue()
 // ::::::::::::::::::
 
 
-const char* LCDDisplay::__class_name = "LCDDisplay";
+const char* LCDDisplay::m_sClassName = "LCDDisplay";
 
 LCDDisplay::LCDDisplay( QWidget * pParent, LCDDigit::LCDType type, int nDigits, bool leftAlign )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_sMsg( "" )
  , m_bLeftAlign( leftAlign )
 {
@@ -321,12 +321,12 @@ void LCDDisplay::digitClicked()
 // :::::::::::::::::::
 
 
-const char* LCDSpinBox::__class_name = "LCDSpinBox";
+const char* LCDSpinBox::m_sClassName = "LCDSpinBox";
 
 // used in PlayerControl
 LCDSpinBox::LCDSpinBox( QWidget *pParent, int nDigits, LCDSpinBoxType type, int nMin, int nMax )
  : QWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_type( type )
  , m_fValue( 0 )
  , m_nMinValue( nMin )

--- a/src/gui/src/Widgets/LCD.h
+++ b/src/gui/src/Widgets/LCD.h
@@ -35,9 +35,10 @@
 
 class LCDDigit : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		enum LCDType {
 			SMALL_BLUE,
 			SMALL_RED,
@@ -57,6 +58,12 @@ class LCDDigit : public QWidget, public H2Core::Object
 		void digitClicked();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		static QPixmap *m_pSmallBlueFontSet;
 		static QPixmap *m_pSmallRedFontSet;
 		static QPixmap *m_pLargeGrayFontSet;
@@ -74,9 +81,10 @@ class LCDDigit : public QWidget, public H2Core::Object
 
 class LCDDisplay : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		LCDDisplay( QWidget * pParent, LCDDigit::LCDType type, int nDigits, bool leftAlign = false );
 		~LCDDisplay();
 
@@ -93,6 +101,12 @@ class LCDDisplay : public QWidget, public H2Core::Object
 		void displayClicked( LCDDisplay* pRef );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		std::vector<LCDDigit*> m_pDisplay;
 		QString m_sMsg;
 		bool m_bLeftAlign;
@@ -101,9 +115,10 @@ class LCDDisplay : public QWidget, public H2Core::Object
 
 class LCDSpinBox : public QWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		enum LCDSpinBoxType {
 			INTEGER,
 			FLOAT
@@ -129,6 +144,12 @@ class LCDSpinBox : public QWidget, public H2Core::Object
 		void displayClicked( LCDDisplay *pRef );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		LCDSpinBoxType m_type;
 		LCDDisplay* m_pDisplay;
 

--- a/src/gui/src/Widgets/LCD.h
+++ b/src/gui/src/Widgets/LCD.h
@@ -33,6 +33,7 @@
 
 #include <vector>
 
+/** \ingroup docGUI docWidgets */
 class LCDDigit : public QWidget, public H2Core::Object
 {
 	Q_OBJECT
@@ -79,6 +80,7 @@ class LCDDigit : public QWidget, public H2Core::Object
 
 
 
+/** \ingroup docGUI docWidgets */
 class LCDDisplay : public QWidget, public H2Core::Object
 {
 	Q_OBJECT
@@ -113,6 +115,7 @@ class LCDDisplay : public QWidget, public H2Core::Object
 };
 
 
+/** \ingroup docGUI docWidgets */
 class LCDSpinBox : public QWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -28,11 +28,11 @@
 
 #include <hydrogen/globals.h>
 
-const char* LCDCombo::__class_name = "LCDCombo";
+const char* LCDCombo::m_sClassName = "LCDCombo";
 
 LCDCombo::LCDCombo( QWidget *pParent, int digits )
 	: QWidget(pParent)
-	, Object( __class_name )
+	, Object( m_sClassName )
 {
 	INFOLOG( "INIT" );
 

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -34,6 +34,7 @@
 class Button;
 class LCDDisplay;
 
+/** \ingroup docGUI docWidgets */
 class LCDCombo : public QWidget, public H2Core::Object
 {
 		Q_OBJECT

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -36,9 +36,10 @@ class LCDDisplay;
 
 class LCDCombo : public QWidget, public H2Core::Object
 {
-		H2_OBJECT
 		Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		LCDCombo( QWidget *pParent, int digits = 5 );
 		~LCDCombo();
 
@@ -57,6 +58,12 @@ class LCDCombo : public QWidget, public H2Core::Object
 		void valueChanged( int idx );
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QList<QAction*> actions;
 		LCDDisplay *display;
 		Button *button;

--- a/src/gui/src/Widgets/MidiActivityWidget.cpp
+++ b/src/gui/src/Widgets/MidiActivityWidget.cpp
@@ -30,11 +30,11 @@
 #include <QMouseEvent>
 #include <QPaintEvent>
 
-const char* MidiActivityWidget::__class_name = "MidiActivityWidget";
+const char* MidiActivityWidget::m_sClassName = "MidiActivityWidget";
 
 MidiActivityWidget::MidiActivityWidget( QWidget * parent )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bValue( false )
 {
 	setAttribute(Qt::WA_NoBackground);

--- a/src/gui/src/Widgets/MidiActivityWidget.h
+++ b/src/gui/src/Widgets/MidiActivityWidget.h
@@ -35,9 +35,10 @@
 
 class MidiActivityWidget : public QWidget, public EventListener, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MidiActivityWidget(QWidget * parent);
 		~MidiActivityWidget();
 
@@ -48,6 +49,12 @@ class MidiActivityWidget : public QWidget, public EventListener, public H2Core::
 		void restoreMidiActivityWidget();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		bool m_bValue;
 		QTimer *m_qTimer;
 		QPixmap m_back;

--- a/src/gui/src/Widgets/MidiActivityWidget.h
+++ b/src/gui/src/Widgets/MidiActivityWidget.h
@@ -33,6 +33,7 @@
 #include "../EventListener.h"
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI docWidgets */
 class MidiActivityWidget : public QWidget, public EventListener, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/MidiLearnable.h
+++ b/src/gui/src/Widgets/MidiLearnable.h
@@ -28,10 +28,12 @@
 
 
 
-/*
-  Every widget which supports MidiLearn should derive from this Class.
-*/
-
+/**
+ * Every widget which supports MidiLearn should derive from this
+ * Class.
+ *
+ * \ingroup docGUI docWidgets
+ */
 class MidiLearnable
 {
 public:

--- a/src/gui/src/Widgets/MidiSenseWidget.cpp
+++ b/src/gui/src/Widgets/MidiSenseWidget.cpp
@@ -24,9 +24,9 @@
 #include "MidiSenseWidget.h"
 #include <hydrogen/hydrogen.h>
 
-const char* MidiSenseWidget::__class_name = "MidiSenseWidget";
+const char* MidiSenseWidget::m_sClassName = "MidiSenseWidget";
 
-MidiSenseWidget::MidiSenseWidget(QWidget* pParent, bool directWr, Action* midiAction): QDialog( pParent ) , Object(__class_name)
+MidiSenseWidget::MidiSenseWidget(QWidget* pParent, bool directWr, Action* midiAction): QDialog( pParent ) , Object(m_sClassName)
 {
 	m_DirectWrite = directWr;
 	m_pAction = midiAction;

--- a/src/gui/src/Widgets/MidiSenseWidget.h
+++ b/src/gui/src/Widgets/MidiSenseWidget.h
@@ -30,6 +30,7 @@
 #include <hydrogen/object.h>
 #include <hydrogen/midi_action.h>
 
+/** \ingroup docGUI docWidgets */
 class MidiSenseWidget : public QDialog ,public H2Core::Object
 	{
 	Q_OBJECT

--- a/src/gui/src/Widgets/MidiSenseWidget.h
+++ b/src/gui/src/Widgets/MidiSenseWidget.h
@@ -32,10 +32,11 @@
 
 class MidiSenseWidget : public QDialog ,public H2Core::Object
 	{
-	H2_OBJECT
 	Q_OBJECT
 
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MidiSenseWidget(QWidget*,bool m_DirectWrite = false , Action* m_pAction = NULL);
 		~MidiSenseWidget();
 
@@ -46,6 +47,12 @@ class MidiSenseWidget : public QDialog ,public H2Core::Object
 		void		updateMidi();
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		QTimer*		m_pUpdateTimer;
 		QLabel*		m_pURLLabel;
 		Action* m_pAction;

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -32,11 +32,11 @@
 
 #include <QHeaderView>
 
-const char* MidiTable::__class_name = "MidiTable";
+const char* MidiTable::m_sClassName = "MidiTable";
 
 MidiTable::MidiTable( QWidget *pParent )
  : QTableWidget( pParent )
- , Object( __class_name )
+ , Object( m_sClassName )
 {
 	__row_count = 0;
 	setupMidiTable();

--- a/src/gui/src/Widgets/MidiTable.h
+++ b/src/gui/src/Widgets/MidiTable.h
@@ -30,6 +30,7 @@
 #  include <QtWidgets>
 #endif
 
+/** \ingroup docGUI docWidgets */
 class MidiTable : public QTableWidget, public H2Core::Object
 {
 	Q_OBJECT

--- a/src/gui/src/Widgets/MidiTable.h
+++ b/src/gui/src/Widgets/MidiTable.h
@@ -32,9 +32,10 @@
 
 class MidiTable : public QTableWidget, public H2Core::Object
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		MidiTable( QWidget* pParent );
 		~MidiTable();
 
@@ -47,6 +48,12 @@ class MidiTable : public QTableWidget, public H2Core::Object
 		void midiSensePressed( int );
 	
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		int __row_count;
 		int currentMidiAutosenseRow;
 		QSignalMapper *signalMapper;

--- a/src/gui/src/Widgets/PixmapWidget.cpp
+++ b/src/gui/src/Widgets/PixmapWidget.cpp
@@ -26,10 +26,10 @@
 
 #include <hydrogen/object.h>
 
-const char* PixmapWidget::__class_name = "PixmapWidget";
+const char* PixmapWidget::m_sClassName = "PixmapWidget";
 
 PixmapWidget::PixmapWidget( QWidget *pParent, const char* sClassName )
- : Object( __class_name )
+ : Object( m_sClassName )
  , QWidget( pParent )
  , m_sPixmapPath( "" )
  , __expand_horiz(false)

--- a/src/gui/src/Widgets/PixmapWidget.h
+++ b/src/gui/src/Widgets/PixmapWidget.h
@@ -30,6 +30,7 @@
 
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI docWidgets */
 class PixmapWidget : public H2Core::Object, public QWidget
 {
 	public:

--- a/src/gui/src/Widgets/PixmapWidget.h
+++ b/src/gui/src/Widgets/PixmapWidget.h
@@ -32,8 +32,9 @@
 
 class PixmapWidget : public H2Core::Object, public QWidget
 {
-    H2_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		PixmapWidget( QWidget *pParent, const char* = "PixmapWidget" );
 		~PixmapWidget();
 
@@ -47,6 +48,13 @@ class PixmapWidget : public H2Core::Object, public QWidget
 		bool __expand_horiz;
 
 		virtual void paintEvent( QPaintEvent* ev);
+	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 };
 
 #endif

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -63,11 +63,11 @@ RotaryTooltip::~RotaryTooltip()
 QPixmap* Rotary::m_background_normal = NULL;
 QPixmap* Rotary::m_background_center = NULL;
 
-const char* Rotary::__class_name = "Rotary";
+const char* Rotary::m_sClassName = "Rotary";
 
 Rotary::Rotary( QWidget* parent, RotaryType type, QString sToolTip, bool bUseIntSteps, bool bUseValueTip )
  : QWidget( parent )
- , Object( __class_name )
+ , Object( m_sClassName )
  , m_bUseIntSteps( bUseIntSteps )
  , m_type( type )
  , m_fMin( 0.0 )

--- a/src/gui/src/Widgets/Rotary.h
+++ b/src/gui/src/Widgets/Rotary.h
@@ -50,9 +50,10 @@ class RotaryTooltip : public QWidget
 
 class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 {
-    H2_OBJECT
 	Q_OBJECT
 	public:
+		/** \return #m_sClassName*/
+		static const char* className() { return m_sClassName; }
 		enum RotaryType {
 			TYPE_NORMAL,
 			TYPE_CENTER
@@ -85,6 +86,12 @@ class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 		void valueChanged(Rotary *ref);
 
 	private:
+		/** Contains the name of the class.
+		 *
+		 * This variable allows from more informative log messages
+		 * with the name of the class the message is generated in
+		 * being displayed as well. Queried using className().*/
+		static const char* m_sClassName;
 		bool m_bUseIntSteps;
 		bool m_bIgnoreMouseMove;
 

--- a/src/gui/src/Widgets/Rotary.h
+++ b/src/gui/src/Widgets/Rotary.h
@@ -35,6 +35,7 @@ class LCDDisplay;
 
 #include <hydrogen/object.h>
 
+/** \ingroup docGUI docWidgets */
 class RotaryTooltip : public QWidget
 {
 	public:
@@ -48,6 +49,7 @@ class RotaryTooltip : public QWidget
 
 
 
+/** \ingroup docGUI docWidgets */
 class Rotary : public QWidget, public H2Core::Object, public MidiLearnable
 {
 	Q_OBJECT


### PR DESCRIPTION
NOTE: This pull request depends on #735 . I know this is really bad style. But since I had to touch almost all source files in both of them, it would be hell of a nuisance to resolve possible merge conflicts.

The documentation of the source code lacks clear structure. A differentiation into inside and outside the `H2Core` namespace is just not enough for so much classes and functions. Also, all the global `audioEngine_*` functions do not show up in the sidebar at all. 

To resolve this problem, I introduced a couple of groups to bundle classes and functions related to a particular topic. They can now be accessed via the `Modules` node in the sidebar.