### PR TITLE
Fix issues reported by clang-tidy / activate clang-tidy on travis builds 

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 Checks:          '-*, modernize-use-nullptr,modernize-use-default, google-readability-braces-around-statements'
 
-WarningsAsErrors: modernize-*
+WarningsAsErrors: 'modernize-*, google-readability-braces-around-statements'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,3 @@
-Checks:          '-*, modernize-use-nullptr,modernize-use-default, google-readability-braces-around-statements,clang-diagnostic-*,clang-analyzer-*'
+Checks:          '-*, modernize-use-nullptr,modernize-use-default, google-readability-braces-around-statements'
 
+WarningsAsErrors: modernize-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
   apt:
     packages:
     - clang
+    - clang-tidy
     - qt5-default
     - qttools5-dev
     - qttools5-dev-tools
@@ -69,7 +70,7 @@ before_install:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]] && [[ "$HOMEBREW_NO_AUTO_UPDATE" -eq "1" ]];
   then test $(PKG_CONFIG_PATH=$(brew --prefix qt5)/lib/pkgconfig pkg-config --modversion Qt5Core) == 5.9.1; fi
 script:
-- git submodule init && git submodule update && mkdir build && cd build && cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 ${CMAKE_OPTIONS}
+- git submodule init && git submodule update && mkdir build && cd build && cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 -DWANT_CLANG_TIDY=1 ${CMAKE_OPTIONS}
   .. && make
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH="$(brew --prefix qt5)/bin:$PATH"
   ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg; fi

--- a/src/core/src/basics/drumkit.cpp
+++ b/src/core/src/basics/drumkit.cpp
@@ -492,9 +492,9 @@ bool Drumkit::install( const QString& path )
 	archive_read_support_format_all( arch );
 
 #if ARCHIVE_VERSION_NUMBER < 3000000
