### PR TITLE
improved NSM support

### DIFF
--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -117,7 +117,7 @@ enum EventType {
 	 * - 0 - Hydrogen::m_pNextSong will be loaded.
 	 * - 1 - Hydrogen::m_pNextSong will be loaded and the audio
 	 *       drivers will be restarted via Hydrogen::restartDrivers()
-	 * - 2 - triggered whenever the #Song was saved via the core part
+	 * - 2 - triggered whenever the Song was saved via the core part
 	 *       (updated the title and status bar).
 	 */
 	EVENT_UPDATE_SONG,

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -70,17 +70,33 @@ enum EventType {
 	 * decoupled from the creation and queuing of the corresponding
 	 * Note itself.
 	 *
+	 * In Director it triggers a change in the displayed number,
+	 * color, tag, and triggers Director::update(). In case the
+	 * provided value is 3, instead of performing the changes above,
+	 * the Director loads the metadata a the current Song.
+	 *
 	 * The associated values do correspond to the following actions:
 	 * - 0: Beat at the beginning of a Pattern in
 	 *      audioEngine_updateNoteQueue(). The corresponding Note will
 	 *      be created with a pitch of 3 and velocity of 1.0.
+	 *      Sets MetronomeWidget::m_state to
+	 *      MetronomeWidget::METRO_ON and triggers
+	 *      MetronomeWidget::updateWidget().
 	 * - 1: Beat in the remainder of a Pattern in
 	 *      audioEngine_updateNoteQueue(). The corresponding Note will
 	 *      be created with a pitch of 0 and velocity of 0.8. In
 	 *      addition, it will be also pushed by
 	 *      Hydrogen::setPatternPos() without creating a Note.
-	 * - 2:
-	 * - 3:
+	 *      Sets MetronomeWidget::m_state to
+	 *      MetronomeWidget::METRO_FIRST and triggers
+	 *      MetronomeWidget::updateWidget().
+	 * - 2: Signals MetronomeWidget to neither update nor setting
+	 *      MetronomeWidget::m_state.
+	 * - 3: Tells the Director that a new Song was loaded and triggers
+	 *      its Director::update().
+	 *      Sets MetronomeWidget::m_state to
+	 *      MetronomeWidget::METRO_ON and triggers
+	 *      MetronomeWidget::updateWidget().
 	 *
 	 * Handled by EventListener::metronomeEvent().
 	 */
@@ -91,7 +107,12 @@ enum EventType {
 	EVENT_PLAYLIST_LOADSONG,
 	EVENT_UNDO_REDO,
 	EVENT_SONG_MODIFIED,
-	EVENT_TEMPO_CHANGED
+	EVENT_TEMPO_CHANGED,
+	/**
+	 * Event triggered whenever the Song was changed outside of the
+	 * GUI, e.g. by session management or and OSC command.
+	 */
+	EVENT_UPDATE_SONG
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -115,7 +115,9 @@ enum EventType {
 	 *
 	 * If the value of the event is 
 	 * - 0 - Hydrogen::m_pNextSong will be loaded.
-	 * - 1 - triggered whenever the #Song was saved via the core part
+	 * - 1 - Hydrogen::m_pNextSong will be loaded and the audio
+	 *       drivers will be restarted via Hydrogen::restartDrivers()
+	 * - 2 - triggered whenever the #Song was saved via the core part
 	 *       (updated the title and status bar).
 	 */
 	EVENT_UPDATE_SONG,

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -109,13 +109,21 @@ enum EventType {
 	EVENT_SONG_MODIFIED,
 	EVENT_TEMPO_CHANGED,
 	/**
-	 * Event triggered whenever the Song was changed outside of the
-	 * GUI, e.g. by session management or and OSC command.
+	 * Event triggering HydrogenApp::updateSongEvent() whenever the
+	 * Song was changed outside of the GUI, e.g. by session management
+	 * or and OSC command.
 	 *
-	 * If the value of the event is 1, HydrogenApp::updateSongEvent()
-	 * will load the #Song prepared in Hydrogen::m_pNextSong.
+	 * If the value of the event is 
+	 * - 0 - Hydrogen::m_pNextSong will be loaded.
+	 * - 1 - triggered whenever the #Song was saved via the core part
+	 *       (updated the title and status bar).
 	 */
-	EVENT_UPDATE_SONG
+	EVENT_UPDATE_SONG,
+	/**
+	 * Triggering HydrogenApp::quitEvent() and enables a shutdown of
+	 * the entire application via the command line.
+	 */
+	EVENT_QUIT
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -111,6 +111,9 @@ enum EventType {
 	/**
 	 * Event triggered whenever the Song was changed outside of the
 	 * GUI, e.g. by session management or and OSC command.
+	 *
+	 * If the value of the event is 1, HydrogenApp::updateSongEvent()
+	 * will load the #Song prepared in Hydrogen::m_pNextSong.
 	 */
 	EVENT_UPDATE_SONG
 };

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -576,11 +576,11 @@ void			previewSample( Sample *pSample );
 	 */
 	void			loadPlaybackTrack( const QString filename );
 
-	/**\return #m_bActiveGUI*/
-	bool			getActiveGUI() const;
-	/**\param bActiveGUI Specifies whether the Qt5 GUI is active. Sets
-	   #m_bActiveGUI.*/
-	void			setActiveGUI( const bool bActiveGUI );
+	/**\return #m_iActiveGUI*/
+	int				getActiveGUI() const;
+	/**\param iActiveGUI Specifies whether the Qt5 GUI is active. Sets
+	   #m_iActiveGUI.*/
+	void			setActiveGUI( const int iActiveGUI );
 	
 	/**\return #m_pNextSong*/
 	Song*			getNextSong() const;
@@ -647,18 +647,25 @@ private:
 	/**
 	 * Specifies whether the Qt5 GUI is active.
 	 *
+	 * This variable has three states:
+	 * - `m_iActiveGUI == 0` - There is no Qt5 GUI.
+	 * - `m_iActiveGUI < 0` - There is a Qt5 GUI but it is not fully
+	 *                        loaded. 
+	 * - `m_iActiveGUI > 0` - There is a Qt5 GUI and it is fully
+	 *                        loaded.
+	 *
 	 * When a new #Song is set via the core part of Hydrogen, e.g. in
 	 * the context of session management, the #Song *must* be set via
 	 * the GUI if active. Else the GUI will freeze.
 	 *
 	 * Set by setActiveGUI() and accessed via getActiveGUI().
 	 */
-	bool			m_bActiveGUI;
+	int				m_iActiveGUI;
 	
 	/**
 	 * Stores a new #Song which is about of the loaded by the GUI.
 	 *
-	 * If #m_bActiveGUI is true, the core part of must not load a new
+	 * If #m_iActiveGUI is true, the core part of must not load a new
 	 * #Song itself. Instead, the new #Song is prepared and stored in
 	 * this object to be loaded by HydrogenApp::updateSongEvent() if
 	 * H2Core::EVENT_UPDATE_SONG is pushed with a '1'.
@@ -756,11 +763,11 @@ inline bool Hydrogen::getPlaybackTrackState()
 	return 	bState;
 }
 
-inline bool Hydrogen::getActiveGUI() const {
-	return m_bActiveGUI;
+inline int Hydrogen::getActiveGUI() const {
+	return m_iActiveGUI;
 }
-inline void Hydrogen::setActiveGUI( const bool bActiveGUI ) {
-	m_bActiveGUI = bActiveGUI;
+inline void Hydrogen::setActiveGUI( const int iActiveGUI ) {
+	m_iActiveGUI = iActiveGUI;
 }
 inline Song* Hydrogen::getNextSong() const {
 	return m_pNextSong;

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -418,7 +418,7 @@ void			previewSample( Sample *pSample );
 	int				getSelectedPatternNumber();
 	/**
 	 * Sets #m_nSelectedPatternNumber.
-	 *f
+	 *
 	 * If Preferences::m_pPatternModePlaysSelected is set to true, the
 	 * AudioEngine is locked before @a nPat will be assigned. But in
 	 * any case the function will push the
@@ -532,6 +532,7 @@ void			previewSample( Sample *pSample );
 	 * \return Speed in beats per minute.
 	 */
 	float			getTimelineBpm( int Beat );
+	/** \return #m_pTimeline*/
 	Timeline*		getTimeline() const;
 	
 	//export management
@@ -575,6 +576,17 @@ void			previewSample( Sample *pSample );
 	 */
 	void			loadPlaybackTrack( const QString filename );
 
+	/**\return #m_bActiveGUI*/
+	bool			getActiveGUI() const;
+	/**\param bActiveGUI Specifies whether the Qt5 GUI is active. Sets
+	   #m_bActiveGUI.*/
+	void			setActiveGUI( const bool bActiveGUI );
+	
+	/**\return #m_pNextSong*/
+	Song*			getNextSong() const;
+	/**\param pNextSong Sets #m_pNextSong. #Song which is about to be
+	   loaded by the GUI.*/
+	void			setNextSong( Song* pNextSong );
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
@@ -632,6 +644,28 @@ private:
 	bool			m_bOldLoopEnabled;
 	bool			m_bExportSessionIsActive;
 	
+	/**
+	 * Specifies whether the Qt5 GUI is active.
+	 *
+	 * When a new #Song is set via the core part of Hydrogen, e.g. in
+	 * the context of session management, the #Song *must* be set via
+	 * the GUI if active. Else the GUI will freeze.
+	 *
+	 * Set by setActiveGUI() and accessed via getActiveGUI().
+	 */
+	bool			m_bActiveGUI;
+	
+	/**
+	 * Stores a new #Song which is about of the loaded by the GUI.
+	 *
+	 * If #m_bActiveGUI is true, the core part of must not load a new
+	 * #Song itself. Instead, the new #Song is prepared and stored in
+	 * this object to be loaded by HydrogenApp::updateSongEvent() if
+	 * H2Core::EVENT_UPDATE_SONG is pushed with a '1'.
+	 *
+	 * Set by setNextSong() and accessed via getNextSong().
+	 */
+	Song*			m_pNextSong;
 
 	/**
 	 * Local instance of the Timeline object.
@@ -722,6 +756,18 @@ inline bool Hydrogen::getPlaybackTrackState()
 	return 	bState;
 }
 
+inline bool Hydrogen::getActiveGUI() const {
+	return m_bActiveGUI;
+}
+inline void Hydrogen::setActiveGUI( const bool bActiveGUI ) {
+	m_bActiveGUI = bActiveGUI;
+}
+inline Song* Hydrogen::getNextSong() const {
+	return m_pNextSong;
+}
+inline void Hydrogen::setNextSong( Song* pNextSong ) {
+	m_pNextSong = pNextSong;
+}
 
 };
 

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -584,9 +584,23 @@ void			previewSample( Sample *pSample );
 	
 	/**\return #m_pNextSong*/
 	Song*			getNextSong() const;
-	/**\param pNextSong Sets #m_pNextSong. #Song which is about to be
+	/**\param pNextSong Sets #m_pNextSong. Song which is about to be
 	   loaded by the GUI.*/
 	void			setNextSong( Song* pNextSong );
+	/** Sets the first Song to be loaded under session management.
+	 *
+	 * Enables the creation of a JACK client with all per track output
+	 * ports present right from the start. This is necessary to ensure
+	 * their connection can be properly restored by external tools.
+	 *
+	 * The function will only work if no audio driver is present
+	 * (since this is the intended use case and the function will be
+	 * harmful if used otherwise. Use setSong() instead.) and fails if
+	 * there is already a Song present.
+	 *
+	 * \param pSong Song to be loaded.
+	 */
+	void			setInitialSong( Song* pSong );
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
@@ -654,8 +668,8 @@ private:
 	 * - `m_iActiveGUI > 0` - There is a Qt5 GUI and it is fully
 	 *                        loaded.
 	 *
-	 * When a new #Song is set via the core part of Hydrogen, e.g. in
-	 * the context of session management, the #Song *must* be set via
+	 * When a new Song is set via the core part of Hydrogen, e.g. in
+	 * the context of session management, the Song *must* be set via
 	 * the GUI if active. Else the GUI will freeze.
 	 *
 	 * Set by setActiveGUI() and accessed via getActiveGUI().
@@ -663,10 +677,10 @@ private:
 	int				m_iActiveGUI;
 	
 	/**
-	 * Stores a new #Song which is about of the loaded by the GUI.
+	 * Stores a new Song which is about of the loaded by the GUI.
 	 *
 	 * If #m_iActiveGUI is true, the core part of must not load a new
-	 * #Song itself. Instead, the new #Song is prepared and stored in
+	 * Song itself. Instead, the new Song is prepared and stored in
 	 * this object to be loaded by HydrogenApp::updateSongEvent() if
 	 * H2Core::EVENT_UPDATE_SONG is pushed with a '1'.
 	 *

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -77,12 +77,31 @@ class MidiActionManager : public H2Core::Object
 		 */
 		static MidiActionManager *__instance;
 
+		/**
+		 * Holds the names of all Action identfiers which Hydrogen is
+		 * able to interpret.
+		 */
 		QStringList actionList;
+
+		/**
+		 * Contains all information to find a particular object in a
+		 * list of objects, like an effect among all LADSPA effects
+		 * present or an individual sample.
+		 */
 		struct targeted_element {
+			/**First level index, like the ID of an Effect or and InstrumentComponent.*/
 			int _id;
+			/**Second level index, like the ID of an InstrumentLayer.*/
 			int _subId;
 		};
+
 		typedef bool (MidiActionManager::*action_f)(Action * , H2Core::Hydrogen * , targeted_element );
+		/**
+		 * Holds all Action identifiers which Hydrogen is able to
+		 * interpret.  
+		 *
+		 * It holds pointer to member function.
+		 */
 		map<string, pair<action_f, targeted_element> > actionMap;
 
 		bool play(Action * , H2Core::Hydrogen * , targeted_element );
@@ -131,11 +150,69 @@ class MidiActionManager : public H2Core::Object
 		bool gain_level_absolute(Action * , H2Core::Hydrogen * , targeted_element );
 		bool pitch_level_absolute(Action * , H2Core::Hydrogen * , targeted_element );
 
+		// Actions required for session management.
+		/**
+		 * Opens an empty Song and saves it to the path provided in
+		 * @a pAction.
+		 *
+		 * \param pAction Action "NEW_SONG" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool new_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Opens the Song specified in the path provided in @a
+		 * pAction.
+		 *
+		 * This will be done without immediately and without saving
+		 * the current Song. All unsaved changes will be lost!
+		 *
+		 * \param pAction Action "OPEN_SONG" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool open_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Saves the current Song.
+		 *
+		 * \param pAction Action "SAVE_SONG" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool save_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Saves the current Song to the path provided in @a pAction.
+		 *
+		 * \param pAction Action "SAVE_SONG_AS" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool save_song_as(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+		/**
+		 * Triggers the shutdown of Hydrogen.
+		 *
+		 * \param pAction Action "QUIT" uniquely triggering this function.
+		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
+		 * \param element Unused.
+		 * \return true on success
+		 */
+		bool quit(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
+
 		QStringList eventList;
 
 		int m_nLastBpmChangeCCParameter;
 
 	public:
+
+		/**
+		 * The handleAction method is the heart of the
+		 * MidiActionManager class. It executes the operations that
+		 * are needed to carry the desired action.
+		 */
 		bool handleAction( Action * );
 		/**
 		 * If #__instance equals 0, a new MidiActionManager

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -156,14 +156,14 @@ class MidiActionManager : public H2Core::Object
 		 * provided in @a pAction.
 		 *
 		 * This will be done without immediately and without saving
-		 * the current #Song. All unsaved changes will be lost! In
+		 * the current Song. All unsaved changes will be lost! In
 		 * addition, the new Song won't be saved by this function. You
 		 * can do so using save_song().
 		 *
 		 * The intended use of this function for session
 		 * management. Therefore the function will *not* store the
 		 * provided in Preferences::m_lastSongFilename and thus
-		 * Hydrogen does not resumes with the particular #Song upon
+		 * Hydrogen does not resumes with the particular Song upon
 		 * restarting.
 		 *
 		 * Right now the function is only able to handle the provided
@@ -181,12 +181,12 @@ class MidiActionManager : public H2Core::Object
 		 * pAction.
 		 *
 		 * This will be done without immediately and without saving
-		 * the current #Song. All unsaved changes will be lost!
+		 * the current Song. All unsaved changes will be lost!
 		 *
 		 * The intended use of this function for session
 		 * management. Therefore the function will *not* store the
 		 * provided in Preferences::m_lastSongFilename and thus
-		 * Hydrogen does not resumes with the particular #Song upon
+		 * Hydrogen does not resumes with the particular Song upon
 		 * restarting.
 		 *
 		 * Right now the function is only able to handle the provided
@@ -200,12 +200,12 @@ class MidiActionManager : public H2Core::Object
 		 */
 		bool open_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
 		/**
-		 * Saves the current #Song.
+		 * Saves the current Song.
 		 *
 		 * The intended use of this function for session
 		 * management. Therefore the function will *not* store the
 		 * provided in Preferences::m_lastSongFilename and thus
-		 * Hydrogen does not resumes with the particular #Song upon
+		 * Hydrogen does not resumes with the particular Song upon
 		 * restarting.
 		 *
 		 * \param pAction Action "SAVE_SONG" uniquely triggering this function.
@@ -220,7 +220,7 @@ class MidiActionManager : public H2Core::Object
 		 * The intended use of this function for session
 		 * management. Therefore the function will *not* store the
 		 * provided in Preferences::m_lastSongFilename and thus
-		 * Hydrogen does not resumes with the particular #Song upon
+		 * Hydrogen does not resumes with the particular Song upon
 		 * restarting.
 		 *
 		 * \param pAction Action "SAVE_SONG_AS" uniquely triggering this function.
@@ -233,7 +233,7 @@ class MidiActionManager : public H2Core::Object
 		 * Triggers the shutdown of Hydrogen.
 		 *
 		 * This will be done without immediately and without saving
-		 * the current #Song. All unsaved changes will be lost!
+		 * the current Song. All unsaved changes will be lost!
 		 *
 		 * The shutdown will only be triggered if
 		 * Hydrogen::m_iActiveGUI is true and the Qt5 GUI is present.

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -236,7 +236,7 @@ class MidiActionManager : public H2Core::Object
 		 * the current #Song. All unsaved changes will be lost!
 		 *
 		 * The shutdown will only be triggered if
-		 * Hydrogen::m_bActiveGUI is true and the Qt5 GUI is present.
+		 * Hydrogen::m_iActiveGUI is true and the Qt5 GUI is present.
 		 *
 		 * \param pAction Action "QUIT" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -249,6 +249,19 @@ class MidiActionManager : public H2Core::Object
 
 		int m_nLastBpmChangeCCParameter;
 
+		/**
+		 * Checks the path of the .h2song provided via OSC.
+		 *
+		 * It will be checked whether @a songPath
+		 * - is absolute
+		 * - has the '.h2song' suffix
+		 * - is writable (if it exists)
+		 *
+		 * \param songPath Absolute path to an .h2song file.
+		 * \return true - if valid.
+		 */
+		bool isSongPathValid( const QString& songPath );
+
 	public:
 
 		/**

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -152,8 +152,23 @@ class MidiActionManager : public H2Core::Object
 
 		// Actions required for session management.
 		/**
-		 * Opens an empty Song and saves it to the path provided in
-		 * @a pAction.
+		 * Create an empty Song which will be stored at to the path
+		 * provided in @a pAction.
+		 *
+		 * This will be done without immediately and without saving
+		 * the current #Song. All unsaved changes will be lost! In
+		 * addition, the new Song won't be saved by this function. You
+		 * can do so using save_song().
+		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
+		 *
+		 * Right now the function is only able to handle the provided
+		 * path as is. Therefore it is important to provide an absolute
+		 * path to a .h2song file.
 		 *
 		 * \param pAction Action "NEW_SONG" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
@@ -166,7 +181,17 @@ class MidiActionManager : public H2Core::Object
 		 * pAction.
 		 *
 		 * This will be done without immediately and without saving
-		 * the current Song. All unsaved changes will be lost!
+		 * the current #Song. All unsaved changes will be lost!
+		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
+		 *
+		 * Right now the function is only able to handle the provided
+		 * path as is. Therefore it is important to provide an absolute
+		 * path to a .h2song file.
 		 *
 		 * \param pAction Action "OPEN_SONG" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
@@ -175,7 +200,13 @@ class MidiActionManager : public H2Core::Object
 		 */
 		bool open_song(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
 		/**
-		 * Saves the current Song.
+		 * Saves the current #Song.
+		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
 		 *
 		 * \param pAction Action "SAVE_SONG" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
@@ -186,6 +217,12 @@ class MidiActionManager : public H2Core::Object
 		/**
 		 * Saves the current Song to the path provided in @a pAction.
 		 *
+		 * The intended use of this function for session
+		 * management. Therefore the function will *not* store the
+		 * provided in Preferences::m_lastSongFilename and thus
+		 * Hydrogen does not resumes with the particular #Song upon
+		 * restarting.
+		 *
 		 * \param pAction Action "SAVE_SONG_AS" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.
 		 * \param element Unused.
@@ -194,6 +231,12 @@ class MidiActionManager : public H2Core::Object
 		bool save_song_as(Action* pAction, H2Core::Hydrogen* pHydrogen, targeted_element element);
 		/**
 		 * Triggers the shutdown of Hydrogen.
+		 *
+		 * This will be done without immediately and without saving
+		 * the current #Song. All unsaved changes will be lost!
+		 *
+		 * The shutdown will only be triggered if
+		 * Hydrogen::m_bActiveGUI is true and the Qt5 GUI is present.
 		 *
 		 * \param pAction Action "QUIT" uniquely triggering this function.
 		 * \param pHydrogen Pointer to the instance of the Hydrogen singleton.

--- a/src/core/include/hydrogen/nsm_client.h
+++ b/src/core/include/hydrogen/nsm_client.h
@@ -71,6 +71,13 @@ class NsmClient : public H2Core::Object
 
 		void shutdown();
 
+		/**
+		 * To determine whether Hydrogen is under Non session management,
+		 * it is not sufficient to check whether the NSM_URL environmental
+		 * variable is set but also whether. 
+		 */
+		bool m_bUnderSessionManagement;
+
 	private:
 		NsmClient();
 

--- a/src/core/include/hydrogen/nsm_client.h
+++ b/src/core/include/hydrogen/nsm_client.h
@@ -28,6 +28,8 @@
 #include <hydrogen/object.h>
 #include <cassert>
 
+#include "hydrogen/nsm.h"
+
 
 /**
 * @class NsmClient
@@ -67,6 +69,17 @@ class NsmClient : public H2Core::Object
 		 */
 		static NsmClient* get_instance() { assert(__instance); return __instance; }
 
+		/**
+		 * Informs the NSM server whether the current Song is modified
+		 * or not.
+		 *
+		 * This function is triggered within
+		 * H2Core::Song::set_is_modified().
+		 *
+		 * \param isDirty true, if the current Song was modified, and
+		 * false if it wasn't
+		 */
+		void sendDirtyState( const bool isDirty );
 		void createInitialClient();
 
 		void shutdown();
@@ -80,6 +93,14 @@ class NsmClient : public H2Core::Object
 
 	private:
 		NsmClient();
+		
+		/**
+		 * Stores the current instance of the NSM client.
+		 *
+		 * Used in sendDirtyState() to establish a communication to
+		 * the NSM server.
+		 */
+		nsm_client_t* m_nsm;
 
 };
 

--- a/src/core/include/hydrogen/nsm_client.h
+++ b/src/core/include/hydrogen/nsm_client.h
@@ -36,6 +36,22 @@
 *
 * @brief Non session manager client implementation
 *
+* Non session management (NSM) is the name for both a standard/API
+* allowing for a reproducible, multi-application session handling in
+* Linux systems as well as for the actual application - the
+* non-session-manager - implementing it.
+*
+* Hydrogen is compliant with the standard, send dirty flag to the NSM
+* server to indicate unsaved changes, and is able to switch between
+* different sessions without restarting the entire
+* application. However, Hydrogen does use several files to store all
+* options the user is able to customize and not all of them are stored
+* inside the folder provided by the NSM server. While the song file
+* will be kept there, both the drumkit and preferences are stored
+* elsewhere. Altering either of them can very well affect the state of
+* the individual session, e.g. by disabling a prior set the per track
+* output option of the JACK driver outside of the session and
+* restarting it. So, be very careful. 
 *
 * @author Sebastian Moors
 *
@@ -47,16 +63,17 @@ class NsmClient : public H2Core::Object
 	public:
 		/**
 		 * Object holding the current NsmClient singleton. It
-		 * is initialized with NULL, set with
+		 * is initialized with nullptr, set with
 		 * create_instance(), and accessed with
 		 * get_instance().
 		 */
 		static NsmClient* __instance;
+		/** Destructor*/
 		~NsmClient();
-
+		/** Thread the NSM client will run in.*/
 		pthread_t m_NsmThread;
 		/**
-		 * If #__instance equals 0, a new NsmClient singleton
+		 * If #__instance equals nullptr, a new NsmClient singleton
 		 * will be created and stored in it.
 		 *
 		 * It is called in
@@ -64,34 +81,61 @@ class NsmClient : public H2Core::Object
 		 */
 		static void create_instance();
 		/**
-		 * Returns a pointer to the current NsmClient
+		 * \return a pointer to the current NsmClient
 		 * singleton stored in #__instance.
 		 */
 		static NsmClient* get_instance() { assert(__instance); return __instance; }
 
 		/**
-		 * Informs the NSM server whether the current Song is modified
-		 * or not.
+		 * Informs the NSM server whether the current H2Core::Song is
+		 * modified or not.
 		 *
 		 * This function is triggered within
 		 * H2Core::Song::set_is_modified().
 		 *
-		 * \param isDirty true, if the current Song was modified, and
-		 * false if it wasn't
+		 * \param isDirty true, if the current H2Core::Song was
+		 * modified, and false if it wasn't
 		 */
 		void sendDirtyState( const bool isDirty );
+		/**
+		 * Actual setup, initialization, and registration of the NSM
+		 * client.
+		 *
+		 * It create a new NSM client, sets the callback functions
+		 * nsm_open_cb() and nsm_save_cb(), and registers the newly
+		 * created client with the NSM server. It also indicates that
+		 * Hydrogen does support the two NSM options "dirty" and
+		 * "switch", allowing the server to notice whenever there are
+		 * unsaved changes and to switch between Songs without
+		 * restarting the whole application.
+		 *
+		 * This function will performs action if a NSM server is
+		 * already running. This will be indicated by a set
+		 * environmental variable called "NSM_URL". However, this is
+		 * condition is not sufficient and only after receiving a
+		 * certain response - handled by the NSM API inside the
+		 * nsm_free() function - to the announce message sent by
+		 * Hydrogen, the client can truly be considered under session
+		 * management. This particular state will be indicated by
+		 * setting #m_bUnderSessionManagement to true.
+		 */
 		void createInitialClient();
 
+		/** Causes the NSM client to not process events anymore.
+		 *
+		 * Sets #NsmShutdown to true.*/
 		void shutdown();
 
 		/**
-		 * To determine whether Hydrogen is under Non session management,
-		 * it is not sufficient to check whether the NSM_URL environmental
-		 * variable is set but also whether. 
+		 * Determines whether Hydrogen is under NSM session
+		 * management.
+		 *
+		 * Set in createInitialClient().
 		 */
 		bool m_bUnderSessionManagement;
 
 	private:
+		/**Constructor*/
 		NsmClient();
 		
 		/**

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -163,6 +163,15 @@ class OscServer : public H2Core::Object
 		 * - PLAYLIST_SONG_Handler()
 		 * - SELECT_INSTRUMENT_Handler()
 		 *
+		 * In case of the session managing handlers the following ones
+		 * only work with no argument present
+		 * - SAVE_SONG_Handler()
+		 * - QUIT_Handler()
+		 * and others only work by supplying a string "s" type message
+		 * - NEW_SONG_Handler()
+		 * - OPEN_SONG_Handler()
+		 * - SAVE_SONG_AS_Handler()
+		 *
 		 * The generic_handler() will be registered to match all paths
 		 * and types.
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -572,6 +572,10 @@ class OscServer : public H2Core::Object
 		 * Creates an Action of type @b NEW_SONG and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2song file. If another file already exists with the
+		 * same name, it will be overwritten.
+		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
 		 * \param argc Number of arguments passed by the OSC message.
@@ -580,6 +584,9 @@ class OscServer : public H2Core::Object
 		/**
 		 * Creates an Action of type @b OPEN_SONG and passes its
 		 * references to MidiActionManager::handleAction().
+		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2song file.
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
@@ -598,6 +605,10 @@ class OscServer : public H2Core::Object
 		/**
 		 * Creates an Action of type @b SAVE_SONG_AS and passes its
 		 * references to MidiActionManager::handleAction().
+		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2song file. If another file already exists with the
+		 * same name, it will be overwritten.
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -568,6 +568,51 @@ class OscServer : public H2Core::Object
 		 * \param i Unused number of arguments passed by the OSC
 		 * message.*/
 		static void REDO_ACTION_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b NEW_SONG and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void NEW_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b OPEN_SONG and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void OPEN_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SAVE_SONG and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void SAVE_SONG_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SAVE_SONG_AS and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void SAVE_SONG_AS_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b QUIT and passes its
+		 * references to MidiActionManager::handleAction().
+		 *
+		 * \param argv Unused pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void QUIT_Handler(lo_arg **argv, int i);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -592,27 +592,27 @@ class OscServer : public H2Core::Object
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
-		static void SAVE_SONG_Handler(lo_arg **argv, int i);
+		static void SAVE_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b SAVE_SONG_AS and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Number of arguments passed by the OSC
 		 * message.*/
-		static void SAVE_SONG_AS_Handler(lo_arg **argv, int i);
+		static void SAVE_SONG_AS_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b QUIT and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
-		static void QUIT_Handler(lo_arg **argv, int i);
+		static void QUIT_Handler(lo_arg **argv, int argc);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -565,27 +565,27 @@ class OscServer : public H2Core::Object
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
+		 * \param argc Number of arguments passed by the OSC
 		 * message.*/
-		static void REDO_ACTION_Handler(lo_arg **argv, int i);
+		static void REDO_ACTION_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b NEW_SONG and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
-		 * message.*/
-		static void NEW_SONG_Handler(lo_arg **argv, int i);
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void NEW_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b OPEN_SONG and passes its
 		 * references to MidiActionManager::handleAction().
 		 *
 		 * \param argv Unused pointer to a vector of arguments passed
 		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
-		 * message.*/
-		static void OPEN_SONG_Handler(lo_arg **argv, int i);
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void OPEN_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Creates an Action of type @b SAVE_SONG and passes its
 		 * references to MidiActionManager::handleAction().

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -54,254 +54,251 @@
 
 namespace H2Core {
 
-	/**
-	 * Sample rate of the JACK audio server.
-	 *
-	 * It is set by the callback function jackDriverSampleRate()
-	 * registered in the JACK server and accessed via
-	 * JackAudioDriver::getSampleRate(). Its initialization is handled by
-	 * JackAudioDriver::init(), which sets it to the sample rate of the
-	 * Hydrogen's external JACK client via _jack_get_sample_rate()_
-	 * (jack/jack.h). 
-	 */
-	unsigned long		jack_server_sampleRate = 0;
-	/**
-	 * Buffer size of the JACK audio server.
-	 *
-	 * It is set by the callback function jackDriverBufferSize()
-	 * registered in the JACK server and accessed via
-	 * JackAudioDriver::getBufferSize(). Its initialization is handled by
-	 * JackAudioDriver::init(), which sets it to the buffer size of the
-	 * Hydrogen's external JACK client via _jack_get_buffer_size()_
-	 * (jack/jack.h). 
-	 */
-	jack_nframes_t		jack_server_bufferSize = 0;
-	/**
-	 * Instance of the JackAudioDriver.
-	 */
-	JackAudioDriver *	pJackDriverInstance = nullptr;
+/**
+ * Sample rate of the JACK audio server.
+ *
+ * It is set by the callback function jackDriverSampleRate()
+ * registered in the JACK server and accessed via
+ * JackAudioDriver::getSampleRate(). Its initialization is handled by
+ * JackAudioDriver::init(), which sets it to the sample rate of the
+ * Hydrogen's external JACK client via _jack_get_sample_rate()_
+ * (jack/jack.h). 
+ */
+unsigned long		jack_server_sampleRate = 0;
+/**
+ * Buffer size of the JACK audio server.
+ *
+ * It is set by the callback function jackDriverBufferSize()
+ * registered in the JACK server and accessed via
+ * JackAudioDriver::getBufferSize(). Its initialization is handled by
+ * JackAudioDriver::init(), which sets it to the buffer size of the
+ * Hydrogen's external JACK client via _jack_get_buffer_size()_
+ * (jack/jack.h). 
+ */
+jack_nframes_t		jack_server_bufferSize = 0;
+/**
+ * Instance of the JackAudioDriver.
+ */
+JackAudioDriver *	pJackDriverInstance = nullptr;
 
 
-	/**
-	 * Callback function for the JACK audio server to set the sample rate
-	 * #H2Core::jack_server_sampleRate and prints a message to
-	 * the #__INFOLOG, which has to be included via a Logger instance in
-	 * the provided @a param.
-	 *
-	 * It gets registered as a callback function of the JACK server in
-	 * JackAudioDriver::init() using _jack_set_sample_rate_callback()_.
-	 *
-	 * \param nframes New sample rate. The object has to be of type
-	 * _jack_nframes_t_, which is defined in the jack/types.h header.
-	 * \param param Object containing a Logger member to display the
-	 * change in the sample rate in its INFOLOG.
-	 *
-	 * @return 0 on success
-	 */
-	int jackDriverSampleRate( jack_nframes_t nframes, void* param ){
-		// Used for logging.
-		Object* __object = ( Object* )param;
-		QString msg = QString("Jack SampleRate changed: the sample rate is now %1/sec").arg( QString::number( (int) nframes ) );
-		// The __INFOLOG macro uses the Object *__object and not the
-		// Object instance as INFOLOG does. It will call
-		// __object->logger()->log( H2Core::Logger::Info, ..., msg )
-		// (see object.h).
-		__INFOLOG( msg );
-		jack_server_sampleRate = nframes;
-		return 0;
+/**
+ * Callback function for the JACK audio server to set the sample rate
+ * #H2Core::jack_server_sampleRate and prints a message to
+ * the #__INFOLOG, which has to be included via a Logger instance in
+ * the provided @a param.
+ *
+ * It gets registered as a callback function of the JACK server in
+ * JackAudioDriver::init() using _jack_set_sample_rate_callback()_.
+ *
+ * \param nframes New sample rate. The object has to be of type
+ * _jack_nframes_t_, which is defined in the jack/types.h header.
+ * \param param Object containing a Logger member to display the
+ * change in the sample rate in its INFOLOG.
+ *
+ * @return 0 on success
+ */
+int jackDriverSampleRate( jack_nframes_t nframes, void* param ){
+	// Used for logging.
+	Object* __object = ( Object* )param;
+	QString msg = QString("Jack SampleRate changed: the sample rate is now %1/sec").arg( QString::number( (int) nframes ) );
+	// The __INFOLOG macro uses the Object *__object and not the
+	// Object instance as INFOLOG does. It will call
+	// __object->logger()->log( H2Core::Logger::Info, ..., msg )
+	// (see object.h).
+	__INFOLOG( msg );
+	jack_server_sampleRate = nframes;
+	return 0;
+}
+/**
+ * Callback function for the JACK audio server to set the buffer size
+ * #H2Core::jack_server_bufferSize.
+ *
+ * It gets registered as a callback function of the JACK server in
+ * JackAudioDriver::init() using _jack_set_buffer_size_callback()_.
+ *
+ * \param nframes New buffer size. The object has to be of type @a
+ * jack_nframes_t, which is defined in the jack/types.h header.
+ * \param arg Not used within the function but kept for compatibility
+ * reasons since the _JackBufferSizeCallback_ (jack/types.h) requires a
+ * second input argument @a arg of type _void_, which is a pointer
+ * supplied by the jack_set_buffer_size_callback() function.
+ *
+ * @return 0 on success
+ */
+int jackDriverBufferSize( jack_nframes_t nframes, void* arg ){
+	// This function does _NOT_ have to be realtime safe.
+	jack_server_bufferSize = nframes;
+	return 0;
+}
+/**
+ * Callback function for the JACK audio server to shutting down the
+ * JACK driver.
+ *
+ * The JackAudioDriver::m_pClient pointer stored in the current
+ * instance of the JACK audio driver #pJackDriverInstance is set to
+ * the nullptr and a Hydrogen::JACK_SERVER_SHUTDOWN error is raised
+ * using Hydrogen::raiseError().
+ *
+ * It gets registered as a callback function of the JACK server in
+ * JackAudioDriver::init() using _jack_on_shutdown()_.
+ *
+ * \param arg Not used within the function but kept for compatibility
+ * reasons since _jack_shutdown()_ (jack/jack.h) the argument @a arg
+ * of type void.
+ */	
+void jackDriverShutdown( void* arg )
+{
+	UNUSED( arg );
+
+	pJackDriverInstance->m_pClient = nullptr;
+	Hydrogen::get_instance()->raiseError( Hydrogen::JACK_SERVER_SHUTDOWN );
+}
+
+
+const char* JackAudioDriver::__class_name = "JackAudioDriver";
+
+JackAudioDriver::JackAudioDriver( JackProcessCallback processCallback )
+	: AudioOutput( __class_name )
+{
+	INFOLOG( "INIT" );
+	// __track_out_enabled is inherited from AudioOutput and
+	// instantiated with false. It will be used by the Sampler and
+	// Hydrogen itself to check whether JackAudioDriver is ordered
+	// to create per-track audio output ports.
+	__track_out_enabled = Preferences::get_instance()->m_bJackTrackOuts;
+
+	pJackDriverInstance = this;
+	this->processCallback = processCallback;
+
+	must_relocate = 0;
+	locate_countdown = 0;
+	bbt_frame_offset = 0;
+	track_port_count = 0;
+	
+	memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
+	memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
+}
+
+JackAudioDriver::~JackAudioDriver()
+{
+	INFOLOG( "DESTROY" );
+	disconnect();
+}
+
+// return 0: ok
+// return 1: cannot activate client
+// return 2: cannot connect output port
+int JackAudioDriver::connect()
+{
+	INFOLOG( "connect" );
+	
+	// The `jack_activate' function is defined in the jack/jack.h
+	// header files and tells the JACK server that the program is
+	// ready to start processing audio. It returns 0 on success
+	// and a non-zero error code otherwise.
+	if ( jack_activate( m_pClient ) ) {
+		Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_ACTIVATE_CLIENT );
+		return 1;
 	}
-	/**
-	 * Callback function for the JACK audio server to set the buffer size
-	 * #H2Core::jack_server_bufferSize.
-	 *
-	 * It gets registered as a callback function of the JACK server in
-	 * JackAudioDriver::init() using _jack_set_buffer_size_callback()_.
-	 *
-	 * \param nframes New buffer size. The object has to be of type @a
-	 * jack_nframes_t, which is defined in the jack/types.h header.
-	 * \param arg Not used within the function but kept for compatibility
-	 * reasons since the _JackBufferSizeCallback_ (jack/types.h) requires a
-	 * second input argument @a arg of type _void_, which is a pointer
-	 * supplied by the jack_set_buffer_size_callback() function.
-	 *
-	 * @return 0 on success
-	 */
-	int jackDriverBufferSize( jack_nframes_t nframes, void* arg ){
-		// This function does _NOT_ have to be realtime safe.
-		jack_server_bufferSize = nframes;
-		return 0;
-	}
-	/**
-	 * Callback function for the JACK audio server to shutting down the
-	 * JACK driver.
-	 *
-	 * The JackAudioDriver::m_pClient pointer stored in the current
-	 * instance of the JACK audio driver #pJackDriverInstance is set to
-	 * the nullptr and a Hydrogen::JACK_SERVER_SHUTDOWN error is raised
-	 * using Hydrogen::raiseError().
-	 *
-	 * It gets registered as a callback function of the JACK server in
-	 * JackAudioDriver::init() using _jack_on_shutdown()_.
-	 *
-	 * \param arg Not used within the function but kept for compatibility
-	 * reasons since _jack_shutdown()_ (jack/jack.h) the argument @a arg
-	 * of type void.
-	 */	
-	void jackDriverShutdown( void* arg )
-	{
-		UNUSED( arg );
-
-		pJackDriverInstance->m_pClient = nullptr;
-		Hydrogen::get_instance()->raiseError( Hydrogen::JACK_SERVER_SHUTDOWN );
-	}
 
 
-	const char* JackAudioDriver::__class_name = "JackAudioDriver";
-
-	JackAudioDriver::JackAudioDriver( JackProcessCallback processCallback )
-		: AudioOutput( __class_name )
-	{
-		INFOLOG( "INIT" );
-		// __track_out_enabled is inherited from AudioOutput and
-		// instantiated with false. It will be used by the Sampler and
-		// Hydrogen itself to check whether JackAudioDriver is ordered
-		// to create per-track audio output ports.
-		__track_out_enabled = Preferences::get_instance()->m_bJackTrackOuts;
-
-		pJackDriverInstance = this;
-		this->processCallback = processCallback;
-
-		must_relocate = 0;
-		locate_countdown = 0;
-		bbt_frame_offset = 0;
-		track_port_count = 0;
-
-		memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
-		memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
-	}
-
-	JackAudioDriver::~JackAudioDriver()
-	{
-		INFOLOG( "DESTROY" );
-		disconnect();
-	}
-
-	// return 0: ok
-	// return 1: cannot activate client
-	// return 2: cannot connect output port
-	int JackAudioDriver::connect()
-	{
-		INFOLOG( "connect" );
-
-		// The `jack_activate' function is defined in the jack/jack.h
-		// header files and tells the JACK server that the program is
-		// ready to start processing audio. It returns 0 on success
-		// and a non-zero error code otherwise.
-		if ( jack_activate( m_pClient ) ) {
-			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_ACTIVATE_CLIENT );
-			return 1;
-		}
-
-
-		bool connect_output_ports = m_bConnectOutFlag;
-
-		memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
-		memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
+	bool connect_output_ports = m_bConnectOutFlag;
 
 #ifdef H2CORE_HAVE_LASH
-		if ( Preferences::get_instance()->useLash() ){
-			LashClient* lashClient = LashClient::get_instance();
-			if (lashClient && lashClient->isConnected()){
-				// INFOLOG( "[LASH] Sending JACK client name to LASH server" );
-				lashClient->sendJackClientName();
+	if ( Preferences::get_instance()->useLash() ){
+		LashClient* lashClient = LashClient::get_instance();
+		if (lashClient && lashClient->isConnected()){
+			// INFOLOG( "[LASH] Sending JACK client name to LASH server" );
+			lashClient->sendJackClientName();
 
-				if (!lashClient->isNewProject()){
-					connect_output_ports = false;
-				}
+			if (!lashClient->isNewProject()){
+				connect_output_ports = false;
 			}
 		}
+	}
 #endif
 
-		if ( connect_output_ports ) {
-			// Connect the ports.
-			// The `jack_connect' function is defined in the
-			// jack/jack.h file. It establishes a connection between
-			// two ports. When a connection exists, data written
-			// to the source port will be available to be read at
-			// the destination port. Returns 0 on success, exits
-			// if the connection is already made, and returns a
-			// non-zero error code otherwise.
-			// Syntax: jack_connect( jack_client_t jack_client,
-			//                       const char *source_port )
-			//                       const char *destination_port
-			// )
-			// The `jack_port_name' function is also defined in
-			// the jack/jack.h header returns the full name of a
-			// provided port of type jack_port_t.
-			if ( jack_connect( m_pClient, jack_port_name( output_port_1 ),
-							   output_port_name_1.toLocal8Bit() ) == 0 &&
-				 jack_connect( m_pClient, jack_port_name( output_port_2 ),
-							   output_port_name_2.toLocal8Bit() ) == 0 ) {
-				return 0;
-			}
-
-			INFOLOG( "Could not connect to the saved output ports. Connect to the first pair of input ports instead." );
-			// The `jack_get_ports' is defined in the jack/jack.h
-			// header file and performs a lookup of ports of the
-			// JACK server based on their e.g. flags. It returns a
-			// NULL-terminated array of ports that match the
-			// specified arguments. The caller is responsible for
-			// calling jack_free() any non-NULL returned
-			// value.
-			const char ** portnames = jack_get_ports( m_pClient, nullptr, nullptr, JackPortIsInput );
-			if ( !portnames || !portnames[0] || !portnames[1] ) {
-				ERRORLOG( "Couldn't locate two Jack input ports" );
-				Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CONNECT_OUTPUT_PORT );
-				return 2;
-			}
-			if ( jack_connect( m_pClient, jack_port_name( output_port_1 ),
-							   portnames[0] ) != 0 ||
-				 jack_connect( m_pClient, jack_port_name( output_port_2 ),
-							   portnames[1] ) != 0 ) {
-				ERRORLOG( "Couldn't connect to first pair of Jack input ports" );
-				Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CONNECT_OUTPUT_PORT );
-				return 2;
-			}
-			free( portnames );
+	if ( connect_output_ports ) {
+		// Connect the ports.
+		// The `jack_connect' function is defined in the
+		// jack/jack.h file. It establishes a connection between
+		// two ports. When a connection exists, data written
+		// to the source port will be available to be read at
+		// the destination port. Returns 0 on success, exits
+		// if the connection is already made, and returns a
+		// non-zero error code otherwise.
+		// Syntax: jack_connect( jack_client_t jack_client,
+		//                       const char *source_port )
+		//                       const char *destination_port
+		// )
+		// The `jack_port_name' function is also defined in
+		// the jack/jack.h header returns the full name of a
+		// provided port of type jack_port_t.
+		if ( jack_connect( m_pClient, jack_port_name( output_port_1 ),
+						   output_port_name_1.toLocal8Bit() ) == 0 &&
+			 jack_connect( m_pClient, jack_port_name( output_port_2 ),
+						   output_port_name_2.toLocal8Bit() ) == 0 ) {
+			return 0;
 		}
 
-		return 0;
+		INFOLOG( "Could not connect to the saved output ports. Connect to the first pair of input ports instead." );
+		// The `jack_get_ports' is defined in the jack/jack.h
+		// header file and performs a lookup of ports of the
+		// JACK server based on their e.g. flags. It returns a
+		// NULL-terminated array of ports that match the
+		// specified arguments. The caller is responsible for
+		// calling jack_free() any non-NULL returned
+		// value.
+		const char ** portnames = jack_get_ports( m_pClient, nullptr, nullptr, JackPortIsInput );
+		if ( !portnames || !portnames[0] || !portnames[1] ) {
+			ERRORLOG( "Couldn't locate two Jack input ports" );
+			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CONNECT_OUTPUT_PORT );
+			return 2;
+		}
+		if ( jack_connect( m_pClient, jack_port_name( output_port_1 ),
+						   portnames[0] ) != 0 ||
+			 jack_connect( m_pClient, jack_port_name( output_port_2 ),
+						   portnames[1] ) != 0 ) {
+			ERRORLOG( "Couldn't connect to first pair of Jack input ports" );
+			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CONNECT_OUTPUT_PORT );
+			return 2;
+		}
+		free( portnames );
 	}
 
-	void JackAudioDriver::disconnect()
-	{
-		INFOLOG( "disconnect" );
+	return 0;
+}
 
-		deactivate();
-		jack_client_t *oldClient = m_pClient;
-		m_pClient = nullptr;
-		if ( oldClient ) {
-			INFOLOG( "calling jack_client_close" );
-			int res = jack_client_close( oldClient );
-			if ( res ) {
-				ERRORLOG( "Error in jack_client_close" );
-				Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CLOSE_CLIENT );
-			}
+void JackAudioDriver::disconnect()
+{
+	INFOLOG( "disconnect" );
+
+	deactivate();
+	jack_client_t *oldClient = m_pClient;
+	m_pClient = nullptr;
+	if ( oldClient ) {
+		INFOLOG( "calling jack_client_close" );
+		int res = jack_client_close( oldClient );
+		if ( res ) {
+			ERRORLOG( "Error in jack_client_close" );
+			Hydrogen::get_instance()->raiseError( Hydrogen::JACK_CANNOT_CLOSE_CLIENT );
 		}
-		m_pClient = nullptr;
 	}
+	m_pClient = nullptr;
+}
 
-	void JackAudioDriver::deactivate()
-	{
-		INFOLOG( "[deactivate]" );
-		if ( m_pClient ) {
-			INFOLOG( "calling jack_deactivate" );
-			int res = jack_deactivate( m_pClient );
-			if ( res ) {
-				ERRORLOG( "Error in jack_deactivate" );
-			}
+void JackAudioDriver::deactivate()
+{
+	INFOLOG( "[deactivate]" );
+	if ( m_pClient ) {
+		INFOLOG( "calling jack_deactivate" );
+		int res = jack_deactivate( m_pClient );
+		if ( res ) {
+			ERRORLOG( "Error in jack_deactivate" );
 		}
-memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
+	}
+	memset( track_output_ports_L, 0, sizeof(track_output_ports_L) );
 	memset( track_output_ports_R, 0, sizeof(track_output_ports_R) );
 }
 
@@ -847,25 +844,15 @@ int JackAudioDriver::init( unsigned bufferSize )
 		// Make Hydrogen the JACK timebase master.
 		initTimeMaster();
 	}
-
-#ifdef H2CORE_HAVE_OSC
-	// When restarting the audio driver after loading a new song under
-	// Non session management all ports have to be registered _prior_
-	// to the activation of the client.
-	if ( NsmClient::get_instance() ) {
-		// The NSM client was already initialized.
-		
-		if ( NsmClient::get_instance()->m_bUnderSessionManagement ){
-			// Under session management
-			Song* pSong = pEngine->getSong();
-			
-			if ( pSong != nullptr ) {
-				makeTrackOutputs( pSong );
-			}
-		}
-		
+	
+	// Whenever there is a Song present, create per track outputs (if
+	// activated in the Preferences).
+	Song* pSong = pEngine->getSong();
+	if ( pSong != nullptr ) {
+		makeTrackOutputs( pSong );
+		setBpm( pSong->__bpm );
+		locate( 0 );
 	}
-#endif
 	
 	return 0;
 }
@@ -877,8 +864,8 @@ void JackAudioDriver::makeTrackOutputs( Song* pSong )
 	if( Preferences::get_instance()->m_bJackTrackOuts == false )
 		return;
 
-	InstrumentList * pInstruments = pSong->get_instrument_list();
-	Instrument * pInstr;
+	InstrumentList *pInstruments = pSong->get_instrument_list();
+	Instrument *pInstr;
 	int nInstruments = ( int ) pInstruments->size();
 
 	// create dedicated channel output ports
@@ -1018,7 +1005,6 @@ void JackAudioDriver::setBpm( float fBPM )
 
 int JackAudioDriver::getNumTracks()
 {
-	//	INFOLOG( "get num tracks()" );
 	return track_port_count;
 }
 

--- a/src/core/src/basics/song.cpp
+++ b/src/core/src/basics/song.cpp
@@ -46,7 +46,10 @@
 #include <hydrogen/helpers/xml.h>
 #include <hydrogen/helpers/filesystem.h>
 #include <hydrogen/hydrogen.h>
+
+#ifdef H2CORE_HAVE_OSC
 #include <hydrogen/nsm_client.h>
+#endif
 
 #include <QDomDocument>
 #include <QDir>
@@ -246,12 +249,15 @@ void Song::set_is_modified(bool is_modified)
 		EventQueue::get_instance()->push_event( EVENT_SONG_MODIFIED, -1 );
 	}
 	
+#ifdef H2CORE_HAVE_OSC
 	// If Hydrogen is under session management (NSM), tell the NSM
 	// server that the Song was modified.
 	NsmClient* pNsmClient = NsmClient::get_instance();
 	if ( pNsmClient && pNsmClient->m_bUnderSessionManagement ) {
 		NsmClient::get_instance()->sendDirtyState( is_modified );
 	}
+#endif
+	
 }
 
 void Song::readTempPatternList( const QString& filename )
@@ -1000,7 +1006,6 @@ Song* SongReader::readSong( const QString& filename )
 		if ( instrumentList_count == 0 ) {
 			WARNINGLOG( "0 instruments?" );
 		}
-
 		pSong->set_instrument_list( pInstrList );
 	} else {
 		ERRORLOG( "Error reading song: instrumentList node not found" );

--- a/src/core/src/basics/song.cpp
+++ b/src/core/src/basics/song.cpp
@@ -247,16 +247,16 @@ void Song::set_is_modified(bool is_modified)
 
 	if(Notify) {
 		EventQueue::get_instance()->push_event( EVENT_SONG_MODIFIED, -1 );
-	}
 	
 #ifdef H2CORE_HAVE_OSC
-	// If Hydrogen is under session management (NSM), tell the NSM
-	// server that the Song was modified.
-	NsmClient* pNsmClient = NsmClient::get_instance();
-	if ( pNsmClient && pNsmClient->m_bUnderSessionManagement ) {
-		NsmClient::get_instance()->sendDirtyState( is_modified );
-	}
+		// If Hydrogen is under session management (NSM), tell the NSM
+		// server that the Song was modified.
+		NsmClient* pNsmClient = NsmClient::get_instance();
+		if ( pNsmClient && pNsmClient->m_bUnderSessionManagement ) {
+			NsmClient::get_instance()->sendDirtyState( is_modified );
+		}
 #endif
+	}
 	
 }
 

--- a/src/core/src/basics/song.cpp
+++ b/src/core/src/basics/song.cpp
@@ -46,6 +46,7 @@
 #include <hydrogen/helpers/xml.h>
 #include <hydrogen/helpers/filesystem.h>
 #include <hydrogen/hydrogen.h>
+#include <hydrogen/nsm_client.h>
 
 #include <QDomDocument>
 #include <QDir>
@@ -243,6 +244,13 @@ void Song::set_is_modified(bool is_modified)
 
 	if(Notify) {
 		EventQueue::get_instance()->push_event( EVENT_SONG_MODIFIED, -1 );
+	}
+	
+	// If Hydrogen is under session management (NSM), tell the NSM
+	// server that the Song was modified.
+	NsmClient* pNsmClient = NsmClient::get_instance();
+	if ( pNsmClient && pNsmClient->m_bUnderSessionManagement ) {
+		NsmClient::get_instance()->sendDirtyState( is_modified );
 	}
 }
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -412,7 +412,25 @@ int				audioEngine_start( bool bLockEngine = false, unsigned nTotalFrames = 0 );
  *   did already locked it.
  */
 void				audioEngine_stop( bool bLockEngine = false );
+/**
+ * Updates the global objects of the audioEngine according to new #Song.
+ *
+ * Calls audioEngine_setupLadspaFX() on
+ * m_pAudioDriver->getBufferSize(),
+ * audioEngine_process_checkBPMChanged(),
+ * audioEngine_renameJackPorts(), adds its first pattern to
+ * #m_pPlayingPatterns, relocates the audio driver to the beginning of
+ * the #Song, and updates the BPM.
+ *
+ * \param pNewSong #Song to load.
+ */
 void				audioEngine_setSong(Song *pNewSong );
+/**
+ * Does the necessary cleanup of the global objects in the audioEngine.
+ *
+ * Class the clear() member of #m_pPlayingPatterns and
+ * #m_pNextPatterns as well as audioEngine_clearNoteQueue();
+ */
 void				audioEngine_removeSong();
 static void			audioEngine_noteOn( Note *note );
 
@@ -1284,6 +1302,7 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	// transport position if it was changed by an user interaction
 	// (e.g. clicking on the timeline).
 	audioEngine_process_transport();
+	
 
 	// ___INFOLOG( QString( "[after process] status: %1, frame: %2, ticksize: %3, bpm: %4" )
 	// 	    .arg( m_pAudioDriver->m_transport.m_status )
@@ -1307,6 +1326,7 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 			 || ( m_pAudioDriver->class_name() == FakeDriver::class_name() )
 			 ) {
 			___INFOLOG( "End of song." );
+			
 			return 1;	// kill the audio AudioDriver thread
 		}
 
@@ -1318,7 +1338,6 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 			static_cast<JackAudioDriver*>(m_pAudioDriver)->locateInNCycles( 0 );
 		}
 #endif
-
 		return 0;
 	} else if ( res2 == 2 ) { // send pattern change
 		sendPatternChange = true;
@@ -1445,7 +1464,6 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	if ( sendPatternChange ) {
 		EventQueue::get_instance()->push_event( EVENT_PATTERN_CHANGED, -1 );
 	}
-
 	return 0;
 }
 
