### PR TITLE
display choice of auto driver

### DIFF
--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -560,8 +560,14 @@ void PreferencesDialog::updateDriverInfo()
 #endif
 
 	if ( driverComboBox->currentText() == "Auto" ) {
-		info += tr("<b>Automatic driver selection</b>");
-
+		info += tr("Automatic driver selection");
+		
+		// Display the selected driver as well.
+		if ( H2Core::Hydrogen::get_instance()->getAudioOutput() != nullptr ) {
+			info += tr("<br><b>")+
+				H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name()+
+				tr("</b> selected");
+		}
 		m_pAudioDeviceTxt->setEnabled(false);
 		m_pAudioDeviceTxt->setText( "" );
 		bufferSizeSpinBox->setEnabled( false );


### PR DESCRIPTION
When choosing the **auto** driver, the `__class_name` of the selected audio driver will be displayed in the Preferences menu.

![preference-auto-driver](https://user-images.githubusercontent.com/14164547/69010871-65f29e00-0964-11ea-9541-32cf010059fc.png)


Solves #786