-	if ( ( r = archive_read_open_file( arch, path.toLocal8Bit(), 10240 ) ) ) {
+	if ( archive_read_open_file( arch, path.toLocal8Bit(), 10240 ) ) {
 #else
-	if ( ( r = archive_read_open_filename( arch, path.toLocal8Bit(), 10240 ) ) ) {
+	if ( archive_read_open_filename( arch, path.toLocal8Bit(), 10240 ) ) {
 #endif
 		_ERRORLOG( QString( "archive_read_open_file() [%1] %2" ).arg( archive_errno( arch ) ).arg( archive_error_string( arch ) ) );
 		archive_read_close( arch );

--- a/src/core/src/basics/sample.cpp
+++ b/src/core/src/basics/sample.cpp
@@ -592,7 +592,7 @@ bool Sample::exec_rubberband_cli( const Rubberband& rb )
 Sample::Loops::LoopMode Sample::parse_loop_mode( const QString& string )
 {
 	QByteArray byteArray =	string.toLocal8Bit();
-	char* mode = byteArray.data();
+	const char* mode = byteArray.data();
 	for( int i=Loops::FORWARD; i<=Loops::PINGPONG; i++ ) {
 		if( 0 == strncasecmp( mode, __loop_modes[i], sizeof( __loop_modes[i] ) ) ) return ( Loops::LoopMode )i;
 	}

--- a/src/core/src/fx/ladspa_fx.cpp
+++ b/src/core/src/fx/ladspa_fx.cpp
@@ -422,8 +422,9 @@ void LadspaFX::connectAudioPorts( float* pIn_L, float* pIn_R, float* pOut_L, flo
 void LadspaFX::processFX( unsigned nFrames )
 {
 //	infoLog( "[LadspaFX::applyFX()]" );
-	if( m_bActivated )
-	m_d->run( m_handle, nFrames );
+	if( m_bActivated ) {
+		m_d->run( m_handle, nFrames );
+	}
 }
 
 void LadspaFX::activate()

--- a/src/core/src/lash/LashClient.cpp
+++ b/src/core/src/lash/LashClient.cpp
@@ -36,7 +36,7 @@
 
 using namespace H2Core;
 
-LashClient* LashClient::__instance = NULL; /// static reference of LashClient class (Singleton)
+LashClient* LashClient::__instance = nullptr; /// static reference of LashClient class (Singleton)
 
 void LashClient::create_instance( const char *lashClass,
 				  const char *viewName,
@@ -97,13 +97,13 @@ lash_event_t* LashClient::getNextEvent()
 
 void LashClient::sendEvent(LASH_Event_Type eventType)
 {
-	sendEvent(eventType, NULL);
+	sendEvent(eventType, nullptr);
 }
 
 void LashClient::sendEvent(LASH_Event_Type eventType, const char* value)
 {
 	lash_event_t *event = lash_event_new_with_type(eventType);
-	if (value != NULL)
+	if (value != nullptr)
 	{
 		lash_event_set_string(event, value);
 	}

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -1060,8 +1060,9 @@ void Preferences::savePreferences()
 	doc.appendChild( rootNode );
 
 	QFile file( Filesystem::usr_config_path() );
-	if ( !file.open(QIODevice::WriteOnly) )
+	if ( !file.open(QIODevice::WriteOnly) ) {
 		return;
+	}
 
 	QTextStream TextStream( &file );
 	doc.save( TextStream, 1 );
@@ -1073,8 +1074,9 @@ void Preferences::setMostRecentFX( QString FX_name )
 {
 	int pos = m_recentFX.indexOf( FX_name );
 
-	if ( pos != -1 )
+	if ( pos != -1 ) {
 		m_recentFX.removeAt( pos );
+	}
 
 	m_recentFX.push_front( FX_name );
 }

--- a/src/core/src/smf/smf.cpp
+++ b/src/core/src/smf/smf.cpp
@@ -281,7 +281,6 @@ void SMFWriter::save( const QString& sFilename, Song *pSong )
 						int nVelocity =
 							(int)( 127.0 * pNote->get_velocity() * velocity_adjustment );
 
-						int nInstr = iList->index(pNote->get_instrument());
 						Instrument *pInstr = pNote->get_instrument();
 						int nPitch = pNote->get_midi_key();
 						
@@ -353,8 +352,9 @@ void SMFWriter::saveSMF( const QString& sFilename, SMF*  pSmf )
 	// save the midi file
 	FILE* file = fopen( sFilename.toLocal8Bit(), "wb" );
 
-    if( file == nullptr )
+	if( file == nullptr ) {
 		return;
+	}
 
 	vector<char> smfVect = pSmf->getBuffer();
 	for ( unsigned i = 0; i < smfVect.size(); i++ ) {

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -153,8 +153,9 @@ void Director::metronomeEvent( int nValue )
 	}
 	else {	//foregroundcolor "rect" for all other blinks
 		m_nCounter++;
-		if( m_nCounter %2 == 0 )
+		if( m_nCounter %2 == 0 ) {
 			m_nFlashingArea = width() * 52.5/100;
+		}
 
 		m_Color = QColor( 24, 250, 31, 255 );
 	}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -188,16 +188,18 @@ void HydrogenApp::setupSinglePanedInterface()
 	m_pTab = new QTabWidget( nullptr );
 
 	// SONG EDITOR
-	if( uiLayout == Preferences::UI_LAYOUT_SINGLE_PANE)
+	if( uiLayout == Preferences::UI_LAYOUT_SINGLE_PANE) {
 		m_pSongEditorPanel = new SongEditorPanel( m_pSplitter );
-	else
+	} else {
 		m_pSongEditorPanel = new SongEditorPanel( m_pTab );
+	}
 
 	WindowProperties songEditorProp = pPref->getSongEditorProperties();
 	m_pSongEditorPanel->resize( songEditorProp.width, songEditorProp.height );
 
-	if( uiLayout == Preferences::UI_LAYOUT_TABBED)
+	if( uiLayout == Preferences::UI_LAYOUT_TABBED) {
 		m_pTab->addTab( m_pSongEditorPanel, tr("Song Editor") );
+	}
 
 	// this HBox will contain the InstrumentRack and the Pattern editor
 	QWidget *pSouthPanel = new QWidget( m_pSplitter );
@@ -238,9 +240,9 @@ void HydrogenApp::setupSinglePanedInterface()
 
 	m_pMainVBox->addSpacing( 3 );
 
-	if( uiLayout == Preferences::UI_LAYOUT_SINGLE_PANE)
+	if( uiLayout == Preferences::UI_LAYOUT_SINGLE_PANE) {
 		m_pMainVBox->addWidget( m_pSplitter );
-	else {
+	} else {
 		m_pMainVBox->addWidget( m_pTab );
 
 	}
@@ -586,8 +588,9 @@ void HydrogenApp::onEventQueueTimer()
 	while(!pQueue->m_addMidiNoteVector.empty()){
 
 		int rounds = 1;
-		if(pQueue->m_addMidiNoteVector[0].b_noteExist)// runn twice, delete old note and add new note. this let the undo stack consistent
+		if(pQueue->m_addMidiNoteVector[0].b_noteExist) { // run twice, delete old note and add new note. this let the undo stack consistent 
 			rounds = 2;
+		}
 		for(int i = 0; i<rounds; i++){
 			SE_addOrDeleteNoteAction *action = new SE_addOrDeleteNoteAction( pQueue->m_addMidiNoteVector[0].m_column,
 																			 pQueue->m_addMidiNoteVector[0].m_row,

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -623,8 +623,9 @@ void InstrumentEditor::selectedInstrumentChangedEvent()
 		std::vector<DrumkitComponent*>* compoList = pSong->get_components();
 		for (auto& it : *pSong->get_components() ) {
 			DrumkitComponent* pDrumkitComponent = it;
-			if( !itemsCompo.contains( pDrumkitComponent->get_name() ) )
+			if( !itemsCompo.contains( pDrumkitComponent->get_name() ) ) {
 				itemsCompo.append( pDrumkitComponent->get_name() );
+			}
 		}
 		itemsCompo.append("--sep--");
 		itemsCompo.append("add");
@@ -1224,10 +1225,11 @@ int InstrumentEditor::findFreeDrumkitComponentId( int startingPoint )
 		}
 	}
 
-	if(bFoundFreeSlot)
+	if(bFoundFreeSlot) {
 		return startingPoint;
-	else
+	} else {
 		return findFreeDrumkitComponentId( startingPoint + 1 );
+	}
 }
 
 void InstrumentEditor::compoChangeAddDelete(QAction* pAction)
@@ -1282,8 +1284,9 @@ void InstrumentEditor::compoChangeAddDelete(QAction* pAction)
 				if( pInstrumentComponent->get_drumkit_componentID() == pDrumkitComponent->get_id() ) {
 					for( int nLayer = 0; nLayer < InstrumentComponent::getMaxLayers(); nLayer++ ) {
 						InstrumentLayer* pLayer = pInstrumentComponent->get_layer( nLayer );
-						if( pLayer )
+						if( pLayer ) {
 							delete pLayer;
+						}
 					}
 					pInstrument->get_components()->erase( pInstrument->get_components()->begin() + o );;
 					break;

--- a/src/gui/src/LadspaFXSelector.cpp
+++ b/src/gui/src/LadspaFXSelector.cpp
@@ -253,8 +253,9 @@ void LadspaFXSelector::on_m_pGroupsListView_currentItemChanged( QTreeWidgetItem 
 			selectedIndex = i;
 		}
 	}
-	if ( selectedIndex >= 0 )
+	if ( selectedIndex >= 0 ) {
 		m_pPluginsListBox->setCurrentRow( selectedIndex );
+	}
 #endif
 }
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -967,17 +967,15 @@ void MainForm::action_banks_open()
 void MainForm::action_instruments_clearAll()
 {
 	switch(
-			 QMessageBox::information( this,
-									 "Hydrogen",
-									 tr("Clear all instruments?"),
-									 tr("Ok"),
-									 tr("Cancel"),
-									 0,      // Enter == button 0
-									 1 )) { // Escape == button 2
-	case 0:
+			 QMessageBox::information( 	this,
+						   	"Hydrogen",
+							tr("Clear all instruments?"),
+							QMessageBox::Cancel | QMessageBox::Ok,
+							QMessageBox::Cancel)) {
+	case QMessageBox::Ok:
 		// ok btn pressed
 		break;
-	case 1:
+	case QMessageBox::Cancel:
 		// cancel btn pressed
 		return;
 	}
@@ -1723,19 +1721,14 @@ void MainForm::action_file_export_lilypond()
 	if ( ( ( Hydrogen::get_instance() )->getState() == STATE_PLAYING ) ) {
 		Hydrogen::get_instance()->sequencer_stop();
 	}
-	switch ( QMessageBox::information(
-					this,
-					"Hydrogen",
-					tr( "\nThe LilyPond export is an experimental feature.\n"
-									"It should work like a charm provided that you use the "
-									"GM-kit, and that you do not use triplet.\n" ),
-					tr( "Ok" ),
-					tr( "&Cancel" ),
-					0,
-					2 ) ) {
-	case 1:
-	case 2: return;
-	}
+
+	QMessageBox::information(
+		this,
+		"Hydrogen",
+		tr( "\nThe LilyPond export is an experimental feature.\n"
+		"It should work like a charm provided that you use the "
+		"GM-kit, and that you do not use triplet.\n" ),
+		QMessageBox::Ok ); 
 
 	QFileDialog fd( this );
 	fd.setFileMode( QFileDialog::AnyFile );
@@ -1966,12 +1959,14 @@ bool MainForm::handleUnsavedChanges()
 	{
 		while ( !done && Playlist::get_instance()->getIsModified() ) {
 			switch(
-					QMessageBox::information( this, "Hydrogen",
-											 tr("\nThe current playlist contains unsaved changes.\n"
-													"Do you want to discard the changes?\n"),
-											tr("&Discard"), tr("&Cancel"),
-											 0,      // Enter == button 0
-											 2 ) ) { // Escape == button 1
+					QMessageBox::information(
+								this, 
+								"Hydrogen",
+								tr("\nThe current playlist contains unsaved changes.\n"
+								"Do you want to discard the changes?\n"),
+								tr("&Discard"), tr("&Cancel"),
+								 nullptr,      // Enter == button 0
+								 2 ) ) { // Escape == button 1
 			case 0: // Discard clicked or Alt+D pressed
 				// don't save but exit
 				done = true;

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -505,16 +505,16 @@ void DrumPatternEditor::keyPressEvent( QKeyEvent *ev )
 		m_pPatternEditorPanel->setCursorPosition( 0 );
 
 	} else if ( ev->matches( QKeySequence::MoveToNextLine ) ) {
-		if ( nSelectedInstrument + 1 < nMaxInstrument )
+		if ( nSelectedInstrument + 1 < nMaxInstrument ) {
 			pH2->setSelectedInstrumentNumber( nSelectedInstrument + 1 );
-
+		}
 	} else if ( ev->matches( QKeySequence::MoveToEndOfDocument ) ) {
 		pH2->setSelectedInstrumentNumber( nMaxInstrument-1 );
 
 	} else if ( ev->matches( QKeySequence::MoveToPreviousLine ) ) {
-		if ( nSelectedInstrument > 0 )
+		if ( nSelectedInstrument > 0 ) {
 			pH2->setSelectedInstrumentNumber( nSelectedInstrument - 1 );
-
+		}
 	} else if ( ev->matches( QKeySequence::MoveToStartOfDocument ) ) {
 		pH2->setSelectedInstrumentNumber( 0 );
 
@@ -1096,7 +1096,7 @@ void DrumPatternEditor::functionPasteNotesUndoAction(std::list<H2Core::Pattern*>
 		// Find destination pattern to perform undo
 		Pattern *pat = patternList->find(pApplied->get_name());
 
-		if (pat != NULL)
+		if (pat != nullptr)
 		{
 			// Remove all notes of applied pattern from destination pattern
 			const Pattern::notes_t* notes = pApplied->get_notes();
@@ -1155,7 +1155,7 @@ void DrumPatternEditor::functionPasteNotesRedoAction(std::list<H2Core::Pattern*>
 
 		Pattern *pat = patternList->find(pPattern->get_name()); // Destination pattern
 
-		if (pat != NULL)
+		if (pat != nullptr)
 		{
 			// Create applied pattern
 			Pattern *pApplied = new Pattern(

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -188,10 +188,11 @@ void InstrumentLine::setSoloed( bool soloed )
 
 void InstrumentLine::setSamplesMissing( bool bSamplesMissing )
 {
-	if ( bSamplesMissing )
+	if ( bSamplesMissing ) {
 		m_pSampleWarning->show();
-	else
+	} else {
 		m_pSampleWarning->hide();
+	}
 }
 
 
@@ -341,12 +342,14 @@ void InstrumentLine::functionPasteInstrumentPatternExec(int patternID)
 	// Get from clipboard & deserialize
 	QClipboard *clipboard = QApplication::clipboard();
 	QString serialized = clipboard->text();
-	if ( !song->pasteInstrumentLineFromString( serialized, patternID, m_nInstrumentNumber, patternList ) )
+	if ( !song->pasteInstrumentLineFromString( serialized, patternID, m_nInstrumentNumber, patternList ) ) {
 		return;
+	}
 
 	// Ignore empty result
-	if (patternList.size() <= 0)
+	if (patternList.size() <= 0) {
 		return;
+	}
 
 	// Create action
 	SE_pasteNotesPatternEditorAction *action = new SE_pasteNotesPatternEditorAction(patternList);

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -571,7 +571,7 @@ void PreferencesDialog::on_okBtn_clicked()
 
 
 	if (m_bNeedDriverRestart) {
-		int res = QMessageBox::information( this, "Hydrogen", tr( "Driver restart required.\n Restart driver?"), tr("&Ok"), tr("&Cancel"), 0, 1 );
+		int res = QMessageBox::information( this, "Hydrogen", tr( "Driver restart required.\n Restart driver?"), tr("&Ok"), tr("&Cancel"), nullptr, 1 );
 		if ( res == 0 ) {
 			Hydrogen::get_instance()->restartDrivers();
 		}

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -407,14 +407,20 @@ void SampleEditor::createNewLayer()
 				pInstrument = pInstrList->get( nInstr );
 			}
 		}
+		
+		H2Core::InstrumentLayer *pLayer = nullptr;
+		if( pInstrument ) {
+			H2Core::InstrumentLayer *pLayer = pInstrument->get_component(0)->get_layer( m_nSelectedLayer );
 
-		H2Core::InstrumentLayer *pLayer = pInstrument->get_component(0)->get_layer( m_nSelectedLayer );
-
-		// insert new sample from newInstrument
-		pLayer->set_sample( pEditSample );
+			// insert new sample from newInstrument
+			pLayer->set_sample( pEditSample );
+		}
 
 		AudioEngine::get_instance()->unlock();
-		m_pTargetSampleView->updateDisplay( pLayer );
+
+		if( pLayer ) {
+			m_pTargetSampleView->updateDisplay( pLayer );
+		}
 	}
 }
 

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -149,11 +149,10 @@ void SongEditorPanelTagWidget::on_okBtn_clicked()
 
 	for( int i = 0; i < __theChangedItems.size() ; i++ )
 	{
-		QTableWidgetItem *newTagItem = new QTableWidgetItem();
 		int songPosition = __theChangedItems.value( i ).toInt();
-		newTagItem = tagTableWidget->item( songPosition, 0 );
-		if ( newTagItem ) {
-			SE_editTagAction *action = new SE_editTagAction(  newTagItem->text() ,oldText.value( songPosition ), songPosition );
+		QTableWidgetItem * pNewTagItem = tagTableWidget->item( songPosition, 0 );
+		if ( pNewTagItem ) {
+			SE_editTagAction *action = new SE_editTagAction(  pNewTagItem->text() ,oldText.value( songPosition ), songPosition );
 			HydrogenApp::get_instance()->m_pUndoStack->push( action );
 		}
 	}

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -88,13 +88,14 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 	QString		drumkitDir = Filesystem::drumkit_dir_search( drumkitName );
 	QString		saveDir = drumkitPathTxt->text();
 	Drumkit*	pDrumkit = nullptr;
+	int nVersionListIndex = versionList->currentIndex();
 	
 	QDir qdTempFolder( Filesystem::tmp_dir() );
 	bool TmpFileCreated = false;
 
 	int componentID = -1;
 	
-	if( versionList->currentIndex() == 1 ) {
+	if( nVersionListIndex == 1 ) {
 		for (uint i = 0; i < drumkitInfoList.size(); i++ ) {
 			pDrumkit = drumkitInfoList[i];
 			if( pDrumkit->get_name().compare( drumkitName ) == 0 ) {
@@ -153,7 +154,7 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 		QString filename = fullDir + "/" + filesList.at(i);
 		QString targetFilename = drumkitName + "/" + filesList.at(i);
 
-		if( versionList->currentIndex() == 1 ) {
+		if( nVersionListIndex == 1 ) {
 			if( filesList.at(i).compare( QString("drumkit.xml") ) == 0 ) {
 				filename = qdTempFolder.filePath( "drumkit.xml" );
 			}


### PR DESCRIPTION
clang-tidy is now enabled by default for travis builds. Currently, only google-readability-braces-around-statements and modernize-use-nullptr/default warning are treated as errors. 