@@ -1500,7 +1518,7 @@ void audioEngine_renameJackPorts(Song * pSong)
 #endif
 }
 
-void audioEngine_setSong( Song * pNewSong )
+void audioEngine_setSong( Song* pNewSong )
 {
 	___WARNINGLOG( QString( "Set song: %1" ).arg( pNewSong->__name ) );
 
@@ -1555,7 +1573,6 @@ void audioEngine_removeSong()
 
 	m_pPlayingPatterns->clear();
 	m_pNextPatterns->clear();
-
 	audioEngine_clearNoteQueue();
 
 	// change the current audio engine state
@@ -2482,8 +2499,8 @@ void Hydrogen::loadPlaybackTrack( const QString filename )
 void Hydrogen::setSong( Song *pSong )
 {
 	assert ( pSong );
-
-	/* Set first pattern */
+	
+	// Move to the beginning.
 	setSelectedPatternNumber( 0 );
 
 	Song* pCurrentSong = getSong();
@@ -2493,12 +2510,11 @@ void Hydrogen::setSong( Song *pSong )
 	}
 
 	if ( pCurrentSong ) {
-
-		AudioEngine::get_instance()->lock( RIGHT_HERE );
 		
+		AudioEngine::get_instance()->lock( RIGHT_HERE );
 		delete pCurrentSong;
 		pCurrentSong = nullptr;
-		
+
 		AudioEngine::get_instance()->unlock();
 
 		/* NOTE: 
@@ -2519,12 +2535,15 @@ void Hydrogen::setSong( Song *pSong )
 	// audioEngine_setSong().
 	__song = pSong;
 
+	
 	// Update the audio engine to work with the new song.
 	audioEngine_setSong( pSong );
 
 	// load new playback track information
 	AudioEngine::get_instance()->get_sampler()->reinitialize_playback_track();
 	
+	// Push current state of Hydrogen to attached control interfaces,
+	// like OSC clients.
 	m_pCoreActionController->initExternalControlInterfaces();
 }
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2535,7 +2535,6 @@ void Hydrogen::setSong( Song *pSong )
 	// audioEngine_setSong().
 	__song = pSong;
 
-	
 	// Update the audio engine to work with the new song.
 	audioEngine_setSong( pSong );
 

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -413,16 +413,16 @@ int				audioEngine_start( bool bLockEngine = false, unsigned nTotalFrames = 0 );
  */
 void				audioEngine_stop( bool bLockEngine = false );
 /**
- * Updates the global objects of the audioEngine according to new #Song.
+ * Updates the global objects of the audioEngine according to new Song.
  *
  * Calls audioEngine_setupLadspaFX() on
  * m_pAudioDriver->getBufferSize(),
  * audioEngine_process_checkBPMChanged(),
  * audioEngine_renameJackPorts(), adds its first pattern to
  * #m_pPlayingPatterns, relocates the audio driver to the beginning of
- * the #Song, and updates the BPM.
+ * the Song, and updates the BPM.
  *
- * \param pNewSong #Song to load.
+ * \param pNewSong Song to load.
  */
 void				audioEngine_setSong(Song *pNewSong );
 /**
@@ -1512,18 +1512,6 @@ void audioEngine_renameJackPorts(Song * pSong)
 	// renames jack ports
 	if ( ! pSong ) return;
 	
-#ifdef H2CORE_HAVE_OSC
-	// When restarting the audio driver after loading a new song under
-	// Non session management all ports have to be registered _prior_
-	// to the activation of the client.
-	if ( NsmClient::get_instance() ) {
-		// The NSM client was already initialized.
-		if ( NsmClient::get_instance()->m_bUnderSessionManagement ){
-			return;
-		}
-	}
-#endif
-	
 	if ( m_pAudioDriver->class_name() == JackAudioDriver::class_name() ) {
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->makeTrackOutputs( pSong );
 	}
@@ -2350,12 +2338,17 @@ void audioEngine_stopAudioDrivers()
 
 
 
-/// Restart all audio and midi drivers by calling first
-/// audioEngine_stopAudioDrivers() and then
-/// audioEngine_startAudioDrivers().
+/** Restart all audio and midi drivers by calling first
+ * audioEngine_stopAudioDrivers() and then
+ * audioEngine_startAudioDrivers().
+ *
+ * If no audio driver is set yet, audioEngine_stopAudioDrivers() is
+ * omitted and the audio driver will be started right away.*/
 void audioEngine_restartAudioDrivers()
 {
-	audioEngine_stopAudioDrivers();
+	if ( m_pAudioDriver != nullptr ) {
+		audioEngine_stopAudioDrivers();
+	}
 	audioEngine_startAudioDrivers();
 }
 
@@ -2392,7 +2385,24 @@ Hydrogen::Hydrogen()
 	// Prevent double creation caused by calls from MIDI thread
 	__instance = this;
 
-	audioEngine_startAudioDrivers();
+	// When under session management and using JACK as audio driver,
+	// it is crucial for Hydrogen to activate the JACK client _after_
+	// the initial Song was set. Else the per track outputs will not
+	// be registered in time and the session software won't be able to
+	// rewire them properly. Therefore, the audio driver is started in
+	// the callback function for opening a Song in nsm_open_cb().
+	//
+	// But the presence of the environmental variable NSM_URL does not
+	// guarantee for a session management to be present (and at this
+	// early point of initialization it's basically impossible to
+	// tell). As a fallback the main() function will check for the
+	// presence of the audio driver after creating both the Hydrogen
+	// and NsmClient instance and prior to the creation of the GUI. If
+	// absent, the starting of the audio driver will be triggered.
+	if ( ! getenv( "NSM_URL" ) ){
+		audioEngine_startAudioDrivers();
+	}
+	
 	for(int i = 0; i< MAX_INSTRUMENTS; i++){
 		m_nInstrumentLookupTable[i] = i;
 	}
@@ -3154,7 +3164,7 @@ void Hydrogen::stopExportSong()
 	}
 
 	AudioEngine::get_instance()->get_sampler()->stop_playing_notes();
-	
+
 	m_pAudioDriver->disconnect();
 
 	m_nSongPos = -1;
@@ -4064,5 +4074,42 @@ void Hydrogen::startNsmClient()
 	}
 }
 #endif
