### PR TITLE
Sanitizers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,83 @@ env:
   global:
   - MAKEFLAGS="-j 2"
 jobs:
+  allow_failures:
+  - name: Address Sanitizer
+  - name: Leak Sanitizer
+  - name: Memory Sanitizer
+
   include:
-  - os: linux
+  - stage: Build
+    name: "Ubuntu 16.04 Xenial"
+    os: linux
     dist: xenial
-  - os: osx
+  - name: "Ubuntu 18.04 Bionic"
+    os: linux
+    dist: bionic
+  - name: "macOS"
+    os: osx
     env:
     - MACOSX_DEPLOYMENT_TARGET="10.12"
-  - os: osx
+  - name: "macOS (legacy)"
+    os: osx
     env:
     - MACOSX_DEPLOYMENT_TARGET="10.10"
     - HOMEBREW_NO_AUTO_UPDATE=1
     - PKG_SUFFIX="-legacy"
     osx_image: xcode9
+
+  - stage: Sanitizers
+    name: Address Sanitizer
+    os: linux
+    dist: bionic
+    env: CMAKE_OPTIONS=-DUSE_SANITIZER=Address
+  - name: Leak Sanitizer
+    os: linux
+    dist: bionic
+    env: CMAKE_OPTIONS=-DUSE_SANITIZER=Leak
+  # - name: Memory Sanitizer
+  #   os: linux
+  #   dist: bionic
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Memory
+  - name: Undefined Behavior Sanitizer
+    os: linux
+    dist: bionic
+    env: CMAKE_OPTIONS=-DUSE_SANITIZER=Undefined
+
+  # - name: Address Sanitizer
+  #   os: osx
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Address
+  # - name: Leak Sanitizer
+  #   os: osx
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Leak
+  # - name: Memory Sanitizer
+  #   os: osx
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Memory
+  # - name: Undefined Behavior Sanitizer
+  #   os: osx
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Undefined
+
+  # - name: Address Sanitizer
+  #   os: linux
+  #   dist: bionic
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Address CC=/usr/bin/clang CXX=/usr/bin/clang++
+  # - name: Leak Sanitizer
+  #   os: linux
+  #   dist: bionic
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Leak CC=/usr/bin/clang CXX=/usr/bin/clang++
+  - name: Memory Sanitizer
+    os: linux
+    dist: bionic
+    env: CMAKE_OPTIONS=-DUSE_SANITIZER=Memory CC=/usr/bin/clang CXX=/usr/bin/clang++
+  # - name: Undefined Behavior Sanitizer
+  #   os: linux
+  #   dist: bionic
+  #   env: CMAKE_OPTIONS=-DUSE_SANITIZER=Undefined CC=/usr/bin/clang CXX=/usr/bin/clang++
+
 addons:
   apt:
     packages:
+    - clang
     - qt5-default
     - qttools5-dev
     - qttools5-dev-tools
@@ -56,7 +118,7 @@ before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$HOMEBREW_NO_AUTO_UPDATE" -eq "1" ]];
   then test $(PKG_CONFIG_PATH=$(brew --prefix qt5)/lib/pkgconfig pkg-config --modversion Qt5Core) == 5.9.1; fi
 script:
-- mkdir build && cd build && cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1
+- mkdir build && cd build && cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 ${CMAKE_OPTIONS}
   .. && make
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH="$(brew --prefix qt5)/bin:$PATH"
   ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ ENDIF()
 
 OPTION(WANT_CPPUNIT         "Include CppUnit test suite" ON)
 
+include(Sanitizers)
+
 IF(WANT_DEBUG)
     SET(CMAKE_BUILD_TYPE Debug)
     SET(H2CORE_HAVE_DEBUG TRUE)

