### PR TITLE
Delay GUI app start to enable HighDPI preferences to take effect. (*actually* fix #914)

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -192,9 +192,8 @@ int main(int argc, char *argv[])
 		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
-		H2QApplication* pQApp = new H2QApplication( argc, argv );
-		pQApp->setApplicationName( "Hydrogen" );
-		pQApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );
+		// Create bootstrap QApplication to get H2 Core set up with correct Filesystem paths before starting GUI application.
+		QCoreApplication *pBootStrApp = new QCoreApplication( argc, argv );
 		
 		QCommandLineParser parser;
 		
@@ -232,7 +231,7 @@ int main(int argc, char *argv[])
 		#endif
 			
 		// Evaluate the options
-		parser.process(*pQApp);
+		parser.process( *pBootStrApp );
 		QString sSelectedDriver = parser.value( audioDriverOption );
 		QString sDrumkitName = parser.value( installDrumkitOption );
 		bool	bNoSplash = parser.isSet( noSplashScreenOption );
@@ -339,6 +338,12 @@ int main(int argc, char *argv[])
 		else if ( sSelectedDriver == "alsa" ) {
 			pPref->m_sAudioDriver = "Alsa";
 		}
+
+		// Bootstrap is complete, start GUI
+		delete pBootStrApp;
+		H2QApplication* pQApp = new H2QApplication( argc, argv );
+		pQApp->setApplicationName( "Hydrogen" );
+		pQApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );
 
 		QString family = pPref->getApplicationFontFamily();
 		pQApp->setFont( QFont( family, pPref->getApplicationFontPointSize() ) );


### PR DESCRIPTION
Delay GUI application initialisation until after High DPI settings can be read from Preferences (this must happen before GUI initialisation)

Bootstrapping the filesystem still requires a QApplication to provide the application path, so a temporary QCoreApplication is used to bootstrap file paths. This is deleted before starting the real QGuiApplication.

This allows the fix for #914 in #921 to function as intended.

Tested and working on Windows at large non-integer scale factors (thanks to MS's free Windows dev VMs!)