### PR TITLE
3 strings missing i18n

### DIFF
--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -211,7 +211,7 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 	filesList.clear();
 
 	QApplication::restoreOverrideCursor();
-	QMessageBox::information( this, "Hydrogen", "Drumkit exported." );
+	QMessageBox::information( this, "Hydrogen", tr("Drumkit exported.") );
 #elif !defined(WIN32)
 
 	if(TmpFileCreated)
@@ -251,10 +251,10 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 
 
 	QApplication::restoreOverrideCursor();
-	QMessageBox::information( this, "Hydrogen", "Drumkit exported." );
+	QMessageBox::information( this, "Hydrogen", tr("Drumkit exported.") );
 #else
 	QApplication::restoreOverrideCursor();
-	QMessageBox::information( this, "Hydrogen", "Drumkit not exported. Operation not supported." );
+	QMessageBox::information( this, "Hydrogen", tr("Drumkit not exported. Operation not supported.") );
 #endif
 }
 


### PR DESCRIPTION
I've spotted a place were strings were missing translation (when exporting a drumkit):

![hydrogen-traduction-manquante](https://user-images.githubusercontent.com/8705846/93883201-88bab500-fce1-11ea-99a7-c9ee8b43b88c.png)

Then, I've looked into the code and here is my try to fix those.

I hope (and think) I did it correctly but since I don't have the time to test a rebuild with this patch right now, I'd appreciate if a programmer could validate this PR after checking it'll not make all the birds exploding. Thanks.