### PR TITLE
Fixing copy constructors & check image path when saving drumkit

### DIFF
--- a/src/core/src/basics/drumkit.cpp
+++ b/src/core/src/basics/drumkit.cpp
@@ -70,7 +70,9 @@ Drumkit::Drumkit( Drumkit* other ) :
 	__instruments = new InstrumentList( other->get_instruments() );
 
 	__components = new std::vector<DrumkitComponent*> ();
-	__components->assign( other->get_components()->begin(), other->get_components()->end() );
+	for (auto it = other->get_components()->begin(); it != other->get_components()->end(); ++it) {
+		__components->push_back(new DrumkitComponent(*it));
+	}
 }
 
 Drumkit::~Drumkit()

--- a/src/core/src/basics/drumkit.cpp
+++ b/src/core/src/basics/drumkit.cpp
@@ -214,10 +214,14 @@ bool Drumkit::save( const QString&					name,
 	pDrumkit->set_info( info );
 	pDrumkit->set_license( license );
 
-	// save the original path
-	QFileInfo fi( image );
-	pDrumkit->set_path( fi.absolutePath() );
-	pDrumkit->set_image( fi.fileName() );
+	// Before storing the absolute path to the image of the drumkit it
+	// has to be checked whether an actual path was supplied. If not,
+	// the construction of QFileInfo will fail.
+	if ( !image.isEmpty() ) {
+		QFileInfo fi( image );
+		pDrumkit->set_path( fi.absolutePath() );
+		pDrumkit->set_image( fi.fileName() );
+	}
 	pDrumkit->set_image_license( imageLicense );
 
 	pDrumkit->set_instruments( new InstrumentList( pInstruments ) );      // FIXME: why must we do that ? there is something weird with updateInstrumentLines

--- a/src/core/src/basics/instrument.cpp
+++ b/src/core/src/basics/instrument.cpp
@@ -131,7 +131,9 @@ Instrument::Instrument( Instrument* other )
 	}
 
 	__components = new std::vector<InstrumentComponent*> ();
-	__components->assign( other->get_components()->begin(), other->get_components()->end() );
+	for (auto it = other->get_components()->begin(); it != other->get_components()->end(); ++it) {
+		__components->push_back(new InstrumentComponent(*it));
+	}
 }
 
 Instrument::~Instrument()

--- a/src/core/src/basics/instrument_layer.cpp
+++ b/src/core/src/basics/instrument_layer.cpp
@@ -53,7 +53,7 @@ InstrumentLayer::InstrumentLayer( InstrumentLayer* other, Sample* sample ) : Obj
 	__end_velocity( other->get_end_velocity() ),
 	__pitch( other->get_pitch() ),
 	__gain( other->get_gain() ),
-	__sample( sample )
+	__sample( new Sample(sample) )
 {
 }
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1043,9 +1043,13 @@ void MainForm::action_instruments_saveLibrary()
 				break;
 			}
 		}
+		
+		// Since Drumkit::load() calls New Drumkit() internally, we
+		// have to take care of destroying it manually.
+		delete pInfo;
 	}
 
-	//System drumkit list
+	// System drumkit list
 	QStringList sys_dks = Filesystem::sys_drumkit_list();
 	for (int i = 0; i < sys_dks.size(); ++i) {
 		QString absPath = Filesystem::sys_drumkits_dir() + sys_dks[i];
@@ -1056,6 +1060,10 @@ void MainForm::action_instruments_saveLibrary()
 				break;
 			}
 		}
+		
+		// Since Drumkit::load() calls New Drumkit() internally, we
+		// have to take care of destroying it manually.
+		delete pInfo;
 	}
 
 	if ( pDrumkitInfo != nullptr ){
@@ -1077,6 +1085,11 @@ void MainForm::action_instruments_saveLibrary()
 
 	//HydrogenApp::get_instance()->getInstrumentRack()->getSoundLibraryPanel()->test_expandedItems();
 	HydrogenApp::get_instance()->getInstrumentRack()->getSoundLibraryPanel()->updateDrumkitList();
+
+	// Cleaning up the last pInfo we did not deleted due to the break
+	// statement.
+	delete pDrumkitInfo;
+
 }
 
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1997,6 +1997,10 @@ void MainForm::action_banks_properties()
 				break;
 			}
 		}
+		
+		// Since Drumkit::load() calls New Drumkit() internally, we
+		// have to take care of destroying it manually.
+		delete pInfo;
 	}
 
 	//System drumkit list
@@ -2010,6 +2014,10 @@ void MainForm::action_banks_properties()
 				break;
 			}
 		}
+		
+		// Since Drumkit::load() calls New Drumkit() internally, we
+		// have to take care of destroying it manually.
+		delete pInfo;
 	}
 
 	if( pDrumkitInfo )
@@ -2021,4 +2029,8 @@ void MainForm::action_banks_properties()
 	{
 		QMessageBox::information( this, "Hydrogen", tr("Retrieving information about drumkit '%1' failed: drumkit does not exist.").arg( sDrumkitName ) );
 	}
+
+	// Cleaning up the last pInfo we did not deleted due to the break
+	// statement.
+	delete pDrumkitInfo;
 }


### PR DESCRIPTION
else the construction of a QFileInfo will cause trouble.

Fix of ~the trivial first part of~ #751