### PR TITLE
OSC session management

### DIFF
--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -70,17 +70,33 @@ enum EventType {
 	 * decoupled from the creation and queuing of the corresponding
 	 * Note itself.
 	 *
+	 * In Director it triggers a change in the displayed number,
+	 * color, tag, and triggers Director::update(). In case the
+	 * provided value is 3, instead of performing the changes above,
+	 * the Director loads the metadata a the current Song.
+	 *
 	 * The associated values do correspond to the following actions:
 	 * - 0: Beat at the beginning of a Pattern in
 	 *      audioEngine_updateNoteQueue(). The corresponding Note will
 	 *      be created with a pitch of 3 and velocity of 1.0.
+	 *      Sets MetronomeWidget::m_state to
+	 *      MetronomeWidget::METRO_ON and triggers
+	 *      MetronomeWidget::updateWidget().
 	 * - 1: Beat in the remainder of a Pattern in
 	 *      audioEngine_updateNoteQueue(). The corresponding Note will
 	 *      be created with a pitch of 0 and velocity of 0.8. In
 	 *      addition, it will be also pushed by
 	 *      Hydrogen::setPatternPos() without creating a Note.
-	 * - 2:
-	 * - 3:
+	 *      Sets MetronomeWidget::m_state to
+	 *      MetronomeWidget::METRO_FIRST and triggers
+	 *      MetronomeWidget::updateWidget().
+	 * - 2: Signals MetronomeWidget to neither update nor setting
+	 *      MetronomeWidget::m_state.
+	 * - 3: Tells the Director that a new Song was loaded and triggers
+	 *      its Director::update().
+	 *      Sets MetronomeWidget::m_state to
+	 *      MetronomeWidget::METRO_ON and triggers
+	 *      MetronomeWidget::updateWidget().
 	 *
 	 * Handled by EventListener::metronomeEvent().
 	 */
@@ -91,7 +107,12 @@ enum EventType {
 	EVENT_PLAYLIST_LOADSONG,
 	EVENT_UNDO_REDO,
 	EVENT_SONG_MODIFIED,
-	EVENT_TEMPO_CHANGED
+	EVENT_TEMPO_CHANGED,
+	/**
+	 * Event triggered whenever the Song was changed outside of the
+	 * GUI, e.g. by session management or and OSC command.
+	 */
+	EVENT_UPDATE_SONG
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -109,13 +109,21 @@ enum EventType {
 	EVENT_SONG_MODIFIED,
 	EVENT_TEMPO_CHANGED,
 	/**
-	 * Event triggered whenever the Song was changed outside of the
-	 * GUI, e.g. by session management or and OSC command.
+	 * Event triggering HydrogenApp::updateSongEvent() whenever the
+	 * Song was changed outside of the GUI, e.g. by session management
+	 * or and OSC command.
 	 *
-	 * If the value of the event is 1, HydrogenApp::updateSongEvent()
-	 * will load the #Song prepared in Hydrogen::m_pNextSong.
+	 * If the value of the event is 
+	 * - 0 - Hydrogen::m_pNextSong will be loaded.
+	 * - 1 - triggered whenever the #Song was saved via the core part
+	 *       (updated the title and status bar).
 	 */
-	EVENT_UPDATE_SONG
+	EVENT_UPDATE_SONG,
+	/**
+	 * Triggering HydrogenApp::quitEvent() and enables a shutdown of
+	 * the entire application via the command line.
+	 */
+	EVENT_QUIT
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -111,6 +111,9 @@ enum EventType {
 	/**
 	 * Event triggered whenever the Song was changed outside of the
 	 * GUI, e.g. by session management or and OSC command.
+	 *
+	 * If the value of the event is 1, HydrogenApp::updateSongEvent()
+	 * will load the #Song prepared in Hydrogen::m_pNextSong.
 	 */
 	EVENT_UPDATE_SONG
 };

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -418,7 +418,7 @@ void			previewSample( Sample *pSample );
 	int				getSelectedPatternNumber();
 	/**
 	 * Sets #m_nSelectedPatternNumber.
-	 *f
+	 *
 	 * If Preferences::m_pPatternModePlaysSelected is set to true, the
 	 * AudioEngine is locked before @a nPat will be assigned. But in
 	 * any case the function will push the
@@ -532,6 +532,7 @@ void			previewSample( Sample *pSample );
 	 * \return Speed in beats per minute.
 	 */
 	float			getTimelineBpm( int Beat );
+	/** \return #m_pTimeline*/
 	Timeline*		getTimeline() const;
 	
 	//export management
@@ -575,6 +576,17 @@ void			previewSample( Sample *pSample );
 	 */
 	void			loadPlaybackTrack( const QString filename );
 
+	/**\return #m_bActiveGUI*/
+	bool			getActiveGUI() const;
+	/**\param bActiveGUI Specifies whether the Qt5 GUI is active. Sets
+	   #m_bActiveGUI.*/
+	void			setActiveGUI( const bool bActiveGUI );
+	
+	/**\return #m_pNextSong*/
+	Song*			getNextSong() const;
+	/**\param pNextSong Sets #m_pNextSong. #Song which is about to be
+	   loaded by the GUI.*/
+	void			setNextSong( Song* pNextSong );
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
@@ -632,6 +644,28 @@ private:
 	bool			m_bOldLoopEnabled;
 	bool			m_bExportSessionIsActive;
 	
+	/**
+	 * Specifies whether the Qt5 GUI is active.
+	 *
+	 * When a new #Song is set via the core part of Hydrogen, e.g. in
+	 * the context of session management, the #Song *must* be set via
+	 * the GUI if active. Else the GUI will freeze.
+	 *
+	 * Set by setActiveGUI() and accessed via getActiveGUI().
+	 */
+	bool			m_bActiveGUI;
+	
+	/**
+	 * Stores a new #Song which is about of the loaded by the GUI.
+	 *
+	 * If #m_bActiveGUI is true, the core part of must not load a new
+	 * #Song itself. Instead, the new #Song is prepared and stored in
+	 * this object to be loaded by HydrogenApp::updateSongEvent() if
+	 * H2Core::EVENT_UPDATE_SONG is pushed with a '1'.
+	 *
+	 * Set by setNextSong() and accessed via getNextSong().
+	 */
+	Song*			m_pNextSong;
 
 	/**
 	 * Local instance of the Timeline object.
@@ -722,6 +756,18 @@ inline bool Hydrogen::getPlaybackTrackState()
 	return 	bState;
 }
 
+inline bool Hydrogen::getActiveGUI() const {
+	return m_bActiveGUI;
+}
+inline void Hydrogen::setActiveGUI( const bool bActiveGUI ) {
+	m_bActiveGUI = bActiveGUI;
+}
+inline Song* Hydrogen::getNextSong() const {
+	return m_pNextSong;
+}
+inline void Hydrogen::setNextSong( Song* pNextSong ) {
+	m_pNextSong = pNextSong;
+}
 
 };
 

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -77,12 +77,31 @@ class MidiActionManager : public H2Core::Object
 		 */
 		static MidiActionManager *__instance;
 
+		/**
+		 * Holds the names of all Action identfiers which Hydrogen is
+		 * able to interpret.
+		 */
 		QStringList actionList;
+
+		/**
+		 * Contains all information to find a particular object in a
+		 * list of objects, like an effect among all LADSPA effects
+		 * present or an individual sample.
+		 */
 		struct targeted_element {
+			/**First level index, like the ID of an Effect or and InstrumentComponent.*/
 			int _id;
+			/**Second level index, like the ID of an InstrumentLayer.*/
 			int _subId;
 		};
+
 		typedef bool (MidiActionManager::*action_f)(Action * , H2Core::Hydrogen * , targeted_element );
+		/**
+		 * Holds all Action identifiers which Hydrogen is able to
+		 * interpret.  
+		 *
+		 * It holds pointer to member function.
+		 */
 		map<string, pair<action_f, targeted_element> > actionMap;
 
 		bool play(Action * , H2Core::Hydrogen * , targeted_element );
@@ -131,11 +150,69 @@ class MidiActionManager : public H2Core::Object
 		bool gain_level_absolute(Action * , H2Core::Hydrogen * , targeted_element );
 		bool pitch_level_absolute(Action * , H2Core::Hydrogen * , targeted_element );
 
+		// Actions required for session management.
+		/**
+		 * Opens an empty Song and saves it to the path provided in
+		 * @a pAction.
+		 *
+		 * \param pAction Action "NEW_SONG" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool new_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Opens the Song specified in the path provided in @a
+		 * pAction.
+		 *
+		 * This will be done without immediately and without saving
+		 * the current Song. All unsaved changes will be lost!
+		 *
+		 * \param pAction Action "OPEN_SONG" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool open_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Saves the current Song.
+		 *
+		 * \param pAction Action "SAVE_SONG" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool save_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Saves the current Song to the path provided in @a pAction.
+		 *
+		 * \param pAction Action "SAVE_SONG_AS" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool save_song_as(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Triggers the shutdown of Hydrogen.
+		 *
+		 * \param pAction Action "QUIT" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool quit(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+
 		QStringList eventList;
 
 		int m_nLastBpmChangeCCParameter;
 
 	public:
+
+		/**
+		 * The handleAction method is the heart of the
+		 * MidiActionManager class. It executes the operations that
+		 * are needed to carry the desired action.
+		 */
 		bool handleAction( Action * );
 		/**
 		 * If #__instance equals 0, a new MidiActionManager

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -249,6 +249,19 @@ class MidiActionManager : public H2Core::Object
 
 		int m_nLastBpmChangeCCParameter;
 
+		/**
+		 * Checks the path of the .h2song provided via OSC.
+		 *
+		 * It will be checked whether @a songPath
+		 * - is absolute
+		 * - has the '.h2song' suffix
+		 * - is writable (if it exists)
+		 *
+		 * \param songPath Absolute path to an .h2song file.
+		 * \return true - if valid.
+		 */
+		bool isSongPathValid( const QString& songPath );
+
 	public:
 
 		/**

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -152,8 +152,23 @@ class MidiActionManager : public H2Core::Object
 
 		// Actions required for session management.
 		/**
-		 * Opens an empty Song and saves it to the path provided in
-		 * @a pAction.
+		 * Create an empty Song which will be stored at to the path
+		 * provided in @a pAction.
+		 *
+		 * This will be done without immediately and without saving
+		 * the current #Song. All unsaved changes will be lost! In
+		 * addition, the new Song won't be saved by this function. You
+		 * can do so using save_song().
+		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
+		 *
+		 * Right now the function is only able to handle the provided
+		 * path as is. Therefore it is important to provide an absolute
+		 * path to a .h2song file.
 		 *
 		 * \param pAction Action "NEW_SONG" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
@@ -166,7 +181,17 @@ class MidiActionManager : public H2Core::Object
 		 * pAction.
 		 *
 		 * This will be done without immediately and without saving
-		 * the current Song. All unsaved changes will be lost!
+		 * the current #Song. All unsaved changes will be lost!
+		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
+		 *
+		 * Right now the function is only able to handle the provided
+		 * path as is. Therefore it is important to provide an absolute
+		 * path to a .h2song file.
 		 *
 		 * \param pAction Action "OPEN_SONG" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
@@ -175,7 +200,13 @@ class MidiActionManager : public H2Core::Object
 		 */
 		bool open_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
 		/**
-		 * Saves the current Song.
+		 * Saves the current #Song.
+		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
 		 *
 		 * \param pAction Action "SAVE_SONG" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
@@ -186,6 +217,12 @@ class MidiActionManager : public H2Core::Object
 		/**
 		 * Saves the current Song to the path provided in @a pAction.
 		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
+		 *
 		 * \param pAction Action "SAVE_SONG_AS" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
 		 * \param element Unused.
@@ -194,6 +231,12 @@ class MidiActionManager : public H2Core::Object
 		bool save_song_as(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
 		/**
 		 * Triggers the shutdown of Hydrogen.
+		 *
+		 * This will be done without immediately and without saving
+		 * the current #Song. All unsaved changes will be lost!
+		 *
+		 * The shutdown will only be triggered if
+		 * Hydrogen::m_bActiveGUI is true and the Qt5 GUI is present.
 		 *
 		 * \param pAction Action "QUIT" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.

--- a/src/core/include/hydrogen/nsm_client.h
+++ b/src/core/include/hydrogen/nsm_client.h
@@ -71,6 +71,13 @@ class NsmClient : public H2Core::Object
 
 		void shutdown();
 
+		/**
+		 * To determine whether Hydrogen is under Non session management,
+		 * it is not sufficient to check whether the NSM_URL environmental
+		 * variable is set but also whether. 
+		 */
+		bool m_bUnderSessionManagement;
+
 	private:
 		NsmClient();
 

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -163,6 +163,15 @@ class OscServer : public H2Core::Object
 		 * - PLAYLIST_SONG_Handler()
 		 * - SELECT_INSTRUMENT_Handler()
 		 *
+		 * In case of the session managing handlers the following ones
+		 * only work with no argument present
+		 * - SAVE_SONG_Handler()
+		 * - QUIT_Handler()
+		 * and others only work by supplying a string "s" type message
+		 * - NEW_SONG_Handler()
+		 * - OPEN_SONG_Handler()
+		 * - SAVE_SONG_AS_Handler()
+		 *
 		 * The generic_handler() will be registered to match all paths
 		 * and types.
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -572,6 +572,10 @@ class OscServer : public H2Core::Object
 		 * Creates an Action of type @b NEW_SONG and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2song file. If another file already exists with the
+		 * same name, it will be overwritten.
+		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
 		 * \param argc Number of arguments passed by the OSC message.
@@ -580,6 +584,9 @@ class OscServer : public H2Core::Object
 		/**
 		 * Creates an Action of type @b OPEN_SONG and passes its
 		 * references to MidiActionManager::handleAction().
+		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2song file.
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
@@ -598,6 +605,10 @@ class OscServer : public H2Core::Object
 		/**
 		 * Creates an Action of type @b SAVE_SONG_AS and passes its
 		 * references to MidiActionManager::handleAction().
+		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2song file. If another file already exists with the
+		 * same name, it will be overwritten.
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -592,27 +592,27 @@ class OscServer : public H2Core::Object
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
-		static void SAVE_SONG_Handler(lo_arg **argv, int i);
+		static void SAVE_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b SAVE_SONG_AS and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Number of arguments passed by the OSC
 		 * message.*/
-		static void SAVE_SONG_AS_Handler(lo_arg **argv, int i);
+		static void SAVE_SONG_AS_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b QUIT and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
-		static void QUIT_Handler(lo_arg **argv, int i);
+		static void QUIT_Handler(lo_arg **argv, int argc);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -150,7 +150,7 @@ class OscServer : public H2Core::Object
 		 * will thus be registered to \e /Hydrogen/PLAY.
 		 *
 		 * Most handler will be registered for both types "" and "f"
-		 * (floats). But the following handlers will be registered fro
+		 * (floats). But the following handlers will be registered for
 		 * floats only:
 		 * - BPM_DECR_Handler()
 		 * - BPM_INCR_Handler()
@@ -568,6 +568,51 @@ class OscServer : public H2Core::Object
 		 * \param i Unused number of arguments passed by the OSC
 		 * message.*/
 		static void REDO_ACTION_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b NEW_SONG and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void NEW_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b OPEN_SONG and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void OPEN_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SAVE_SONG and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void SAVE_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SAVE_SONG_AS and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void SAVE_SONG_AS_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b QUIT and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void QUIT_Handler(lo_arg **argv, int i);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -565,27 +565,27 @@ class OscServer : public H2Core::Object
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Number of arguments passed by the OSC
 		 * message.*/
-		static void REDO_ACTION_Handler(lo_arg **argv, int i);
+		static void REDO_ACTION_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b NEW_SONG and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
-		 * message.*/
-		static void NEW_SONG_Handler(lo_arg **argv, int i);
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void NEW_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b OPEN_SONG and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
-		 * message.*/
-		static void OPEN_SONG_Handler(lo_arg **argv, int i);
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void OPEN_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b SAVE_SONG and passes its
 		 * references to MidiActionManager::handleAction().

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -412,7 +412,25 @@ int				audioEngine_start( bool bLockEngine = false, unsigned nTotalFrames = 0 );
  *   did already locked it.
  */
 void				audioEngine_stop( bool bLockEngine = false );
+/**
+ * Updates the global objects of the audioEngine according to new #Song.
+ *
+ * Calls audioEngine_setupLadspaFX() on
+ * m_pAudioDriver->getBufferSize(),
+ * audioEngine_process_checkBPMChanged(),
+ * audioEngine_renameJackPorts(), adds its first pattern to
+ * #m_pPlayingPatterns, relocates the audio driver to the beginning of
+ * the #Song, and updates the BPM.
+ *
+ * \param pNewSong #Song to load.
+ */
 void				audioEngine_setSong(Song *pNewSong );
+/**
+ * Does the necessary cleanup of the global objects in the audioEngine.
+ *
+ * Class the clear() member of #m_pPlayingPatterns and
+ * #m_pNextPatterns as well as audioEngine_clearNoteQueue();
+ */
 void				audioEngine_removeSong();
 static void			audioEngine_noteOn( Note *note );
 
@@ -1284,6 +1302,7 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	// transport position if it was changed by an user interaction
 	// (e.g. clicking on the timeline).
 	audioEngine_process_transport();
+	
 
 	// ___INFOLOG( QString( "[after process] status: %1, frame: %2, ticksize: %3, bpm: %4" )
 	// 	    .arg( m_pAudioDriver->m_transport.m_status )
@@ -1307,6 +1326,7 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 			 || ( m_pAudioDriver->class_name() == FakeDriver::class_name() )
 			 ) {
 			___INFOLOG( "End of song." );
+			
 			return 1;	// kill the audio AudioDriver thread
 		}
 
@@ -1318,7 +1338,6 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 			static_cast<JackAudioDriver*>(m_pAudioDriver)->locateInNCycles( 0 );
 		}
 #endif
-
 		return 0;
 	} else if ( res2 == 2 ) { // send pattern change
 		sendPatternChange = true;
@@ -1445,7 +1464,6 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	if ( sendPatternChange ) {
 		EventQueue::get_instance()->push_event( EVENT_PATTERN_CHANGED, -1 );
 	}
-
 	return 0;
 }
 
