### PR TITLE
Fix #904 (crash on kit export) and other crashes etc.

### DIFF
--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -291,7 +291,13 @@ bool Sampler::__render_note( Note* pNote, unsigned nBufferSize, Song* pSong )
 			||	pInstr->is_metronome_instrument()){
 			pMainCompo = pEngine->getSong()->get_components()->front();
 		} else {
-			pMainCompo = pEngine->getSong()->get_component( pCompo->get_drumkit_componentID() );
+			int nComponentID = pCompo->get_drumkit_componentID();
+			if ( nComponentID >= 0 ) {
+				pMainCompo = pEngine->getSong()->get_component( nComponentID );
+			} else {
+				/* Invalid component found. This is possible on loading older or broken song files. */
+				pMainCompo = pEngine->getSong()->get_components()->front();
+			}
 		}
 
 		assert(pMainCompo);
@@ -697,6 +703,8 @@ bool Sampler::processPlaybackTrack(int nBufferSize)
 	InstrumentComponent *pCompo = __playback_instrument->get_components()->front();
 	Sample *pSample = pCompo->get_layer(0)->get_sample();
 
+	assert(pSample);
+
 	float fVal_L;
 	float fVal_R;
 
@@ -705,8 +713,6 @@ bool Sampler::processPlaybackTrack(int nBufferSize)
 	
 	float fInstrPeak_L = __playback_instrument->get_peak_l(); // this value will be reset to 0 by the mixer..
 	float fInstrPeak_R = __playback_instrument->get_peak_r(); // this value will be reset to 0 by the mixer..
-
-	assert(pSample);
 
 	int nAvail_bytes = 0;
 	int	nInitialBufferPos = 0;

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -112,9 +112,9 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 				break;
 			}
 		}
+		assert( pDrumkit );
 	}
-	
-	assert( pDrumkit );
+
 
 #if defined(H2CORE_HAVE_LIBARCHIVE)
 	QString fullDir = drumkitDir + "/" + drumkitName;
@@ -142,7 +142,11 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 	#endif
 
 	archive_write_set_format_pax_restricted(a);
-	archive_write_open_filename(a, outname.toUtf8().constData());
+	int ret = archive_write_open_filename(a, outname.toUtf8().constData());
+	if ( ret != ARCHIVE_OK ) {
+		QMessageBox::critical( this, "Hydrogen", QString("Couldn't create archive '%0'").arg( outname ) );
+		return;
+	}
 	for (int i = 0; i < filesList.size(); i++) {
 		QString filename = fullDir + "/" + filesList.at(i);
 		QString targetFilename = drumkitName + "/" + filesList.at(i);


### PR DESCRIPTION
This fixes:
  - crash on exporting (#904)
  - crash on songs with invalid instrument components (old songs)
  - misleading message that kit exported OK when archive actually failed to open.
  - misplaced assert that's placed too late, after code that would
    cause a segfault if the assertion's expression were to be false