### PR TITLE
order in EnvelopePoint() call and bug fix

### DIFF
--- a/src/core/src/basics/sample.cpp
+++ b/src/core/src/basics/sample.cpp
@@ -100,12 +100,12 @@ Sample::Sample( Sample* pOther ): Object( __class_name ),
 
 	PanEnvelope* pPan = pOther->get_pan_envelope();
 	for( int i=0; i<pPan->size(); i++ ) {
-		__pan_envelope.push_back( std::make_unique<EnvelopePoint>( pPan->at(i)->value, pPan->at(i)->frame ) );
+		__pan_envelope.push_back( std::make_unique<EnvelopePoint>( pPan->at(i).get() ) );
 	}
 
 	PanEnvelope* pVelocity = pOther->get_velocity_envelope();
 	for( int i=0; i<pVelocity->size(); i++ ) {
-		__velocity_envelope.push_back( std::make_unique<EnvelopePoint>( pVelocity->at(i)->value, pVelocity->at(i)->frame ) );
+		__velocity_envelope.push_back( std::make_unique<EnvelopePoint>( pVelocity->at(i).get() ) );
 	}
 }
 
@@ -349,7 +349,7 @@ void Sample::apply_velocity( const VelocityEnvelope& v )
 		}
 		
 		for(auto& pEnvPtr : v){
-			__velocity_envelope.emplace_back( std::make_unique<EnvelopePoint>( pEnvPtr->value, pEnvPtr->frame ) );
+			__velocity_envelope.emplace_back( std::make_unique<EnvelopePoint>( pEnvPtr.get() ) );
 		}
 	}
 	__is_modified = true;
@@ -393,7 +393,7 @@ void Sample::apply_pan( const PanEnvelope& p )
 		}
 		
 		for(auto& pEnvPtr : p){
-			__pan_envelope.emplace_back( std::make_unique<EnvelopePoint>( pEnvPtr->value, pEnvPtr->frame ) );
+			__pan_envelope.emplace_back( std::make_unique<EnvelopePoint>( pEnvPtr.get() ) );
 		}
 	}
 	__is_modified = true;

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -214,7 +214,7 @@ void SampleEditor::getAllFrameInfos()
 		m_pTargetSampleView->get_pan()->push_back( std::make_unique<EnvelopePoint>( m_pTargetSampleView->width(), m_pTargetSampleView->height()/2 ) );
 	} else {
 		for(auto& pEnvPtr : *pSample->get_pan_envelope() ){
-			m_pTargetSampleView->get_pan()->emplace_back( std::make_unique<EnvelopePoint>( pEnvPtr->value, pEnvPtr->frame ) );
+			m_pTargetSampleView->get_pan()->emplace_back( std::make_unique<EnvelopePoint>( pEnvPtr.get() ) );
 		}
 	}
 

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -115,12 +115,12 @@ void TargetWaveDisplay::paintEvent(QPaintEvent *ev)
 		painter.drawEllipse ( m_VelocityEnvelope[i]->frame - 6/2, m_VelocityEnvelope[i]->value  - 6/2, 6, 6 );
 	}
 