+
+void Hydrogen::setInitialSong( Song *pSong ) {
+
+	// Since the function is only intended to set a Song prior to the
+	// initial creation of the audio driver, it will cause the
+	// application to get out of sync if used elsewhere. The following
+	// checks ensure it is called in the right context.
+	if ( pSong == nullptr ) {
+		return;
+	}
+	if ( __song != nullptr ) {
+		return;
+	}
+	if ( m_pAudioDriver != nullptr ) {
+		return;
+	}
+	
+	// Just to be sure.
+	AudioEngine::get_instance()->lock( RIGHT_HERE );
+
+	// Find the first pattern and set as current.
+	if ( pSong->get_pattern_list()->size() > 0 ) {
+		m_pPlayingPatterns->add( pSong->get_pattern_list()->get( 0 ) );
+	}
+
+	AudioEngine::get_instance()->unlock();
+
+	// Move to the beginning.
+	setSelectedPatternNumber( 0 );
+
+	__song = pSong;
+
+	// Push current state of Hydrogen to attached control interfaces,
+	// like OSC clients.
+	m_pCoreActionController->initExternalControlInterfaces();
+			
+}
 
 }; /* Namespace */

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -1028,6 +1028,8 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	
 	// Check whether the provided path is valid.
 	if ( !isSongPathValid( songPath ) ) {
+		std::cout << "Error: Song path [" << songPath.toLocal8Bit().data() 
+				  << "] is not valid!" << std::endl;
 		return false;
 	}
 	
