### PR TITLE
Fix issues found by valgrind

### DIFF
--- a/src/core/include/hydrogen/basics/sample.h
+++ b/src/core/include/hydrogen/basics/sample.h
@@ -337,8 +337,8 @@ class Sample : public H2Core::Object
 
 inline void Sample::unload()
 {
-	if( __data_l ) delete __data_l;
-	if( __data_r ) delete __data_r;
+	if( __data_l ) delete [] __data_l;
+	if( __data_r ) delete [] __data_r;
 	__frames = __sample_rate = 0;
 	/** #__is_modified = false; leave this unchanged as pan,
 	    velocity, loop and rubberband are kept unchanged */

--- a/src/core/src/basics/sample.cpp
+++ b/src/core/src/basics/sample.cpp
@@ -169,7 +169,8 @@ bool Sample::load()
 {
 	// Will contain a bunch of metadata about the loaded sample.
 	SF_INFO sound_info;
-	
+	sound_info.format = 0;
+
 	// Opens file in read-only mode.
 	SNDFILE* file = sf_open( __filepath.toLocal8Bit(), SFM_READ, &sound_info );
 	if ( !file ) {

--- a/src/core/src/basics/sample.cpp
+++ b/src/core/src/basics/sample.cpp
@@ -168,8 +168,7 @@ void Sample::apply( const Loops& loops, const Rubberband& rubber, const Velocity
 bool Sample::load()
 {
 	// Will contain a bunch of metadata about the loaded sample.
-	SF_INFO sound_info;
-	sound_info.format = 0;
+	SF_INFO sound_info = {0};
 
 	// Opens file in read-only mode.
 	SNDFILE* file = sf_open( __filepath.toLocal8Bit(), SFM_READ, &sound_info );

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2511,18 +2511,18 @@ void Hydrogen::setSong( Song *pSong )
 	}
 
 	if ( pCurrentSong ) {
-		
+		/* NOTE: 
+		 *       - this is actually some kind of cleanup 
+		 *       - removeSong cares itself for acquiring a lock
+		 */
+		removeSong();
+
 		AudioEngine::get_instance()->lock( RIGHT_HERE );
 		delete pCurrentSong;
 		pCurrentSong = nullptr;
 
 		AudioEngine::get_instance()->unlock();
 
-		/* NOTE: 
-		 *       - this is actually some kind of cleanup 
-		 *       - removeSong cares itself for acquiring a lock
-		 */
-		removeSong();
 	}
 
 	/* Reset GUI */


### PR DESCRIPTION
Fixes for a few issues found by valgrind's memcheck:

  - Potential crash: using Hydrogen::setSong() to set a new song while
    an existing song is playing will delete the old song, including
    its samples, before stopping the player.
  - Mismatched new[] / delete (should be delete[]) in samples buffers
  - potentially undefined execution control flow in libsndfile under
    sf_open: the API spec says that SF_INFO.format should be
    initialised to 0 before calling sf_open