### PR TITLE
Tuplets

### DIFF
--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -453,6 +453,16 @@ public:
 	bool			isPatternEditorUsingTriplets();
 	void			setPatternEditorUsingTriplets( bool value );
 
+	bool			isPatternEditorUsingQuintuplets();
+	void			setPatternEditorUsingQuintuplets( bool value );
+
+	bool			isPatternEditorUsingSeptuplets();
+	void			setPatternEditorUsingSeptuplets( bool value );
+
+	bool			isPatternEditorUsing9tuplets();
+	void			setPatternEditorUsing9tuplets( bool value );
+
+
 	bool			isFXTabVisible();
 	void			setFXTabVisible( bool value );
 	
@@ -672,6 +682,9 @@ private:
 	float					mixerFalloffSpeed;
 	int						m_nPatternEditorGridResolution;
 	bool					m_bPatternEditorUsingTriplets;
+	bool					m_bPatternEditorUsingQuintuplets;
+	bool					m_bPatternEditorUsingSeptuplets;
+	bool					m_bPatternEditorUsing9tuplets;
 	bool					m_bShowInstrumentPeaks;
 	bool					m_bIsFXTabVisible;
 	bool					m_bShowAutomationArea;
@@ -945,12 +958,37 @@ inline void Preferences::setPatternEditorGridResolution( int value ) {
 	m_nPatternEditorGridResolution = value;
 }
 
+inline bool Preferences::isPatternEditorUsingQuintuplets() {
+	return m_bPatternEditorUsingQuintuplets;
+}
+
+inline bool Preferences::isPatternEditorUsingSeptuplets() {
+	return m_bPatternEditorUsingSeptuplets;
+}
+
+inline bool Preferences::isPatternEditorUsing9tuplets() {
+	return m_bPatternEditorUsing9tuplets;
+}
+
+
 inline bool Preferences::isPatternEditorUsingTriplets() {
 	return m_bPatternEditorUsingTriplets;
 }
 inline void Preferences::setPatternEditorUsingTriplets( bool value ) {
 	m_bPatternEditorUsingTriplets = value;
 }
