### PR TITLE
Fix buffer overflow in TargetWaveDisplay

### DIFF
--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -94,12 +94,12 @@ void TargetWaveDisplay::paintEvent(QPaintEvent *ev)
 	int LCenter = VCenter -4;
 	int RCenter = VCenter +4;
 
-	for ( int x = 0; x < width(); x++ ) {
+	for ( int x = 0; x < width() - 1; x++ ) {
 		painter.drawLine( x, LCenter, x, -m_pPeakData_Left[x +1] +LCenter  );
 	}
 
 	painter.setPen( QColor( 116, 186, 255 ));
-	for ( int x = 0; x < width(); x++ ) {
+	for ( int x = 0; x < width() - 1; x++ ) {
 		painter.drawLine( x, RCenter, x, -m_pPeakData_Right[x +1] +RCenter  );
 	}
 


### PR DESCRIPTION
PeakDataLeft and Right are of length w, but the max value accessed is w (m_pPeakData_Left[w]), when it should be w-1, which results in a buffer overflow.

This commit makes the for loops accessing this data iterate one less time, resulting in x+1 == width()-1 which is the max of this array.

shortened AddressSanitizer trace:
```
==12167==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61f000054da4 at pc 0x558b9b984c00 bp 0x7fffabe3ce70 sp 0x7fffabe3ce60
READ of size 4 at 0x61f000054da4 thread T0
    #0 0x558b9b984bff in TargetWaveDisplay::paintEvent(QPaintEvent*) /home/tatokis/hydrogen/src/gui/src/SampleEditor/TargetWaveDisplay.cpp:98
    #1 0x7fb163e6d04d in QWidget::event(QEvent*) (/lib/x86_64-linux-gnu/libQt5Widgets.so.5+0x1ad04d)
    #2 0x7fb163e2aa85 in QApplicationPrivate::notify_helper(QObject*, QEvent*) (/lib/x86_64-linux-gnu/libQt5Widgets.so.5+0x16aa85)
[…]
    #32 0x558b9ba817fd in main /home/tatokis/hydrogen/src/gui/src/main.cpp:406
    #33 0x7fb1629871e2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x271e2)
    #34 0x558b9b7bb7ad in _start (/home/tatokis/hydrogen/build/src/gui/hydrogen+0x1557ad)

0x61f000054da4 is located 0 bytes to the right of 3364-byte region [0x61f000054080,0x61f000054da4)
allocated by thread T0 here:
    #0 0x7fb1648c7a67 in operator new[](unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0x10fa67)
    #1 0x558b9b9841df in TargetWaveDisplay::TargetWaveDisplay(QWidget*) /home/tatokis/hydrogen/src/gui/src/SampleEditor/TargetWaveDisplay.cpp:62
    #2 0x558b9b963656 in SampleEditor::SampleEditor(QWidget*, int, int, QString) /home/tatokis/hydrogen/src/gui/src/SampleEditor/SampleEditor.cpp:86
    #3 0x558b9b816c48 in HydrogenApp::showSampleEditor(QString, int, int) /home/tatokis/hydrogen/src/gui/src/HydrogenApp.cpp:453
    #4 0x558b9b82fd18 in InstrumentEditor::buttonClicked(Button*) /home/tatokis/hydrogen/src/gui/src/InstrumentEditor/InstrumentEditor.cpp:876
    #5 0x558b9ba8e85d in InstrumentEditor::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) /home/tatokis/hydrogen/build/src/gui/hydrogen_autogen/IJUGGYNT6S/moc_InstrumentEditor.cpp:139
    #6 0x7fb1631693f7 in QMetaObject::activate(QObject*, int, int, void**) (/lib/x86_64-linux-gnu/libQt5Core.so.5+0x2b13f7)
    #7 0x558b9ba86857 in Button::clicked(Button*) /home/tatokis/hydrogen/build/src/gui/hydrogen_autogen/3ITBSYFC75/moc_Button.cpp:192
    #8 0x558b9ba4c5e6 in Button::mouseReleaseEvent(QMouseEvent*) /home/tatokis/hydrogen/src/gui/src/Widgets/Button.cpp:152
    #9 0x7fb163e6d04d in QWidget::event(QEvent*) (/lib/x86_64-linux-gnu/libQt5Widgets.so.5+0x1ad04d)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/tatokis/hydrogen/src/gui/src/SampleEditor/TargetWaveDisplay.cpp:98 in TargetWaveDisplay::paintEvent(QPaintEvent*)
Shadow bytes around the buggy address:
  0x0c3e80002960: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e80002970: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e80002980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e80002990: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e800029a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c3e800029b0: 00 00 00 00[04]fa fa fa fa fa fa fa fa fa fa fa
  0x0c3e800029c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c3e800029d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e800029e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e800029f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3e80002a00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==12167==ABORTING

```