@@ -1500,7 +1518,7 @@ void audioEngine_renameJackPorts(Song * pSong)
 #endif
 }
 
-void audioEngine_setSong( Song * pNewSong )
+void audioEngine_setSong( Song* pNewSong )
 {
 	___WARNINGLOG( QString( "Set song: %1" ).arg( pNewSong->__name ) );
 
@@ -1555,7 +1573,6 @@ void audioEngine_removeSong()
 
 	m_pPlayingPatterns->clear();
 	m_pNextPatterns->clear();
-
 	audioEngine_clearNoteQueue();
 
 	// change the current audio engine state
@@ -2482,8 +2499,8 @@ void Hydrogen::loadPlaybackTrack( const QString filename )
 void Hydrogen::setSong( Song *pSong )
 {
 	assert ( pSong );
-
-	/* Set first pattern */
+	
+	// Move to the beginning.
 	setSelectedPatternNumber( 0 );
 
 	Song* pCurrentSong = getSong();
@@ -2493,12 +2510,11 @@ void Hydrogen::setSong( Song *pSong )
 	}
 
 	if ( pCurrentSong ) {
-
-		AudioEngine::get_instance()->lock( RIGHT_HERE );
 		
+		AudioEngine::get_instance()->lock( RIGHT_HERE );
 		delete pCurrentSong;
 		pCurrentSong = nullptr;
-		
+
 		AudioEngine::get_instance()->unlock();
 
 		/* NOTE: 
@@ -2519,12 +2535,15 @@ void Hydrogen::setSong( Song *pSong )
 	// audioEngine_setSong().
 	__song = pSong;
 
+	
 	// Update the audio engine to work with the new song.
 	audioEngine_setSong( pSong );
 
 	// load new playback track information
 	AudioEngine::get_instance()->get_sampler()->reinitialize_playback_track();
 	
+	// Push current state of Hydrogen to attached control interfaces,
+	// like OSC clients.
 	m_pCoreActionController->initExternalControlInterfaces();
 }
 

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -36,6 +36,8 @@
 #include <hydrogen/Preferences.h>
 #include <hydrogen/midi_action.h>
 
+#include <hydrogen/basics/drumkit.h>
+
 #include <sstream>
 
 using namespace H2Core;
@@ -119,6 +121,7 @@ MidiActionManager::MidiActionManager() : Object( __class_name ) {
 	actionMap.insert(make_pair("MASTER_VOLUME_ABSOLUTE", make_pair(&MidiActionManager::master_volume_absolute, empty)));
 	actionMap.insert(make_pair("STRIP_VOLUME_RELATIVE", make_pair(&MidiActionManager::strip_volume_relative, empty)));
 	actionMap.insert(make_pair("STRIP_VOLUME_ABSOLUTE", make_pair(&MidiActionManager::strip_volume_absolute, empty)));
+	
 	for(int i = 0; i < MAX_FX; ++i) {
 		targeted_element effect = {i,0};
 		ostringstream toChar;
@@ -172,8 +175,14 @@ MidiActionManager::MidiActionManager() : Object( __class_name ) {
 	actionMap.insert(make_pair("UNDO_ACTION", make_pair(&MidiActionManager::undo_action, empty)));
 	actionMap.insert(make_pair("REDO_ACTION", make_pair(&MidiActionManager::redo_action, empty)));
 
+	// Adding actions required for session management
+	actionMap.insert(make_pair("NEW_SONG", make_pair(&MidiActionManager::new_song, empty)));
+	actionMap.insert(make_pair("OPEN_SONG", make_pair(&MidiActionManager::open_song, empty)));
+	actionMap.insert(make_pair("SAVE_SONG", make_pair(&MidiActionManager::save_song, empty)));
+	actionMap.insert(make_pair("SAVE_SONG_AS", make_pair(&MidiActionManager::save_song_as, empty)));
+	actionMap.insert(make_pair("QUIT", make_pair(&MidiActionManager::quit, empty)));
 	/*
-		the actionList holds all Action identfiers which hydrogen is able to interpret.
+	  the actionList holds all Action identfiers which hydrogen is able to interpret.
 	*/
 	actionList <<"";
 	for(map<string, pair<action_f, targeted_element> >::const_iterator actionIterator = actionMap.begin();
@@ -953,10 +962,31 @@ bool MidiActionManager::redo_action(Action * , Hydrogen* , targeted_element ) {
 	return true;
 }
 
-/**
- * The handleAction method is the heart of the MidiActionManager class.
- * It executes the operations that are needed to carry the desired action.
- */
+bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[new_song]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[open_song]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[save_song]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[save_song_as]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::quit(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[quit]" << std::endl;
+	return true;
+}
+
 bool MidiActionManager::handleAction( Action * pAction ) {
 
 	Hydrogen *pEngine = Hydrogen::get_instance();

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -1036,6 +1036,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	QFileInfo songFileInfo = QFileInfo( songPath );
 	if ( !songFileInfo.exists() ) {
 		std::cout << "Error: Selected Song does not exist!" << std::endl;
+		return false;
 	}
 	
 	// Create an empty Song.

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -989,8 +989,6 @@ bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_
 	
 	pSong->set_filename( songPath );
 	
-	std::cout << "[new_song] songPath: " << songPath.toLocal8Bit().data() << std::endl;
-	
 	if ( pHydrogen->getActiveGUI() ) {
 		
 		// Store the prepared Song for the GUI to access after the
@@ -1001,7 +999,7 @@ bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_
 		// core part itself.
 		// Triggers an update of the Qt5 GUI and tells it to update
 		// the song itself.
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
 		
 	} else {
 
@@ -1048,8 +1046,6 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		return false;
 	}
 	
-	std::cout << "[open_song] songPath: " << songPath.toLocal8Bit().data() << std::endl;
-	
 	if ( pHydrogen->getActiveGUI() ) {
 		
 		// Store the prepared Song for the GUI to access after the
@@ -1073,8 +1069,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 }
 
 bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
-	std::cout << "[save_song]" << std::endl;
-	
+
 	// Get the current Song which is about to be saved.
 	Song* pSong = pHydrogen->getSong();
 	
@@ -1106,8 +1101,6 @@ bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted
 }
 
 bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
-	std::cout << "[save_song_as]" << std::endl;
-	
 	// Get the current Song which is about to be saved.
 	Song* pSong = pHydrogen->getSong();
 	
@@ -1143,8 +1136,6 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 }
 
 bool MidiActionManager::quit(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
-	
-	std::cout << "[quit]" << std::endl;
 	
 	// Update the status bar.
 	if ( pHydrogen->getActiveGUI() ) {

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -97,6 +97,7 @@ NsmClient::NsmClient()
 	: Object( __class_name )
 {
 	m_NsmThread = 0;
+	m_bUnderSessionManagement = false;
 }
 
 void NsmClient::create_instance()
@@ -148,6 +149,10 @@ void NsmClient::createInitialClient()
 					___ERRORLOG("Error creating NSM thread\n	");
 					return;
 				}
+				
+				// Everything worked fine and H2 can now be considered
+				// under session management.
+				m_bUnderSessionManagement = true;
 
 			}
 			else

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -560,6 +560,42 @@ void OscServer::REDO_ACTION_Handler(lo_arg **argv,int i)
 	pActionManager->handleAction( &currentAction );
 }
 
+// Actions required for session management.
+void OscServer::NEW_SONG_Handler(lo_arg **argv, int i) {
+	Action currentAction("NEW_SONG");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::OPEN_SONG_Handler(lo_arg **argv, int i) {
+	Action currentAction("OPEN_SONG");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::SAVE_SONG_Handler(lo_arg **argv, int i) {
+	Action currentAction("SAVE_SONG");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int i) {
+	Action currentAction("SAVE_SONG_AS");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::QUIT_Handler(lo_arg **argv, int i) {
+	Action currentAction("QUIT");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
 bool IsLoAddressEqual( lo_address first, lo_address second )
 {
 	bool portEqual = ( strcmp( lo_address_get_port( first ), lo_address_get_port( second ) ) == 0);
@@ -820,7 +856,18 @@ void OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/UNDO_ACTION", "f", UNDO_ACTION_Handler);
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "", REDO_ACTION_Handler);
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "f", REDO_ACTION_Handler);
-	
+
+	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "", NEW_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "f", NEW_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "", OPEN_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "f", OPEN_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "f", SAVE_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "", SAVE_SONG_AS_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "f", SAVE_SONG_AS_Handler);
+	m_pServerThread->add_method("/Hydrogen/QUIT", "", QUIT_Handler);
+	m_pServerThread->add_method("/Hydrogen/QUIT", "f", QUIT_Handler);
+
 	/*
 	 * Start the server.
 	 */
@@ -828,6 +875,7 @@ void OscServer::start()
 
 
 	INFOLOG(QString("Osc server started. Listening on port %1").arg( m_pPreferences->getOscServerPort() ));
+	
 }
 
 OscServer::~OscServer()

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -576,28 +576,44 @@ void OscServer::NEW_SONG_Handler(lo_arg **argv, int argc) {
 	}
 }
 
-void OscServer::OPEN_SONG_Handler(lo_arg **argv, int i) {
+void OscServer::OPEN_SONG_Handler(lo_arg **argv, int argc) {
 	Action currentAction("OPEN_SONG");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+
+	// Accessing the provided path for the new Song.
+	if ( argc > 0 ) {
+		currentAction.setParameter1( QString::fromUtf8( &argv[0]->s ) );
+		pActionManager->handleAction(&currentAction);
+	} else {
+		// This shouldn't be happening since the handler function is
+		// only registered with an "s" lo_type argument.
+	}
 	
 	pActionManager->handleAction(&currentAction);
 }
 
-void OscServer::SAVE_SONG_Handler(lo_arg **argv, int i) {
+void OscServer::SAVE_SONG_Handler(lo_arg **argv, int argc) {
 	Action currentAction("SAVE_SONG");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 	
 	pActionManager->handleAction(&currentAction);
 }
 
-void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int i) {
+void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int argc) {
 	Action currentAction("SAVE_SONG_AS");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
-	
-	pActionManager->handleAction(&currentAction);
+
+	// Accessing the provided path for the new Song.
+	if ( argc > 0 ) {
+		currentAction.setParameter1( QString::fromUtf8( &argv[0]->s ) );
+		pActionManager->handleAction(&currentAction);
+	} else {
+		// This shouldn't be happening since the handler function is
+		// only registered with an "s" lo_type argument.
+	}
 }
 
-void OscServer::QUIT_Handler(lo_arg **argv, int i) {
+void OscServer::QUIT_Handler(lo_arg **argv, int argc) {
 	Action currentAction("QUIT");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 	
@@ -866,14 +882,10 @@ void OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "f", REDO_ACTION_Handler);
 
 	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "s", NEW_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "", OPEN_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "f", OPEN_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "s", OPEN_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "f", SAVE_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "", SAVE_SONG_AS_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "f", SAVE_SONG_AS_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "s", SAVE_SONG_AS_Handler);
 	m_pServerThread->add_method("/Hydrogen/QUIT", "", QUIT_Handler);
-	m_pServerThread->add_method("/Hydrogen/QUIT", "f", QUIT_Handler);
 
 	/*
 	 * Start the server.

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -561,11 +561,19 @@ void OscServer::REDO_ACTION_Handler(lo_arg **argv,int i)
 }
 
 // Actions required for session management.
-void OscServer::NEW_SONG_Handler(lo_arg **argv, int i) {
-	Action currentAction("NEW_SONG");
-	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+void OscServer::NEW_SONG_Handler(lo_arg **argv, int argc) {
 	
-	pActionManager->handleAction(&currentAction);
+	Action currentAction("NEW_SONG");	
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+
+	// Accessing the provided path for the new Song.
+	if ( argc > 0 ) {
+		currentAction.setParameter1( QString::fromUtf8( &argv[0]->s ) );
+		pActionManager->handleAction(&currentAction);
+	} else {
+		// This shouldn't be happening since the handler function is
+		// only registered with an "s" lo_type argument.
+	}
 }
 
 void OscServer::OPEN_SONG_Handler(lo_arg **argv, int i) {
@@ -857,8 +865,7 @@ void OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "", REDO_ACTION_Handler);
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "f", REDO_ACTION_Handler);
 
-	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "", NEW_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "f", NEW_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "s", NEW_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "", OPEN_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "f", OPEN_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -45,6 +45,7 @@ class EventListener
 		virtual void undoRedoActionEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void tempoChangedEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void updateSongEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void quitEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -44,6 +44,7 @@ class EventListener
 		virtual void playlistLoadSongEvent( int nIndex ){ UNUSED( nIndex ); }
 		virtual void undoRedoActionEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void tempoChangedEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void updateSongEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -115,6 +115,11 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 
 	m_pPlaylistDialog = new PlaylistDialog( nullptr );
 	m_pDirector = new Director( nullptr );
+	
+	// Since HydrogenApp does implement some handler functions for
+	// Events as well, it should be registered as an Eventlistener
+	// itself.
+	addEventListener( this );
 }
 
 
@@ -477,6 +482,11 @@ void HydrogenApp::onEventQueueTimer()
 
 	Event event;
 	while ( ( event = pQueue->pop_event() ).type != EVENT_NONE ) {
+		
+		// Provide the event to all EventListeners registered to
+		// HydrogenApp. By registering itself as EventListener and
+		// implementing at least on the methods used below a
+		// particular GUI component can react on specific events.
 		for (int i = 0; i < (int)m_EventListeners.size(); i++ ) {
 			EventListener *pListener = m_EventListeners[ i ];
 
@@ -554,20 +564,18 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 				
 			case EVENT_UPDATE_SONG:
-				std::cout << "[onEventQueueTimer] EVENT_UPDATE_SONG" << std::endl;
-				updateSongEvent( event.value );
+				pListener->updateSongEvent( event.value );
 				break;
 				
 			case EVENT_QUIT:
-				std::cout << "[onEventQueueTimer] EVENT_QUIT" << std::endl;
-				quitEvent( event.value );
+				pListener->quitEvent( event.value );
 				break;
 
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}
-
 		}
+
 	}
 
 	// midi notes
@@ -628,8 +636,6 @@ void HydrogenApp::cleanupTemporaryFiles()
 
 void HydrogenApp::updateSongEvent( int nValue ) {
 	
-	std::cout << "[updateSong] start" << std::endl;
-	
 	Hydrogen* pHydrogen = Hydrogen::get_instance();	
 
 	if ( nValue == 0 ) {
@@ -673,8 +679,6 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 
 void HydrogenApp::quitEvent( int nValue ) {
 
-	std::cout << "[quitEvent] start" << std::endl;
-	
 	m_pMainForm->closeAll();
 	
 }

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -504,7 +504,7 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 
 			case EVENT_SONG_MODIFIED:
-				songModifiedEvent();
+				pListener->songModifiedEvent();
 				break;
 
 			case EVENT_SELECTED_PATTERN_CHANGED:

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -69,7 +69,7 @@ class SampleEditor;
 class Director;
 class InfoBar;
 
-class HydrogenApp : public QObject, public H2Core::Object
+class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 {
 		H2_OBJECT
 	Q_OBJECT

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -221,6 +221,12 @@ class HydrogenApp : public QObject, public H2Core::Object
 		 * \param nValue unused
 		 */
 		virtual void updateSongEvent( int nValue );
+		/**
+		 * Calls closeAll() to shutdown Hydrogen.
+		 *
+		 * \param nValue unused
+		 */
+		virtual void quitEvent( int nValue );
 };
 
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -167,8 +167,8 @@ class HydrogenApp : public QObject, public H2Core::Object
 		     EventListener::undoRedoActionEvent()
 		 * - H2Core::EVENT_TEMPO_CHANGED -> 
 		     EventListener::tempoChangedEvent()
-		 * - H2Core::EVENT_MISMATCHING_SAMPLE_RATE -> 
-		     EventListener::mismatchingSampleRateEvent()
+		 * - H2Core::EVENT_UPDATE_SONG -> 
+		     EventListener::updateSongEvent()
 		 * - H2Core::EVENT_NONE -> nothing
 		 *
 		 * In addition, all MIDI notes in
@@ -178,7 +178,6 @@ class HydrogenApp : public QObject, public H2Core::Object
 		*/
 		void onEventQueueTimer();
 		void currentTabChanged(int);
-
 
 	private:
 		static HydrogenApp *		m_pInstance;	///< HydrogenApp instance
@@ -210,6 +209,18 @@ class HydrogenApp : public QObject, public H2Core::Object
 
 		void setupSinglePanedInterface();
 		virtual void songModifiedEvent();
+
+		/**
+		 * Refreshes and updates the GUI after the Song was changed in
+		 * the core part of Hydrogen.
+		 *
+		 * When using session management or changing the Song using
+		 * an OSC message, this command will get core and GUI in sync
+		 * again. 
+		 *
+		 * \param nValue unused
+		 */
+		virtual void updateSongEvent( int nValue );
 };
 
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -138,6 +138,7 @@ public slots:
 		void action_toggle_input_mode();
 
 		void handleSigUsr1();
