### PR TITLE
Add option to fill with syncopated notes

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -109,6 +109,12 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 	m_pFunctionPopupSub->addAction( tr( "Fill 1/8 notes" ), this, SLOT( functionFillEveryEightNotes() ) );
 	m_pFunctionPopupSub->addAction( tr( "Fill 1/12 notes" ), this, SLOT( functionFillEveryTwelveNotes() ) );
 	m_pFunctionPopupSub->addAction( tr( "Fill 1/16 notes" ), this, SLOT( functionFillEverySixteenNotes() ) );
+	m_pFunctionPopupSub->addAction( tr( "Fill 1/2 notes (syncopated)" ), this, SLOT( functionFillEveryTwoNotesSyncopated() ) );
+	m_pFunctionPopupSub->addAction( tr( "Fill 1/4 notes (syncopated)" ), this, SLOT( functionFillEveryFourNotesSyncopated() ) );
+	m_pFunctionPopupSub->addAction( tr( "Fill 1/6 notes (syncopated)" ), this, SLOT( functionFillEverySixNotesSyncopated() ) );
+	m_pFunctionPopupSub->addAction( tr( "Fill 1/8 notes (syncopated)" ), this, SLOT( functionFillEveryEightNotesSyncopated() ) );
+	m_pFunctionPopupSub->addAction( tr( "Fill 1/12 notes (syncopated)" ), this, SLOT( functionFillEveryTwelveNotesSyncopated() ) );
+	m_pFunctionPopupSub->addAction( tr( "Fill 1/16 notes (syncopated)" ), this, SLOT( functionFillEverySixteenNotesSyncopated() ) );
 	m_pFunctionPopup->addMenu( m_pFunctionPopupSub );
 
 	m_pFunctionPopup->addAction( tr( "Randomize velocity" ), this, SLOT( functionRandomizeVelocity() ) );
@@ -337,7 +343,14 @@ void InstrumentLine::functionFillEveryEightNotes(){ functionFillNotes(8); }
 void InstrumentLine::functionFillEveryTwelveNotes(){ functionFillNotes(12); }
 void InstrumentLine::functionFillEverySixteenNotes(){ functionFillNotes(16); }
 
-void InstrumentLine::functionFillNotes( int every )
+void InstrumentLine::functionFillEveryTwoNotesSyncopated(){ functionFillNotes(2,true); }
+void InstrumentLine::functionFillEveryFourNotesSyncopated(){ functionFillNotes(4,true); }
+void InstrumentLine::functionFillEverySixNotesSyncopated(){ functionFillNotes(6,true); }
+void InstrumentLine::functionFillEveryEightNotesSyncopated(){ functionFillNotes(8,true); }
+void InstrumentLine::functionFillEveryTwelveNotesSyncopated(){ functionFillNotes(12,true); }
+void InstrumentLine::functionFillEverySixteenNotesSyncopated(){ functionFillNotes(16,true); }
+
+void InstrumentLine::functionFillNotes( int every, bool syncopated )
 {
 	Hydrogen *pEngine = Hydrogen::get_instance();
 
@@ -351,7 +364,7 @@ void InstrumentLine::functionFillNotes( int every )
 		nBase = 4;
 	}
 	int nResolution = 4 * MAX_NOTES * every / ( nBase * pPatternEditor->getResolution() );
-
+	int startPos = syncopated ? nResolution/2 : 0;
 
 	Song *pSong = pEngine->getSong();
 
@@ -365,7 +378,7 @@ void InstrumentLine::functionFillNotes( int every )
 		if (nSelectedInstrument != -1) {
 			Instrument *instrRef = (pSong->get_instrument_list())->get( nSelectedInstrument );
 
-			for (int i = 0; i < nPatternSize; i += nResolution) {
+			for (int i = startPos; i < nPatternSize; i += nResolution) {
 				bool noteAlreadyPresent = false;
 				const Pattern::notes_t* notes = pCurrentPattern->get_notes();
 				FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -68,7 +68,13 @@ class InstrumentLine : public PixmapWidget
 		void functionFillEveryEightNotes();
 		void functionFillEveryTwelveNotes();
 		void functionFillEverySixteenNotes();
-		void functionFillNotes( int every );
+		void functionFillEveryTwoNotesSyncopated();
+		void functionFillEveryFourNotesSyncopated();
+		void functionFillEverySixNotesSyncopated();
+		void functionFillEveryEightNotesSyncopated();
+		void functionFillEveryTwelveNotesSyncopated();
+		void functionFillEverySixteenNotesSyncopated();
+		void functionFillNotes( int every,  bool syncopated=false);
 		void functionCopyInstrumentPattern();
 		void functionCopyAllInstrumentPatterns();
 		void functionPasteInstrumentPattern();


### PR DESCRIPTION
Hello everyone,

I have been using Hydrogen for a long time. The missing feature that I wanted the most was the ability to fill with syncopated notes. I use these a lot while making beats. For example, if you want to create a skank beat you could fill 1/4 notes on the kick drum, but you had to fill the snare manually. With this feature you can just choose "Fill 1/4 notes (syncopated)" and it will fill every fourth note starting from the first eighth note.

As I am new around here, you may want to review the code to see if it complies to your coding conventions and project structure. Thanks in advance for feedback.