### PR TITLE
16ths-meters for pattern size menu

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -112,7 +112,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	__pattern_size_combo = new LCDCombo(pSizeResol, 4);
 	__pattern_size_combo->move( 34, 2 );
 	__pattern_size_combo->setToolTip( trUtf8("Select pattern size") );
-	for ( int i = 1; i <= 32; i++) {
+	for ( int i = 1; i <= 64; i++) {
 		__pattern_size_combo->addItem( QString( "%1" ).arg( i ) );
 	}
 	// is triggered from inside selectedPatternChangedEvent()
@@ -615,7 +615,7 @@ void PatternEditorPanel::selectedPatternChangedEvent()
 
 		// update pattern size combobox
 		int nPatternSize = m_pPattern->get_length();
-		int nEighth = MAX_NOTES / 8;
+		int nEighth = MAX_NOTES / 16;
 		__pattern_size_combo->select( (nPatternSize / nEighth) - 1 );
 	}
 	else {
@@ -799,7 +799,7 @@ void PatternEditorPanel::patternSizeChanged( int nSelected )
 		return;
 	}
 
-	int nEighth = MAX_NOTES / 8;
+	int nEighth = MAX_NOTES / 16;
 
 	if ( !m_bEnablePatternResize ) {
 		__pattern_size_combo->select( ((m_pPattern->get_length() / nEighth) - 1), false );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -615,8 +615,8 @@ void PatternEditorPanel::selectedPatternChangedEvent()
 
 		// update pattern size combobox
 		int nPatternSize = m_pPattern->get_length();
-		int nEighth = MAX_NOTES / 16;
-		__pattern_size_combo->select( (nPatternSize / nEighth) - 1 );
+		int n16th = MAX_NOTES / 16;
+		__pattern_size_combo->select( (nPatternSize / n16th) - 1 );
 	}
 	else {
 		m_pPattern = NULL;
@@ -799,15 +799,15 @@ void PatternEditorPanel::patternSizeChanged( int nSelected )
 		return;
 	}
 
-	int nEighth = MAX_NOTES / 16;
+	int n16th = MAX_NOTES / 16;
 
 	if ( !m_bEnablePatternResize ) {
-		__pattern_size_combo->select( ((m_pPattern->get_length() / nEighth) - 1), false );
+		__pattern_size_combo->select( ((m_pPattern->get_length() / n16th) - 1), false );
 		QMessageBox::information( this, "Hydrogen", trUtf8( "Is not possible to change the pattern size when playing." ) );
 		return;
 	}
 
-	m_pPattern->set_length( nEighth * ( nSelected + 1 ) );
+	m_pPattern->set_length( n16th * ( nSelected + 1 ) );
 
 	m_pPatternEditorRuler->updateEditor( true );	// redraw all
 	m_pNoteVelocityEditor->updateEditor();


### PR DESCRIPTION
For simplicity I am opening a pull request related to issue #755

Basically here the pattern size menu shows integers from 1 to 64 (instead of 1-32) and they are considered to be 16ths instead of 8ths.
It allows to set meters like 5/16.

Variable `nEighth` should be renamed `nSixteenth` but I have not done it yet