+		void closeAll();
 
 	private slots:
 		void onAutoSaveTimer();
@@ -181,7 +182,6 @@ public slots:
 		/** Create the menubar */
 		void createMenuBar();
 
-		void closeAll();
 		void openSongFile( const QString& sFilename );
 		void checkMidiSetup();
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -368,6 +368,9 @@ int main(int argc, char *argv[])
 
 		// Hydrogen here to honor all preferences.
 		H2Core::Hydrogen::create_instance();
+		
+		// Tell Hydrogen it was started via the QT5 GUI.
+		H2Core::Hydrogen::get_instance()->setActiveGUI( true );
 
 #ifdef H2CORE_HAVE_OSC
 		H2Core::Hydrogen::get_instance()->startNsmClient();


### PR DESCRIPTION
I'm working on a proper reimplementation of the NSM (Non Session Management) since in its current state it is not working at all. But I thought instead of implementing all the required handlers in some NSM specific classes and introduce even more redundancy in the code, I created some more general OSC handlers taking care of all the basic functionality.

You can now use these five new messages to control Hydrogen via the command line
`oscsend localhost 19462 /Hydrogen/NEW_SONG s "$HOME/test.h2song"`
`oscsend localhost 19462 /Hydrogen/OPEN_SONG s "$HOME/test.h2song"`
`oscsend localhost 19462 /Hydrogen/SAVE_SONG`
`oscsend localhost 19462 /Hydrogen/SAVE_SONG_AS s "$HOME/test.h2song"`
`oscsend localhost 19462 /Hydrogen/QUIT_SONG`

This can become very handy in case we plan to revive the CLI.

## Notes about the implementation
I introduced two variable specifying whether Hydrogen is under session management and if the Qt5 GUI is active. If the latter is true, the new `Song` **must** be set via the GUI itself or it will freeze. To support this, another `Event` called `EVENT_UPDATE_SONG` was introduced. 

Shutting down the application is only handled by the GUI right now using the `EVENT_QUIT` `Event`. 

I also found a bug in the `Event` dispatcher `HydrogenApp::onEventQueueTimer()`. Since `HydrogenApp` was not itself added as an `EventListener` all its methods implementing the `EventListener` were called as many times as `EventListener`s enrolled.