### PR TITLE
Osc scripting of Timeline and Jack options

### DIFF
--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -118,10 +118,61 @@ class CoreActionController : public H2Core::Object {
 		 */
 		bool quit();
 
+		/**
+		 * (De)activates the usage of the Timeline.
+		 *
+		 * Note that this function will fail in the presence of the
+		 * Jack audio driver and an external timebase master (see Hydrogen::haveJackTimebaseClient()).
+		 *
+		 * @param bActivate If true - activate or if false -
+		 * deactivate.
+		 *
+		 * @return bool true on success
+		 */
 		bool activateTimeline( bool bActivate );
+		/**
+		 * Adds a tempo marker to the Timeline.
+		 *
+		 * @param nPosition Location of the tempo marker in bars.
+		 * @param fBpm Speed associated with the tempo marker.
+		 *
+		 * @return bool true on success
+		 */
 		bool addTempoMarker( int nPosition, float fBpm );
+		/**
+		 * Delete a tempo marker from the Timeline.
+		 *
+		 * If no Tempo marker is present at @a nPosition, the function
+		 * will return true as well.
+		 *
+		 * @param nPosition Location of the tempo marker in bars.
+		 *
+		 * @return bool true on success
+		 */
 		bool deleteTempoMarker( int nPosition );
+		/**
+		 * (De)activates the usage of Jack transport.
+		 *
+		 * Note that this function will fail if Jack is not used as
+		 * audio driver.
+		 *
+		 * @param bActivate If true - activate or if false -
+		 * deactivate.
+		 *
+		 * @return bool true on success
+		 */
 		bool activateJackTransport( bool bActivate );
+		/**
+		 * (De)activates the usage of Jack timebase master.
+		 *
+		 * Note that this function will fail if Jack is not used as
+		 * audio driver.
+		 *
+		 * @param bActivate If true - activate or if false -
+		 * deactivate.
+		 *
+		 * @return bool true on success
+		 */
 		bool activateJackTimebaseMaster( bool bActivate );
 		
 		// -----------------------------------------------------------

--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -117,6 +117,12 @@ class CoreActionController : public H2Core::Object {
 		 * \return true on success
 		 */
 		bool quit();
+
+		bool activateTimeline( bool bActivate );
+		bool addTempoMarker( int nPosition, float fBpm );
+		bool deleteTempoMarker( int nPosition );
+		bool activateJackTransport( bool bActivate );
+		bool activateJackTimebaseMaster( bool bActivate );
 		
 		// -----------------------------------------------------------
 		// Helper functions

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -123,7 +123,17 @@ enum EventType {
 	 * Triggering HydrogenApp::quitEvent() and enables a shutdown of
 	 * the entire application via the command line.
 	 */
-	EVENT_QUIT
+	EVENT_QUIT,
+
+	/** Enables/disables the usage of the Timeline.*/ 
+	EVENT_TIMELINE_ACTIVATION,
+	/** Tells the GUI some parts of the Timeline - currently
+		adding/deleting of tempo markers - were modified.*/
+	EVENT_TIMELINE_UPDATE,
+	/** Toggles the button indicating the usage Jack transport.*/
+	EVENT_JACK_TRANSPORT_ACTIVATION,
+	/** Toggles the button indicating the usage Jack timebase master.*/
+	EVENT_JACK_TIMEBASE_ACTIVATION
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -527,10 +527,6 @@ void			previewSample( Sample *pSample );
 	 * Returns the local speed at a specific @a nBar in the
 	 * Timeline.
 	 *
-	 * Timeline::HTimelineVector::m_htimelinebpm of the first
-	 * Timeline::HTimelineVector::m_htimelinebeat bigger than @a
-	 * nBar will be returned.
-	 *
 	 * If Hydrogen is in Song::PATTERN_MODE or
 	 * Preferences::__useTimelineBpm is set to false, the global
 	 * speed of the current Song Song::__bpm or, if no Song is

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -631,10 +631,49 @@ class OscServer : public H2Core::Object
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void QUIT_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::activateTimeline().
+		 *
+		 * \param argv The "i" field does contain the value supplied
+		 * by the user. If it is 0, the Timeline will be
+		 * deactivated. Else, it will be activated instead.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
 		static void TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::addTempoMarker().
+		 *
+		 * \param argv The first field "i" does contain the bar at
+		 * which to place the new Timeline::TempoMarker while the
+		 * second one "f" specifies its tempo in bpm.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
 		static void TIMELINE_ADD_MARKER_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::deleteTempoMarker().
+		 *
+		 * \param argv The first field "i" does contain the bar at
+		 * which to delete a Timeline::TempoMarker.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
 		static void TIMELINE_DELETE_MARKER_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::activatedJackTransport().
+		 *
+		 * \param argv The "i" field does contain the value supplied
+		 * by the user. If it is 0, the Jack transport will be
+		 * deactivated. Else, it will be activated instead.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
 		static void JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::activateJackTimebaseMaster().
+		 *
+		 * \param argv The "i" field does contain the value supplied
+		 * by the user. If it is 0, the Jack timebase master will be
+		 * deactivated. Else, it will be activated instead.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
 		static void JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc);
 		/** 
 		 * Catches any incoming messages and display them. 

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -631,6 +631,11 @@ class OscServer : public H2Core::Object
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void QUIT_Handler(lo_arg **argv, int argc);
+		static void TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc);
+		static void TIMELINE_ADD_MARKER_Handler(lo_arg **argv, int argc);
+		static void TIMELINE_DELETE_MARKER_Handler(lo_arg **argv, int argc);
+		static void JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc);
+		static void JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -27,6 +27,14 @@
 
 namespace H2Core
 {
+	/**
+	 * Timeline class storing and handling all TempoMarkers and Tags.
+	 *
+	 * All methods altering the TempoMarker and Tag are members of
+	 * this class and the former are added as const structs to
+	 * m_tempoMarkers or m_tags. To alter one of them, one has to
+	 * delete it and add a new, altered version.
+	 */
 	class Timeline : public H2Core::Object
 	{
 		H2_OBJECT
@@ -35,36 +43,50 @@ namespace H2Core
 			Timeline();
 			~Timeline();
 
-			/// timeline vector
+			/**
+			 * TempoMarker specifies a change in speed during the
+			 * Song.
+			 */
 			struct TempoMarker
 			{
 				int		nBar;		// beat position in timeline
 				float	fBpm;		// tempo in beats per minute
 			};
 
-			/// timeline tag vector
+			/** 
+			 * Tag specifies a note added to a certain position in the
+			Song.
+			*/
 			struct Tag
 			{
 				int		nBar;		// beat position in timeline
 				QString sTag;		// tag
 			};
 
+
+			/**
+			 * @param nBar Position of the Timeline to query for a 
+			 *   tempo marker.
+			 * @param fBpm New tempo in beats per minute. All values
+			 *   below 30 and above 500 will be cut.
+			 */
 			void		addTempoMarker( int nBar, float fBpm );
+			/**
+			 * @param nBar Position of the Timeline to delete the
+			 * tempo marker at (if one is present).
+			 */
 			void		deleteTempoMarker( int nBar );
 			void		deleteAllTempoMarkers();
 			/**
 			 * Returns the tempo of the Song at a given bar.
 			 *
-			 * If there is no tempo marker at the provided `nBar`, the
-			 * value of the most previous one will be returned
-			 * instead.
-			 *
 			 * @param nBar Position of the Timeline to query for a 
-			 *   tag.
-			 * @param bSticky If set to true either the tag at `nBar`
-			 *   or - if none is present - the nearest previous tag is
-			 *   returned. If set to false, only the precise position
-			 *   `nBar` is taken into account.
+			 *   tempo marker.
+			 * @param bSticky If set to true either the tempo marker
+			 *   at `nBar` or - if none is present - the nearest
+			 *   previous tempo marker is returned. If set to false,
+			 *   only the precise position `nBar` is taken into
+			 *   account.
 			 *
 			 * TODO: For now the function returns 0 if the bar is
 			 * positioned _before_ the first tempo marker. The calling
@@ -74,9 +96,22 @@ namespace H2Core
 			 */
 			float		getTempoAtBar( int nBar, bool bSticky ) const;
 
+			/**
+			 * @return std::vector<std::shared_ptr<const TempoMarker>>
+			 * Provides read-only access to m_tempoMarker.
+			 */
 			const std::vector<std::shared_ptr<const TempoMarker>> getAllTempoMarkers() const;
 
+			/**
+			 * @param nBar Position of the Timeline to query for a 
+			 *   tag.
+			 * @param sTag New tag in beats per minute.
+			 */
 			void		addTag( int nBar, QString sTag );
+			/**
+			 * @param nBar Position of the Timeline to delete the tag
+			 * at (if one is present).
+			 */
 			void		deleteTag( int nBar );
 			void 		deleteAllTags();
 			/**
@@ -94,9 +129,12 @@ namespace H2Core
 			 */
 
 			const QString getTagAtBar( int nBar, bool bSticky ) const;
+			/**
+			 * @return std::vector<std::shared_ptr<const Tag>>
+			 * Provides read-only access to m_tags.
+			 */
 			const std::vector<std::shared_ptr<const Tag>> getAllTags() const;
 		private:
-			///sample editor vectors
 			void		sortTempoMarkers();
 			void		sortTags();
 

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -35,17 +35,17 @@ namespace H2Core
 			Timeline();
 
 			/// timeline vector
-			struct HTimelineVector
+			struct TempoMarker
 			{
-				int		m_htimelinebeat;		//beat position in timeline
-				float	m_htimelinebpm;		//BPM
+				int		nBar;		// beat position in timeline
+				float	fBpm;		// tempo in beats per minute
 			};
 
 			/// timeline tag vector
-			struct HTimelineTagVector
+			struct Tag
 			{
-				int		m_htimelinetagbeat;		//beat position in timeline
-				QString m_htimelinetag;			// tag
+				int		nBar;		// beat position in timeline
+				QString sTag;		// tag
 			};
 
 			void		addTempoMarker( int nBar, float fBpm );
@@ -72,7 +72,7 @@ namespace H2Core
 			 * taken care of with #854.
 			 */
 			float		getTempoAtBar( int nBar, bool bSticky ) const;
-			const std::vector<const HTimelineVector*> getAllTempoMarkers() const;
+			const std::vector<const TempoMarker*> getAllTempoMarkers() const;
 
 			void		addTag( int nBar, QString sTag );
 			void		deleteTag( int nBar );
@@ -92,42 +92,42 @@ namespace H2Core
 			 */
 
 			const QString getTagAtBar( int nBar, bool bSticky ) const;
-			const std::vector<const Timeline::HTimelineTagVector*> getAllTags() const;
+			const std::vector<const Timeline::Tag*> getAllTags() const;
 		private:
 			///sample editor vectors
-			void		sortTimelineVector();
-			void		sortTimelineTagVector();
+			void		sortTempoMarkers();
+			void		sortTags();
 
-			std::vector<const HTimelineVector*> m_timelinevector;
-			std::vector<const HTimelineTagVector*> m_timelinetagvector;
+			std::vector<const TempoMarker*> m_tempoMarkers;
+			std::vector<const Tag*> m_tags;
 
-			struct TimelineComparator
+			struct TempoMarkerComparator
 			{
-				bool operator()( HTimelineVector const *lhs, HTimelineVector const *rhs)
+				bool operator()( TempoMarker const *lhs, TempoMarker const *rhs)
 				{
-					return lhs->m_htimelinebeat < rhs->m_htimelinebeat;
+					return lhs->nBar < rhs->nBar;
 				}
 			};
 
-			struct TimelineTagComparator
+			struct TagComparator
 			{
-				bool operator()( HTimelineTagVector const *lhs, HTimelineTagVector const *rhs)
+				bool operator()( Tag const *lhs, Tag const *rhs)
 				{
-					return lhs->m_htimelinetagbeat < rhs->m_htimelinetagbeat;
+					return lhs->nBar < rhs->nBar;
 				}
 			};
 	};
 inline void Timeline::deleteAllTempoMarkers() {
-	m_timelinevector.clear();
+	m_tempoMarkers.clear();
 }
 inline void Timeline::deleteAllTags() {
-	m_timelinevector.clear();
+	m_tags.clear();
 }
-inline const std::vector<const Timeline::HTimelineVector*> Timeline::getAllTempoMarkers() const {
-	return m_timelinevector;
+inline const std::vector<const Timeline::TempoMarker*> Timeline::getAllTempoMarkers() const {
+	return m_tempoMarkers;
 }
-inline const std::vector<const Timeline::HTimelineTagVector*> Timeline::getAllTags() const {
-	return m_timelinetagvector;
+inline const std::vector<const Timeline::Tag*> Timeline::getAllTags() const {
+	return m_tags;
 }
 };
 #endif // TIMELINE_H

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -34,13 +34,6 @@ namespace H2Core
 		public:
 			Timeline();
 
-			void		addTempoMarker( int nPosition, float fBpm );
-			void		deleteTempoMarker( int nPosition );
-
-			///sample editor vectors
-			void		sortTimelineVector();
-			void		sortTimelineTagVector();
-
 			/// timeline vector
 			struct HTimelineVector
 			{
@@ -55,6 +48,29 @@ namespace H2Core
 				QString m_htimelinetag;			// tag
 			};
 
+			void		addTempoMarker( int nBar, float fBpm );
+			void		deleteTempoMarker( int nBar );
+			void		deleteAllTempoMarkers();
+			/**
+			 * Returns the tempo of the Song at a given bar.
+			 *
+			 * TODO: For now the function returns 0 if the bar is
+			 * positioned _before_ the first tempo marker. The calling
+			 * routine Hydrogen::getTimelineBpm() will take care of
+			 * this and replaces it with pSong->__bpm. This will be
+			 * taken care of with #854.
+			 */
+			float		getTempoAtBar( int nBar ) const;
+			std::vector<HTimelineVector> getAllTempoMarkers() const;
+
+			void		addTag( int nBar, QString sTag );
+			void		deleteTag( int nBar );
+			void 		deleteAllTags();
+			std::vector<Timeline::HTimelineTagVector> getAllTags() const;
+
+			///sample editor vectors
+			void		sortTimelineVector();
+			void		sortTimelineTagVector();
 
 			std::vector<HTimelineVector> m_timelinevector;
 			std::vector<HTimelineTagVector> m_timelinetagvector;
@@ -79,6 +95,17 @@ namespace H2Core
 		private:
 
 	};
+inline void Timeline::deleteAllTempoMarkers() {
+	m_timelinevector.clear();
+}
+inline void Timeline::deleteAllTags() {
+	m_timelinevector.clear();
+}
+inline std::vector<Timeline::HTimelineVector> Timeline::getAllTempoMarkers() const {
+	return m_timelinevector;
+}
+inline std::vector<Timeline::HTimelineTagVector> Timeline::getAllTags() const {
+	return m_timelinetagvector;
+}
 };
-
 #endif // TIMELINE_H

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -23,6 +23,8 @@
 #ifndef TIMELINE_H
 #define TIMELINE_H
 
+#include <memory>
+
 #include <hydrogen/object.h>
 
 namespace H2Core

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -34,6 +34,9 @@ namespace H2Core
 		public:
 			Timeline();
 
+			void		addTempoMarker( int nPosition, float fBpm );
+			void		deleteTempoMarker( int nPosition );
+
 			///sample editor vectors
 			void		sortTimelineVector();
 			void		sortTimelineTagVector();

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -54,18 +54,45 @@ namespace H2Core
 			/**
 			 * Returns the tempo of the Song at a given bar.
 			 *
+			 * If there is no tempo marker at the provided `nBar`, the
+			 * value of the most previous one will be returned
+			 * instead.
+			 *
+			 * @param nBar Position of the Timeline to query for a 
+			 *   tag.
+			 * @param bSticky If set to true either the tag at `nBar`
+			 *   or - if none is present - the nearest previous tag is
+			 *   returned. If set to false, only the precise position
+			 *   `nBar` is taken into account.
+			 *
 			 * TODO: For now the function returns 0 if the bar is
 			 * positioned _before_ the first tempo marker. The calling
 			 * routine Hydrogen::getTimelineBpm() will take care of
 			 * this and replaces it with pSong->__bpm. This will be
 			 * taken care of with #854.
 			 */
-			float		getTempoAtBar( int nBar ) const;
+			float		getTempoAtBar( int nBar, bool bSticky ) const;
 			std::vector<HTimelineVector> getAllTempoMarkers() const;
 
 			void		addTag( int nBar, QString sTag );
 			void		deleteTag( int nBar );
 			void 		deleteAllTags();
+			/**
+			 * Returns the tag of the Song at a given bar.
+			 *
+			 * @param nBar Position of the Timeline to query for a 
+			 *   tag.
+			 * @param bSticky If set to true either the tag at `nBar`
+			 *   or - if none is present - the nearest previous tag is
+			 *   returned. If set to false, only the precise position
+			 *   `nBar` is taken into account.
+			 * 
+			 * The function returns "" if the bar is positioned
+			 * _before_ the first tag or none is present at all.
+			 */
+
+			const QString getTagAtBar( int nBar, bool bSticky ) const;
+		
 			std::vector<Timeline::HTimelineTagVector> getAllTags() const;
 
 			///sample editor vectors

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -33,6 +33,7 @@ namespace H2Core
 
 		public:
 			Timeline();
+			~Timeline();
 
 			/// timeline vector
 			struct TempoMarker
@@ -72,7 +73,8 @@ namespace H2Core
 			 * taken care of with #854.
 			 */
 			float		getTempoAtBar( int nBar, bool bSticky ) const;
-			const std::vector<const TempoMarker*> getAllTempoMarkers() const;
+
+			const std::vector<std::shared_ptr<const TempoMarker>> getAllTempoMarkers() const;
 
 			void		addTag( int nBar, QString sTag );
 			void		deleteTag( int nBar );
@@ -92,26 +94,25 @@ namespace H2Core
 			 */
 
 			const QString getTagAtBar( int nBar, bool bSticky ) const;
-			const std::vector<const Timeline::Tag*> getAllTags() const;
+			const std::vector<std::shared_ptr<const Tag>> getAllTags() const;
 		private:
 			///sample editor vectors
 			void		sortTempoMarkers();
 			void		sortTags();
 
-			std::vector<const TempoMarker*> m_tempoMarkers;
-			std::vector<const Tag*> m_tags;
+			std::vector<std::shared_ptr<const TempoMarker>> m_tempoMarkers;
+			std::vector<std::shared_ptr<const Tag>> m_tags;
 
 			struct TempoMarkerComparator
 			{
-				bool operator()( TempoMarker const *lhs, TempoMarker const *rhs)
+				bool operator()( const std::shared_ptr<const TempoMarker> lhs, const std::shared_ptr<const TempoMarker> rhs)
 				{
 					return lhs->nBar < rhs->nBar;
 				}
 			};
-
 			struct TagComparator
 			{
-				bool operator()( Tag const *lhs, Tag const *rhs)
+				bool operator()( const std::shared_ptr<const Tag> lhs, const std::shared_ptr<const Tag> rhs)
 				{
 					return lhs->nBar < rhs->nBar;
 				}
@@ -123,10 +124,10 @@ inline void Timeline::deleteAllTempoMarkers() {
 inline void Timeline::deleteAllTags() {
 	m_tags.clear();
 }
-inline const std::vector<const Timeline::TempoMarker*> Timeline::getAllTempoMarkers() const {
+inline const std::vector<std::shared_ptr<const Timeline::TempoMarker>> Timeline::getAllTempoMarkers() const {
 	return m_tempoMarkers;
 }
-inline const std::vector<const Timeline::Tag*> Timeline::getAllTags() const {
+inline const std::vector<std::shared_ptr<const Timeline::Tag>> Timeline::getAllTags() const {
 	return m_tags;
 }
 };

--- a/src/core/include/hydrogen/timeline.h
+++ b/src/core/include/hydrogen/timeline.h
@@ -72,7 +72,7 @@ namespace H2Core
 			 * taken care of with #854.
 			 */
 			float		getTempoAtBar( int nBar, bool bSticky ) const;
-			std::vector<HTimelineVector> getAllTempoMarkers() const;
+			const std::vector<const HTimelineVector*> getAllTempoMarkers() const;
 
 			void		addTag( int nBar, QString sTag );
 			void		deleteTag( int nBar );
@@ -92,35 +92,30 @@ namespace H2Core
 			 */
 
 			const QString getTagAtBar( int nBar, bool bSticky ) const;
-		
-			std::vector<Timeline::HTimelineTagVector> getAllTags() const;
-
+			const std::vector<const Timeline::HTimelineTagVector*> getAllTags() const;
+		private:
 			///sample editor vectors
 			void		sortTimelineVector();
 			void		sortTimelineTagVector();
 
-			std::vector<HTimelineVector> m_timelinevector;
-			std::vector<HTimelineTagVector> m_timelinetagvector;
+			std::vector<const HTimelineVector*> m_timelinevector;
+			std::vector<const HTimelineTagVector*> m_timelinetagvector;
 
 			struct TimelineComparator
 			{
-				bool operator()( HTimelineVector const& lhs, HTimelineVector const& rhs)
+				bool operator()( HTimelineVector const *lhs, HTimelineVector const *rhs)
 				{
-					return lhs.m_htimelinebeat < rhs.m_htimelinebeat;
+					return lhs->m_htimelinebeat < rhs->m_htimelinebeat;
 				}
 			};
 
 			struct TimelineTagComparator
 			{
-				bool operator()( HTimelineTagVector const& lhs, HTimelineTagVector const& rhs)
+				bool operator()( HTimelineTagVector const *lhs, HTimelineTagVector const *rhs)
 				{
-					return lhs.m_htimelinetagbeat < rhs.m_htimelinetagbeat;
+					return lhs->m_htimelinetagbeat < rhs->m_htimelinetagbeat;
 				}
 			};
-
-
-		private:
-
 	};
 inline void Timeline::deleteAllTempoMarkers() {
 	m_timelinevector.clear();
@@ -128,10 +123,10 @@ inline void Timeline::deleteAllTempoMarkers() {
 inline void Timeline::deleteAllTags() {
 	m_timelinevector.clear();
 }
-inline std::vector<Timeline::HTimelineVector> Timeline::getAllTempoMarkers() const {
+inline const std::vector<const Timeline::HTimelineVector*> Timeline::getAllTempoMarkers() const {
 	return m_timelinevector;
 }
-inline std::vector<Timeline::HTimelineTagVector> Timeline::getAllTags() const {
+inline const std::vector<const Timeline::HTimelineTagVector*> Timeline::getAllTags() const {
 	return m_timelinetagvector;
 }
 };

--- a/src/core/src/IO/disk_writer_driver.cpp
+++ b/src/core/src/IO/disk_writer_driver.cpp
@@ -175,7 +175,7 @@ void* diskWriterDriver_thread( void* param )
 		Timeline* pTimeline = pEngine->getTimeline();
 		if(Preferences::get_instance()->getUseTimelineBpm() ){
 
-			float fTimelineBpm = pTimeline->getTempoAtBar( patternPosition );
+			float fTimelineBpm = pTimeline->getTempoAtBar( patternPosition, true );
 			if ( fTimelineBpm != 0 ) {
 				validBpm = fTimelineBpm;
 			}

--- a/src/core/src/IO/disk_writer_driver.cpp
+++ b/src/core/src/IO/disk_writer_driver.cpp
@@ -174,16 +174,12 @@ void* diskWriterDriver_thread( void* param )
 		// check pattern bpm if timeline bpm is in use
 		Timeline* pTimeline = pEngine->getTimeline();
 		if(Preferences::get_instance()->getUseTimelineBpm() ){
-			if( pTimeline->m_timelinevector.size() >= 1 ){
-				
-				for ( int t = 0; t < pTimeline->m_timelinevector.size(); t++){
-					if(pTimeline->m_timelinevector[t].m_htimelinebeat == patternPosition &&
-							pTimeline->m_timelinevector[t].m_htimelinebpm != validBpm){
-						validBpm =  pTimeline->m_timelinevector[t].m_htimelinebpm;
-					}
-					
-				}
+
+			float fTimelineBpm = pTimeline->getTempoAtBar( patternPosition );
+			if ( fTimelineBpm != 0 ) {
+				validBpm = fTimelineBpm;
 			}
+			
 			pDriver->setBpm(validBpm);
 			fTicksize = pDriver->m_nSampleRate * 60.0 / validBpm / Hydrogen::get_instance()->getSong()->__resolution;
 			pDriver->audioEngine_process_checkBPMChanged();

--- a/src/core/src/basics/song.cpp
+++ b/src/core/src/basics/song.cpp
@@ -1203,32 +1203,26 @@ Song* SongReader::readSong( const QString& filename )
 	}
 
 	Timeline* pTimeline = Hydrogen::get_instance()->getTimeline();
-	pTimeline->m_timelinevector.clear();
-	Timeline::HTimelineVector tlvector;
+	pTimeline->deleteAllTempoMarkers();
 	QDomNode bpmTimeLine = songNode.firstChildElement( "BPMTimeLine" );
 	if ( !bpmTimeLine.isNull() ) {
 		QDomNode newBPMNode = bpmTimeLine.firstChildElement( "newBPM" );
 		while( !newBPMNode.isNull() ) {
-			tlvector.m_htimelinebeat = LocalFileMng::readXmlInt( newBPMNode, "BAR", 0 );
-			tlvector.m_htimelinebpm = LocalFileMng::readXmlFloat( newBPMNode, "BPM", 120.0 );
-			pTimeline->m_timelinevector.push_back( tlvector );
-			pTimeline->sortTimelineVector();
+			pTimeline->addTempoMarker( LocalFileMng::readXmlInt( newBPMNode, "BAR", 0 ),
+									   LocalFileMng::readXmlFloat( newBPMNode, "BPM", 120.0 ) );
 			newBPMNode = newBPMNode.nextSiblingElement( "newBPM" );
 		}
 	} else {
 		WARNINGLOG( "bpmTimeLine node not found" );
 	}
 
-	pTimeline->m_timelinetagvector.clear();
-	Timeline::HTimelineTagVector tltagvector;
+	pTimeline->deleteAllTags();
 	QDomNode timeLineTag = songNode.firstChildElement( "timeLineTag" );
 	if ( !timeLineTag.isNull() ) {
 		QDomNode newTAGNode = timeLineTag.firstChildElement( "newTAG" );
 		while( !newTAGNode.isNull() ) {
-			tltagvector.m_htimelinetagbeat = LocalFileMng::readXmlInt( newTAGNode, "BAR", 0 );
-			tltagvector.m_htimelinetag = LocalFileMng::readXmlString( newTAGNode, "TAG", "" );
-			pTimeline->m_timelinetagvector.push_back( tltagvector );
-			pTimeline->sortTimelineTagVector();
+			pTimeline->addTag( LocalFileMng::readXmlInt( newTAGNode, "BAR", 0 ),
+							   LocalFileMng::readXmlString( newTAGNode, "TAG", "" ) );
 			newTAGNode = newTAGNode.nextSiblingElement( "newTAG" );
 		}
 	} else {

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -304,7 +304,7 @@ bool CoreActionController::newSong( const QString& songPath ) {
 	}
 	
 	// Remove all BPM tags on the Timeline.
-	pHydrogen->getTimeline()->m_timelinevector.clear();
+	pHydrogen->getTimeline()->deleteAllTempoMarkers();
 	
 	// Create an empty Song.
 	auto pSong = Song::get_empty_song();
@@ -351,7 +351,7 @@ bool CoreActionController::openSong (const QString& songPath ) {
 	}
 	
 	// Remove all BPM tags on the Timeline.
-	pHydrogen->getTimeline()->m_timelinevector.clear();
+	pHydrogen->getTimeline()->deleteAllTempoMarkers();
 	
 	// Check whether the provided path is valid.
 	if ( !isSongPathValid( songPath ) ) {
@@ -506,7 +506,9 @@ bool CoreActionController::activateTimeline( bool active ) {
 }
 
 bool CoreActionController::addTempoMarker( int nPosition, float fBpm ) {
-	Hydrogen::get_instance()->getTimeline()->addTempoMarker( nPosition, fBpm );
+	auto pTimeline = Hydrogen::get_instance()->getTimeline();
+	pTimeline->deleteTempoMarker( nPosition );
+	pTimeline->addTempoMarker( nPosition, fBpm );
 
 	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
 

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -536,7 +536,8 @@ bool CoreActionController::deleteTempoMarker( int nPosition ) {
 }
 
 bool CoreActionController::activateJackTransport( bool bActivate ) {
-
+	
+#ifdef H2CORE_HAVE_JACK
 	if ( !Hydrogen::get_instance()->haveJackAudioDriver() ) {
 		ERRORLOG( "Unable to (de)activate Jack transport. Please select the Jack driver first." );
 		return false;
@@ -553,10 +554,15 @@ bool CoreActionController::activateJackTransport( bool bActivate ) {
 	EventQueue::get_instance()->push_event( EVENT_JACK_TRANSPORT_ACTIVATION, static_cast<int>( bActivate ) );
 	
 	return true;
+#else
+	ERRORLOG( "Unable to (de)activate Jack transport. Your Hydrogen version was not compiled with jack support." );
+	return false;
+#endif
 }
 
 bool CoreActionController::activateJackTimebaseMaster( bool bActivate ) {
 
+#ifdef H2CORE_HAVE_JACK
 	if ( !Hydrogen::get_instance()->haveJackAudioDriver() ) {
 		ERRORLOG( "Unable to (de)activate Jack timebase master. Please select the Jack driver first." );
 		return false;
@@ -575,5 +581,9 @@ bool CoreActionController::activateJackTimebaseMaster( bool bActivate ) {
 	EventQueue::get_instance()->push_event( EVENT_JACK_TIMEBASE_ACTIVATION, static_cast<int>( bActivate ) );
 	
 	return true;
+#else
+	ERRORLOG( "Unable to (de)activate Jack timebase master. Your Hydrogen version was not compiled with jack support." );
+	return false;
+#endif
 }
 }

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -469,7 +469,6 @@ bool CoreActionController::quit() {
 	return true;
 }
 
-
 bool CoreActionController::isSongPathValid( const QString& songPath ) {
 	
 	QFileInfo songFileInfo = QFileInfo( songPath );
@@ -496,6 +495,36 @@ bool CoreActionController::isSongPathValid( const QString& songPath ) {
 	
 	return true;
 }
+
+bool CoreActionController::activateTimeline( bool active ) {
+
+	Preferences::get_instance()->setUseTimelineBpm( active );
 	
+	EventQueue::get_instance()->push_event( EVENT_TIMELINE_ACTIVATION, static_cast<int>(active) );
 	
+	return true;
+}
+
+bool CoreActionController::addTempoMarker( int nPosition, float fBpm ) {
+	Hydrogen::get_instance()->getTimeline()->addTempoMarker( nPosition, fBpm );
+
+	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
+
+	return true;
+}
+
+bool CoreActionController::deleteTempoMarker( int nPosition ) {
+	Hydrogen::get_instance()->getTimeline()->deleteTempoMarker( nPosition );
+	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
+
+	return true;
+}
+
+bool CoreActionController::activateJackTransport( bool bActivate ) {
+	return true;
+}
+
+bool CoreActionController::activateJackTimebaseMaster( bool bActivate ) {
+	return true;
+}
 }

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -498,7 +498,6 @@ bool CoreActionController::isSongPathValid( const QString& songPath ) {
 }
 
 bool CoreActionController::activateTimeline( bool bActivate ) {
-
 	auto pHydrogen = Hydrogen::get_instance();
 	
 	if ( pHydrogen->haveJackTimebaseClient() ) {

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -4003,12 +4003,12 @@ float Hydrogen::getTimelineBpm( int nBar )
 	}
 
 	// Determine the speed at the supplied beat.
-	for ( int i = 0; i < static_cast<int>(m_pTimeline->m_timelinevector.size()); i++) {
-		if ( m_pTimeline->m_timelinevector[i].m_htimelinebeat > nBar ) {
-			break;
-		}
-
-		fBPM = m_pTimeline->m_timelinevector[i].m_htimelinebpm;
+	float fTimelineBpm = m_pTimeline->getTempoAtBar( nBar );
+	if ( fTimelineBpm != 0 ) {
+		/* TODO: For now the function returns 0 if the bar is
+		 * positioned _before_ the first tempo marker. This will be
+		 * taken care of with #854. */
+		fBPM = fTimelineBpm;
 	}
 
 	return fBPM;

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -4003,7 +4003,7 @@ float Hydrogen::getTimelineBpm( int nBar )
 	}
 
 	// Determine the speed at the supplied beat.
-	float fTimelineBpm = m_pTimeline->getTempoAtBar( nBar );
+	float fTimelineBpm = m_pTimeline->getTempoAtBar( nBar, true );
 	if ( fTimelineBpm != 0 ) {
 		/* TODO: For now the function returns 0 if the bar is
 		 * positioned _before_ the first tempo marker. This will be

--- a/src/core/src/local_file_mgr.cpp
+++ b/src/core/src/local_file_mgr.cpp
@@ -649,8 +649,8 @@ int SongWriter::writeSong( Song * pSong, const QString& filename )
 	if ( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < static_cast<int>(tempoMarkerVector.size()); t++){
 			QDomNode newBPMNode = doc.createElement( "newBPM" );
-			LocalFileMng::writeXmlString( newBPMNode, "BAR",QString("%1").arg( tempoMarkerVector[t].m_htimelinebeat ));
-			LocalFileMng::writeXmlString( newBPMNode, "BPM", QString("%1").arg( tempoMarkerVector[t].m_htimelinebpm  ) );
+			LocalFileMng::writeXmlString( newBPMNode, "BAR",QString("%1").arg( tempoMarkerVector[t]->m_htimelinebeat ));
+			LocalFileMng::writeXmlString( newBPMNode, "BPM", QString("%1").arg( tempoMarkerVector[t]->m_htimelinebpm  ) );
 			bpmTimeLine.appendChild( newBPMNode );
 		}
 	}
@@ -664,8 +664,8 @@ int SongWriter::writeSong( Song * pSong, const QString& filename )
 	if ( tagVector.size() >= 1 ){
 		for ( int t = 0; t < static_cast<int>(tagVector.size()); t++){
 			QDomNode newTAGNode = doc.createElement( "newTAG" );
-			LocalFileMng::writeXmlString( newTAGNode, "BAR",QString("%1").arg( tagVector[t].m_htimelinetagbeat ));
-			LocalFileMng::writeXmlString( newTAGNode, "TAG", QString("%1").arg( tagVector[t].m_htimelinetag ) );
+			LocalFileMng::writeXmlString( newTAGNode, "BAR",QString("%1").arg( tagVector[t]->m_htimelinetagbeat ));
+			LocalFileMng::writeXmlString( newTAGNode, "TAG", QString("%1").arg( tagVector[t]->m_htimelinetag ) );
 			timeLineTag.appendChild( newTAGNode );
 		}
 	}

--- a/src/core/src/local_file_mgr.cpp
+++ b/src/core/src/local_file_mgr.cpp
@@ -649,8 +649,8 @@ int SongWriter::writeSong( Song * pSong, const QString& filename )
 	if ( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < static_cast<int>(tempoMarkerVector.size()); t++){
 			QDomNode newBPMNode = doc.createElement( "newBPM" );
-			LocalFileMng::writeXmlString( newBPMNode, "BAR",QString("%1").arg( tempoMarkerVector[t]->m_htimelinebeat ));
-			LocalFileMng::writeXmlString( newBPMNode, "BPM", QString("%1").arg( tempoMarkerVector[t]->m_htimelinebpm  ) );
+			LocalFileMng::writeXmlString( newBPMNode, "BAR",QString("%1").arg( tempoMarkerVector[t]->nBar ));
+			LocalFileMng::writeXmlString( newBPMNode, "BPM", QString("%1").arg( tempoMarkerVector[t]->fBpm  ) );
 			bpmTimeLine.appendChild( newBPMNode );
 		}
 	}
@@ -664,8 +664,8 @@ int SongWriter::writeSong( Song * pSong, const QString& filename )
 	if ( tagVector.size() >= 1 ){
 		for ( int t = 0; t < static_cast<int>(tagVector.size()); t++){
 			QDomNode newTAGNode = doc.createElement( "newTAG" );
-			LocalFileMng::writeXmlString( newTAGNode, "BAR",QString("%1").arg( tagVector[t]->m_htimelinetagbeat ));
-			LocalFileMng::writeXmlString( newTAGNode, "TAG", QString("%1").arg( tagVector[t]->m_htimelinetag ) );
+			LocalFileMng::writeXmlString( newTAGNode, "BAR",QString("%1").arg( tagVector[t]->nBar ));
+			LocalFileMng::writeXmlString( newTAGNode, "TAG", QString("%1").arg( tagVector[t]->sTag ) );
 			timeLineTag.appendChild( newTAGNode );
 		}
 	}

--- a/src/core/src/local_file_mgr.cpp
+++ b/src/core/src/local_file_mgr.cpp
@@ -644,11 +644,13 @@ int SongWriter::writeSong( Song * pSong, const QString& filename )
 
 	QDomNode bpmTimeLine = doc.createElement( "BPMTimeLine" );
 
-	if(pTimeline->m_timelinevector.size() >= 1 ){
-		for ( int t = 0; t < static_cast<int>(pTimeline->m_timelinevector.size()); t++){
+	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();
+	
+	if ( tempoMarkerVector.size() >= 1 ){
+		for ( int t = 0; t < static_cast<int>(tempoMarkerVector.size()); t++){
 			QDomNode newBPMNode = doc.createElement( "newBPM" );
-			LocalFileMng::writeXmlString( newBPMNode, "BAR",QString("%1").arg( pTimeline->m_timelinevector[t].m_htimelinebeat ));
-			LocalFileMng::writeXmlString( newBPMNode, "BPM", QString("%1").arg( pTimeline->m_timelinevector[t].m_htimelinebpm  ) );
+			LocalFileMng::writeXmlString( newBPMNode, "BAR",QString("%1").arg( tempoMarkerVector[t].m_htimelinebeat ));
+			LocalFileMng::writeXmlString( newBPMNode, "BPM", QString("%1").arg( tempoMarkerVector[t].m_htimelinebpm  ) );
 			bpmTimeLine.appendChild( newBPMNode );
 		}
 	}
@@ -656,11 +658,14 @@ int SongWriter::writeSong( Song * pSong, const QString& filename )
 
 	//time line tag
 	QDomNode timeLineTag = doc.createElement( "timeLineTag" );
-	if(pTimeline->m_timelinetagvector.size() >= 1 ){
-		for ( int t = 0; t < static_cast<int>(pTimeline->m_timelinetagvector.size()); t++){
+
+	auto tagVector = pTimeline->getAllTags();
+	
+	if ( tagVector.size() >= 1 ){
+		for ( int t = 0; t < static_cast<int>(tagVector.size()); t++){
 			QDomNode newTAGNode = doc.createElement( "newTAG" );
-			LocalFileMng::writeXmlString( newTAGNode, "BAR",QString("%1").arg( pTimeline->m_timelinetagvector[t].m_htimelinetagbeat ));
-			LocalFileMng::writeXmlString( newTAGNode, "TAG", QString("%1").arg( pTimeline->m_timelinetagvector[t].m_htimelinetag  ) );
+			LocalFileMng::writeXmlString( newTAGNode, "BAR",QString("%1").arg( tagVector[t].m_htimelinetagbeat ));
+			LocalFileMng::writeXmlString( newTAGNode, "TAG", QString("%1").arg( tagVector[t].m_htimelinetag ) );
 			timeLineTag.appendChild( newTAGNode );
 		}
 	}

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -633,6 +633,50 @@ void OscServer::QUIT_Handler(lo_arg **argv, int argc) {
 	pController->quit();
 }
 
+void OscServer::TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+
+	if ( &argv[0]->i != 0 ) { 
+		pController->activateTimeline( true );
+	} else {
+		pController->activateTimeline( false );
+	}
+}
+
+void OscServer::TIMELINE_ADD_MARKER_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	pController->addTempoMarker(argv[0]->i, argv[1]->f);
+}
+
+void OscServer::TIMELINE_DELETE_MARKER_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	pController->deleteTempoMarker(argv[0]->i);
+}
+
+void OscServer::JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+
+	if ( &argv[1]->i != 0 ) {
+		pController->activateJackTransport( true );
+	} else {
+		pController->activateJackTransport( false );
+	}
+}
+
+void OscServer::JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	if ( &argv[1]->i != 0 ) {
+		pController->activateJackTimebaseMaster( true );
+	} else {
+		pController->activateJackTimebaseMaster( false );
+	}
+}
+
 // -------------------------------------------------------------------
 // Helper functions
 
@@ -906,6 +950,12 @@ bool OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "s", SAVE_SONG_AS_Handler);
 	m_pServerThread->add_method("/Hydrogen/QUIT", "", QUIT_Handler);
 
+	m_pServerThread->add_method("/Hydrogen/TIMELINE_ACTIVATION", "i", TIMELINE_ACTIVATION_Handler);
+	m_pServerThread->add_method("/Hydrogen/TIMELINE_ADD_MARKER", "if", TIMELINE_ADD_MARKER_Handler);
+	m_pServerThread->add_method("/Hydrogen/TIMELINE_DELETE_MARKER", "i", TIMELINE_DELETE_MARKER_Handler);
+
+	m_pServerThread->add_method("/Hydrogen/JACK_TRANSPORT_ACTIVATION", "i", JACK_TRANSPORT_ACTIVATION_Handler);
+	m_pServerThread->add_method("/Hydrogen/JACK_TIMEBASE_MASTER_ACTIVATION", "", JACK_TIMEBASE_MASTER_ACTIVATION_Handler);
 	/*
 	 * Start the server.
 	 */

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -637,7 +637,7 @@ void OscServer::TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 
 	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
 
-	if ( &argv[0]->i != 0 ) { 
+	if ( argv[0]->i != 0 ) { 
 		pController->activateTimeline( true );
 	} else {
 		pController->activateTimeline( false );
@@ -660,7 +660,7 @@ void OscServer::JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc) {
 	
 	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
 
-	if ( &argv[1]->i != 0 ) {
+	if ( argv[0]->i != 0 ) {
 		pController->activateJackTransport( true );
 	} else {
 		pController->activateJackTransport( false );
@@ -668,9 +668,9 @@ void OscServer::JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc) {
 }
 
 void OscServer::JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc) {
-	
+
 	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
-	if ( &argv[1]->i != 0 ) {
+	if ( argv[0]->i != 0 ) {
 		pController->activateJackTimebaseMaster( true );
 	} else {
 		pController->activateJackTimebaseMaster( false );
@@ -955,7 +955,7 @@ bool OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/TIMELINE_DELETE_MARKER", "i", TIMELINE_DELETE_MARKER_Handler);
 
 	m_pServerThread->add_method("/Hydrogen/JACK_TRANSPORT_ACTIVATION", "i", JACK_TRANSPORT_ACTIVATION_Handler);
-	m_pServerThread->add_method("/Hydrogen/JACK_TIMEBASE_MASTER_ACTIVATION", "", JACK_TIMEBASE_MASTER_ACTIVATION_Handler);
+	m_pServerThread->add_method("/Hydrogen/JACK_TIMEBASE_MASTER_ACTIVATION", "i", JACK_TIMEBASE_MASTER_ACTIVATION_Handler);
 	/*
 	 * Start the server.
 	 */

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -42,7 +42,7 @@ namespace H2Core
 
 		HTimelineVector tlvector = { nBar, fBpm };
 
-		m_timelinevector.push_back( tlvector );
+		m_timelinevector.push_back( &tlvector );
 		sortTimelineVector();
 	}
 
@@ -51,7 +51,7 @@ namespace H2Core
 		// Erase the value to set the new value
 		if ( m_timelinevector.size() >= 1 ){
 			for ( int t = 0; t < m_timelinevector.size(); t++ ){
-				if ( m_timelinevector[t].m_htimelinebeat == nBar ) {
+				if ( m_timelinevector[t]->m_htimelinebeat == nBar ) {
 					m_timelinevector.erase( m_timelinevector.begin() +  t);
 				}
 			}
@@ -63,15 +63,15 @@ namespace H2Core
 
 		if ( bSticky ) {
 			for ( int i = 0; i < static_cast<int>(m_timelinevector.size()); i++) {
-				if ( m_timelinevector[i].m_htimelinebeat > nBar ) {
+				if ( m_timelinevector[i]->m_htimelinebeat > nBar ) {
 					break;
 				}
-				fBpm = m_timelinevector[i].m_htimelinebpm;
+				fBpm = m_timelinevector[i]->m_htimelinebpm;
 			}
 		} else {
 			for ( int t = 0; t < static_cast<int>(m_timelinevector.size()); t++ ){
-				if ( m_timelinevector[t].m_htimelinebeat == nBar ){
-					fBpm = m_timelinevector[t].m_htimelinebpm;
+				if ( m_timelinevector[t]->m_htimelinebeat == nBar ){
+					fBpm = m_timelinevector[t]->m_htimelinebpm;
 				}
 			}
 		}
@@ -83,7 +83,7 @@ namespace H2Core
 		
 		HTimelineTagVector tlvector = { nBar, sTag };
 
-		m_timelinetagvector.push_back( tlvector );
+		m_timelinetagvector.push_back( &tlvector );
 		sortTimelineTagVector();
 	}
 
@@ -92,7 +92,7 @@ namespace H2Core
 		// Erase the value to set the new value
 		if ( m_timelinetagvector.size() >= 1 ){
 			for ( int t = 0; t < m_timelinetagvector.size(); t++ ){
-				if ( m_timelinetagvector[t].m_htimelinetagbeat == nBar ) {
+				if ( m_timelinetagvector[t]->m_htimelinetagbeat == nBar ) {
 					m_timelinetagvector.erase( m_timelinetagvector.begin() +  t);
 				}
 			}
@@ -107,15 +107,15 @@ namespace H2Core
 
 		if ( bSticky ) {
 			for ( int t = 0; t < static_cast<int>(m_timelinetagvector.size()); t++ ){
-				if ( m_timelinetagvector[t].m_htimelinetagbeat > nBar ){
+				if ( m_timelinetagvector[t]->m_htimelinetagbeat > nBar ){
 					break;
 				}
-				sTag = m_timelinetagvector[t].m_htimelinetag;
+				sTag = m_timelinetagvector[t]->m_htimelinetag;
 			}
 		} else {
 			for ( int t = 0; t < static_cast<int>(m_timelinetagvector.size()); t++ ){
-				if ( m_timelinetagvector[t].m_htimelinetagbeat == nBar ){
-					sTag =  m_timelinetagvector[t].m_htimelinetag;
+				if ( m_timelinetagvector[t]->m_htimelinetagbeat == nBar ){
+					sTag =  m_timelinetagvector[t]->m_htimelinetag;
 				}
 			}
 		}

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -32,9 +32,7 @@ namespace H2Core
 	{
 	}
 
-	void Timeline::addTempoMarker( int nPosition, float fBpm ) {
-
-		deleteTempoMarker( nPosition );
+	void Timeline::addTempoMarker( int nBar, float fBpm ) {
 		
 		if ( fBpm < 30.0 ) {
 			fBpm = 30.0;
@@ -42,19 +40,54 @@ namespace H2Core
 			fBpm = 500.0;
 		}
 
-		HTimelineVector tlvector = { nPosition - 1, fBpm };
+		HTimelineVector tlvector = { nBar, fBpm };
 
 		m_timelinevector.push_back( tlvector );
 		sortTimelineVector();
 	}
 
-	void Timeline::deleteTempoMarker( int nPosition ) {
+	void Timeline::deleteTempoMarker( int nBar ) {
 
 		// Erase the value to set the new value
 		if ( m_timelinevector.size() >= 1 ){
 			for ( int t = 0; t < m_timelinevector.size(); t++ ){
-				if ( m_timelinevector[t].m_htimelinebeat == nPosition -1 ) {
+				if ( m_timelinevector[t].m_htimelinebeat == nBar ) {
 					m_timelinevector.erase( m_timelinevector.begin() +  t);
+				}
+			}
+		}
+	}
+
+	float Timeline::getTempoAtBar( int nBar ) const
+	{
+		float fBpm = 0;
+		
+		for ( int i = 0; i < static_cast<int>(m_timelinevector.size()); i++) {
+			if ( m_timelinevector[i].m_htimelinebeat > nBar ) {
+				break;
+			}
+
+			fBpm = m_timelinevector[i].m_htimelinebpm;
+		}
+
+		return fBpm;
+	}
+
+	void Timeline::addTag( int nBar, QString sTag ) {
+		
+		HTimelineTagVector tlvector = { nBar, sTag };
+
+		m_timelinetagvector.push_back( tlvector );
+		sortTimelineTagVector();
+	}
+
+	void Timeline::deleteTag( int nBar ) {
+
+		// Erase the value to set the new value
+		if ( m_timelinetagvector.size() >= 1 ){
+			for ( int t = 0; t < m_timelinetagvector.size(); t++ ){
+				if ( m_timelinetagvector[t].m_htimelinetagbeat == nBar ) {
+					m_timelinetagvector.erase( m_timelinetagvector.begin() +  t);
 				}
 			}
 		}

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -58,16 +58,22 @@ namespace H2Core
 		}
 	}
 
-	float Timeline::getTempoAtBar( int nBar ) const
-	{
+	float Timeline::getTempoAtBar( int nBar, bool bSticky ) const {
 		float fBpm = 0;
-		
-		for ( int i = 0; i < static_cast<int>(m_timelinevector.size()); i++) {
-			if ( m_timelinevector[i].m_htimelinebeat > nBar ) {
-				break;
-			}
 
-			fBpm = m_timelinevector[i].m_htimelinebpm;
+		if ( bSticky ) {
+			for ( int i = 0; i < static_cast<int>(m_timelinevector.size()); i++) {
+				if ( m_timelinevector[i].m_htimelinebeat > nBar ) {
+					break;
+				}
+				fBpm = m_timelinevector[i].m_htimelinebpm;
+			}
+		} else {
+			for ( int t = 0; t < static_cast<int>(m_timelinevector.size()); t++ ){
+				if ( m_timelinevector[t].m_htimelinebeat == nBar ){
+					fBpm = m_timelinevector[t].m_htimelinebpm;
+				}
+			}
 		}
 
 		return fBpm;
@@ -91,8 +97,32 @@ namespace H2Core
 				}
 			}
 		}
+		
+		sortTimelineTagVector();
 	}
 
+	const QString Timeline::getTagAtBar( int nBar, bool bSticky ) const {
+
+		QString sTag("");
+
+		if ( bSticky ) {
+			for ( int t = 0; t < static_cast<int>(m_timelinetagvector.size()); t++ ){
+				if ( m_timelinetagvector[t].m_htimelinetagbeat > nBar ){
+					break;
+				}
+				sTag = m_timelinetagvector[t].m_htimelinetag;
+			}
+		} else {
+			for ( int t = 0; t < static_cast<int>(m_timelinetagvector.size()); t++ ){
+				if ( m_timelinetagvector[t].m_htimelinetagbeat == nBar ){
+					sTag =  m_timelinetagvector[t].m_htimelinetag;
+				}
+			}
+		}
+
+		return sTag;
+	}
+	
 	void Timeline::sortTimelineVector()
 	{
 		//sort the timeline vector to beats a < b

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -32,6 +32,11 @@ namespace H2Core
 	{
 	}
 
+	Timeline::~Timeline() {
+		m_tempoMarkers.clear();
+		m_tags.clear();
+	}
+
 	void Timeline::addTempoMarker( int nBar, float fBpm ) {
 		
 		if ( fBpm < 30.0 ) {
@@ -40,9 +45,11 @@ namespace H2Core
 			fBpm = 500.0;
 		}
 
-		TempoMarker tempoMarker = { nBar, fBpm };
+		std::shared_ptr<TempoMarker> pTempoMarker( new TempoMarker );
+		pTempoMarker->nBar = nBar;
+		pTempoMarker->fBpm = fBpm;
 
-		m_tempoMarkers.push_back( &tempoMarker );
+		m_tempoMarkers.push_back( pTempoMarker );
 		sortTempoMarkers();
 	}
 
@@ -81,9 +88,11 @@ namespace H2Core
 
 	void Timeline::addTag( int nBar, QString sTag ) {
 		
-		Tag tag = { nBar, sTag };
+		std::shared_ptr<Tag> pTag( new Tag );
+		pTag->nBar = nBar;
+		pTag->sTag = sTag;
 
-		m_tags.push_back( &tag );
+		m_tags.push_back( std::move( pTag ) );
 		sortTags();
 	}
 

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -40,19 +40,19 @@ namespace H2Core
 			fBpm = 500.0;
 		}
 
-		HTimelineVector tlvector = { nBar, fBpm };
+		TempoMarker tempoMarker = { nBar, fBpm };
 
-		m_timelinevector.push_back( &tlvector );
-		sortTimelineVector();
+		m_tempoMarkers.push_back( &tempoMarker );
+		sortTempoMarkers();
 	}
 
 	void Timeline::deleteTempoMarker( int nBar ) {
 
 		// Erase the value to set the new value
-		if ( m_timelinevector.size() >= 1 ){
-			for ( int t = 0; t < m_timelinevector.size(); t++ ){
-				if ( m_timelinevector[t]->m_htimelinebeat == nBar ) {
-					m_timelinevector.erase( m_timelinevector.begin() +  t);
+		if ( m_tempoMarkers.size() >= 1 ){
+			for ( int t = 0; t < m_tempoMarkers.size(); t++ ){
+				if ( m_tempoMarkers[t]->nBar == nBar ) {
+					m_tempoMarkers.erase( m_tempoMarkers.begin() +  t);
 				}
 			}
 		}
@@ -62,16 +62,16 @@ namespace H2Core
 		float fBpm = 0;
 
 		if ( bSticky ) {
-			for ( int i = 0; i < static_cast<int>(m_timelinevector.size()); i++) {
-				if ( m_timelinevector[i]->m_htimelinebeat > nBar ) {
+			for ( int i = 0; i < static_cast<int>(m_tempoMarkers.size()); i++) {
+				if ( m_tempoMarkers[i]->nBar > nBar ) {
 					break;
 				}
-				fBpm = m_timelinevector[i]->m_htimelinebpm;
+				fBpm = m_tempoMarkers[i]->fBpm;
 			}
 		} else {
-			for ( int t = 0; t < static_cast<int>(m_timelinevector.size()); t++ ){
-				if ( m_timelinevector[t]->m_htimelinebeat == nBar ){
-					fBpm = m_timelinevector[t]->m_htimelinebpm;
+			for ( int t = 0; t < static_cast<int>(m_tempoMarkers.size()); t++ ){
+				if ( m_tempoMarkers[t]->nBar == nBar ){
+					fBpm = m_tempoMarkers[t]->fBpm;
 				}
 			}
 		}
@@ -81,58 +81,58 @@ namespace H2Core
 
 	void Timeline::addTag( int nBar, QString sTag ) {
 		
-		HTimelineTagVector tlvector = { nBar, sTag };
+		Tag tag = { nBar, sTag };
 
-		m_timelinetagvector.push_back( &tlvector );
-		sortTimelineTagVector();
+		m_tags.push_back( &tag );
+		sortTags();
 	}
 
 	void Timeline::deleteTag( int nBar ) {
 
 		// Erase the value to set the new value
-		if ( m_timelinetagvector.size() >= 1 ){
-			for ( int t = 0; t < m_timelinetagvector.size(); t++ ){
-				if ( m_timelinetagvector[t]->m_htimelinetagbeat == nBar ) {
-					m_timelinetagvector.erase( m_timelinetagvector.begin() +  t);
+		if ( m_tags.size() >= 1 ){
+			for ( int t = 0; t < m_tags.size(); t++ ){
+				if ( m_tags[t]->nBar == nBar ) {
+					m_tags.erase( m_tags.begin() +  t);
 				}
 			}
 		}
 		
-		sortTimelineTagVector();
+		sortTags();
 	}
 
 	const QString Timeline::getTagAtBar( int nBar, bool bSticky ) const {
 
-		QString sTag("");
+		QString sCurrentTag("");
 
 		if ( bSticky ) {
-			for ( int t = 0; t < static_cast<int>(m_timelinetagvector.size()); t++ ){
-				if ( m_timelinetagvector[t]->m_htimelinetagbeat > nBar ){
+			for ( int t = 0; t < static_cast<int>(m_tags.size()); t++ ){
+				if ( m_tags[t]->nBar > nBar ){
 					break;
 				}
-				sTag = m_timelinetagvector[t]->m_htimelinetag;
+				sCurrentTag = m_tags[t]->sTag;
 			}
 		} else {
-			for ( int t = 0; t < static_cast<int>(m_timelinetagvector.size()); t++ ){
-				if ( m_timelinetagvector[t]->m_htimelinetagbeat == nBar ){
-					sTag =  m_timelinetagvector[t]->m_htimelinetag;
+			for ( int t = 0; t < static_cast<int>(m_tags.size()); t++ ){
+				if ( m_tags[t]->nBar == nBar ){
+					sCurrentTag =  m_tags[t]->sTag;
 				}
 			}
 		}
 
-		return sTag;
+		return sCurrentTag;
 	}
 	
-	void Timeline::sortTimelineVector()
+	void Timeline::sortTempoMarkers()
 	{
 		//sort the timeline vector to beats a < b
-		sort(m_timelinevector.begin(), m_timelinevector.end(), TimelineComparator());
+		sort(m_tempoMarkers.begin(), m_tempoMarkers.end(), TempoMarkerComparator());
 	}
 
-	void Timeline::sortTimelineTagVector()
+	void Timeline::sortTags()
 	{
 		//sort the timeline vector to beats a < b
-		sort(m_timelinetagvector.begin(), m_timelinetagvector.end(), TimelineTagComparator());
+		sort(m_tags.begin(), m_tags.end(), TagComparator());
 	}
 
 };

--- a/src/core/src/timeline.cpp
+++ b/src/core/src/timeline.cpp
@@ -32,6 +32,34 @@ namespace H2Core
 	{
 	}
 
+	void Timeline::addTempoMarker( int nPosition, float fBpm ) {
+
+		deleteTempoMarker( nPosition );
+		
+		if ( fBpm < 30.0 ) {
+			fBpm = 30.0;
+		} else if ( fBpm > 500.0 ) {
+			fBpm = 500.0;
+		}
+
+		HTimelineVector tlvector = { nPosition - 1, fBpm };
+
+		m_timelinevector.push_back( tlvector );
+		sortTimelineVector();
+	}
+
+	void Timeline::deleteTempoMarker( int nPosition ) {
+
+		// Erase the value to set the new value
+		if ( m_timelinevector.size() >= 1 ){
+			for ( int t = 0; t < m_timelinevector.size(); t++ ){
+				if ( m_timelinevector[t].m_htimelinebeat == nPosition -1 ) {
+					m_timelinevector.erase( m_timelinevector.begin() +  t);
+				}
+			}
+		}
+	}
+
 	void Timeline::sortTimelineVector()
 	{
 		//sort the timeline vector to beats a < b

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -160,20 +160,8 @@ void Director::metronomeEvent( int nValue )
 	}
 
 	// get tags
-	m_sTAG="";
-	m_sTAG2="";
-	for ( size_t t = 0; t < m_pTimeline->m_timelinetagvector.size(); t++){
-		if(t+1<m_pTimeline->m_timelinetagvector.size() &&
-				m_pTimeline->m_timelinetagvector[t+1].m_htimelinetagbeat == m_nBar ){
-			m_sTAG2 =  m_pTimeline->m_timelinetagvector[t+1].m_htimelinetag ;
-		}
-		if ( m_pTimeline->m_timelinetagvector[t].m_htimelinetagbeat <= m_nBar-1){
-			m_sTAG =  m_pTimeline->m_timelinetagvector[t].m_htimelinetag ;
-		}
-		if( m_pTimeline->m_timelinetagvector[t].m_htimelinetagbeat > m_nBar-1){
-			break;
-		}
-	}
+	m_sTAG = m_pTimeline->getTagAtBar( m_nBar, false );
+	m_sTAG2 = m_pTimeline->getTagAtBar( m_nBar - 1, true );
 	update();
 }
 

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -46,6 +46,10 @@ class EventListener
 		virtual void tempoChangedEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void updateSongEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void quitEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void timelineActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void timelineUpdateEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void jackTransportActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void jackTimebaseActivationEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -691,8 +691,8 @@ void ExportSongDialog::calculateRubberbandTime()
 
 	if ( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < tempoMarkerVector.size(); t++){
-			if(tempoMarkerVector[t]->m_htimelinebpm < lowBPM){
-				lowBPM =  tempoMarkerVector[t]->m_htimelinebpm;
+			if(tempoMarkerVector[t]->fBpm < lowBPM){
+				lowBPM =  tempoMarkerVector[t]->fBpm;
 			}
 
 		}

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -689,10 +689,10 @@ void ExportSongDialog::calculateRubberbandTime()
 	float oldBPM = m_pEngine->getSong()->__bpm;
 	float lowBPM = oldBPM;
 
-	if( tempoMarkerVector.size() >= 1 ){
+	if ( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < tempoMarkerVector.size(); t++){
-			if(tempoMarkerVector[t].m_htimelinebpm < lowBPM){
-				lowBPM =  tempoMarkerVector[t].m_htimelinebpm;
+			if(tempoMarkerVector[t]->m_htimelinebpm < lowBPM){
+				lowBPM =  tempoMarkerVector[t]->m_htimelinebpm;
 			}
 
 		}

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -97,7 +97,7 @@ ExportSongDialog::ExportSongDialog(QWidget* parent)
 	}
 
 	// use of timeline
-	if( m_pEngine->getTimeline()->m_timelinevector.size() > 0 ){
+	if( m_pEngine->getTimeline()->getAllTempoMarkers().size() > 0 ){
 		toggleTimeLineBPMCheckBox->setChecked(m_pPreferences->getUseTimelineBpm());
 		m_bOldTimeLineBPMMode = m_pPreferences->getUseTimelineBpm();
 		connect(toggleTimeLineBPMCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleTimeLineBPMMode( bool )));
@@ -684,14 +684,15 @@ void ExportSongDialog::calculateRubberbandTime()
 	okBtn->setEnabled(false);
 	
 	Timeline* pTimeline = m_pEngine->getTimeline();
+	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();
 
 	float oldBPM = m_pEngine->getSong()->__bpm;
 	float lowBPM = oldBPM;
 
-	if( pTimeline->m_timelinevector.size() >= 1 ){
-		for ( int t = 0; t < pTimeline->m_timelinevector.size(); t++){
-			if(pTimeline->m_timelinevector[t].m_htimelinebpm < lowBPM){
-				lowBPM =  pTimeline->m_timelinevector[t].m_htimelinebpm;
+	if( tempoMarkerVector.size() >= 1 ){
+		for ( int t = 0; t < tempoMarkerVector.size(); t++){
+			if(tempoMarkerVector[t].m_htimelinebpm < lowBPM){
+				lowBPM =  tempoMarkerVector[t].m_htimelinebpm;
 			}
 
 		}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -575,6 +575,22 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->quitEvent( event.value );
 				break;
 
+			case EVENT_TIMELINE_ACTIVATION:
+				pListener->timelineActivationEvent( event.value );
+				break;
+
+			case EVENT_TIMELINE_UPDATE:
+				pListener->timelineUpdateEvent( event.value );
+				break;
+
+			case EVENT_JACK_TRANSPORT_ACTIVATION:
+				pListener->jackTransportActivationEvent( event.value );
+				break;
+
+			case EVENT_JACK_TIMEBASE_ACTIVATION:
+				pListener->jackTimebaseActivationEvent( event.value );
+				break;
+				
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -659,7 +659,7 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		updateWindowTitle();
 		getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
 		getSongEditorPanel()->updatePositionRuler();
-		pHydrogen->getTimeline()->m_timelinetagvector.clear();
+		pHydrogen->getTimeline()->deleteAllTags();
 	
 		// Trigger a reset of the Director and MetronomeWidget.
 		EventQueue::get_instance()->push_event( EVENT_METRONOME, 2 );

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -227,6 +227,7 @@ class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 		 * \param nValue unused
 		 */
 		virtual void quitEvent( int nValue );
+	
 };
 
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -528,14 +528,14 @@ void MainForm::action_file_new()
 	}
 
 	h2app->m_pUndoStack->clear();
-	pEngine->getTimeline()->m_timelinevector.clear();
+	pEngine->getTimeline()->deleteAllTempoMarkers();
+	pEngine->getTimeline()->deleteAllTags();
 	Song * pSong = Song::get_empty_song();
 	pSong->set_filename( "" );
 	h2app->setSong(pSong);
 	pEngine->setSelectedPatternNumber( 0 );
 	h2app->getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
 	h2app->getSongEditorPanel()->updatePositionRuler();
-	pEngine->getTimeline()->m_timelinetagvector.clear();
 
 	// update director tags
 	EventQueue::get_instance()->push_event( EVENT_METRONOME, 2 );
@@ -1357,7 +1357,7 @@ void MainForm::openSongFile( const QString& sFilename )
 		pEngine->sequencer_stop();
 	}
 
-	pEngine->getTimeline()->m_timelinetagvector.clear();
+	pEngine->getTimeline()->deleteAllTags();
 
 	h2app->closeFXProperties();
 

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -1115,6 +1115,33 @@ void PlayerControl::tempoChangedEvent( int nValue )
 	m_pLCDBPMSpinbox->setValue( m_pEngine->getSong()->__bpm );
 }
 
+void PlayerControl::jackTransportActivationEvent( int nValue ) {
+
+	if ( nValue == 0 && m_pJackTransportBtn->isPressed() ){
+		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-transport mode = Off"), 5000);
+		m_pJackMasterBtn->setPressed( false );
+		m_pJackMasterBtn->setDisabled( true );
+	} else if ( nValue != 0 && !m_pJackTransportBtn->isPressed() ) {
+		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-transport mode = On"), 5000);
+		m_pJackMasterBtn->setPressed( false );
+		m_pJackMasterBtn->setDisabled( false );
+	}
+}
+
+void PlayerControl::jackTimebaseActivationEvent( int nValue ) {
+
+	if ( nValue == 0 && m_pJackMasterBtn->isPressed() ){
+		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-Time-Master mode = Off"), 5000);
+		m_pJackMasterBtn->setPressed( false );
+		
+	} else if ( nValue != 0 && !m_pJackMasterBtn->isPressed() ) {
+		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-Time-Master mode = On"), 5000);
+		m_pJackMasterBtn->setPressed( false );
+	}
+	
+	HydrogenApp::get_instance()->getSongEditorPanel()->updateTimelineUsage();
+}
+
 //::::::::::::::::::::::::::::::::::::::::::::::::
 
 const char* MetronomeWidget::__class_name = "MetronomeWidget";

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -1123,20 +1123,18 @@ void PlayerControl::jackTransportActivationEvent( int nValue ) {
 		m_pJackMasterBtn->setDisabled( true );
 	} else if ( nValue != 0 && !m_pJackTransportBtn->isPressed() ) {
 		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-transport mode = On"), 5000);
-		m_pJackMasterBtn->setPressed( false );
 		m_pJackMasterBtn->setDisabled( false );
 	}
 }
 
 void PlayerControl::jackTimebaseActivationEvent( int nValue ) {
-
 	if ( nValue == 0 && m_pJackMasterBtn->isPressed() ){
 		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-Time-Master mode = Off"), 5000);
 		m_pJackMasterBtn->setPressed( false );
 		
 	} else if ( nValue != 0 && !m_pJackMasterBtn->isPressed() ) {
 		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Jack-Time-Master mode = On"), 5000);
-		m_pJackMasterBtn->setPressed( false );
+		m_pJackMasterBtn->setPressed( true );
 	}
 	
 	HydrogenApp::get_instance()->getSongEditorPanel()->updateTimelineUsage();

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -94,8 +94,11 @@ class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 		void showMessage( const QString& msg, int msec );
 		void showScrollMessage( const QString& msg, int msec, bool test );
 		void resetStatusLabel();
-		
+
 		virtual void tempoChangedEvent( int nValue );
+		virtual void jackTransportActivationEvent( int nValue );
+		virtual void jackTimebaseActivationEvent( int nValue );
+													
 
 	private slots:
 		void recBtnClicked(Button* ref);

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -833,7 +833,7 @@ void PlaylistDialog::on_m_pPlaylistTree_itemDoubleClicked ()
 	m_pPlayBtn->setPressed(false);
 
 	Timeline* pTimeline = pEngine->getTimeline();
-	pTimeline->m_timelinetagvector.clear();
+	pTimeline->deleteAllTags();
 
 	Song *pSong = Song::load ( selected );
 	if ( pSong == nullptr ){

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2588,6 +2588,8 @@ void SongEditorPositionRuler::updatePosition()
 void SongEditorPositionRuler::editTimeLineAction( int nNewPosition, float fNewBpm )
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
+
+	pHydrogen->getTimeline()->deleteTempoMarker( nNewPosition - 1 );
 	pHydrogen->getTimeline()->addTempoMarker( nNewPosition - 1, fNewBpm );
 	createBackground();
 }

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2359,7 +2359,7 @@ void SongEditorPositionRuler::createBackground()
 	for (uint i = 0; i < m_nMaxPatternSequence + 1; i++) {
 		uint x = 10 + i * m_nGridWidth;
 		for ( int t = 0; t < static_cast<int>(tagVector.size()); t++){
-			if ( tagVector[t]->m_htimelinetagbeat == i ) {
+			if ( tagVector[t]->nBar == i ) {
 				p.setPen( Qt::cyan );
 				p.drawText( x - m_nGridWidth / 2 , 12, m_nGridWidth * 2, height() , Qt::AlignCenter, "T");
 			}
@@ -2390,8 +2390,8 @@ void SongEditorPositionRuler::createBackground()
 		p.drawLine( x, 2, x, 5 );
 		p.drawLine( x, 19, x, 20 );
 		for ( int t = 0; t < static_cast<int>(tempoMarkerVector.size()); t++){
-			if ( tempoMarkerVector[t]->m_htimelinebeat == i ) {
-				sprintf( tempo, "%d",  ((int)tempoMarkerVector[t]->m_htimelinebpm) );
+			if ( tempoMarkerVector[t]->nBar == i ) {
+				sprintf( tempo, "%d",  ((int)tempoMarkerVector[t]->fBpm) );
 				p.drawText( x - m_nGridWidth, 3, m_nGridWidth * 2, height() / 2 - 5, Qt::AlignCenter, tempo );
 			}
 		}

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -93,6 +93,7 @@ SongEditor::SongEditor( QWidget *parent, QScrollArea *pScrollView, SongEditorPan
  , m_pSongEditorPanel( pSongEditorPanel )
  , m_bDragging( false )
 {
+
 	setAttribute(Qt::WA_NoBackground);
 	setFocusPolicy (Qt::StrongFocus);
 
@@ -1344,6 +1345,7 @@ void SongEditor::updateEditorandSetTrue()
 	m_bSequenceChanged = true;
 	update();
 }
+
 // :::::::::::::::::::
 
 
@@ -2269,6 +2271,11 @@ void SongEditorPatternList::mouseMoveEvent(QMouseEvent *event)
 	pDrag->exec( Qt::CopyAction | Qt::MoveAction );
 
 	QWidget::mouseMoveEvent(event);
+}
+
+void SongEditorPatternList::timelineUpdateEvent( int nEvent ){
+	HydrogenApp::get_instance()->getSongEditorPanel()->updateAll();
+	Hydrogen::get_instance()->getSong()->set_is_modified( true );
 }
 
 // ::::::::::::::::::::::::::

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2359,7 +2359,7 @@ void SongEditorPositionRuler::createBackground()
 	for (uint i = 0; i < m_nMaxPatternSequence + 1; i++) {
 		uint x = 10 + i * m_nGridWidth;
 		for ( int t = 0; t < static_cast<int>(tagVector.size()); t++){
-			if ( tagVector[t].m_htimelinetagbeat == i ) {
+			if ( tagVector[t]->m_htimelinetagbeat == i ) {
 				p.setPen( Qt::cyan );
 				p.drawText( x - m_nGridWidth / 2 , 12, m_nGridWidth * 2, height() , Qt::AlignCenter, "T");
 			}
@@ -2390,8 +2390,8 @@ void SongEditorPositionRuler::createBackground()
 		p.drawLine( x, 2, x, 5 );
 		p.drawLine( x, 19, x, 20 );
 		for ( int t = 0; t < static_cast<int>(tempoMarkerVector.size()); t++){
-			if ( tempoMarkerVector[t].m_htimelinebeat == i ) {
-				sprintf( tempo, "%d",  ((int)tempoMarkerVector[t].m_htimelinebpm) );
+			if ( tempoMarkerVector[t]->m_htimelinebeat == i ) {
+				sprintf( tempo, "%d",  ((int)tempoMarkerVector[t]->m_htimelinebpm) );
 				p.drawText( x - m_nGridWidth, 3, m_nGridWidth * 2, height() / 2 - 5, Qt::AlignCenter, tempo );
 			}
 		}
@@ -2625,6 +2625,5 @@ void SongEditorPositionRuler::deleteTagAction( QString text, int position )
 		pTimeline->deleteTag( position );
 	}
 	
-	pTimeline->sortTimelineTagVector();
 	createBackground();
 }

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2585,47 +2585,17 @@ void SongEditorPositionRuler::updatePosition()
 }
 
 
-void SongEditorPositionRuler::editTimeLineAction( int newPosition, float newBpm )
+void SongEditorPositionRuler::editTimeLineAction( int nNewPosition, float fNewBpm )
 {
-	Hydrogen* pEngine = Hydrogen::get_instance();
-	Timeline* pTimeline = pEngine->getTimeline();
-
-	//erase the value to set the new value
-	if( pTimeline->m_timelinevector.size() >= 1 ){
-		for ( int t = 0; t < pTimeline->m_timelinevector.size(); t++){
-			if ( pTimeline->m_timelinevector[t].m_htimelinebeat == newPosition -1 ) {
-				pTimeline->m_timelinevector.erase( pTimeline->m_timelinevector.begin() +  t);
-			}
-		}
-	}
-
-	Timeline::HTimelineVector tlvector;
-
-	tlvector.m_htimelinebeat = newPosition -1 ;
-
-	if( newBpm < 30.0 ) newBpm = 30.0;
-	if( newBpm > 500.0 ) newBpm = 500.0;
-	tlvector.m_htimelinebpm = newBpm;
-	pTimeline->m_timelinevector.push_back( tlvector );
-	pTimeline->sortTimelineVector();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getTimeline()->addTempoMarker( nNewPosition, fNewBpm );
 	createBackground();
 }
 
-
-
-void SongEditorPositionRuler::deleteTimeLinePosition( int position )
+void SongEditorPositionRuler::deleteTimeLinePosition( int nPosition )
 {
-	Hydrogen* pEngine = Hydrogen::get_instance();
-	Timeline* pTimeline = pEngine->getTimeline();
-
-	//erase the value to set the new value
-	if( pTimeline->m_timelinevector.size() >= 1 ){
-		for ( int t = 0; t < pTimeline->m_timelinevector.size(); t++){
-			if ( pTimeline->m_timelinevector[t].m_htimelinebeat == position -1 ) {
-				pTimeline->m_timelinevector.erase( pTimeline->m_timelinevector.begin() +  t);
-			}
-		}
-	}
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getTimeline()->deleteTempoMarker( nPosition );
 	createBackground();
 }
 

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2588,14 +2588,14 @@ void SongEditorPositionRuler::updatePosition()
 void SongEditorPositionRuler::editTimeLineAction( int nNewPosition, float fNewBpm )
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	pHydrogen->getTimeline()->addTempoMarker( nNewPosition, fNewBpm );
+	pHydrogen->getTimeline()->addTempoMarker( nNewPosition - 1, fNewBpm );
 	createBackground();
 }
 
 void SongEditorPositionRuler::deleteTimeLinePosition( int nPosition )
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	pHydrogen->getTimeline()->deleteTempoMarker( nPosition );
+	pHydrogen->getTimeline()->deleteTempoMarker( nPosition - 1 );
 	createBackground();
 }
 

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -181,6 +181,7 @@ class SongEditorPatternList : public QWidget, public H2Core::Object, public Even
 		void inlineEditingEntered();
 		virtual void dragEnterEvent(QDragEnterEvent *event);
 		virtual void dropEvent(QDropEvent *event);
+		virtual void timelineUpdateEvent( int nValue );
 
 	private:
 		uint m_nGridHeight;

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -527,7 +527,8 @@ void SongEditorPanel::updateAll()
 
 	m_pSongEditor->createBackground();
 	m_pSongEditor->update();
-	
+
+	updatePositionRuler();
 	updateTimelineUsage();
 
  	m_pAutomationPathView->setAutomationPath( pSong->get_velocity_automation_path() );

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -967,7 +967,6 @@ void SongEditorPanel::toggleAutomationAreaVisibility()
 
 
 void SongEditorPanel::timelineActivationEvent( int nEvent ){
-
 	if ( nEvent == 0 && m_pTimeLineToggleBtn->isPressed() ) {
 		m_pTimeLineToggleBtn->setPressed( false );
 		HydrogenApp::get_instance()->setStatusBarMessage(tr(" Timeline = Off"), 5000);

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -964,3 +964,16 @@ void SongEditorPanel::toggleAutomationAreaVisibility()
 	}
 }
 
+
+void SongEditorPanel::timelineActivationEvent( int nEvent ){
+
+	if ( nEvent == 0 && m_pTimeLineToggleBtn->isPressed() ) {
+		m_pTimeLineToggleBtn->setPressed( false );
+		HydrogenApp::get_instance()->setStatusBarMessage(tr(" Timeline = Off"), 5000);
+	} else if ( nEvent != 0 && !m_pTimeLineToggleBtn->isPressed() ) {
+		m_pTimeLineToggleBtn->setPressed( true );
+		HydrogenApp::get_instance()->setStatusBarMessage(tr(" Timeline = On"), 5000);
+	}
+	
+	m_pPositionRuler->createBackground();
+}

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -88,6 +88,8 @@ class SongEditorPanel : public QWidget, public EventListener, public H2Core::Obj
 		 * gone or Hydrogen itself becomes the timebase master.
 		 */
 		void updateTimelineUsage();
+		virtual void timelineActivationEvent( int nValue );
+
 	private slots:
 		void vScrollTo( int value );
 		void hScrollTo( int value );

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -58,8 +58,8 @@ SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int beat )
 	//restore the bpm value
 	if( tempoMarkers.size() > 0 ){
 		for ( int t = 0; t < tempoMarkers.size(); t++ ){
-			if ( tempoMarkers[t]->m_htimelinebeat == m_stimelineposition ) {
-				lineEditBpm->setText( QString("%1").arg( tempoMarkers[t]->m_htimelinebpm ) );
+			if ( tempoMarkers[t]->nBar == m_stimelineposition ) {
+				lineEditBpm->setText( QString("%1").arg( tempoMarkers[t]->fBpm ) );
 				deleteBtn->setEnabled ( true );
 				return;
 			}
@@ -101,8 +101,8 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 	//search for an old entry
 	if( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < tempoMarkerVector.size(); t++){
-			if ( tempoMarkerVector[t]->m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
-				fOldBpm = tempoMarkerVector[t]->m_htimelinebpm;
+			if ( tempoMarkerVector[t]->nBar == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
+				fOldBpm = tempoMarkerVector[t]->fBpm;
 			}
 		}
 	}
@@ -124,8 +124,8 @@ void SongEditorPanelBpmWidget::on_deleteBtn_clicked()
 	//search for an old entry
 	if( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < tempoMarkerVector.size(); t++){
-			if ( tempoMarkerVector[t]->m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
-				fOldBpm = tempoMarkerVector[t]->m_htimelinebpm;
+			if ( tempoMarkerVector[t]->nBar == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
+				fOldBpm = tempoMarkerVector[t]->fBpm;
 			}
 		}
 	}

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -51,27 +51,26 @@ SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int beat )
 	lineEditBeat->setText(QString("%1").arg( m_stimelineposition + 1) );
 	deleteBtn->setEnabled ( false );
 
-	Hydrogen* engine = Hydrogen::get_instance();
-	Timeline* pTimeline = engine->getTimeline();
-	std::vector<Timeline::HTimelineVector> timelineVector = pTimeline->m_timelinevector;
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Timeline* pTimeline = pHydrogen->getTimeline();
+	std::vector<Timeline::HTimelineVector> tempoMarkers = pTimeline->getAllTempoMarkers();
 
 	//restore the bpm value
-	if( timelineVector.size() > 0 ){
-		for ( int t = 0; t < timelineVector.size(); t++ ){
-//			ERRORLOG(QString("%1 %2").arg(Hydrogen::get_instance()->m_timelinevector[t].m_htimelinebeat).arg(m_stimelineposition));
-			if ( timelineVector[t].m_htimelinebeat == m_stimelineposition ) {
-				lineEditBpm->setText( QString("%1").arg( timelineVector[t].m_htimelinebpm ) );
+	if( tempoMarkers.size() > 0 ){
+		for ( int t = 0; t < tempoMarkers.size(); t++ ){
+			if ( tempoMarkers[t].m_htimelinebeat == m_stimelineposition ) {
+				lineEditBpm->setText( QString("%1").arg( tempoMarkers[t].m_htimelinebpm ) );
 				deleteBtn->setEnabled ( true );
 				return;
 			}
 			else
 			{
-				lineEditBpm->setText( QString("%1").arg( engine->getNewBpmJTM()) );
+				lineEditBpm->setText( QString("%1").arg( pHydrogen->getNewBpmJTM()) );
 			}
 		}
 	}else
 	{
-		lineEditBpm->setText( QString("%1").arg( engine->getNewBpmJTM() ) );
+		lineEditBpm->setText( QString("%1").arg( pHydrogen->getNewBpmJTM() ) );
 	}
 }
 
@@ -94,21 +93,22 @@ void SongEditorPanelBpmWidget::on_CancelBtn_clicked()
 
 void SongEditorPanelBpmWidget::on_okBtn_clicked()
 {
-	Hydrogen* engine = Hydrogen::get_instance();
-	Timeline* pTimeline = engine->getTimeline();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Timeline* pTimeline = pHydrogen->getTimeline();
+	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();
 
-	float oldBpm = -1.0;	
+	float fOldBpm = -1.0;
 	//search for an old entry
-	if( pTimeline->m_timelinevector.size() >= 1 ){
-		for ( int t = 0; t < pTimeline->m_timelinevector.size(); t++){
-			if ( pTimeline->m_timelinevector[t].m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
-				oldBpm = pTimeline->m_timelinevector[t].m_htimelinebpm;
+	if( tempoMarkerVector.size() >= 1 ){
+		for ( int t = 0; t < tempoMarkerVector.size(); t++){
+			if ( tempoMarkerVector[t].m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
+				fOldBpm = tempoMarkerVector[t].m_htimelinebpm;
 			}
 		}
 	}
 
 
-	SE_editTimeLineAction *action = new SE_editTimeLineAction( lineEditBeat->text().toInt(), oldBpm, QString( lineEditBpm->text() ).toFloat() );
+	SE_editTimeLineAction *action = new SE_editTimeLineAction( lineEditBeat->text().toInt(), fOldBpm, QString( lineEditBpm->text() ).toFloat() );
 	HydrogenApp::get_instance()->m_pUndoStack->push( action );
 	accept();
 }
@@ -116,20 +116,21 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 
 void SongEditorPanelBpmWidget::on_deleteBtn_clicked()
 {
-	Hydrogen* engine = Hydrogen::get_instance();
-	Timeline* pTimeline = engine->getTimeline();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Timeline* pTimeline = pHydrogen->getTimeline();
+	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();
 
-	float oldBpm = -1.0;	
+	float fOldBpm = -1.0;
 	//search for an old entry
-	if( pTimeline->m_timelinevector.size() >= 1 ){
-		for ( int t = 0; t < pTimeline->m_timelinevector.size(); t++){
-			if ( pTimeline->m_timelinevector[t].m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
-				oldBpm = pTimeline->m_timelinevector[t].m_htimelinebpm;
+	if( tempoMarkerVector.size() >= 1 ){
+		for ( int t = 0; t < tempoMarkerVector.size(); t++){
+			if ( tempoMarkerVector[t].m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
+				fOldBpm = tempoMarkerVector[t].m_htimelinebpm;
 			}
 		}
 	}
 
-	SE_deleteTimeLineAction *action = new SE_deleteTimeLineAction( lineEditBeat->text().toInt(), oldBpm );
+	SE_deleteTimeLineAction *action = new SE_deleteTimeLineAction( lineEditBeat->text().toInt(), fOldBpm );
 	HydrogenApp::get_instance()->m_pUndoStack->push( action );
 	accept();
 }

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -53,13 +53,13 @@ SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int beat )
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	Timeline* pTimeline = pHydrogen->getTimeline();
-	std::vector<Timeline::HTimelineVector> tempoMarkers = pTimeline->getAllTempoMarkers();
+	auto tempoMarkers = pTimeline->getAllTempoMarkers();
 
 	//restore the bpm value
 	if( tempoMarkers.size() > 0 ){
 		for ( int t = 0; t < tempoMarkers.size(); t++ ){
-			if ( tempoMarkers[t].m_htimelinebeat == m_stimelineposition ) {
-				lineEditBpm->setText( QString("%1").arg( tempoMarkers[t].m_htimelinebpm ) );
+			if ( tempoMarkers[t]->m_htimelinebeat == m_stimelineposition ) {
+				lineEditBpm->setText( QString("%1").arg( tempoMarkers[t]->m_htimelinebpm ) );
 				deleteBtn->setEnabled ( true );
 				return;
 			}
@@ -101,8 +101,8 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 	//search for an old entry
 	if( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < tempoMarkerVector.size(); t++){
-			if ( tempoMarkerVector[t].m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
-				fOldBpm = tempoMarkerVector[t].m_htimelinebpm;
+			if ( tempoMarkerVector[t]->m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
+				fOldBpm = tempoMarkerVector[t]->m_htimelinebpm;
 			}
 		}
 	}
@@ -124,8 +124,8 @@ void SongEditorPanelBpmWidget::on_deleteBtn_clicked()
 	//search for an old entry
 	if( tempoMarkerVector.size() >= 1 ){
 		for ( int t = 0; t < tempoMarkerVector.size(); t++){
-			if ( tempoMarkerVector[t].m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
-				fOldBpm = tempoMarkerVector[t].m_htimelinebpm;
+			if ( tempoMarkerVector[t]->m_htimelinebeat == ( QString( lineEditBeat->text() ).toInt() ) -1 ) {
+				fOldBpm = tempoMarkerVector[t]->m_htimelinebpm;
 			}
 		}
 	}

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -66,52 +66,51 @@ void SongEditorPanelTagWidget::a_itemIsChanged(QTableWidgetItem *item)
 
 void SongEditorPanelTagWidget::createTheTagTableWidget()
 {
-	Hydrogen* engine = Hydrogen::get_instance();
-	Timeline* pTimeline = engine->getTimeline();
-	int patterngroupvectorsize;
-	patterngroupvectorsize = engine->getSong()->get_pattern_group_vector()->size();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Timeline* pTimeline = pHydrogen->getTimeline();
+	int nPatternGroupVectorSize;
+	nPatternGroupVectorSize = pHydrogen->getSong()->get_pattern_group_vector()->size();
 	
-	for( int i = 0; i < patterngroupvectorsize; i++ )
+	for( int i = 0; i < nPatternGroupVectorSize; i++ )
 	{
 		tagTableWidget->insertRow( i );
 	}
 
-	std::vector<Timeline::HTimelineTagVector> timelineTagVector = pTimeline->m_timelinetagvector;
+	std::vector<Timeline::HTimelineTagVector> tagVector = pTimeline->getAllTags();
 
 	//read the tag vector and fill all tags into items
-	if( timelineTagVector.size() > 0 ){
-		for ( unsigned int t = 0; t < timelineTagVector.size(); t++ ){
+	if( tagVector.size() > 0 ){
+		for ( unsigned int t = 0; t < tagVector.size(); t++ ){
 			QTableWidgetItem *newTagItem = new QTableWidgetItem();
-			newTagItem->setText( QString( "%1" ).arg( timelineTagVector[t].m_htimelinetag ) );
-			tagTableWidget->setItem( timelineTagVector[t].m_htimelinetagbeat, 0, newTagItem );
+			newTagItem->setText( QString( "%1" ).arg( tagVector[t].m_htimelinetag ) );
+			tagTableWidget->setItem( tagVector[t].m_htimelinetagbeat, 0, newTagItem );
 			tagTableWidget->setCurrentItem( newTagItem );
 			tagTableWidget->openPersistentEditor( newTagItem );
 		}
 	}
 
-	//activate the clicked item and
-	//if you click on an existing tag
-	//fill in the old contend
-	if( timelineTagVector.size() > 0 ){
+	// activate the clicked item and if you click on an existing tag
+	// fill in the old contend
+	if( tagVector.size() > 0 ){
 		int vpos = -1;
 		QTableWidgetItem *newTagItem2 = new QTableWidgetItem();
 		newTagItem2->setText( QString( "" ) );
-		for ( unsigned int t = 0; t < timelineTagVector.size(); t++ ){
-			if( timelineTagVector[t].m_htimelinetagbeat == m_stimelineposition){
+		for ( unsigned int t = 0; t < tagVector.size(); t++ ){
+			if( tagVector[t].m_htimelinetagbeat == m_stimelineposition){
 				vpos = t;
 			}
 		}
 
 		if( vpos >-1 ){
-			newTagItem2->setText( QString( "%1" ).arg( timelineTagVector[vpos].m_htimelinetag ) );
+			newTagItem2->setText( QString( "%1" ).arg( tagVector[vpos].m_htimelinetag ) );
 		}
 		tagTableWidget->setItem( m_stimelineposition , 0, newTagItem2 );
 		tagTableWidget->setCurrentItem( newTagItem2 );
 		tagTableWidget->openPersistentEditor( newTagItem2 );
 	}
 
-	//add first tag
-	if( timelineTagVector.size() == 0 ){
+	// add first tag
+	if( tagVector.size() == 0 ){
 		QTableWidgetItem *newTagItem3 = new QTableWidgetItem();
 		tagTableWidget->setItem( m_stimelineposition , 0, newTagItem3 );
 		tagTableWidget->setCurrentItem( newTagItem3 );
@@ -129,21 +128,23 @@ void SongEditorPanelTagWidget::on_CancelBtn_clicked()
 
 void SongEditorPanelTagWidget::on_okBtn_clicked()
 {
-	Hydrogen* engine = Hydrogen::get_instance();
-	Timeline* pTimeline = engine->getTimeline();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Timeline* pTimeline = pHydrogen->getTimeline();
+	auto tagVector = pTimeline->getAllTags();
 
-	int patterngroupvectorsize;
-	patterngroupvectorsize = engine->getSong()->get_pattern_group_vector()->size();
+	int nPatternGroupVectorSize;
+	nPatternGroupVectorSize = pHydrogen->getSong()->get_pattern_group_vector()->size();
 
 	//oldText list contains all old item values. we need them for undo an item
-	QStringList oldText;
+	QStringList sOldText;
 
-	if(pTimeline->m_timelinetagvector.size() > 0){
-		for (int i = 0; i < patterngroupvectorsize; i++){
-			oldText << "";
+	if(tagVector.size() > 0){
+		for (int i = 0; i < nPatternGroupVectorSize; i++){
+			sOldText << "";
 		}
-		for(int i = 0; i < pTimeline->m_timelinetagvector.size(); ++i){
-			oldText.replace(pTimeline->m_timelinetagvector[i].m_htimelinetagbeat , pTimeline->m_timelinetagvector[i].m_htimelinetag);
+		for(int i = 0; i < tagVector.size(); ++i){
+			sOldText.replace(tagVector[i].m_htimelinetagbeat,
+							 tagVector[i].m_htimelinetag);
 		}
 	}
 
@@ -153,7 +154,7 @@ void SongEditorPanelTagWidget::on_okBtn_clicked()
 		int songPosition = __theChangedItems.value( i ).toInt();
 		newTagItem = tagTableWidget->item( songPosition, 0 );
 		if ( newTagItem ) {
-			SE_editTagAction *action = new SE_editTagAction(  newTagItem->text() ,oldText.value( songPosition ), songPosition );
+			SE_editTagAction *action = new SE_editTagAction( newTagItem->text() ,sOldText.value( songPosition ), songPosition );
 			HydrogenApp::get_instance()->m_pUndoStack->push( action );
 		}
 	}

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -82,13 +82,13 @@ void SongEditorPanelTagWidget::createTheTagTableWidget()
 	if( tagVector.size() > 0 ){
 		for ( unsigned int t = 0; t < tagVector.size(); t++ ){
 			QTableWidgetItem *newTagItem = new QTableWidgetItem();
-			newTagItem->setText( QString( "%1" ).arg( tagVector[t]->m_htimelinetag ) );
-			tagTableWidget->setItem( tagVector[t]->m_htimelinetagbeat, 0, newTagItem );
+			newTagItem->setText( QString( "%1" ).arg( tagVector[t]->sTag ) );
+			tagTableWidget->setItem( tagVector[t]->nBar, 0, newTagItem );
 			tagTableWidget->setCurrentItem( newTagItem );
 			tagTableWidget->openPersistentEditor( newTagItem );
 		}
 	}
-
+	
 	// activate the clicked item and if you click on an existing tag
 	// fill in the old contend
 	if( tagVector.size() > 0 ){
@@ -96,13 +96,13 @@ void SongEditorPanelTagWidget::createTheTagTableWidget()
 		QTableWidgetItem *newTagItem2 = new QTableWidgetItem();
 		newTagItem2->setText( QString( "" ) );
 		for ( unsigned int t = 0; t < tagVector.size(); t++ ){
-			if( tagVector[t]->m_htimelinetagbeat == m_stimelineposition){
+			if( tagVector[t]->nBar == m_stimelineposition){
 				vpos = t;
 			}
 		}
 
 		if( vpos >-1 ){
-			newTagItem2->setText( QString( "%1" ).arg( tagVector[vpos]->m_htimelinetag ) );
+			newTagItem2->setText( QString( "%1" ).arg( tagVector[vpos]->sTag ) );
 		}
 		tagTableWidget->setItem( m_stimelineposition , 0, newTagItem2 );
 		tagTableWidget->setCurrentItem( newTagItem2 );
@@ -137,14 +137,13 @@ void SongEditorPanelTagWidget::on_okBtn_clicked()
 
 	//oldText list contains all old item values. we need them for undo an item
 	QStringList sOldText;
-
 	if(tagVector.size() > 0){
 		for (int i = 0; i < nPatternGroupVectorSize; i++){
 			sOldText << "";
 		}
 		for(int i = 0; i < tagVector.size(); ++i){
-			sOldText.replace(tagVector[i]->m_htimelinetagbeat,
-							 tagVector[i]->m_htimelinetag);
+			sOldText.replace(tagVector[i]->nBar,
+							 tagVector[i]->sTag);
 		}
 	}
 

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -76,14 +76,14 @@ void SongEditorPanelTagWidget::createTheTagTableWidget()
 		tagTableWidget->insertRow( i );
 	}
 
-	std::vector<Timeline::HTimelineTagVector> tagVector = pTimeline->getAllTags();
+	auto tagVector = pTimeline->getAllTags();
 
 	//read the tag vector and fill all tags into items
 	if( tagVector.size() > 0 ){
 		for ( unsigned int t = 0; t < tagVector.size(); t++ ){
 			QTableWidgetItem *newTagItem = new QTableWidgetItem();
-			newTagItem->setText( QString( "%1" ).arg( tagVector[t].m_htimelinetag ) );
-			tagTableWidget->setItem( tagVector[t].m_htimelinetagbeat, 0, newTagItem );
+			newTagItem->setText( QString( "%1" ).arg( tagVector[t]->m_htimelinetag ) );
+			tagTableWidget->setItem( tagVector[t]->m_htimelinetagbeat, 0, newTagItem );
 			tagTableWidget->setCurrentItem( newTagItem );
 			tagTableWidget->openPersistentEditor( newTagItem );
 		}
@@ -96,13 +96,13 @@ void SongEditorPanelTagWidget::createTheTagTableWidget()
 		QTableWidgetItem *newTagItem2 = new QTableWidgetItem();
 		newTagItem2->setText( QString( "" ) );
 		for ( unsigned int t = 0; t < tagVector.size(); t++ ){
-			if( tagVector[t].m_htimelinetagbeat == m_stimelineposition){
+			if( tagVector[t]->m_htimelinetagbeat == m_stimelineposition){
 				vpos = t;
 			}
 		}
 
 		if( vpos >-1 ){
-			newTagItem2->setText( QString( "%1" ).arg( tagVector[vpos].m_htimelinetag ) );
+			newTagItem2->setText( QString( "%1" ).arg( tagVector[vpos]->m_htimelinetag ) );
 		}
 		tagTableWidget->setItem( m_stimelineposition , 0, newTagItem2 );
 		tagTableWidget->setCurrentItem( newTagItem2 );
@@ -143,8 +143,8 @@ void SongEditorPanelTagWidget::on_okBtn_clicked()
 			sOldText << "";
 		}
 		for(int i = 0; i < tagVector.size(); ++i){
-			sOldText.replace(tagVector[i].m_htimelinetagbeat,
-							 tagVector[i].m_htimelinetag);
+			sOldText.replace(tagVector[i]->m_htimelinetagbeat,
+							 tagVector[i]->m_htimelinetag);
 		}
 	}
 


### PR DESCRIPTION
I did add some OSC commands to automate some transport related buttons of the GUI and to add/delete tempo markers from the timeline.

e.g. try
```bash
oscsend localhost 9000 /Hydrogen/TIMELINE_ADD_MARKER if 14 199
```

But in addition I also restructured large parts of the Timeline code. I had some difficulties understanding the dynamics of this class since almost all code acting on its member variables was located outside of the class (especially within the GUI). I, instead, put it all into the Timeline class itself and only provide a read-only version of the member variables to the GUI. This way - at least for me - it is way more obvious what is happening at which point. 

(Sorry for entangling two different things in here)

Edit:
Adding/removing the tempo marker is not covered by the undo/redo action yet. In our current Event type only a single integer can be provided, which is not enough to let the GUI know both position and speed of the marker. I will make an issue and take care of this later.