### PR TITLE
Support opening songs with double click etc

### DIFF
--- a/macos/CFBundleDocumentTypes.json
+++ b/macos/CFBundleDocumentTypes.json
@@ -2,17 +2,17 @@
     {
         "CFBundleTypeName": "Hydrogen song",
         "CFBundleTypeExtensions": ["h2song"],
-        "CFBundleTypeRole": "Owner"
+        "CFBundleTypeRole": "Editor"
     },
     {
         "CFBundleTypeName": "Hydrogen drumkit",
         "CFBundleTypeExtensions": ["h2drumkit"],
-        "CFBundleTypeRole": "Owner"
+        "CFBundleTypeRole": "Editor"
     },
     {
         "CFBundleTypeName": "Hydrogen playlist",
         "CFBundleTypeExtensions": ["h2playlist"],
-        "CFBundleTypeRole": "Owner"
+        "CFBundleTypeRole": "Editor"
     },
     {
         "CFBundleTypeName": "Hydrogen pattern",

--- a/macos/CFBundleDocumentTypes.json
+++ b/macos/CFBundleDocumentTypes.json
@@ -1,0 +1,21 @@
+[
+    {
+        "CFBundleTypeName": "Hydrogen song",
+        "CFBundleTypeExtensions": ["h2song"],
+        "CFBundleTypeRole": "Owner"
+    },
+    {
+        "CFBundleTypeName": "Hydrogen drumkit",
+        "CFBundleTypeExtensions": ["h2drumkit"],
+        "CFBundleTypeRole": "Owner"
+    },
+    {
+        "CFBundleTypeName": "Hydrogen playlist",
+        "CFBundleTypeExtensions": ["h2playlist"],
+        "CFBundleTypeRole": "Owner"
+    },
+    {
+        "CFBundleTypeName": "Hydrogen pattern",
+        "CFBundleTypeExtensions": ["h2pattern"]
+    }
+]

--- a/src/core/include/hydrogen/helpers/filesystem.h
+++ b/src/core/include/hydrogen/helpers/filesystem.h
@@ -27,6 +27,7 @@ class Filesystem : public H2Core::Object
 		static const QString scripts_ext;
 		static const QString patterns_ext;
 		static const QString playlist_ext;
+		static const QString drumkit_ext;
 		static const QString songs_filter_name;
 		static const QString scripts_filter_name;
 		static const QString patterns_filter_name;

--- a/src/core/src/helpers/filesystem.cpp
+++ b/src/core/src/helpers/filesystem.cpp
@@ -57,6 +57,7 @@ const QString Filesystem::scripts_ext = ".sh";
 const QString Filesystem::songs_ext = ".h2song";
 const QString Filesystem::patterns_ext = ".h2pattern";
 const QString Filesystem::playlist_ext = ".h2playlist";
+const QString Filesystem::drumkit_ext = ".h2drumkit";
 const QString Filesystem::scripts_filter_name = "Hydrogen Scripts (*.sh)";
 const QString Filesystem::songs_filter_name = "Hydrogen Songs (*.h2song)";
 const QString Filesystem::patterns_filter_name = "Hydrogen Patterns (*.h2pattern)";

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -58,8 +58,12 @@ if(APPLE)
     add_custom_command(
         TARGET hydrogen
         POST_BUILD
-        COMMAND plutil -insert CFBundleDocumentTypes
-                       -json
+        COMMAND
+            plutil -extract CFBuneouxdleDocumentTypes json
+                   -o /dev/null
+                   hydrogen.app/Contents/Info.plist 
+            || plutil -insert CFBundleDocumentTypes
+                      -json
                          \"` cat ${CMAKE_SOURCE_DIR}/macos/CFBundleDocumentTypes.json `\"
                        hydrogen.app/Contents/Info.plist )
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -55,6 +55,16 @@ if(APPLE)
         POST_BUILD
         COMMAND plutil -replace NSHighResolutionCapable -bool true hydrogen.app/Contents/Info.plist
     )
+    add_custom_command(
+        TARGET hydrogen
+        POST_BUILD
+        COMMAND plutil -insert CFBundleDocumentTypes
+                       -json
+                         \"` cat ${CMAKE_SOURCE_DIR}/macos/CFBundleDocumentTypes.json `\"
+                       hydrogen.app/Contents/Info.plist )
+
+    ADD_DEPENDENCIES(hydrogen ${CMAKE_SOURCE_DIR}/macos/CFBundleDocumentTypes.json)
+
 endif()
 
 TARGET_LINK_LIBRARIES(hydrogen

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -59,9 +59,9 @@ if(APPLE)
         TARGET hydrogen
         POST_BUILD
         COMMAND
-            plutil -extract CFBuneouxdleDocumentTypes json
+            plutil -extract CFBundleDocumentTypes json
                    -o /dev/null
-                   hydrogen.app/Contents/Info.plist 
+                   hydrogen.app/Contents/Info.plist >/dev/null
             || plutil -insert CFBundleDocumentTypes
                       -json
                          \"` cat ${CMAKE_SOURCE_DIR}/macos/CFBundleDocumentTypes.json `\"

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -95,8 +95,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename )
 	: QMainWindow( nullptr, nullptr )
 	, Object( __class_name )
 {
-	m_sInitialOpenFilename = "";
-	m_bIsInitialised = false;
 	setMinimumSize( QSize( 1000, 500 ) );
 
 #ifndef WIN32
@@ -108,9 +106,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename )
 
 
 	m_pQApp = app;