-	for ( int i = 0; i < static_cast<int>(__pan.size()) -1; i++){
+	for ( int i = 0; i < static_cast<int>(m_PanEnvelope.size()) -1; i++){
 		//pan line
 		painter.setPen( QPen(QColor( 249, 235, 116, 200 ) ,1 , Qt::SolidLine) );
-		painter.drawLine( __pan[i]->frame, __pan[i]->value, __pan[i + 1]->frame, __pan[i +1]->value );
+		painter.drawLine( m_PanEnvelope[i]->frame, m_PanEnvelope[i]->value, m_PanEnvelope[i + 1]->frame, m_PanEnvelope[i +1]->value );
 		painter.setBrush(QColor( 77, 189, 55 ));
-		painter.drawEllipse ( __pan[i]->frame - 6/2, __pan[i]->value  - 6/2, 6, 6 );
+		painter.drawEllipse ( m_PanEnvelope[i]->frame - 6/2, m_PanEnvelope[i]->value  - 6/2, 6, 6 );
 	}
 
 
@@ -140,9 +140,9 @@ void TargetWaveDisplay::paintEvent(QPaintEvent *ev)
 	//first rect
 	painter.setPen( QPen(QColor( 249, 235, 116, 200 ) ,1 , Qt::SolidLine) );
 	painter.setBrush(QColor( 77, 189, 55 ));
-	painter.drawRect ( __pan[0]->frame - 12/2, __pan[0]->value  - 6/2, 12, 6 );
+	painter.drawRect ( m_PanEnvelope[0]->frame - 12/2, m_PanEnvelope[0]->value  - 6/2, 12, 6 );
 	//last rect
-	painter.drawRect ( __pan[__pan.size() -1]->frame - 12/2, __pan[__pan.size() -1]->value  - 6/2, 12, 6 );
+	painter.drawRect ( m_PanEnvelope[m_PanEnvelope.size() -1]->frame - 12/2, m_PanEnvelope[m_PanEnvelope.size() -1]->value  - 6/2, 12, 6 );
 
 
 	painter.setPen( QPen( QColor( 255, 255, 255 ), 1, Qt::DotLine ) );
@@ -276,7 +276,7 @@ void TargetWaveDisplay::mouseMoveEvent(QMouseEvent *ev)
 					Value = ev->y();
 				}
 				m_VelocityEnvelope.push_back( std::make_unique<EnvelopePoint>( Frame, Value) );
-				//sort( m_VelocityEnvelope.begin(), m_VelocityEnvelope.end(), EnvelopePoint::Comparator() );
+				sort( m_VelocityEnvelope.begin(), m_VelocityEnvelope.end(), EnvelopePoint::Comparator() );
 				update();
 				return;
 			}else
@@ -298,23 +298,23 @@ void TargetWaveDisplay::mouseMoveEvent(QMouseEvent *ev)
 		m_nX = ev->x();
 		m_nY = ev->y();
 
