### PR TITLE
Workaround liblo's broken use of <cassert> #897

### DIFF
--- a/src/tests/osc_server_test.h
+++ b/src/tests/osc_server_test.h
@@ -4,9 +4,9 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
+#include <hydrogen/hydrogen.h>
 #include <lo/lo.h>
 #include <lo/lo_cpp.h>
-#include <hydrogen/hydrogen.h>
 
 class OscServerTest : public CppUnit::TestFixture {
 	CPPUNIT_TEST_SUITE( OscServerTest );


### PR DESCRIPTION
liblo #include's <cassert> from inside its namespace, with the result that subsequent inclusion of <cassert> won't see the needed __assert_fail symbols in the global namespace.

This should resolve #897. 