-
-	// To pick up FileOpen messages, early to allow for intercepting initial open events.
-	m_pQApp->installEventFilter( this );
 
 	m_pQApp->processEvents();
 
@@ -222,12 +217,9 @@ MainForm::MainForm( QApplication *app, const QString& songFilename )
 		}
 	}
 
-	m_bIsInitialised = true;
-	if ( !m_sInitialOpenFilename.isEmpty() ) {
-		QFileOpenEvent ev( m_sInitialOpenFilename );
-		// We handled an early request to open a file. Process it now.
-		QApplication::sendEvent( this, &ev );
-	}
+	// To pick up FileOpen messages
+	m_pQApp->installEventFilter( this );
+
 }
 
 
@@ -1522,28 +1514,22 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 		QFileOpenEvent *fe = dynamic_cast<QFileOpenEvent*>(e);
 		assert( fe != nullptr );
 		QString sFileName = fe->file();
-		if ( m_bIsInitialised ) {
 
-			if ( sFileName.endsWith( H2Core::Filesystem::songs_ext ) ) {
-				if ( handleUnsavedChanges() ) {
-					openSongFile( sFileName );
-				}
-
-			} else if ( sFileName.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
-				H2Core::Drumkit::install( sFileName );
-
-			} else if ( sFileName.endsWith( H2Core::Filesystem::playlist_ext ) ) {
-				bool loadlist = HydrogenApp::get_instance()->getPlayListDialog()->loadListByFileName( sFileName );
-				if ( loadlist ) {
-					H2Core::Playlist::get_instance()->setNextSongByNumber( 0 );
-				}
+		if ( sFileName.endsWith( H2Core::Filesystem::songs_ext ) ) {
+			if ( handleUnsavedChanges() ) {
+				openSongFile( sFileName );
 			}
-		} else {
-			// Initialisation isn't completed yet, so keep the
-			// requested filename and handle when initialisation is
-			// complete.
-			m_sInitialOpenFilename = sFileName;
+
+		} else if ( sFileName.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
+			H2Core::Drumkit::install( sFileName );
+
+		} else if ( sFileName.endsWith( H2Core::Filesystem::playlist_ext ) ) {
+			bool loadlist = HydrogenApp::get_instance()->getPlayListDialog()->loadListByFileName( sFileName );
+			if ( loadlist ) {
+				H2Core::Playlist::get_instance()->setNextSongByNumber( 0 );
+			}
 		}
+		return true;
 
 	} else if ( e->type() == QEvent::KeyPress ) {
 		// special processing for key press

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -216,10 +216,6 @@ MainForm::MainForm( QApplication *app, const QString& songFilename )
 			_ERRORLOG ( "Error loading the playlist" );
 		}
 	}
-
-	// To pick up FileOpen messages
-	m_pQApp->installEventFilter( this );
-
 }
 
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1525,7 +1525,9 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 		if ( m_bIsInitialised ) {
 
 			if ( sFileName.endsWith( H2Core::Filesystem::songs_ext ) ) {
-				openSongFile( sFileName );
+				if ( handleUnsavedChanges() ) {
+					openSongFile( sFileName );
+				}
 
 			} else if ( sFileName.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
 				H2Core::Drumkit::install( sFileName );

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -179,9 +179,6 @@ public slots:
 
 		QTimer		m_AutosaveTimer;
 
-		bool m_bIsInitialised;
-		QString m_sInitialOpenFilename;
-
 		/** Create the menubar */
 		void createMenuBar();
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -179,6 +179,9 @@ public slots:
 
 		QTimer		m_AutosaveTimer;
 
+		bool m_bIsInitialised;
+		QString m_sInitialOpenFilename;
+
 		/** Create the menubar */
 		void createMenuBar();
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
 		parser.addOption( songFileOption );
 		parser.addOption( kitOption );
 		parser.addOption( verboseOption );
-		
+		parser.addPositionalArgument( "file", "Song, playlist or Drumkit file" );
 		
 		//Conditional options
 		#ifdef H2CORE_HAVE_JACKSESSION
@@ -203,6 +203,23 @@ int main(int argc, char *argv[])
 				logLevelOpt =  H2Core::Logger::parse_log_level( sVerbosityString.toLocal8Bit() );
 			} else {
 				logLevelOpt = H2Core::Logger::Error|H2Core::Logger::Warning;
+			}
+		}
+
+		// Operating system GUIs typically pass documents to open as
+		// simple positional arguments to the process command
+		// line. Handling this here enables "Open with" as well as
+		// default document bindings to work.
+		QString sArg;
+		foreach ( sArg, parser.positionalArguments() ) {
+			if ( sArg.endsWith( H2Core::Filesystem::songs_ext ) ) {
+				sSongFilename = sArg;
+			}
+			if ( sArg.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
+				sDrumkitName = sArg;
+			}
+			if ( sArg.endsWith( H2Core::Filesystem::playlist_ext ) ) {
+				sPlaylistFilename = sArg;
 			}
 		}
 		


### PR DESCRIPTION
Adds support for song and playlist opening and drumkit import from
Explorer/Finder/etc.
  - add positional parameters to command line processing for easier
    Linux and Windows support
  - respond to FileOpen events in MainForm to intercept OS file
    open requsets (necessary for opening at all from Finder on Mac
    OS)