### PR TITLE
Fix copy constructor of `Sample`

### DIFF
--- a/src/core/src/basics/sample.cpp
+++ b/src/core/src/basics/sample.cpp
@@ -69,8 +69,13 @@ Sample::Sample( Sample* pOther ): Object( __class_name ),
 {
 	__data_l = new float[__frames];
 	__data_r = new float[__frames];
-	memcpy( __data_l, pOther->get_data_l(), __frames );
-	memcpy( __data_r, pOther->get_data_r(), __frames );
+	
+	// Since the third argument of memcpy takes the number of bytes,
+	// which are about to be copied, and the data is given in float,
+	// which are  four bytes each, the number of copied frames
+	// `__frames` has to be multiplied by four.
+	memcpy( __data_l, pOther->get_data_l(), __frames * 4 );
+	memcpy( __data_r, pOther->get_data_r(), __frames * 4 );
 
 	PanEnvelope* pPan = pOther->get_pan_envelope();
 	for( int i=0; i<pPan->size(); i++ ) {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3260,11 +3260,10 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool conditional )
 		Instrument *pNewInstr = pDrumkitInstrList->get( nInstr );
 		assert( pNewInstr );
 		INFOLOG( QString( "Loading instrument (%1 of %2) [%3]" )
-				 .arg( nInstr )
+				 .arg( nInstr + 1 )
 				 .arg( pDrumkitInstrList->size() )
 				 .arg( pNewInstr->get_name() ) );
 
-		// creo i nuovi layer in base al nuovo strumento
 		// Moved code from here right into the Instrument class - Jakob Lund.
 		pInstr->load_from( pDrumkitInfo, pNewInstr );
 	}


### PR DESCRIPTION
Since the underlying data is given in float and the number of floats instead of the corresponding number of bytes is handed to the `memcpy` function call, only 25% of the samples have been copied.

This fixes #764.

I'm a little puzzled how this could remain unnoticed.