### PR TITLE
Fix bug #876: crash undoing move patterns left

### DIFF
--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -508,7 +508,7 @@ void SongEditor::movePatternCellAction( std::vector<QPoint> movingCells, std::ve
 
 	if ( bIsCtrlPressed) //Copy
 	{
-				if( undo )
+		if( undo )
 		{
 			// remove the old patterns
 			for ( uint i = 0; i < selectedCells.size(); i++ ) {
@@ -527,15 +527,17 @@ void SongEditor::movePatternCellAction( std::vector<QPoint> movingCells, std::ve
 
 
 
-				PatternList* pColumn = nullptr;
-				if ( cell.x() < (int)pColumns->size() ) {
-					pColumn = (*pColumns)[ cell.x() ];
+				if ( cell.x() >= 0 ) {
+					PatternList* pColumn = nullptr;
+					if ( cell.x() < (int)pColumns->size() ) {
+						pColumn = (*pColumns)[ cell.x() ];
+					}
+					else {
+						pColumn = new PatternList();
+						pColumns->push_back( pColumn );
+					}
+					pColumn->del(pPatternList->get( cell.y() ) );
 				}
-				else {
-					pColumn = new PatternList();
-					pColumns->push_back( pColumn );
-				}
-				pColumn->del(pPatternList->get( cell.y() ) );
 			}
 
 		}
@@ -579,14 +581,16 @@ void SongEditor::movePatternCellAction( std::vector<QPoint> movingCells, std::ve
 			}
 
 
-			if ( cell.x() < (int)pColumns->size() ) {
-				pColumn = (*pColumns)[ cell.x() ];
+			if ( cell.x() >= 0 ) {
+				if ( cell.x() < (int)pColumns->size() ) {
+					pColumn = (*pColumns)[ cell.x() ];
+				}
+				else {
+					pColumn = new PatternList();
+					pColumns->push_back( pColumn );
+				}
+				pColumn->del(pPatternList->get( cell.y() ) );
 			}
-			else {
-				pColumn = new PatternList();
-				pColumns->push_back( pColumn );
-			}
-			pColumn->del(pPatternList->get( cell.y() ) );
 		}
 	}
 


### PR DESCRIPTION
Fix for bug #876 . movingCells can contain column indices less than 0, so guard against this when selecting patterns to delete in response to an undo.