@@ -1220,5 +1222,7 @@ bool MidiActionManager::isSongPathValid( const QString& songPath ) {
 			"]. The provided file must have the suffix '.h2song'!" << std::endl;
 		return false;
 	}
+	
+	return true;
 	
 }

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -36,6 +36,8 @@
 #include <hydrogen/Preferences.h>
 #include <hydrogen/midi_action.h>
 
+#include <hydrogen/basics/drumkit.h>
+
 #include <sstream>
 
 using namespace H2Core;
@@ -119,6 +121,7 @@ MidiActionManager::MidiActionManager() : Object( __class_name ) {
 	actionMap.insert(make_pair("MASTER_VOLUME_ABSOLUTE", make_pair(&MidiActionManager::master_volume_absolute, empty)));
 	actionMap.insert(make_pair("STRIP_VOLUME_RELATIVE", make_pair(&MidiActionManager::strip_volume_relative, empty)));
 	actionMap.insert(make_pair("STRIP_VOLUME_ABSOLUTE", make_pair(&MidiActionManager::strip_volume_absolute, empty)));
+	
 	for(int i = 0; i < MAX_FX; ++i) {
 		targeted_element effect = {i,0};
 		ostringstream toChar;
@@ -172,8 +175,14 @@ MidiActionManager::MidiActionManager() : Object( __class_name ) {
 	actionMap.insert(make_pair("UNDO_ACTION", make_pair(&MidiActionManager::undo_action, empty)));
 	actionMap.insert(make_pair("REDO_ACTION", make_pair(&MidiActionManager::redo_action, empty)));
 
+	// Adding actions required for session management
+	actionMap.insert(make_pair("NEW_SONG", make_pair(&MidiActionManager::new_song, empty)));
+	actionMap.insert(make_pair("OPEN_SONG", make_pair(&MidiActionManager::open_song, empty)));
+	actionMap.insert(make_pair("SAVE_SONG", make_pair(&MidiActionManager::save_song, empty)));
+	actionMap.insert(make_pair("SAVE_SONG_AS", make_pair(&MidiActionManager::save_song_as, empty)));
+	actionMap.insert(make_pair("QUIT", make_pair(&MidiActionManager::quit, empty)));
 	/*
-		the actionList holds all Action identfiers which hydrogen is able to interpret.
+	  the actionList holds all Action identfiers which hydrogen is able to interpret.
 	*/
 	actionList <<"";
 	for(map<string, pair<action_f, targeted_element> >::const_iterator actionIterator = actionMap.begin();
@@ -953,10 +962,31 @@ bool MidiActionManager::redo_action(Action * , Hydrogen* , targeted_element ) {
 	return true;
 }
 
-/**
- * The handleAction method is the heart of the MidiActionManager class.
- * It executes the operations that are needed to carry the desired action.
- */
+bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[new_song]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[open_song]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[save_song]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[save_song_as]" << std::endl;
+	return true;
+}
+
+bool MidiActionManager::quit(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
+	std::cout << "[quit]" << std::endl;
+	return true;
+}
+
 bool MidiActionManager::handleAction( Action * pAction ) {
 
 	Hydrogen *pEngine = Hydrogen::get_instance();

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -1036,6 +1036,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	QFileInfo songFileInfo = QFileInfo( songPath );
 	if ( !songFileInfo.exists() ) {
 		std::cout << "Error: Selected Song does not exist!" << std::endl;
+		return false;
 	}
 	
 	// Create an empty Song.

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -989,7 +989,7 @@ bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_
 	
 	pSong->set_filename( songPath );
 	
-	if ( pHydrogen->getActiveGUI() ) {
+	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
 		// Store the prepared Song for the GUI to access after the
 		// EVENT_UPDATE_SONG event was triggered.
@@ -1037,7 +1037,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		return false;
 	}
 	
-	// Create an empty Song.
+	// Open the Song.
 	Song* pSong = Song::load( songPath );
 	
 	if ( pSong == nullptr ) {
@@ -1046,7 +1046,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		return false;
 	}
 	
-	if ( pHydrogen->getActiveGUI() ) {
+	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
 		// Store the prepared Song for the GUI to access after the
 		// EVENT_UPDATE_SONG event was triggered.
@@ -1091,7 +1091,7 @@ bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	}
 	
 	// Update the status bar.
-	if ( pHydrogen->getActiveGUI() ) {
+	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
 		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
 		
@@ -1126,7 +1126,7 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 	}
 	
 	// Update the status bar.
-	if ( pHydrogen->getActiveGUI() ) {
+	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
 		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
 		
@@ -1138,7 +1138,7 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 bool MidiActionManager::quit(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
 	
 	// Update the status bar.
-	if ( pHydrogen->getActiveGUI() ) {
+	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
 		EventQueue::get_instance()->push_event( EVENT_QUIT, 0 );
 		

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -1063,7 +1063,6 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		// core part itself.
 		// Triggers an update of the Qt5 GUI and tells it to update
 		// the song itself.
-		std::cout << "push_event" << std::endl;
 		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, eventValue );
 		
 	} else {

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -989,8 +989,6 @@ bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_
 	
 	pSong->set_filename( songPath );
 	
-	std::cout << "[new_song] songPath: " << songPath.toLocal8Bit().data() << std::endl;
-	
 	if ( pHydrogen->getActiveGUI() ) {
 		
 		// Store the prepared Song for the GUI to access after the
@@ -1001,7 +999,7 @@ bool MidiActionManager::new_song(Action* pAction, Hydrogen* pHydrogen, targeted_
 		// core part itself.
 		// Triggers an update of the Qt5 GUI and tells it to update
 		// the song itself.
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
 		
 	} else {
 
@@ -1048,8 +1046,6 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		return false;
 	}
 	
-	std::cout << "[open_song] songPath: " << songPath.toLocal8Bit().data() << std::endl;
-	
 	if ( pHydrogen->getActiveGUI() ) {
 		
 		// Store the prepared Song for the GUI to access after the
@@ -1073,8 +1069,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 }
 
 bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
-	std::cout << "[save_song]" << std::endl;
-	
+
 	// Get the current Song which is about to be saved.
 	Song* pSong = pHydrogen->getSong();
 	
@@ -1106,8 +1101,6 @@ bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted
 }
 
 bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
-	std::cout << "[save_song_as]" << std::endl;
-	
 	// Get the current Song which is about to be saved.
 	Song* pSong = pHydrogen->getSong();
 	
@@ -1143,8 +1136,6 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 }
 
 bool MidiActionManager::quit(Action* pAction, Hydrogen* pHydrogen, targeted_element element) {
-	
-	std::cout << "[quit]" << std::endl;
 	
 	// Update the status bar.
 	if ( pHydrogen->getActiveGUI() ) {

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -1055,7 +1055,7 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		// Determines whether (1) or not (0) the audio driver should
 		// be restarted by the GUI handling the event.
 		int eventValue = 0;
-		if ( QString::compare( pAction->getParameter2(), "1" ) ){
+		if ( pAction->getParameter2().toInt() == 1 ){
 			eventValue = 1;
 		}
 		
@@ -1089,7 +1089,8 @@ bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	QString filename = pSong->get_filename();
 	
 	if ( filename.isEmpty() ) {
-		std::cout << "Error: Unable to save Song. Empty filename!" << std::endl;
+		std::cout << "Error: Unable to save Song. Empty filename! " 
+				  << filename.toLocal8Bit().data() << std::endl;
 		
 		return false;
 	}
@@ -1097,7 +1098,8 @@ bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	// Actual saving
 	bool saved = pSong->save( filename );
 	if ( !saved ) {
-		ERRORLOG( QString( "Current Song could not be saved!" ) );
+		ERRORLOG( QString( "Current Song [%1] could not be saved!" 
+						   ).arg( filename ) );
 		
 		return false;
 	}
@@ -1124,7 +1126,8 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 	}
 	
 	if ( songPath.isEmpty() ) {
-		std::cout << "Error: Unable to save Song. Empty filename!" << std::endl;
+		std::cout << "Error: Unable to save Song. Empty filename!" 
+				  << pSong->get_filename().toLocal8Bit().data() << std::endl;
 		
 		return false;
 	}
@@ -1132,7 +1135,8 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 	// Actual saving
 	bool saved = pSong->save( songPath );
 	if ( !saved ) {
-		ERRORLOG( QString( "Current Song could not be saved!" ) );
+		ERRORLOG( QString( "Current Song [%1] could not be saved!" 
+						   ).arg( pSong->get_filename() ) );
 		
 		return false;
 	}

--- a/src/core/src/midi_action.cpp
+++ b/src/core/src/midi_action.cpp
@@ -1051,17 +1051,30 @@ bool MidiActionManager::open_song(Action* pAction, Hydrogen* pHydrogen, targeted
 		// Store the prepared Song for the GUI to access after the
 		// EVENT_UPDATE_SONG event was triggered.
 		pHydrogen->setNextSong( pSong );
+
+		// Determines whether (1) or not (0) the audio driver should
+		// be restarted by the GUI handling the event.
+		int eventValue = 0;
+		if ( QString::compare( pAction->getParameter2(), "1" ) ){
+			eventValue = 1;
+		}
 		
 		// If the GUI is active, the Song *must not* be set by the
 		// core part itself.
 		// Triggers an update of the Qt5 GUI and tells it to update
 		// the song itself.
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
+		std::cout << "push_event" << std::endl;
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, eventValue );
 		
 	} else {
 
 		// Update the Song.
 		pHydrogen->setSong( pSong );
+
+		// Restarting the audio engine.
+		if ( QString::compare( pAction->getParameter2(), "1" ) ){
+			pHydrogen->restartDrivers();
+		}
 		
 	}
 
@@ -1093,7 +1106,7 @@ bool MidiActionManager::save_song(Action* pAction, Hydrogen* pHydrogen, targeted
 	// Update the status bar.
 	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
 		
 	}
 	
@@ -1128,7 +1141,7 @@ bool MidiActionManager::save_song_as(Action* pAction, Hydrogen* pHydrogen, targe
 	// Update the status bar.
 	if ( pHydrogen->getActiveGUI() != 0 ) {
 		
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
 		
 	}
 	

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -239,11 +239,15 @@ static int nsm_open_cb (const char *name,
 			return ERR_LAUNCH_FAILED;
 		}
 		
-		// Wait until the Song was set (asynchronously by the GUI).
+		// Wait until the Song was set (asynchronously by the GUI) and
+		// the GUI is fully loaded. In case there is no GUI,
+		// pHydrogen->getActiveGUI() will return 0 and cause no
+		// waiting at all.
 		int numberOfChecks = 10;
 		int check = 0;
 		while ( true ) {
-			if ( pCurrentSong != pHydrogen->getSong() ) {
+			if ( ( pCurrentSong != pHydrogen->getSong() ) &&
+				 ( pHydrogen->getActiveGUI() >= 0 ) ) {
 				break;
 			}
 			// Don't wait indefinitely.

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -30,7 +30,6 @@
 #if defined(H2CORE_HAVE_OSC) || _DOXYGEN_
 
 #include "hydrogen/nsm_client.h"
-#include "hydrogen/nsm.h"
 #include "hydrogen/event_queue.h"
 #include "hydrogen/hydrogen.h"
 #include "hydrogen/basics/song.h"
@@ -162,6 +161,7 @@ static int nsm_save_cb( char **out_msg, void *userdata )
 
 	return ERR_OK;
 }
+
 void* nsm_processEvent(void* data)
 {
 	nsm_client_t* nsm = (nsm_client_t*) data;
@@ -214,6 +214,10 @@ void NsmClient::createInitialClient()
 	if ( nsm_url )
 	{
 		nsm = nsm_new();
+		
+		// Store the nsm client in a private member variable for later
+		// access.
+		m_nsm = nsm;
 
 		if ( nsm )
 		{
@@ -222,7 +226,7 @@ void NsmClient::createInitialClient()
 
 			if ( nsm_init( nsm, nsm_url ) == 0 )
 			{
-				nsm_send_announce( nsm, "Hydrogen", ":switch:", byteArray.data() );
+				nsm_send_announce( nsm, "Hydrogen", ":dirty:switch:", byteArray.data() );
 				nsm_check_wait( nsm, 10000 );
 
 				if(pthread_create(&m_NsmThread, nullptr, nsm_processEvent, nsm)) {
@@ -248,5 +252,15 @@ void NsmClient::createInitialClient()
 		___WARNINGLOG("No NSM URL available: no NSM management\n");
 	}
 }
+
+void NsmClient::sendDirtyState( const bool isDirty ) {
+	
+	if ( isDirty ) {
+		nsm_send_is_dirty( m_nsm );
+	} else {
+		nsm_send_is_clean( m_nsm );
+	}
+}
+
 #endif /* H2CORE_HAVE_OSC */
 

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -112,13 +112,16 @@ static int nsm_open_cb (const char *name,
 						void *userdata )
 {
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	std::cout << "\033[1;30m[Hydrogen]\033[32m Loading song " << 
+		name << ".\033[0m" << std::endl;
 	
 	// Handle supplied Song name. Hydrogen sends a unique string, like
 	// - if the display_name == Hydrogen - "Hydrogen.nJKUV". We will
 	// just append the .h2song and use it as Song path.
 	
 	if ( !name ) {
-		___ERRORLOG( QString( "No `name` provided!" ) );
+		std::cout << std::endl <<
+			"\033[1;30m[Hydrogen]\033[31m Error: No `name` supplied in NSM open callback!\033[0m" << std::endl;
 		return ERR_LAUNCH_FAILED;
 	}
 
@@ -134,11 +137,11 @@ static int nsm_open_cb (const char *name,
 			// Setup JACK here, client_id gets the JACK client name
 			pPref->setNsmClientId( QString( client_id ) );
 		} else {
-			___ERRORLOG( "No client_id supplied in NSM open callback!" );
+			std::cout << "\033[1;30m[Hydrogen]\033[31m Error: No `client_id` supplied in NSM open callback!\033[0m" << std::endl;
 			return ERR_LAUNCH_FAILED;
 		}
 	} else {
-		___ERRORLOG( "Preferences instance is not ready yet!" );
+		std::cout << "\033[1;30m[Hydrogen]\033[31m Error: Preferences instance is not ready yet!\033[0m" << std::endl;
 		return ERR_NOT_NOW;
 	}
 	
@@ -151,7 +154,7 @@ static int nsm_open_cb (const char *name,
 
 		pSong = H2Core::Song::load( songPath );
 		if ( pSong == nullptr ) {
-			___ERRORLOG( QString( "Error: Unable to open Song." ) );
+			std::cout << "\033[1;30m[Hydrogen]\033[31m Error: Unable to open Song.\033[0m" << std::endl;
 			return ERR_LAUNCH_FAILED;
 		}
 		
@@ -161,7 +164,7 @@ static int nsm_open_cb (const char *name,
 		// to an empty default Song.
 		pSong = H2Core::Song::get_empty_song();
 		if ( pSong == nullptr ) {
-			___ERRORLOG( QString( "Error: Unable to open new Song." ) );
+			std::cout << "\033[1;30m[Hydrogen]\033[31m Error: Unable to open new Song.\033[0m" << std::endl;
 			return ERR_LAUNCH_FAILED;
 		}
 		pSong->set_filename( songPath );
@@ -229,7 +232,7 @@ static int nsm_open_cb (const char *name,
 		bool ok = pActionManager->handleAction( &currentAction );
 
 		if ( !ok ) {
-			___ERRORLOG( QString( "Unable to handle opening action!" ) );
+			std::cout << "\033[1;30m[Hydrogen]\033[31m Error: Unable to handle opening action!\033[0m" << std::endl;
 			return ERR_LAUNCH_FAILED;
 		}
 		
@@ -248,6 +251,8 @@ static int nsm_open_cb (const char *name,
 			sleep(1);
 		}
 	}
+	
+	std::cout << "\033[1;30m[Hydrogen]\033[32m Song loaded!" << std::endl;
 	
 	return ERR_OK;
 }
@@ -271,6 +276,8 @@ static int nsm_save_cb( char **out_msg, void *userdata )
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
 	pActionManager->handleAction(&currentAction);
+	
+	std::cout << "\033[1;30m[Hydrogen]\033[32m Song saved!\033[0m" << std::endl;
 
 	return ERR_OK;
 }

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -97,6 +97,7 @@ NsmClient::NsmClient()
 	: Object( __class_name )
 {
 	m_NsmThread = 0;
+	m_bUnderSessionManagement = false;
 }
 
 void NsmClient::create_instance()
@@ -148,6 +149,10 @@ void NsmClient::createInitialClient()
 					___ERRORLOG("Error creating NSM thread\n	");
 					return;
 				}
+				
+				// Everything worked fine and H2 can now be considered
+				// under session management.
+				m_bUnderSessionManagement = true;
 
 			}
 			else

--- a/src/core/src/nsm_client.cpp
+++ b/src/core/src/nsm_client.cpp
@@ -61,6 +61,8 @@ static int nsm_open_cb (const char *name,
 
 	QString songPath = QString( "%1.h2song" ).arg( name );
 	QFileInfo songFileInfo = QFileInfo( songPath );
+	
+	H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
 
 	// When starting Hydrogen with its Qt5 GUI activated the chosen
 	// Song will be set via the GUI. But since it is constructed after
@@ -70,7 +72,7 @@ static int nsm_open_cb (const char *name,
 	// the construction of MainForm). Therefore the next line will
 	// check whether there is a GUI present and if it is setup
 	// already.
-	if ( H2Core::Hydrogen::get_instance()->getActiveGUI() < 0 ) {
+	if ( pHydrogen->getActiveGUI() < 0 ) {
 		
 		// There is a GUI, but it is not ready yet. Therefore we have
 		// to duplicate some of the logic from the OSC messages,
@@ -86,7 +88,7 @@ static int nsm_open_cb (const char *name,
 				return ERR_LAUNCH_FAILED;
 			}
 			
-			H2Core::Hydrogen::get_instance()->setNextSong( pSong );
+			pHydrogen->setNextSong( pSong );
 			
 		} else {
 			
@@ -95,7 +97,7 @@ static int nsm_open_cb (const char *name,
 			H2Core::Song *pSong = H2Core::Song::get_empty_song();
 			pSong->set_filename( songPath );
 			
-			H2Core::Hydrogen::get_instance()->setNextSong( pSong );
+			pHydrogen->setNextSong( pSong );
 			
 		}
 	} else {
@@ -145,6 +147,7 @@ static int nsm_open_cb (const char *name,
 	}
 	
 	// Restarting JACK server.
+	pHydrogen->restartDrivers();
 	
 	return ERR_OK;
 }

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -560,6 +560,42 @@ void OscServer::REDO_ACTION_Handler(lo_arg **argv,int i)
 	pActionManager->handleAction( &currentAction );
 }
 
+// Actions required for session management.
+void OscServer::NEW_SONG_Handler(lo_arg **argv, int i) {
+	Action currentAction("NEW_SONG");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::OPEN_SONG_Handler(lo_arg **argv, int i) {
+	Action currentAction("OPEN_SONG");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::SAVE_SONG_Handler(lo_arg **argv, int i) {
+	Action currentAction("SAVE_SONG");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int i) {
+	Action currentAction("SAVE_SONG_AS");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
+void OscServer::QUIT_Handler(lo_arg **argv, int i) {
+	Action currentAction("QUIT");
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+	
+	pActionManager->handleAction(&currentAction);
+}
+
 bool IsLoAddressEqual( lo_address first, lo_address second )
 {
 	bool portEqual = ( strcmp( lo_address_get_port( first ), lo_address_get_port( second ) ) == 0);
@@ -820,7 +856,18 @@ void OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/UNDO_ACTION", "f", UNDO_ACTION_Handler);
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "", REDO_ACTION_Handler);
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "f", REDO_ACTION_Handler);
-	
+
+	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "", NEW_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "f", NEW_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "", OPEN_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "f", OPEN_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "f", SAVE_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "", SAVE_SONG_AS_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "f", SAVE_SONG_AS_Handler);
+	m_pServerThread->add_method("/Hydrogen/QUIT", "", QUIT_Handler);
+	m_pServerThread->add_method("/Hydrogen/QUIT", "f", QUIT_Handler);
+
 	/*
 	 * Start the server.
 	 */
@@ -828,6 +875,7 @@ void OscServer::start()
 
 
 	INFOLOG(QString("Osc server started. Listening on port %1").arg( m_pPreferences->getOscServerPort() ));
+	
 }
 
 OscServer::~OscServer()

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -576,28 +576,44 @@ void OscServer::NEW_SONG_Handler(lo_arg **argv, int argc) {
 	}
 }
 
-void OscServer::OPEN_SONG_Handler(lo_arg **argv, int i) {
+void OscServer::OPEN_SONG_Handler(lo_arg **argv, int argc) {
 	Action currentAction("OPEN_SONG");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+
+	// Accessing the provided path for the new Song.
+	if ( argc > 0 ) {
+		currentAction.setParameter1( QString::fromUtf8( &argv[0]->s ) );
+		pActionManager->handleAction(&currentAction);
+	} else {
+		// This shouldn't be happening since the handler function is
+		// only registered with an "s" lo_type argument.
+	}
 	
 	pActionManager->handleAction(&currentAction);
 }
 
-void OscServer::SAVE_SONG_Handler(lo_arg **argv, int i) {
+void OscServer::SAVE_SONG_Handler(lo_arg **argv, int argc) {
 	Action currentAction("SAVE_SONG");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 	
 	pActionManager->handleAction(&currentAction);
 }
 
-void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int i) {
+void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int argc) {
 	Action currentAction("SAVE_SONG_AS");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
-	
-	pActionManager->handleAction(&currentAction);
+
+	// Accessing the provided path for the new Song.
+	if ( argc > 0 ) {
+		currentAction.setParameter1( QString::fromUtf8( &argv[0]->s ) );
+		pActionManager->handleAction(&currentAction);
+	} else {
+		// This shouldn't be happening since the handler function is
+		// only registered with an "s" lo_type argument.
+	}
 }
 
-void OscServer::QUIT_Handler(lo_arg **argv, int i) {
+void OscServer::QUIT_Handler(lo_arg **argv, int argc) {
 	Action currentAction("QUIT");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 	
@@ -866,14 +882,10 @@ void OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "f", REDO_ACTION_Handler);
 
 	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "s", NEW_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "", OPEN_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "f", OPEN_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "s", OPEN_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "f", SAVE_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "", SAVE_SONG_AS_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "f", SAVE_SONG_AS_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "s", SAVE_SONG_AS_Handler);
 	m_pServerThread->add_method("/Hydrogen/QUIT", "", QUIT_Handler);
-	m_pServerThread->add_method("/Hydrogen/QUIT", "f", QUIT_Handler);
 
 	/*
 	 * Start the server.

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -561,11 +561,19 @@ void OscServer::REDO_ACTION_Handler(lo_arg **argv,int i)
 }
 
 // Actions required for session management.
-void OscServer::NEW_SONG_Handler(lo_arg **argv, int i) {
-	Action currentAction("NEW_SONG");
-	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+void OscServer::NEW_SONG_Handler(lo_arg **argv, int argc) {
 	
-	pActionManager->handleAction(&currentAction);
+	Action currentAction("NEW_SONG");	
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+
+	// Accessing the provided path for the new Song.
+	if ( argc > 0 ) {
+		currentAction.setParameter1( QString::fromUtf8( &argv[0]->s ) );
+		pActionManager->handleAction(&currentAction);
+	} else {
+		// This shouldn't be happening since the handler function is
+		// only registered with an "s" lo_type argument.
+	}
 }
 
 void OscServer::OPEN_SONG_Handler(lo_arg **argv, int i) {
@@ -857,8 +865,7 @@ void OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "", REDO_ACTION_Handler);
 	m_pServerThread->add_method("/Hydrogen/REDO_ACTION", "f", REDO_ACTION_Handler);
 
-	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "", NEW_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "f", NEW_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/NEW_SONG", "s", NEW_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "", OPEN_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/OPEN_SONG", "f", OPEN_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -45,6 +45,7 @@ class EventListener
 		virtual void undoRedoActionEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void tempoChangedEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void updateSongEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void quitEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -44,6 +44,7 @@ class EventListener
 		virtual void playlistLoadSongEvent( int nIndex ){ UNUSED( nIndex ); }
 		virtual void undoRedoActionEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void tempoChangedEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void updateSongEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -90,20 +90,19 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 	connect( m_pEventQueueTimer, SIGNAL( timeout() ), this, SLOT( onEventQueueTimer() ) );
 	m_pEventQueueTimer->start( QUEUE_TIMER_PERIOD );
 
-
-	// Create the audio engine :)
-	Hydrogen::create_instance();
-	
 #ifdef H2CORE_HAVE_OSC
+	// When under Non Session Management the new Song will be
+	// loaded by the corresponding NSM client instance.
 	if ( ! NsmClient::get_instance()->m_bUnderSessionManagement ) {
 		Hydrogen::get_instance()->setSong( pFirstSong );
+		Preferences::get_instance()->setLastSongFilename( pFirstSong->get_filename() );
 	}
 #endif
 #ifndef H2CORE_HAVE_OSC
 	Hydrogen::get_instance()->setSong( pFirstSong );
+	Preferences::get_instance()->setLastSongFilename( pFirstSong->get_filename() );
 #endif
 	
-	Preferences::get_instance()->setLastSongFilename( pFirstSong->get_filename() );
 	SoundLibraryDatabase::create_instance();
 
 	//setup the undo stack

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -115,6 +115,11 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 
 	m_pPlaylistDialog = new PlaylistDialog( nullptr );
 	m_pDirector = new Director( nullptr );
+	
+	// Since HydrogenApp does implement some handler functions for
+	// Events as well, it should be registered as an Eventlistener
+	// itself.
+	addEventListener( this );
 }
 
 
@@ -477,6 +482,11 @@ void HydrogenApp::onEventQueueTimer()
 
 	Event event;
 	while ( ( event = pQueue->pop_event() ).type != EVENT_NONE ) {
+		
+		// Provide the event to all EventListeners registered to
+		// HydrogenApp. By registering itself as EventListener and
+		// implementing at least on the methods used below a
+		// particular GUI component can react on specific events.
 		for (int i = 0; i < (int)m_EventListeners.size(); i++ ) {
 			EventListener *pListener = m_EventListeners[ i ];
 
@@ -554,20 +564,18 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 				
 			case EVENT_UPDATE_SONG:
-				std::cout << "[onEventQueueTimer] EVENT_UPDATE_SONG" << std::endl;
-				updateSongEvent( event.value );
+				pListener->updateSongEvent( event.value );
 				break;
 				
 			case EVENT_QUIT:
-				std::cout << "[onEventQueueTimer] EVENT_QUIT" << std::endl;
-				quitEvent( event.value );
+				pListener->quitEvent( event.value );
 				break;
 
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}
-
 		}
+
 	}
 
 	// midi notes
@@ -628,8 +636,6 @@ void HydrogenApp::cleanupTemporaryFiles()
 
 void HydrogenApp::updateSongEvent( int nValue ) {
 	
-	std::cout << "[updateSong] start" << std::endl;
-	
 	Hydrogen* pHydrogen = Hydrogen::get_instance();	
 
 	if ( nValue == 0 ) {
@@ -673,8 +679,6 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 
 void HydrogenApp::quitEvent( int nValue ) {
 
-	std::cout << "[quitEvent] start" << std::endl;
-	
 	m_pMainForm->closeAll();
 	
 }

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -504,7 +504,7 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 
 			case EVENT_SONG_MODIFIED:
-				songModifiedEvent();
+				pListener->songModifiedEvent();
 				break;
 
 			case EVENT_SELECTED_PATTERN_CHANGED:

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -635,19 +635,20 @@ void HydrogenApp::cleanupTemporaryFiles()
 }
 
 void HydrogenApp::updateSongEvent( int nValue ) {
-	
+		
 	Hydrogen* pHydrogen = Hydrogen::get_instance();	
-
-	if ( nValue == 0 ) {
+	
+	if ( nValue == 0 || nValue == 1 ) {
 
 		// Set a Song prepared by the core part.
 		Song* pNextSong = pHydrogen->getNextSong();
+		
 		pHydrogen->setSong( pNextSong );
-	
+
 		// Cleanup
 		closeFXProperties();
 		m_pUndoStack->clear();
-	
+
 		// Update GUI components
 		m_pSongEditorPanel->updateAll();
 		m_pPatternEditorPanel->updateSLnameLabel();
@@ -663,8 +664,13 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		m_pSongEditorPanel->updateAll();
 		m_pPatternEditorPanel->updateSLnameLabel();
 		updateWindowTitle();
+
+		// Restarting the audio driver.
+		if ( nValue == 1 ) {
+			pHydrogen->restartDrivers();
+		}
 		
-	} else if ( nValue == 1 ) {
+	} else if ( nValue == 2 ) {
 		
 		QString filename = pHydrogen->getSong()->get_filename();
 		

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -27,7 +27,6 @@
 #include <hydrogen/fx/LadspaFX.h>
 #include <hydrogen/Preferences.h>
 #include <hydrogen/helpers/filesystem.h>
-#include <hydrogen/nsm_client.h>
 
 #include "HydrogenApp.h"
 #include "Skin.h"
@@ -637,7 +636,7 @@ void HydrogenApp::cleanupTemporaryFiles()
 }
 
 void HydrogenApp::updateSongEvent( int nValue ) {
-		
+	
 	Hydrogen* pHydrogen = Hydrogen::get_instance();	
 	
 	if ( nValue == 0 || nValue == 1 ) {
@@ -666,9 +665,9 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		m_pSongEditorPanel->updateAll();
 		m_pPatternEditorPanel->updateSLnameLabel();
 		updateWindowTitle();
-
+		
 		// Restarting the audio driver.
-		if ( nValue == 1 ) {
+		if ( nValue == 1 ) {	
 			pHydrogen->restartDrivers();
 		}
 		

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -53,6 +53,10 @@
 
 #include "Widgets/InfoBar.h"
 
+#ifdef H2CORE_HAVE_OSC
+#include <hydrogen/nsm_client.h>
+#endif
+
 
 #include <QtGui>
 #if QT_VERSION >= 0x050000
@@ -89,7 +93,16 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 
 	// Create the audio engine :)
 	Hydrogen::create_instance();
+	
+#ifdef H2CORE_HAVE_OSC
+	if ( ! NsmClient::get_instance()->m_bUnderSessionManagement ) {
+		Hydrogen::get_instance()->setSong( pFirstSong );
+	}
+#endif
+#ifndef H2CORE_HAVE_OSC
 	Hydrogen::get_instance()->setSong( pFirstSong );
+#endif
+	
 	Preferences::get_instance()->setLastSongFilename( pFirstSong->get_filename() );
 	SoundLibraryDatabase::create_instance();
 
@@ -643,7 +656,7 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 
 		// Set a Song prepared by the core part.
 		Song* pNextSong = pHydrogen->getNextSong();
-		
+
 		pHydrogen->setSong( pNextSong );
 
 		// Cleanup

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -27,6 +27,7 @@
 #include <hydrogen/fx/LadspaFX.h>
 #include <hydrogen/Preferences.h>
 #include <hydrogen/helpers/filesystem.h>
+#include <hydrogen/nsm_client.h>
 
 #include "HydrogenApp.h"
 #include "Skin.h"
@@ -317,16 +318,17 @@ void HydrogenApp::closeFXProperties()
 #endif
 }
 
-void HydrogenApp::setSong(Song* song)
+void HydrogenApp::setSong(Song* pSong)
 {
-	Hydrogen::get_instance()->setSong( song );
-	Preferences::get_instance()->setLastSongFilename( song->get_filename() );
+	Hydrogen::get_instance()->setSong( pSong );
+	
+	Preferences::get_instance()->setLastSongFilename( pSong->get_filename() );
 
 	m_pSongEditorPanel->updateAll();
 	m_pPatternEditorPanel->updateSLnameLabel();
 
 	updateWindowTitle();
-
+	
 	m_pMainForm->updateRecentUsedSongList();
 }
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -69,7 +69,7 @@ class SampleEditor;
 class Director;
 class InfoBar;
 
-class HydrogenApp : public QObject, public H2Core::Object
+class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 {
 		H2_OBJECT
 	Q_OBJECT

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -221,6 +221,12 @@ class HydrogenApp : public QObject, public H2Core::Object
 		 * \param nValue unused
 		 */
 		virtual void updateSongEvent( int nValue );
+		/**
+		 * Calls closeAll() to shutdown Hydrogen.
+		 *
+		 * \param nValue unused
+		 */
+		virtual void quitEvent( int nValue );
 };
 
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -167,8 +167,8 @@ class HydrogenApp : public QObject, public H2Core::Object
 		     EventListener::undoRedoActionEvent()
 		 * - H2Core::EVENT_TEMPO_CHANGED -> 
 		     EventListener::tempoChangedEvent()
-		 * - H2Core::EVENT_MISMATCHING_SAMPLE_RATE -> 
-		     EventListener::mismatchingSampleRateEvent()
+		 * - H2Core::EVENT_UPDATE_SONG -> 
+		     EventListener::updateSongEvent()
 		 * - H2Core::EVENT_NONE -> nothing
 		 *
 		 * In addition, all MIDI notes in
@@ -178,7 +178,6 @@ class HydrogenApp : public QObject, public H2Core::Object
 		*/
 		void onEventQueueTimer();
 		void currentTabChanged(int);
-
 
 	private:
 		static HydrogenApp *		m_pInstance;	///< HydrogenApp instance
@@ -210,6 +209,18 @@ class HydrogenApp : public QObject, public H2Core::Object
 
 		void setupSinglePanedInterface();
 		virtual void songModifiedEvent();
+
+		/**
+		 * Refreshes and updates the GUI after the Song was changed in
+		 * the core part of Hydrogen.
+		 *
+		 * When using session management or changing the Song using
+		 * an OSC message, this command will get core and GUI in sync
+		 * again. 
+		 *
+		 * \param nValue unused
+		 */
+		virtual void updateSongEvent( int nValue );
 };
 
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -145,9 +145,10 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 		}
 	} else {
 		// When under Non Session Management the new Song will be
-		// prepared by the corresponding NSM client instance and in here
-		// we will just obtain and load it.
-		pSong = Hydrogen::get_instance()->getNextSong();
+		// prepared by the corresponding NSM client instance and in
+		// here we will just obtain and handed to the HydrogenApp but
+		// not load there.
+		pSong = Hydrogen::get_instance()->getSong();
 
 		// In case something went wrong when setting the Song to the
 		// loaded by the GUI via an OSC command, load the default Song
@@ -160,7 +161,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 	}
 
 	showDevelWarning();
-
 	h2app = new HydrogenApp( this, pSong );
 	h2app->addEventListener( this );
 	createMenuBar();

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -35,6 +35,7 @@
 #include <hydrogen/basics/drumkit_component.h>
 #include <hydrogen/basics/playlist.h>
 #include <hydrogen/lilypond/lilypond.h>
+#include <hydrogen/nsm_client.h>
 
 #include "AboutDialog.h"
 #include "AudioEngineInfoForm.h"
@@ -103,7 +104,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 	connect(snUsr1, SIGNAL(activated(int)), this, SLOT( handleSigUsr1() ));
 #endif
 
-
 	m_pQApp = app;
 
 	m_pQApp->processEvents();
@@ -111,7 +111,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 	Song *pSong = nullptr;
 	
 	if ( bLoadSong ) {
-
 		if ( !songFilename.isEmpty() ) {
 			pSong = Song::load( songFilename );
 
@@ -119,8 +118,7 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 			 * If the song could not be loaded, create
 			 * a new one with the specified filename
 			 */
-			if (pSong == nullptr) {
-				//QMessageBox::warning( this, "Hydrogen", tr("Error restoring last song.") );
+			if ( pSong == nullptr ) {
 				pSong = Song::get_empty_song();
 				pSong->set_filename( songFilename );
 			}
@@ -131,7 +129,7 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 			QString filename = pref->getLastSongFilename();
 			if ( restoreLastSong && ( !filename.isEmpty() )) {
 				pSong = Song::load( filename );
-				if (pSong == nullptr) {
+				if ( pSong == nullptr ) {
 					//QMessageBox::warning( this, "Hydrogen", trUtf8("Error restoring last song.") );
 					pSong = Song::get_empty_song();
 					pSong->set_filename( "" );
@@ -155,8 +153,9 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 			pSong = Song::get_empty_song();
 			pSong->set_filename( songFilename );
 		}
+		
 	}
-	
+
 	showDevelWarning();
 
 	h2app = new HydrogenApp( this, pSong );
@@ -184,7 +183,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 	connect( &m_AutosaveTimer, SIGNAL(timeout()), this, SLOT(onAutoSaveTimer()));
 	m_AutosaveTimer.start( 60 * 1000 );
 
-
 #ifdef H2CORE_HAVE_LASH
 
 	if ( Preferences::get_instance()->useLash() ){
@@ -206,7 +204,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 	}
 #endif
 
-
 	//playlist display timer
 	QTimer *playlistDisplayTimer = new QTimer(this);
 	connect( playlistDisplayTimer, SIGNAL( timeout() ), this, SLOT( onPlaylistDisplayTimer() ) );
@@ -221,7 +218,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename, const bool b
 
 	m_pUndoView = new QUndoView(h2app->m_pUndoStack);
 	m_pUndoView->setWindowTitle(tr("Undo history"));
-
 
 	//restore last playlist
 	if(		Preferences::get_instance()->isRestoreLastPlaylistEnabled()
@@ -275,21 +271,41 @@ void MainForm::createMenuBar()
 	// FILE menu
 	QMenu *m_pFileMenu = m_pMenubar->addMenu( tr( "Pro&ject" ) );
 
-	m_pFileMenu->addAction( tr( "&New" ), this, SLOT( action_file_new() ), QKeySequence( "Ctrl+N" ) );
-	m_pFileMenu->addAction( tr( "Show &info" ), this, SLOT( action_file_songProperties() ), QKeySequence( "" ) );
+	// Then under session management a couple of options will be named
+	// differently and some must be even omitted. 
+	bool bUnderSessionManagement = NsmClient::get_instance()->m_bUnderSessionManagement;
+	
+	QString textFileNew, textFileOpen, textFileOpenRecent, textFileSaveAs;
+	
+	if ( bUnderSessionManagement ) {
+		textFileNew = "Replace with &new Song";
+		textFileOpen = "&Import into Session";
+		textFileOpenRecent = "Import &recent into Session";
+		textFileSaveAs = "Export from Session &as...";
+	} else {
+		textFileNew = "&New";
+		textFileOpen = "&Open";
+		textFileOpenRecent = "Open &recent";
+		textFileSaveAs = "Save &as...";
+	}
+	
+	m_pFileMenu->addAction( textFileNew, this, SLOT( action_file_new() ), QKeySequence( "Ctrl+N" ) );
+	
+	m_pFileMenu->addAction( trUtf8( "Show &info" ), this, SLOT( action_file_songProperties() ), QKeySequence( "" ) );
+	
+	m_pFileMenu->addSeparator();				// -----
+
+	m_pFileMenu->addAction( textFileOpen, this, SLOT( action_file_open() ), QKeySequence( "Ctrl+O" ) );
+	if ( ! bUnderSessionManagement ) {
+		m_pFileMenu->addAction( trUtf8( "Open &Demo" ), this, SLOT( action_file_openDemo() ), QKeySequence( "Ctrl+D" ) );
+	}
+	m_pRecentFilesMenu = m_pFileMenu->addMenu( textFileOpenRecent );
 
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction( tr( "&Open" ), this, SLOT( action_file_open() ), QKeySequence( "Ctrl+O" ) );
-	m_pFileMenu->addAction( tr( "Open &Demo" ), this, SLOT( action_file_openDemo() ), QKeySequence( "Ctrl+D" ) );
-
-	m_pRecentFilesMenu = m_pFileMenu->addMenu( tr( "Open &recent" ) );
-
-	m_pFileMenu->addSeparator();				// -----
-
-	m_pFileMenu->addAction( tr( "&Save" ), this, SLOT( action_file_save() ), QKeySequence( "Ctrl+S" ) );
-	m_pFileMenu->addAction( tr( "Save &as..." ), this, SLOT( action_file_save_as() ), QKeySequence( "Ctrl+Shift+S" ) );
-
+	m_pFileMenu->addAction( trUtf8( "&Save" ), this, SLOT( action_file_save() ), QKeySequence( "Ctrl+S" ) );
+	m_pFileMenu->addAction( textFileSaveAs, this, SLOT( action_file_save_as() ), QKeySequence( "Ctrl+Shift+S" ) );
+	
 	m_pFileMenu->addSeparator();				// -----
 
 	m_pFileMenu->addAction ( tr ( "Open &Pattern" ), this, SLOT ( action_file_openPattern() ), QKeySequence ( "" ) );
@@ -529,6 +545,8 @@ bool MainForm::action_file_exit()
 
 void MainForm::action_file_new()
 {
+	bool bUnderSessionManagement = NsmClient::get_instance()->m_bUnderSessionManagement;
+	
 	Hydrogen * pEngine = Hydrogen::get_instance();
 	if ( (pEngine->getState() == STATE_PLAYING) ) {
 		pEngine->sequencer_stop();
@@ -538,11 +556,38 @@ void MainForm::action_file_new()
 	if(!proceed) {
 		return;
 	}
-
+	
 	h2app->m_pUndoStack->clear();
 	pEngine->getTimeline()->m_timelinevector.clear();
-	Song * pSong = Song::get_empty_song();
-	pSong->set_filename( "" );
+	Song* pSong = Song::get_empty_song();
+	
+	// When under session management the filename of the current Song
+	// has to be preserved.
+	QString currentFilename;
+	if ( bUnderSessionManagement ) {
+		currentFilename = H2Core::Hydrogen::get_instance()->getSong()->get_filename();
+		
+		// Just a single click will allow the user to discard the
+		// current song and replace it with an empty one with now way
+		// of undoing the action. Therefore, a warning popup will
+		// check whether the action was intentional.
+		QMessageBox confirmationBox;
+		confirmationBox.setText( "Replace current song with empty one?" );
+		confirmationBox.setInformativeText( "You won't be able to undo this action! Please export the current song from the session first in order to keep it." );
+		confirmationBox.setStandardButtons( QMessageBox::Yes | QMessageBox::No );
+		confirmationBox.setDefaultButton( QMessageBox::No );
+		
+		int confirmationChoice = confirmationBox.exec();
+		
+		if ( confirmationChoice == QMessageBox::No ) {
+			return;
+		}
+								 
+		pSong->set_filename( currentFilename );
+	} else {
+		pSong->set_filename( "" );
+	}
+	
 	h2app->setSong(pSong);
 	pEngine->setSelectedPatternNumber( 0 );
 	h2app->getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
@@ -559,6 +604,8 @@ void MainForm::action_file_new()
 
 void MainForm::action_file_save_as()
 {
+	bool bUnderSessionManagement = NsmClient::get_instance()->m_bUnderSessionManagement;
+		
 	Hydrogen* pEngine = Hydrogen::get_instance();
 
 	if ( pEngine->getState() == STATE_PLAYING ) {
@@ -570,12 +617,18 @@ void MainForm::action_file_save_as()
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::songs_filter_name );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
-	fd.setWindowTitle( tr( "Save song" ) );
+
+	if ( bUnderSessionManagement ) {	
+		fd.setWindowTitle( trUtf8( "Export song from Session" ) );
+	} else {
+		fd.setWindowTitle( trUtf8( "Save song" ) );
+	}
+	
 	fd.setSidebarUrls( fd.sidebarUrls() << QUrl::fromLocalFile( Filesystem::songs_dir() ) );
 
-	Song *song = pEngine->getSong();
+	Song* pSong = pEngine->getSong();
 	QString defaultFilename;
-	QString lastFilename = song->get_filename();
+	QString lastFilename = pSong->get_filename();
 
 	if ( lastFilename.isEmpty() ) {
 		defaultFilename = pEngine->getSong()->__name;
@@ -598,10 +651,19 @@ void MainForm::action_file_save_as()
 			filename += Filesystem::songs_ext;
 		}
 
-		song->set_filename(filename);
+		pSong->set_filename(filename);
 		action_file_save();
 	}
-	h2app->setScrollStatusBarMessage( tr("Song saved as.") + QString(" Into: ") + defaultFilename, 2000 );
+
+	// When Hydrogen is under session management, the file name
+	// provided by the NSM server has to be preserved.
+	if ( bUnderSessionManagement ) {
+		pSong->set_filename( lastFilename );
+		h2app->setScrollStatusBarMessage( trUtf8("Song exported as.") + QString(" Into: ") + defaultFilename, 2000 );
+	} else {
+		h2app->setScrollStatusBarMessage( trUtf8("Song saved as.") + QString(" Into: ") + defaultFilename, 2000 );
+	}
+	
 	h2app->updateWindowTitle();
 }
 
@@ -626,13 +688,18 @@ void MainForm::action_file_save()
 	} else {
 		Preferences::get_instance()->setLastSongFilename( pSong->get_filename() );
 
-		// add the new loaded song in the "last used song" vector
-		Preferences *pPref = Preferences::get_instance();
-		vector<QString> recentFiles = pPref->getRecentFiles();
-		recentFiles.insert( recentFiles.begin(), filename );
-		pPref->setRecentFiles( recentFiles );
+		// Add the new loaded song in the "last used song"
+		// vector. 
+		// This behavior is prohibited under session management. Only
+		// songs open during normal runs will be listed.
+		if ( ! NsmClient::get_instance()->m_bUnderSessionManagement ) {
+			Preferences *pPref = Preferences::get_instance();
+			vector<QString> recentFiles = pPref->getRecentFiles();
+			recentFiles.insert( recentFiles.begin(), filename );
+			pPref->setRecentFiles( recentFiles );
 
-		updateRecentUsedSongList();
+			updateRecentUsedSongList();
+		}
 
 		h2app->setScrollStatusBarMessage( tr("Song saved.") + QString(" Into: ") + filename, 2000 );
 		EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
@@ -721,10 +788,12 @@ void MainForm::action_file_export_pattern_as()
 	}
 }
 
-void MainForm::action_file_open() 
-{
+void MainForm::action_file_open() {
+	bool bUnderSessionManagement = NsmClient::get_instance()->m_bUnderSessionManagement;
+		
 	if ( ((Hydrogen::get_instance())->getState() == STATE_PLAYING) ) {
 		Hydrogen::get_instance()->sequencer_stop();
+		
 	}
 
 	bool proceed = handleUnsavedChanges();
@@ -740,7 +809,11 @@ void MainForm::action_file_open()
 	fd.setDirectory( lastUsedDir );
 	fd.setNameFilter( Filesystem::songs_filter_name );
 
-	fd.setWindowTitle( tr( "Open song" ) );
+	if ( bUnderSessionManagement ) {
+		fd.setWindowTitle( trUtf8( "Import song into Session" ) );
+	} else {
+		fd.setWindowTitle( trUtf8( "Open song" ) );
+	}
 
 	QString filename;
 	if (fd.exec() == QDialog::Accepted) {
@@ -748,8 +821,24 @@ void MainForm::action_file_open()
 		lastUsedDir = fd.directory().absolutePath();
 	}
 
+	// When under session management the filename of the current Song
+	// has to be preserved.
+	QString currentFilename;
+	if ( bUnderSessionManagement ) {
+		currentFilename = H2Core::Hydrogen::get_instance()->getSong()->get_filename();
+	}
 	if ( !filename.isEmpty() ) {
 		openSongFile( filename );
+	}
+
+	if ( bUnderSessionManagement ) {
+		
+		Song* pSong = H2Core::Hydrogen::get_instance()->getSong();
+		if ( pSong == nullptr ) {
+			ERRORLOG( QString( "No song present while under session management" ) );
+			return;
+		}
+		pSong->set_filename( currentFilename );
 	}
 
 	HydrogenApp::get_instance()->getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
@@ -1343,8 +1432,19 @@ void MainForm::updateRecentUsedSongList()
 
 void MainForm::action_file_open_recent(QAction *pAction)
 {
-	//	INFOLOG( pAction->text() );
+	// When under session management the filename of the current Song
+	// has to be preserved.
+	bool bUnderSessionManagement = NsmClient::get_instance()->m_bUnderSessionManagement;
+	QString currentFilename;
+	if ( bUnderSessionManagement ) {
+		currentFilename = H2Core::Hydrogen::get_instance()->getSong()->get_filename();
+	}
+	
 	openSongFile( pAction->text() );
+	
+	if ( bUnderSessionManagement ) {
+		H2Core::Hydrogen::get_instance()->getSong()->set_filename( currentFilename );
+	}
 }
 
 
@@ -1368,12 +1468,18 @@ void MainForm::openSongFile( const QString& sFilename )
 
 	h2app->m_pUndoStack->clear();
 
-	// add the new loaded song in the "last used song" vector
-	Preferences *pPref = Preferences::get_instance();
-	vector<QString> recentFiles = pPref->getRecentFiles();
-	recentFiles.insert( recentFiles.begin(), sFilename );
-	pPref->setRecentFiles( recentFiles );
+	// Add the new loaded song in the "last used song" vector.  This
+	// behavior is prohibited under session management. Only songs
+	// open during normal runs will be listed.
 
+	// add the new loaded song in the "last used song" vector
+	if ( ! NsmClient::get_instance()->m_bUnderSessionManagement ) {
+		Preferences *pPref = Preferences::get_instance();
+		vector<QString> recentFiles = pPref->getRecentFiles();
+		recentFiles.insert( recentFiles.begin(), sFilename );
+		pPref->setRecentFiles( recentFiles );
+	}
+	
 	h2app->setSong( pSong );
 
 	updateRecentUsedSongList();

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -67,10 +67,48 @@ public slots:
 		void showPreferencesDialog();
 		void showUserManual();
 
+		/**
+		 * Project > New handling function.
+		 *
+		 * Creates an empty Song and set it as the current one.
+		 *
+		 * When Hydrogen is under session management (NSM) this
+		 * function will assume that there is already a Song present
+		 * (which is the case). Else it will return without doing
+		 * anything. It uses the current Song to assign the it file
+		 * path to the empty one since the name provided by the NSM
+		 * server must be used or the restart of the session fails.
+		 */
 		void action_file_new();
+		
+		/**
+		 * Project > Open / Import into Session handling function.
+		 *
+		 * Opens an existing Song.
+		 *
+		 * When Hydrogen is under session management (NSM) this
+		 * function will assume that there is already a Song present
+		 * (which is the case). Else it will return without doing
+		 * anything. It opens the chosen file and uses the current
+		 * Song to assign its file path to the opened one since the
+		 * name provided by the NSM server must be used or the restart
+		 * of the session fails.
+		 */
 		void action_file_open();
 		void action_file_openDemo();
 		void action_file_save();
+		
+		/**
+		 * Project > Save As / Export from Session handling function.
+		 *
+		 * Saves the current Song in a different path.
+		 *
+		 * When Hydrogen is under session management (NSM) this
+		 * function will store the Song in the chosen location but
+		 * keeps its previous file path associated with it since the
+		 * name provided by the NSM server must be used or the restart
+		 * of the session fails.
+		 */
 		void action_file_save_as();
 		void action_file_openPattern();
 		void action_file_export_pattern_as();

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -138,6 +138,7 @@ public slots:
 		void action_toggle_input_mode();
 
 		void handleSigUsr1();
+		void closeAll();
 
 	private slots:
 		void onAutoSaveTimer();
@@ -181,7 +182,6 @@ public slots:
 		/** Create the menubar */
 		void createMenuBar();
 
-		void closeAll();
 		void openSongFile( const QString& sFilename );
 		void checkMidiSetup();
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -51,7 +51,7 @@ class MainForm : public QMainWindow, public EventListener, public H2Core::Object
 	public:
 		QApplication* m_pQApp;
 
-		MainForm( QApplication *app, const QString& songFilename );
+		MainForm( QApplication *app, const QString& songFilename, const bool bLoadSong );
 		~MainForm();
 
 		void updateRecentUsedSongList();

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -59,7 +59,10 @@
 #include <hydrogen/basics/sample.h>
 #include <hydrogen/basics/song.h>
 #include <hydrogen/helpers/filesystem.h>
+
+#ifdef H2CORE_HAVE_OSC
 #include <hydrogen/nsm_client.h>
+#endif
 
 using namespace H2Core;
 
@@ -742,8 +745,8 @@ void SoundLibraryPanel::on_songLoadAction()
 		return;
 	}
 
-	// Add the new loaded song in the "last used song"
-	// vector. 
+#ifdef H2CORE_HAVE_OSC
+	// Add the new loaded song in the "last used song" vector. 
 	// This behavior is prohibited under session management. Only
 	// songs open during normal runs will be listed.
 	if ( ! NsmClient::get_instance()->m_bUnderSessionManagement ) {
@@ -753,6 +756,14 @@ void SoundLibraryPanel::on_songLoadAction()
 		recentFiles.insert( recentFiles.begin(), sFilename );
 		pPref->setRecentFiles( recentFiles );
 	}
+#endif
+#ifndef H2CORE_HAVE_OSC
+	Preferences *pPref = Preferences::get_instance();
+
+	std::vector<QString> recentFiles = pPref->getRecentFiles();
+	recentFiles.insert( recentFiles.begin(), sFilename );
+	pPref->setRecentFiles( recentFiles );
+#endif
 
 	HydrogenApp* pH2App = HydrogenApp::get_instance();
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -59,6 +59,7 @@
 #include <hydrogen/basics/sample.h>
 #include <hydrogen/basics/song.h>
 #include <hydrogen/helpers/filesystem.h>
+#include <hydrogen/nsm_client.h>
 
 using namespace H2Core;
 
@@ -734,19 +735,24 @@ void SoundLibraryPanel::on_songLoadAction()
 	if ( pHydrogen->getState() == STATE_PLAYING ) {
 		pHydrogen->sequencer_stop();
 	}
-
+	
 	Song *pSong = Song::load( sFilename );
 	if ( pSong == nullptr ) {
 		QMessageBox::information( this, "Hydrogen", tr("Error loading song.") );
 		return;
 	}
 
-	// add the new loaded song in the "last used song" vector
-	Preferences *pPref = Preferences::get_instance();
+	// Add the new loaded song in the "last used song"
+	// vector. 
+	// This behavior is prohibited under session management. Only
+	// songs open during normal runs will be listed.
+	if ( ! NsmClient::get_instance()->m_bUnderSessionManagement ) {
+		Preferences *pPref = Preferences::get_instance();
 
-	std::vector<QString> recentFiles = pPref->getRecentFiles();
-	recentFiles.insert( recentFiles.begin(), sFilename );
-	pPref->setRecentFiles( recentFiles );
+		std::vector<QString> recentFiles = pPref->getRecentFiles();
+		recentFiles.insert( recentFiles.begin(), sFilename );
+		pPref->setRecentFiles( recentFiles );
+	}
 
 	HydrogenApp* pH2App = HydrogenApp::get_instance();
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
 
 		SplashScreen *pSplash = new SplashScreen();
 
-		if (bNoSplash) {
+		if ( bNoSplash ||  getenv( "NSM_URL" ) ) {
 			pSplash->hide();
 		}
 		else {

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -45,13 +45,16 @@
 #include <hydrogen/midi_map.h>
 #include <hydrogen/audio_engine.h>
 #include <hydrogen/hydrogen.h>
-#include <hydrogen/nsm_client.h>
 #include <hydrogen/globals.h>
 #include <hydrogen/event_queue.h>
 #include <hydrogen/Preferences.h>
 #include <hydrogen/h2_exception.h>
 #include <hydrogen/basics/playlist.h>
 #include <hydrogen/helpers/filesystem.h>
+
+#ifdef H2CORE_HAVE_OSC
+#include <hydrogen/nsm_client.h>
+#endif
 
 #include <signal.h>
 #include <iostream>
@@ -308,12 +311,17 @@ int main(int argc, char *argv[])
 
 		SplashScreen *pSplash = new SplashScreen();
 
+#ifdef H2CORE_HAVE_OSC
 		if ( bNoSplash ||  getenv( "NSM_URL" ) ) {
 			pSplash->hide();
 		}
 		else {
 			pSplash->show();
 		}
+#endif
+#ifndef H2CORE_HAVE_OSC
+		pSplash->show();
+#endif
 
 #ifdef H2CORE_HAVE_LASH
 		if ( H2Core::Preferences::get_instance()->useLash() ){
@@ -379,6 +387,8 @@ int main(int argc, char *argv[])
 
 #ifdef H2CORE_HAVE_OSC
 		H2Core::Hydrogen::get_instance()->startNsmClient();
+		
+		std::cout << "[main] USBM" << std::endl;
 		
 		if ( NsmClient::get_instance()->m_bUnderSessionManagement ){
 			

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -368,6 +368,9 @@ int main(int argc, char *argv[])
 
 		// Hydrogen here to honor all preferences.
 		H2Core::Hydrogen::create_instance();
+		
+		// Tell Hydrogen it was started via the QT5 GUI.
+		H2Core::Hydrogen::get_instance()->setActiveGUI( true );
 
 #ifdef H2CORE_HAVE_OSC
 		H2Core::Hydrogen::get_instance()->startNsmClient();

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -399,6 +399,15 @@ int main(int argc, char *argv[])
 		}
 			
 #endif
+		// If the NSM_URL variable is present, Hydrogen will not
+		// initialize the audio driver and leaves this to the callback
+		// function nsm_open_cb of the NSM client (which will be
+		// called by now). However, the presence of the environmental
+		// variable does not guarantee for a session management and if
+		// no audio driver is initialized yet, we will do it here. 
+		if ( H2Core::Hydrogen::get_instance()->getAudioOutput() == nullptr ) {
+			H2Core::Hydrogen::get_instance()->restartDrivers();
+		}
 
 		MainForm *pMainForm = new MainForm( pQApp, sSongFilename, bLoadSong );
 		pMainForm->show();

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -388,8 +388,6 @@ int main(int argc, char *argv[])
 #ifdef H2CORE_HAVE_OSC
 		H2Core::Hydrogen::get_instance()->startNsmClient();
 		
-		std::cout << "[main] USBM" << std::endl;
-		
 		if ( NsmClient::get_instance()->m_bUnderSessionManagement ){
 			
 			// When using the Non Session Management system, the new


### PR DESCRIPTION
At the current state Hydrogen is, unfortunately, not compliant at all with the NSM standard and thus can only barely fits within session management. Most notable: due to the lack a automatic rewiring similar to #549 the per track output option is basically unusable. I added a couple of changes to make Hydrogen more compliant with the standard. This pull request is based on and supersedes  #773 

New features/improvements:
- All wiring of the JACK ports in session management (in presence of an application like `JackPatch` is persistent and will be restored when reloading the session. 
- User interface compliant with NSM standard
- H2 does use the name provided by the NSM server to store the song corresponding to the session in the designated session folder
- H2 is now able to support switching between different sessions without restarting the whole application. Instead, the new song is loaded and the audio driver restarted.
- H2 sends a 'dirty' flag to the NSM server to indicate unsaved changes.

Especially the first one gave me quite a headache. It turned out that the Song must already be present when starting the audio driver so JACK can create all track output ports along the main left and right output right away. Doing it at a later point in time won't work. I therefore introduced (among other changes) a new function called `Hydrogen::setInitialSong()` for a Song to be present when starting the audio driver without calling any of the audio driver-related routines in `Hydrogen::setSong()`. Note that while the checking whether H2 is under session management or not is specific to NSM, the solution should be extended to other session management systems like LADISH without a problem.