+inline void Preferences::setPatternEditorUsingQuintuplets( bool value ) {
+  m_bPatternEditorUsingQuintuplets = value;
+}
+
+inline void Preferences::setPatternEditorUsingSeptuplets( bool value ) {
+  m_bPatternEditorUsingSeptuplets = value;
+}
+
+inline void Preferences::setPatternEditorUsing9tuplets( bool value ) {
+  m_bPatternEditorUsing9tuplets = value;
+}
+
 
 inline bool Preferences::isFXTabVisible() {
 	return m_bIsFXTabVisible;

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2549,7 +2549,18 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 	Preferences *pPreferences = Preferences::get_instance();
 	unsigned int nRealColumn = 0;
 	unsigned res = pPreferences->getPatternEditorGridResolution();
-	int nBase = pPreferences->isPatternEditorUsingTriplets() ? 3 : 4;
+	//int nBase = pPreferences->isPatternEditorUsingTriplets() ? 3 : 4;
+	int nBase;
+	if(pPreferences->isPatternEditorUsingTriplets())
+		nBase = 3;
+	else if(pPreferences->isPatternEditorUsingQuintuplets())
+		nBase = 5;
+	else if(pPreferences->isPatternEditorUsingSeptuplets())
+		nBase = 7;
+	else if(pPreferences->isPatternEditorUsing9tuplets())
+		nBase = 9;
+	else
+		nBase = 4;
 	int scalar = ( 4 * MAX_NOTES ) / ( res * nBase );
 	bool hearnote = forcePlay;
 	int currentPatternNumber;

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -53,9 +53,13 @@ class DrumPatternEditor : public QWidget, public EventListener, public H2Core::O
 		DrumPatternEditor(QWidget* parent, PatternEditorPanel *panel);
 		~DrumPatternEditor();
 
-		void setResolution(uint res, bool bUseTriplets);
+		void setResolution(uint res, bool bUseTriplets, bool bUseQuintuplets, bool bUseSeptuplets, bool bUse9tuplets);
+
 		uint getResolution() {	return m_nResolution;	}
 		bool isUsingTriplets() { return m_bUseTriplets;	}
+	  	bool isUsingQuintuplets() { return m_bUseQuintuplets;}
+	  	bool isUsingSeptuplets() { return m_bUseSeptuplets;}
+	  	bool isUsing9tuplets() { return m_bUse9tuplets;	}
 
 		void zoom_in();
 		void zoom_out();
@@ -117,6 +121,9 @@ class DrumPatternEditor : public QWidget, public EventListener, public H2Core::O
 		int m_nEditorHeight;
 		uint m_nResolution;
 		bool m_bUseTriplets;
+		bool m_bUseQuintuplets;
+		bool m_bUseSeptuplets;
+		bool m_bUse9tuplets;
 
 		bool m_bRightBtnPressed;
 		H2Core::Note *m_pDraggedNote;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -114,15 +114,25 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 	if (pPatternEditor->isUsingTriplets()) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
 	int width = (m_nGridWidth * 4 *  MAX_NOTES) / ( nBase * pPatternEditor->getResolution());
 	int x_pos = ev->x();
 	int column;
+
 	column = (x_pos - 20) + (width / 2);
 	column = column / width;
-	column = (column * 4 * MAX_NOTES) / ( nBase * pPatternEditor->getResolution() );
+	column = round( (float) (column * 4 * MAX_NOTES) / ( nBase * pPatternEditor->getResolution() ) ); //round for best tuplets approximation.
 
 	int nSelectedInstrument = Hydrogen::get_instance()->getSelectedInstrumentNumber();
 	Song *pSong = (Hydrogen::get_instance())->getSong();
@@ -238,6 +248,15 @@ void NotePropertiesRuler::pressAction( int x, int y)
 	if (pPatternEditor->isUsingTriplets()) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
@@ -246,7 +265,7 @@ void NotePropertiesRuler::pressAction( int x, int y)
 	int column;
 	column = (x_pos - 20) + (width / 2);
 	column = column / width;
-	column = (column * 4 * MAX_NOTES) / ( nBase * pPatternEditor->getResolution() );
+	column = round( (float) (column * 4 * MAX_NOTES) / ( nBase * pPatternEditor->getResolution() ) ); //round for best tuplets approximation.
 	float val = height() - y;
 	if (val > height()) {
 		val = height();
@@ -320,6 +339,15 @@ void NotePropertiesRuler::pressAction( int x, int y)
 		if (pPatternEditor->isUsingTriplets()) {
 			nBase = 3;
 		}
+		else if (pPatternEditor->isUsingQuintuplets()) {
+			nBase = 5;
+		}
+		else if (pPatternEditor->isUsingSeptuplets()) {
+			nBase = 7;
+		}
+		else if (pPatternEditor->isUsing9tuplets()) {
+			nBase = 9;
+		}
 		else {
 			nBase = 4;
 		}
@@ -328,7 +356,7 @@ void NotePropertiesRuler::pressAction( int x, int y)
 		int column;
 		column = (x_pos - 20) + (width / 2);
 		column = column / width;
-		column = (column * 4 * MAX_NOTES) / ( nBase * pPatternEditor->getResolution() );
+		column = round( (float) (column * 4 * MAX_NOTES) / ( nBase * pPatternEditor->getResolution() ) ); //round for best tuplets approximation. Good for the finest listeners!
 
 		bool columnChange = false;
 		if( __columnCheckOnXmouseMouve != column ){
@@ -549,70 +577,83 @@ void NotePropertiesRuler::createVelocityBackground(QPixmap *pixmap)
 	if (pPatternEditor->isUsingTriplets()) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
 
-	int n4th = 4 * MAX_NOTES / (nBase * 4);
-	int n8th = 4 * MAX_NOTES / (nBase * 8);
-	int n16th = 4 * MAX_NOTES / (nBase * 16);
-	int n32th = 4 * MAX_NOTES / (nBase * 32);
-	int n64th = 4 * MAX_NOTES / (nBase * 64);
+	int n4th = MAX_NOTES / 4;
+	int n8th = MAX_NOTES / 8;
+	int n16th = MAX_NOTES / 16;
+	int n32th = MAX_NOTES / 32;
+	int n64th = MAX_NOTES / 64;
+
 	int nResolution = pPatternEditor->getResolution();
 
+	uint x; // position for drawline; 
+	int nLine = 0; //position of vertical line in ticks
 
-	if ( !pPatternEditor->isUsingTriplets() ) {
+	if ( !pPatternEditor->isUsingTriplets() && !pPatternEditor->isUsingQuintuplets() && !pPatternEditor->isUsingSeptuplets() && !pPatternEditor->isUsing9tuplets() ) {
 
-		for (uint i = 0; i < nNotes + 1; i++) {
-			uint x = 20 + i * m_nGridWidth;
-
-			if ( (i % n4th) == 0 ) {
-				if (nResolution >= 4) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  MAX_NOTES * k * 2 / (nBase * nResolution);
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ( (nLine % n4th) == 0 ) {
+					if (nResolution >= 4) {
+						p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n8th) == 0 ) {
-				if (nResolution >= 8) {
-					p.setPen( QPen( res_2, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n8th) == 0 ) {
+					if (nResolution >= 8) {
+						p.setPen( QPen( res_2, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n16th) == 0 ) {
-				if (nResolution >= 16) {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n16th) == 0 ) {
+					if (nResolution >= 16) {
+						p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n32th) == 0 ) {
-				if (nResolution >= 32) {
-					p.setPen( QPen( res_4, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n32th) == 0 ) {
+					if (nResolution >= 32) {
+						p.setPen( QPen( res_4, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n64th) == 0 ) {
-				if (nResolution >= 64) {
-					p.setPen( QPen( res_5, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n64th) == 0 ) {
+					if (nResolution >= 64) {
+						p.setPen( QPen( res_5, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
 			}
 		}
 	}
-	else {	// Triplets
-		uint nCounter = 0;
-		int nSize = 4 * MAX_NOTES / (nBase * nResolution);
+	else {	// Tuplets
+		int nCounter = 0;
 
-		for (uint i = 0; i < nNotes + 1; i++) {
-			uint x = 20 + i * m_nGridWidth;
-
-			if ( (i % nSize) == 0) {
-				if ((nCounter % 3) == 0) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  round( (float) MAX_NOTES * k * 4 / (nBase * nResolution) ); //round for best tuplets approximation.
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ((nCounter % nBase) == 0) {
+					p.setPen( QPen( res_1, 0, Qt::DotLine  ) );
 				}
 				else {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+					p.setPen( QPen( res_3, 0, Qt::DotLine  ) );
 				}
-				p.drawLine(x, 0, x, m_nEditorHeight);
+				p.drawLine(x, 1, x, m_nEditorHeight - 1);
 				nCounter++;
 			}
 		}
@@ -719,70 +760,83 @@ void NotePropertiesRuler::createPanBackground(QPixmap *pixmap)
 	if (pPatternEditor->isUsingTriplets()) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
 
-	int n4th = 4 * MAX_NOTES / (nBase * 4);
-	int n8th = 4 * MAX_NOTES / (nBase * 8);
-	int n16th = 4 * MAX_NOTES / (nBase * 16);
-	int n32th = 4 * MAX_NOTES / (nBase * 32);
-	int n64th = 4 * MAX_NOTES / (nBase * 64);
+	int n4th = MAX_NOTES / 4;
+	int n8th = MAX_NOTES / 8;
+	int n16th = MAX_NOTES / 16;
+	int n32th = MAX_NOTES / 32;
+	int n64th = MAX_NOTES / 64;
 
 	int nResolution = pPatternEditor->getResolution();
 
-	if ( !pPatternEditor->isUsingTriplets() ) {
+	uint x; // position for drawline; 
+	int nLine = 0; //position of vertical line in ticks
 
-		for (uint i = 0; i < nNotes +1 ; i++) {
-			uint x = 20 + i * m_nGridWidth;
+	if ( !pPatternEditor->isUsingTriplets() && !pPatternEditor->isUsingQuintuplets() && !pPatternEditor->isUsingSeptuplets() && !pPatternEditor->isUsing9tuplets() ) {
 
-			if ( (i % n4th) == 0 ) {
-				if (nResolution >= 4) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  MAX_NOTES * k * 2 / (nBase * nResolution);
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ( (nLine % n4th) == 0 ) {
+					if (nResolution >= 4) {
+						p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n8th) == 0 ) {
-				if (nResolution >= 8) {
-					p.setPen( QPen( res_2, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n8th) == 0 ) {
+					if (nResolution >= 8) {
+						p.setPen( QPen( res_2, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n16th) == 0 ) {
-				if (nResolution >= 16) {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n16th) == 0 ) {
+					if (nResolution >= 16) {
+						p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n32th) == 0 ) {
-				if (nResolution >= 32) {
-					p.setPen( QPen( res_4, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n32th) == 0 ) {
+					if (nResolution >= 32) {
+						p.setPen( QPen( res_4, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n64th) == 0 ) {
-				if (nResolution >= 64) {
-					p.setPen( QPen( res_5, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n64th) == 0 ) {
+					if (nResolution >= 64) {
+						p.setPen( QPen( res_5, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
 			}
 		}
 	}
-	else {	// Triplets
-		uint nCounter = 0;
-		int nSize = 4 * MAX_NOTES / (nBase * nResolution);
+	else {	// Tuplets
+		int nCounter = 0;
 
-		for (uint i = 0; i < nNotes +1; i++) {
-			uint x = 20 + i * m_nGridWidth;
-
-			if ( (i % nSize) == 0) {
-				if ((nCounter % 3) == 0) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  round( (float) MAX_NOTES * k * 4 / (nBase * nResolution) ); //round for best tuplets approximation.
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ((nCounter % nBase) == 0) {
+					p.setPen( QPen( res_1, 0, Qt::DotLine  ) );
 				}
 				else {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+					p.setPen( QPen( res_3, 0, Qt::DotLine  ) );
 				}
-				p.drawLine(x, 0, x, m_nEditorHeight);
+				p.drawLine(x, 1, x, m_nEditorHeight - 1);
 				nCounter++;
 			}
 		}
@@ -879,70 +933,83 @@ void NotePropertiesRuler::createLeadLagBackground(QPixmap *pixmap)
 	if (pPatternEditor->isUsingTriplets()) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
 
-	int n4th = 4 * MAX_NOTES / (nBase * 4);
-	int n8th = 4 * MAX_NOTES / (nBase * 8);
-	int n16th = 4 * MAX_NOTES / (nBase * 16);
-	int n32th = 4 * MAX_NOTES / (nBase * 32);
-	int n64th = 4 * MAX_NOTES / (nBase * 64);
+	int n4th = MAX_NOTES / 4;
+	int n8th = MAX_NOTES / 8;
+	int n16th = MAX_NOTES / 16;
+	int n32th = MAX_NOTES / 32;
+	int n64th = MAX_NOTES / 64;
 
 	int nResolution = pPatternEditor->getResolution();
 
-	if ( !pPatternEditor->isUsingTriplets() ) {
+	uint x; // position for drawline; 
+	int nLine = 0; //position of vertical line in ticks
 
-		for (uint i = 0; i < nNotes + 1; i++) {
-			uint x = 20 + i * m_nGridWidth;
+	if ( !pPatternEditor->isUsingTriplets() && !pPatternEditor->isUsingQuintuplets() && !pPatternEditor->isUsingSeptuplets() && !pPatternEditor->isUsing9tuplets() ) {
 
-			if ( (i % n4th) == 0 ) {
-				if (nResolution >= 4) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  MAX_NOTES * k * 2 / (nBase * nResolution);
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ( (nLine % n4th) == 0 ) {
+					if (nResolution >= 4) {
+						p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n8th) == 0 ) {
-				if (nResolution >= 8) {
-					p.setPen( QPen( res_2, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n8th) == 0 ) {
+					if (nResolution >= 8) {
+						p.setPen( QPen( res_2, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n16th) == 0 ) {
-				if (nResolution >= 16) {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n16th) == 0 ) {
+					if (nResolution >= 16) {
+						p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n32th) == 0 ) {
-				if (nResolution >= 32) {
-					p.setPen( QPen( res_4, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n32th) == 0 ) {
+					if (nResolution >= 32) {
+						p.setPen( QPen( res_4, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n64th) == 0 ) {
-				if (nResolution >= 64) {
-					p.setPen( QPen( res_5, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n64th) == 0 ) {
+					if (nResolution >= 64) {
+						p.setPen( QPen( res_5, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
 			}
 		}
 	}
-	else {  // Triplets
-		uint nCounter = 0;
-		int nSize = 4 * MAX_NOTES / (nBase * nResolution);
+	else {	// Tuplets
+		int nCounter = 0;
 
-		for (uint i = 0; i < nNotes + 1; i++) {
-			uint x = 20 + i * m_nGridWidth;
-
-			if ( (i % nSize) == 0) {
-				if ((nCounter % 3) == 0) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  round( (float) MAX_NOTES * k * 4 / (nBase * nResolution) ); //round for best tuplets approximation.
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ((nCounter % nBase) == 0) {
+					p.setPen( QPen( res_1, 0, Qt::DotLine  ) );
 				}
 				else {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+					p.setPen( QPen( res_3, 0, Qt::DotLine  ) );
 				}
-				p.drawLine(x, 0, x, m_nEditorHeight);
+				p.drawLine(x, 1, x, m_nEditorHeight - 1);
 				nCounter++;
 			}
 		}
@@ -1069,70 +1136,83 @@ void NotePropertiesRuler::createNoteKeyBackground(QPixmap *pixmap)
 	if (pPatternEditor->isUsingTriplets()) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
 
-	int n4th = 4 * MAX_NOTES / (nBase * 4);
-	int n8th = 4 * MAX_NOTES / (nBase * 8);
-	int n16th = 4 * MAX_NOTES / (nBase * 16);
-	int n32th = 4 * MAX_NOTES / (nBase * 32);
-	int n64th = 4 * MAX_NOTES / (nBase * 64);
+	int n4th = MAX_NOTES / 4;
+	int n8th = MAX_NOTES / 8;
+	int n16th = MAX_NOTES / 16;
+	int n32th = MAX_NOTES / 32;
+	int n64th = MAX_NOTES / 64;
+
 	int nResolution = pPatternEditor->getResolution();
 
+	uint x; // position for drawline; 
+	int nLine = 0; //position of vertical line in ticks
 
-	if ( !pPatternEditor->isUsingTriplets() ) {
+	if ( !pPatternEditor->isUsingTriplets() && !pPatternEditor->isUsingQuintuplets() && !pPatternEditor->isUsingSeptuplets() && !pPatternEditor->isUsing9tuplets() ) {
 
-		for (uint i = 0; i < nNotes + 1; i++) {
-			uint x = 20 + i * m_nGridWidth;
-
-			if ( (i % n4th) == 0 ) {
-				if (nResolution >= 4) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  MAX_NOTES * k * 2 / (nBase * nResolution);
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ( (nLine % n4th) == 0 ) {
+					if (nResolution >= 4) {
+						p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n8th) == 0 ) {
-				if (nResolution >= 8) {
-					p.setPen( QPen( res_2, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n8th) == 0 ) {
+					if (nResolution >= 8) {
+						p.setPen( QPen( res_2, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n16th) == 0 ) {
-				if (nResolution >= 16) {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n16th) == 0 ) {
+					if (nResolution >= 16) {
+						p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n32th) == 0 ) {
-				if (nResolution >= 32) {
-					p.setPen( QPen( res_4, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n32th) == 0 ) {
+					if (nResolution >= 32) {
+						p.setPen( QPen( res_4, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
-			}
-			else if ( (i % n64th) == 0 ) {
-				if (nResolution >= 64) {
-					p.setPen( QPen( res_5, 0, Qt::DotLine ) );
-					p.drawLine(x, 0, x, m_nEditorHeight);
+				else if ( (nLine % n64th) == 0 ) {
+					if (nResolution >= 64) {
+						p.setPen( QPen( res_5, 0, Qt::DotLine ) );
+						p.drawLine(x, 0, x, m_nEditorHeight);
+					}
 				}
 			}
 		}
 	}
-	else {	// Triplets
-		uint nCounter = 0;
-		int nSize = 4 * MAX_NOTES / (nBase * nResolution);
+	else {	// Tuplets
+		int nCounter = 0;
 
-		for (uint i = 0; i < nNotes + 1; i++) {
-			uint x = 20 + i * m_nGridWidth;
-
-			if ( (i % nSize) == 0) {
-				if ((nCounter % 3) == 0) {
-					p.setPen( QPen( res_1, 0, Qt::DotLine ) );
+		for ( int k = 0; nLine < nNotes; k++ ) {
+			nLine =  round( (float) MAX_NOTES * k * 4 / (nBase * nResolution) ); //round for best tuplets approximation.
+			x = 20 + nLine * m_nGridWidth;
+			if (nLine < nNotes){
+				if ((nCounter % nBase) == 0) {
+					p.setPen( QPen( res_1, 0, Qt::DotLine  ) );
 				}
 				else {
-					p.setPen( QPen( res_3, 0, Qt::DotLine ) );
+					p.setPen( QPen( res_3, 0, Qt::DotLine  ) );
 				}
-				p.drawLine(x, 0, x, m_nEditorHeight);
+				p.drawLine(x, 1, x, m_nEditorHeight - 1);
 				nCounter++;
 			}
 		}

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -347,11 +347,19 @@ void InstrumentLine::functionFillNotes( int every )
 	if ( pPatternEditor->isUsingTriplets() ) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
-	int nResolution = 4 * MAX_NOTES * every / ( nBase * pPatternEditor->getResolution() );
-
+	int nResolution = pPatternEditor->getResolution();
 
 	Song *pSong = pEngine->getSong();
 
@@ -364,11 +372,12 @@ void InstrumentLine::functionFillNotes( int every )
 
 		if (nSelectedInstrument != -1) {
 			Instrument *instrRef = (pSong->get_instrument_list())->get( nSelectedInstrument );
-
-			for (int i = 0; i < nPatternSize; i += nResolution) {
+			int nPos;
+			for (int k = 0; nPos < nPatternSize; k++) {
 				bool noteAlreadyPresent = false;
 				const Pattern::notes_t* notes = pCurrentPattern->get_notes();
-				FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {
+				nPos =  round( (float) MAX_NOTES * every * 4 * k / (nBase * nResolution) );//round for best tuplets approximation.
+				FOREACH_NOTE_CST_IT_BOUND(notes,it,nPos) {
 					Note *pNote = it->second;
 					if ( pNote->get_instrument() == instrRef ) {
 						// note already exists
@@ -377,8 +386,8 @@ void InstrumentLine::functionFillNotes( int every )
 					}
 				}
 
-				if ( noteAlreadyPresent == false ) {
-					notePositions << QString("%1").arg(i);
+				if ( noteAlreadyPresent == false && nPos < nPatternSize) {
+					notePositions << QString("%1").arg( nPos );
 				}
 			}
 			SE_fillNotesRightClickAction *action = new SE_fillNotesRightClickAction( notePositions, nSelectedInstrument, pEngine->getSelectedPatternNumber() );
@@ -402,10 +411,19 @@ void InstrumentLine::functionRandomizeVelocity()
 	if ( pPatternEditor->isUsingTriplets() ) {
 		nBase = 3;
 	}
+	else if (pPatternEditor->isUsingQuintuplets()) {
+		nBase = 5;
+	}
+	else if (pPatternEditor->isUsingSeptuplets()) {
+		nBase = 7;
+	}
+	else if (pPatternEditor->isUsing9tuplets()) {
+		nBase = 9;
+	}
 	else {
 		nBase = 4;
 	}
-	int nResolution = 4 * MAX_NOTES / ( nBase * pPatternEditor->getResolution() );
+	int nResolution = pPatternEditor->getResolution();
 
 	Song *pSong = pEngine->getSong();
 
@@ -419,10 +437,11 @@ void InstrumentLine::functionRandomizeVelocity()
 
 		if (nSelectedInstrument != -1) {
 			Instrument *instrRef = (pSong->get_instrument_list())->get( nSelectedInstrument );
-
-			for (int i = 0; i < nPatternSize; i += nResolution) {
+			int nPos;
+			for (int k = 0; nPos < nPatternSize; k++) {
 				const Pattern::notes_t* notes = pCurrentPattern->get_notes();
-				FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {
+				nPos =  round( (float) MAX_NOTES * 4 * k / (nBase * nResolution) );//round for best tuplets approximation.
+				FOREACH_NOTE_CST_IT_BOUND(notes,it,nPos) {
 					Note *pNote = it->second;
 					if ( pNote->get_instrument() == instrRef ) {
 						float fVal = ( rand() % 100 ) / 100.0;
@@ -435,6 +454,7 @@ void InstrumentLine::functionRandomizeVelocity()
 							fVal = 1;
 						}
 						noteVeloValue << QString("%1").arg(fVal);
+						pNote->set_velocity(fVal); // TODO this line was added to make Randomize working for Tuplets (otherwise only some notes are randomized), but it does NOT allow 'UNDO' ACTION! by oddtime
 					}
 				}
 			}

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -112,7 +112,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	__pattern_size_combo = new LCDCombo(pSizeResol, 4);
 	__pattern_size_combo->move( 34, 2 );
 	__pattern_size_combo->setToolTip( trUtf8("Select pattern size") );
-	for ( int i = 1; i <= 32; i++) {
+	for ( int i = 1; i <= 64; i++) {
 		__pattern_size_combo->addItem( QString( "%1" ).arg( i ) );
 	}
 	// is triggered from inside selectedPatternChangedEvent()
@@ -615,7 +615,7 @@ void PatternEditorPanel::selectedPatternChangedEvent()
 
 		// update pattern size combobox
 		int nPatternSize = m_pPattern->get_length();
-		int nEighth = MAX_NOTES / 8;
+		int nEighth = MAX_NOTES / 16;
 		__pattern_size_combo->select( (nPatternSize / nEighth) - 1 );
 	}
 	else {
@@ -799,7 +799,7 @@ void PatternEditorPanel::patternSizeChanged( int nSelected )
 		return;
 	}
 
-	int nEighth = MAX_NOTES / 8;
+	int nEighth = MAX_NOTES / 16;
 
 	if ( !m_bEnablePatternResize ) {
 		__pattern_size_combo->select( ((m_pPattern->get_length() / nEighth) - 1), false );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -615,8 +615,8 @@ void PatternEditorPanel::selectedPatternChangedEvent()
 
 		// update pattern size combobox
 		int nPatternSize = m_pPattern->get_length();
-		int nEighth = MAX_NOTES / 16;
-		__pattern_size_combo->select( (nPatternSize / nEighth) - 1 );
+		int n16th = MAX_NOTES / 16;
+		__pattern_size_combo->select( (nPatternSize / n16th) - 1 );
 	}
 	else {
 		m_pPattern = NULL;
@@ -799,15 +799,15 @@ void PatternEditorPanel::patternSizeChanged( int nSelected )
 		return;
 	}
 
-	int nEighth = MAX_NOTES / 16;
+	int n16th = MAX_NOTES / 16;
 
 	if ( !m_bEnablePatternResize ) {
-		__pattern_size_combo->select( ((m_pPattern->get_length() / nEighth) - 1), false );
+		__pattern_size_combo->select( ((m_pPattern->get_length() / n16th) - 1), false );
 		QMessageBox::information( this, "Hydrogen", trUtf8( "Is not possible to change the pattern size when playing." ) );
 		return;
 	}
 
-	m_pPattern->set_length( nEighth * ( nSelected + 1 ) );
+	m_pPattern->set_length( n16th * ( nSelected + 1 ) );
 
 	m_pPatternEditorRuler->updateEditor( true );	// redraw all
 	m_pNoteVelocityEditor->updateEditor();

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -53,7 +53,7 @@ class PianoRollEditor: public QWidget, public EventListener, public H2Core::Obje
 		virtual void selectedInstrumentChangedEvent();
 		virtual void patternModifiedEvent();
 		//~ Implements EventListener interface
-		void setResolution(uint res, bool bUseTriplets);
+		void setResolution(uint res, bool bUseTriplets, bool bUseQuintuplets, bool bUseSeptuplets, bool bUse9tuplets);
 
 		void zoom_in();
 		void zoom_out();
@@ -92,6 +92,9 @@ class PianoRollEditor: public QWidget, public EventListener, public H2Core::Obje
 		uint m_nResolution;
 		bool m_bRightBtnPressed;
 		bool m_bUseTriplets;
+	  	bool m_bUseQuintuplets;
+	  	bool m_bUseSeptuplets;
+	  	bool m_bUse9tuplets;
 
 		H2Core::Pattern *m_pPattern;
 


### PR DESCRIPTION
Similar to Pull Request #364, applied to v1.0.0beta.

I am new to github, C++, Qt... sorry for any errors, it was a hard job. I hope to help to develop the tuplet feature which is important for many users. 
Thank to all the people behind such a fantastic drum machine.
I am happy to receive feedback, opinions and suggestions.

**Changes made** (compared to #364):
- correct grid visualization
- position of tuplet notes is explicitly rounded, for best approximation (since implicit int cast rounds always down). In my opinion that makes the inexact tuplets a bit more pleasant to hear, at least for quintuplets.
- 'Resolution' is scaled according to the notation rule for the tuplet number (See [https://en.wikipedia.org/wiki/Tuplet]() )
- fixed fillNotes function
- Update velocity randomize

**Still to solve** (help is welcome)
 - velocity randomize function: I can't figure out why the same changes that work for the fillnotes function, are not working for velocity randomize function. So I added a line that does the job but you cannot undo the action.
In file  `src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp` line 457:
`pNote->set_velocity(fVal);`

**Idea for perfect tuplets**
The problem of discrepancy between the ideal exact (non integer) and the rounded (integer) position of notes - due to finite resolution = 48 ticks/quarter which is not multiple of 5,7,9 - may be solved via the leadlag note property...
It would be simpler for me if some H2 expert told me
-how lead lag value acts,
-where in the code,
-how to mod the code so that a wanted leadlag is set together with a new note.

Note: the first two commits are present in my previous pull request too (about pattern size menu, very simple)...