--- a/cmake/Sanitizers.cmake
+++ b/cmake/Sanitizers.cmake
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2018 by George Cave - gcave@stablecoder.ca
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+set(USE_SANITIZER
+    ""
+    CACHE
+      STRING
+      "Compile with a sanitizer. Options are: Address, Memory, MemoryWithOrigins, Undefined, Thread, Leak, 'Address;Undefined'"
+)
+
+function(append value)
+  foreach(variable ${ARGN})
+    set(${variable}
+        "${${variable}} ${value}"
+        PARENT_SCOPE)
+  endforeach(variable)
+endfunction()
+
+if(USE_SANITIZER)
+  append("-fno-omit-frame-pointer" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+
+  if(UNIX)
+
+    if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+      append("-O1" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    endif()
+
+    if(USE_SANITIZER MATCHES "([Aa]ddress);([Uu]ndefined)"
+       OR USE_SANITIZER MATCHES "([Uu]ndefined);([Aa]ddress)")
+      message(STATUS "Building with Address, Undefined sanitizers")
+      append("-fsanitize=address,undefined" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    elseif(USE_SANITIZER MATCHES "([Aa]ddress)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-address-use-after-scope
+      message(STATUS "Building with Address sanitizer")
+      append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    elseif(USE_SANITIZER MATCHES "([Mm]emory([Ww]ith[Oo]rigins)?)")
+      # Optional: -fno-optimize-sibling-calls -fsanitize-memory-track-origins=2
+      append("-fsanitize=memory" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+      if(USE_SANITIZER MATCHES "([Mm]emory[Ww]ith[Oo]rigins)")
+        message(STATUS "Building with MemoryWithOrigins sanitizer")
+        append("-fsanitize-memory-track-origins" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+      else()
+        message(STATUS "Building with Memory sanitizer")
+      endif()
+    elseif(USE_SANITIZER MATCHES "([Uu]ndefined)")
+      message(STATUS "Building with Undefined sanitizer")
+      append("-fsanitize=undefined" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+      if(EXISTS "${BLACKLIST_FILE}")
+        append("-fsanitize-blacklist=${BLACKLIST_FILE}" CMAKE_C_FLAGS
+               CMAKE_CXX_FLAGS)
+      endif()
+    elseif(USE_SANITIZER MATCHES "([Tt]hread)")
+      message(STATUS "Building with Thread sanitizer")
+      append("-fsanitize=thread" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    elseif(USE_SANITIZER MATCHES "([Ll]eak)")
+      message(STATUS "Building with Leak sanitizer")
+      append("-fsanitize=leak" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(
+        FATAL_ERROR "Unsupported value of USE_SANITIZER: ${USE_SANITIZER}")
+    endif()
+  elseif(MSVC)
+    if(USE_SANITIZER MATCHES "([Aa]ddress)")
+      message(STATUS "Building with Address sanitizer")
+      append("-fsanitize=address" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    else()
+      message(
+        FATAL_ERROR
+          "This sanitizer not yet supported in the MSVC environment: ${USE_SANITIZER}"
+      )
+    endif()
+  else()
+    message(FATAL_ERROR "USE_SANITIZER is not supported on this platform.")
+  endif()
+
+endif()


### PR DESCRIPTION
Hi!

I've expanded our Travis CI pipeline to run various sanitisers as second stage (i.e. only after regular build and unit tests succeed).

# The good

* It runs Address Sanitizer, Memory Sanitizer, Leak Sanitizer and Undefined Behaviour Sanitizer on Travis CI as part of pipeline, allowing us to catch more bugs, on every commit to master, and on every Pull Request

* It looks pretty:

![Zrzut ekranu 2020-05-04 o 23 15 45](https://user-images.githubusercontent.com/1619113/81014488-3aedff00-8e5d-11ea-9bde-787a15ddb7d6.png)


* I've also added Ubuntu 18.04 Bionic Beaver to build/unit tests job so that we test on more recent Linux distro.

* It's not intrusive, I've only added some jobs to `.travis.yml` so there are no changes in "production" code, so it can be safely merged.

# The bad

* I've left some commented out code - I've tried running those sanitisers on three platforms - Linux/GCC, Mac/LLVM and Linux/LLVM. I've found no significant differences between those platforms, so I left only Linux/GCC (except Memory Sanitizer that only ran successfully on Linux/LLVM). I left the rest commented out for reference only, and I think those jobs could be removed.

# The ugly

* Address Sanitizer, Memory Sanitizer, Leak Sanitizer fail. I've marked them with `allow_failures` so that they do not fail whole pipeline. I think there are some false positives, I'll try to sort that out. Once those jobs are stable, `allow_failures` feature can be turned off.

* Currently, pipeline is set up weird. Mac binary packages are built and uploaded on step one, and then sanitisers are run. It would make more sense to build and upload packages after sanitisers, but it wouldn't be easy to build pipeline like that.

* Sanitisers are run on test suite, and test suite tests only core, therefore sanitizers also exercise only core. GUI is not checked.