### PR TITLE
Add timed waits for audioengine lock ( part fix for #857 )

### DIFF
--- a/src/core/include/hydrogen/audio_engine.h
+++ b/src/core/include/hydrogen/audio_engine.h
@@ -28,10 +28,10 @@
 #include <hydrogen/sampler/Sampler.h>
 #include <hydrogen/synth/Synth.h>
 
-#include <pthread.h>
 #include <string>
 #include <cassert>
-
+#include <mutex>
+#include <chrono>
 
 /** \def RIGHT_HERE
  * Macro intended to be used for the logging of the locking of the
@@ -84,11 +84,7 @@ public:
 
 	/** Mutex locking of the AudioEngine.
 	 *
-	 * It passes the address of the #__engine_mutex object to
-	 * _pthread_mutex_lock()_ (pthread.h) to lock the AudioEngine
-	 * and transfer ownership of the #__engine_mutex to the
-	 * calling thread. Only this very thread can unlock() the
-	 * engine again.
+	 * Lock the AudioEngine for exclusive access by this thread.
 	 *
 	 * The documentation below may serve as a guide for future
 	 * implementations. At the moment the logging of the locking
@@ -124,25 +120,40 @@ public:
 	/**
 	 * Mutex locking of the AudioEngine.
 	 *
-	 * This function is equivalent to lock() but calls
-	 * _pthread_mutex_trylock()_ (pthread.h) instead and returns a
-	 * bool depending on its results.
+	 * This function is equivalent to lock() but returns false
+	 * immediaely if the lock canot be obtained immediately.
 	 *
 	 * \param file File the locking occurs in.
 	 * \param line Line of the file the locking occurs in.
 	 * \param function Function the locking occurs in.
 	 *
 	 * \return
-	 * - true : On success (if _pthread_mutex_lock()_ returns
-	 *   0)
+	 * - true : On success
 	 * - false : Else
 	 */
 	bool try_lock( const char* file, unsigned int line, const char* function );
+
+	/**
+	 * Mutex locking of the AudioEngine.
+	 *
+	 * This function is equivalent to lock() but will only wait for a
+	 * given period of time. If the lock cannot be acquired in this
+	 * time, it will return false.
+	 *
+	 * \param duration Time (in microseconds) to wait for the lock.
+	 * \param file File the locking occurs in.
+	 * \param line Line of the file the locking occurs in.
+	 * \param function Function the locking occurs in.
+	 *
+	 * \return
+	 * - true : On successful acquisition of the lock
+	 * - false : On failure
+	 */
+	bool try_lock_for( std::chrono::microseconds duration, const char* file, unsigned int line, const char* function );
 	/**
 	 * Mutex unlocking of the AudioEngine.
 	 *
-	 * Calls _pthread_mutex_unlock()_ (pthread.h) on the address
-	 * of #__engine_mutex and leaves #__locker untouched.
+	 * Unlocks the AudioEngine to allow other threads acces, and leaves #__locker untouched.
 	 */
 	void unlock();
 	
@@ -174,7 +185,7 @@ private:
 	  * try_lock() and to unlock it via unlock(). It is
 	  * initialized in AudioEngine() and not explicitly exited.
 	  */
-	pthread_mutex_t __engine_mutex;
+	std::timed_mutex __engine_mutex;
 
 	/**
 	 * This struct is most probably intended to be used for

--- a/src/core/src/audio_engine.cpp
+++ b/src/core/src/audio_engine.cpp
@@ -53,8 +53,6 @@ AudioEngine::AudioEngine()
 	__instance = this;
 	INFOLOG( "INIT" );
 
-	pthread_mutex_init( &__engine_mutex, nullptr );
-
 	__sampler = new Sampler;
 	__synth = new Synth;
 
@@ -97,7 +95,7 @@ Synth* AudioEngine::get_synth()
 
 void AudioEngine::lock( const char* file, unsigned int line, const char* function )
 {
-	pthread_mutex_lock( &__engine_mutex );
+	__engine_mutex.lock();
 	__locker.file = file;
 	__locker.line = line;
 	__locker.function = function;
@@ -107,9 +105,25 @@ void AudioEngine::lock( const char* file, unsigned int line, const char* functio
 
 bool AudioEngine::try_lock( const char* file, unsigned int line, const char* function )
 {
-	int res = pthread_mutex_trylock( &__engine_mutex );
-	if ( res != 0 ) {
+	bool res = __engine_mutex.try_lock();
+	if ( !res ) {
 		// Lock not obtained
+		return false;
+	}
+	__locker.file = file;
+	__locker.line = line;
+	__locker.function = function;
+	return true;
+}
+
+bool AudioEngine::try_lock_for( std::chrono::microseconds duration, const char* file, unsigned int line, const char* function )
+{
+	bool res = __engine_mutex.try_lock_for( duration );
+	if ( !res ) {
+		// Lock not obtained
+		WARNINGLOG( QString( "Lock timeout: lock timeout %1:%2%3, lock held by %s:%s:%s" )
+					.arg( file ).arg( function ).arg( line )
+					.arg( __locker.file ).arg( __locker.function ).arg( __locker.line ));
 		return false;
 	}
 	__locker.file = file;
@@ -129,7 +143,7 @@ float AudioEngine::compute_tick_size(int sampleRate, int bpm, int resolution)
 void AudioEngine::unlock()
 {
 	// Leave "__locker" dirty.
-	pthread_mutex_unlock( &__engine_mutex );
+	__engine_mutex.unlock();
 }
 
 


### PR DESCRIPTION
See also: https://github.com/cme/hydrogen/blob/timed_locks_profiling/profiling/report.md

This avoids cases where playback might be disrupted due to the GUI
grabbing the lock to update song position or edit patterns / song
structure while playing. Such locks are very short-lived, much
shorter than is typically needed to process a buffer of song data,
so waiting until the lock can be acquired is a very short delay.

To avoid excessive waits which would cause a buffer to be dropped
anyway or otherwise delivered to the sound driver too late, the
available slack time is calculated and lock waits are limited to
that slack time.

This change also changes the audioengine lock from a pthreads mutex
to a C++11 std::timed_mutex: this is because pthreads mutexes support
timed locking on Linux, FreeBSD and Windows, but bizarrely *not*
on macOS, presumably because it would make the mutex structure
larger. std::timed_mutex already implements this on all platforms,
so use it in preference.