### PR TITLE
Correct midi channel export (fixes #580)

### DIFF
--- a/src/core/src/smf/smf.cpp
+++ b/src/core/src/smf/smf.cpp
@@ -207,6 +207,7 @@ vector<char> SMF::getBuffer()
 
 const unsigned int TPQN = 192;
 const unsigned int DRUM_CHANNEL = 9;
+const unsigned int NOTE_LENGTH = 12;
 
 const char* SMFWriter::__class_name = "SMFWriter";
 
@@ -283,26 +284,32 @@ void SMFWriter::save( const QString& sFilename, Song *pSong )
 						int nInstr = iList->index(pNote->get_instrument());
 						Instrument *pInstr = pNote->get_instrument();
 						int nPitch = pNote->get_midi_key();
-
+						
+						int nChannel =  pInstr->get_midi_out_channel();
+						if ( nChannel == -1 ) {
+							nChannel = DRUM_CHANNEL;
+						}
+						
+						int nLength = pNote->get_length();
+						if ( nLength == -1 ) {
+							nLength = NOTE_LENGTH;
+						}
+						
 						// get events for specific instrument
 						EventList* eventList = getEvents(pSong, pInstr);
-
 						eventList->push_back(
 							new SMFNoteOnEvent(
 								nStartTicks + nNote,
-								DRUM_CHANNEL,
+								nChannel,
 								nPitch,
 								nVelocity
 								)
 							);
-						int nLength = 12;
-						if ( pNote->get_length() != -1 ) {
-							nLength = pNote->get_length();
-						}
+							
 						eventList->push_back(
 							new SMFNoteOffEvent(
 								nStartTicks + nNote + nLength,
-								DRUM_CHANNEL,
+								nChannel,
 								nPitch,
 								nVelocity
 								)


### PR DESCRIPTION
This PR fixes #580  

Currently H2 gives user an ability to set custom channel to a specific instrument however it exports all midi notes into 10-th drum dedicated channel.
This PR fixes it so midi export will write proper channel data for all notes.
As a positive side effect this will allow to use midi multitrack export with LMMS, because LMMS squishes all notes from one channel into one track. So for LMMS user will need to set each track to separate channel

Changes are very small and localized in one file smf.cpp and they can be quickly reviewed.

To test those changes you need some kind of a midi editor, midi viewer or midi friendly DAW. 

I can not find how to test this in Ardour it looks like this program omits midi channels entirely.

In Rosegarden after midi import the channels for each track will be on the left info panel under the name "instrument" (screenshot 1)

In Qtractor you need to double click on the track  after import and look at the track options    (screenshot 2)

![rose](https://user-images.githubusercontent.com/1179773/78508554-526b9680-7790-11ea-976b-8e5ea3b508e7.png)

![qtractor](https://user-images.githubusercontent.com/1179773/78508574-8a72d980-7790-11ea-8735-83c7d4c26b7e.png)