-		for ( int i = 0; i < static_cast<int>(__pan.size()); i++){
-			if ( __pan[i]->frame >= ev->x() - snapradius && __pan[i]->frame <= ev->x() + snapradius ) {
-				__pan.erase( __pan.begin() + i);
+		for ( int i = 0; i < static_cast<int>(m_PanEnvelope.size()); i++){
+			if ( m_PanEnvelope[i]->frame >= ev->x() - snapradius && m_PanEnvelope[i]->frame <= ev->x() + snapradius ) {
+				m_PanEnvelope.erase( m_PanEnvelope.begin() + i);
 				int Frame = 0;
 				int Value = 0;
 				if ( i == 0 ){
 					Frame = 0;
 					Value = ev->y();
-				} else if ( i == static_cast<int>(__pan.size()) ) {
-					Frame = __pan[i]->frame;
+				} else if ( i == static_cast<int>(m_PanEnvelope.size()) ) {
+					Frame = m_PanEnvelope[i]->frame;
 					Value = ev->y();
 				} else {
 					Frame = ev->x();
 					Value = ev->y();
 				}
-				__pan.push_back( std::make_unique<EnvelopePoint>(Value, Frame) );
-				sort( __pan.begin(), __pan.end(), EnvelopePoint::Comparator() );
+				m_PanEnvelope.push_back( std::make_unique<EnvelopePoint>(Frame, Value) );
+				sort( m_PanEnvelope.begin(), m_PanEnvelope.end(), EnvelopePoint::Comparator() );
 				update();
 				return;
 			}else
@@ -384,8 +384,8 @@ void TargetWaveDisplay::mousePressEvent(QMouseEvent *ev)
 	///edit panorama points
 	else if( EditType == 1 ){
 		// test if there is already a point
-		for ( int i = 0; i < static_cast<int>(__pan.size()); ++i){
-			if ( __pan[i]->frame >= ev->x() - SnapRadius && __pan[i]->frame <= ev->x() + SnapRadius ){
+		for ( int i = 0; i < static_cast<int>(m_PanEnvelope.size()); ++i){
+			if ( m_PanEnvelope[i]->frame >= ev->x() - SnapRadius && m_PanEnvelope[i]->frame <= ev->x() + SnapRadius ){
 				NewPoint = false;
 			}
 		}
@@ -400,8 +400,8 @@ void TargetWaveDisplay::mousePressEvent(QMouseEvent *ev)
 			if ( ev->y() >= UI_HEIGHT ) y = UI_HEIGHT;
 			if ( ev->x() <= SnapRadius ) x = SnapRadius;
 			if ( ev->x() >= UI_WIDTH-SnapRadius ) x = UI_WIDTH-SnapRadius;
-			__pan.push_back( std::make_unique<EnvelopePoint>( x, y ) );
-			sort( __pan.begin(), __pan.end(), EnvelopePoint::Comparator() );
+			m_PanEnvelope.push_back( std::make_unique<EnvelopePoint>( x, y ) );
+			sort( m_PanEnvelope.begin(), m_PanEnvelope.end(), EnvelopePoint::Comparator() );
 		}
 
 
@@ -415,10 +415,10 @@ void TargetWaveDisplay::mousePressEvent(QMouseEvent *ev)
 			}
 			m_sInfo = "";
 
-			for ( int i = 0; i < static_cast<int>(__pan.size()); i++){
-				if ( __pan[i]->frame >= ev->x() - SnapRadius && __pan[i]->frame <= ev->x() + SnapRadius ){
-					if ( __pan[i]->frame == 0 || __pan[i]->frame == UI_WIDTH) return;
-					__pan.erase( __pan.begin() +  i);
+			for ( int i = 0; i < static_cast<int>(m_PanEnvelope.size()); i++){
+				if ( m_PanEnvelope[i]->frame >= ev->x() - SnapRadius && m_PanEnvelope[i]->frame <= ev->x() + SnapRadius ){
+					if ( m_PanEnvelope[i]->frame == 0 || m_PanEnvelope[i]->frame == UI_WIDTH) return;
+					m_PanEnvelope.erase( m_PanEnvelope.begin() +  i);
 				}
 			}
 		}

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.h
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.h
@@ -52,7 +52,7 @@ class TargetWaveDisplay : public QWidget, public H2Core::Object
 		void updateDisplayPointer();
 		void paintLocatorEventTargetDisplay( int pos, bool last_event);
 		void paintEvent(QPaintEvent *ev);
-		H2Core::Sample::PanEnvelope* get_pan() { return &__pan; }
+		std::vector<std::unique_ptr<H2Core::EnvelopePoint>>* get_pan() { return &m_PanEnvelope; }
 		std::vector<std::unique_ptr<H2Core::EnvelopePoint>>* get_velocity() { return &m_VelocityEnvelope; }
 
 	private:
@@ -77,7 +77,7 @@ class TargetWaveDisplay : public QWidget, public H2Core::Object
 		virtual void mousePressEvent(QMouseEvent *ev);
 		virtual void mouseReleaseEvent(QMouseEvent *ev);
 
-		H2Core::Sample::PanEnvelope __pan;
+		std::vector<std::unique_ptr<H2Core::EnvelopePoint>> m_PanEnvelope;
 		std::vector<std::unique_ptr<H2Core::EnvelopePoint>> m_VelocityEnvelope;
 };
 


### PR DESCRIPTION
- the order of the `value` and `frame` argument of the `EnvelopePoint` class have been mixed up at several points. Instead of providing arguments, I used the copy constructor as much as possible to prevent these problems from occurring again.
- `TargetWaveDisplay.__pan` was renamed to `m_PanEnvelope` to reflect the changes in `__velocity`. Same thing for its type
- A comment in TargetWaveDisplay.cpp was removed. This fixes #782