### PR TITLE
Fix #922: Rewriting Jack synchronization in the presences of an external timebase master

### DIFF
--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -2777,10 +2777,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>konstanter Takt</translation>
     </message>
     <message>
-        <source>constant tempo</source>
-        <translation>konstantes Tempo</translation>
-    </message>
-    <message>
         <source>matching bars</source>
         <translation>Übereinstimmende Takte</translation>
     </message>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -452,7 +452,7 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
-        <translation type="unfinished">Verzeichnis %1 existiert nicht</translation>
+        <translation>Verzeichnis %1 existiert nicht</translation>
     </message>
 </context>
 <context>
@@ -572,10 +572,6 @@ Overwrite the existing file?</source>
     <message>
         <source>Interpolation: </source>
         <translation>Interpolation: </translation>
-    </message>
-    <message>
-        <source>Choose type of interpolation methode</source>
-        <translation>Wähle eine Interpolationsmethode</translation>
     </message>
     <message>
         <source>Linear</source>
@@ -912,6 +908,14 @@ Bist Du sicher?
         <source>Fill 1/16 notes</source>
         <translation>(1/16) Füge jede sechzehnte Note ein</translation>
     </message>
+    <message>
+        <source>Some samples for this instrument failed to load.</source>
+        <translation>Einige Sample für dieses Instrument konnten nicht geladen werden.</translation>
+    </message>
+    <message>
+        <source>One or more samples for this instrument failed to load. This may be because the songfile uses an older default drumkit. This might be fixed by opening a new drumkit.</source>
+        <translation>Ein oder mehrere Samples für dieses Instrument konnten nicht geladen werden. Dies kann an einem veralteten Schlagzeug liegen, was durch das Laden eines neueren behoben werden kann.</translation>
+    </message>
 </context>
 <context>
     <name>InstrumentRack</name>
@@ -1172,10 +1176,6 @@ MIDI = %2</translation>
         <translation>Änderungen &amp;verwerfen</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Abbrechen</translation>
-    </message>
-    <message>
         <source>Error loading song.</source>
         <translation>Fehler beim Laden des Songs.</translation>
     </message>
@@ -1298,10 +1298,6 @@ MIDI = %2</translation>
     <message>
         <source>Clear all instruments?</source>
         <translation>Alle Instrumente löschen?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>OK</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
@@ -1537,15 +1533,15 @@ It should work like a charm provided that you use the GM-kit, and that you do no
     </message>
     <message>
         <source>&amp;Timeline</source>
-        <translation type="unfinished"></translation>
+        <translation>Timeline</translation>
     </message>
     <message>
         <source>&amp;Playback track</source>
-        <translation type="unfinished"></translation>
+        <translation>Playback Track</translation>
     </message>
     <message>
         <source>Jack driver: cannot disconnect client</source>
-        <translation type="unfinished"></translation>
+        <translation>Jack Treiber: Trennen des Clients fehlgeschlagen</translation>
     </message>
     <message>
         <source>OSC Server: Cannot connect to given port, using temporary port instead</source>
@@ -1554,6 +1550,27 @@ It should work like a charm provided that you use the GM-kit, and that you do no
     <message>
         <source>Retrieving information about drumkit &apos;%1&apos; failed: drumkit does not exist.</source>
         <translation>Konnte keine Information zu Schlagzeug &apos;%1&apos; abrufen: Schlagzeug existiert nicht.</translation>
+    </message>
+    <message>
+        <source>Some samples used by this song failed to load. If you save the song now these missing samples will be removed from the song entirely.
+Are you sure you want to save?</source>
+        <translation>Einige Samples für dieses Lied konnten nicht geladen werden. Be erneutem Speichern werden die fehlenden vollständig entfernt.</translation>
+    </message>
+    <message>
+        <source>Song drumkit samples</source>
+        <translation>Lied: Schlagzeugsamples</translation>
+    </message>
+    <message>
+        <source>Some samples used in this song could not be loaded. This may be because it uses an older default drumkit. This might be fixed by opening a new drumkit.</source>
+        <translation>Ein oder mehrere Samples für dieses Lied konnten nicht geladen werden. Dies kann an einem veralteten Schlagzeug liegen, was durch das Laden eines neueren behoben werden kann.</translation>
+    </message>
+    <message>
+        <source>Open drumkit</source>
+        <translation>Öffne Schlagzeug</translation>
+    </message>
+    <message>
+        <source>Could not write to temporary directory %1.</source>
+        <translation>Fehler beim Schreiben in temporären Ordner %1.</translation>
     </message>
 </context>
 <context>
@@ -2050,6 +2067,14 @@ It should work like a charm provided that you use the GM-kit, and that you do no
         <source>Switch metronome on/off</source>
         <translation>Metronom An/Aus</translation>
     </message>
+    <message>
+        <source>Jack-Time-Master mode = Off</source>
+        <translation>Jack-Time-Master Modus aus</translation>
+    </message>
+    <message>
+        <source>Jack-Time-Master mode = On</source>
+        <translation>Jack-Time-Master Modus aus</translation>
+    </message>
 </context>
 <context>
     <name>PlaylistDialog</name>
@@ -2354,7 +2379,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Automatic driver selection</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatische Treiberauswahl</translation>
     </message>
     <message>
         <source>&lt;br&gt;&lt;b&gt;</source>
@@ -2363,6 +2388,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>&lt;/b&gt; selected</source>
         <translation>&lt;/b&gt; selected</translation>
+    </message>
+    <message>
+        <source>Hydrogen must be restarted for language change to take effect</source>
+        <translation>Ein Neustart ist nötig, damit Sprachänderungen wirksam werden</translation>
     </message>
 </context>
 <context>
@@ -2688,10 +2717,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Erzeuge Ausgänge für jedes einzelne Instrument</translation>
     </message>
     <message>
-        <source>Enable feedback</source>
-        <translation>Rückkopplung aktivieren</translation>
-    </message>
-    <message>
         <source>&amp;OSC</source>
         <translation>&amp;OSC</translation>
     </message>
@@ -2713,23 +2738,67 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>second step, adjust offset between last controller/keyboard trigger and the deferred sequencer startup </source>
-        <translation type="unfinished"></translation>
+        <translation>Zweiter Schritt: Feinjustiere den Offset zwischen den letzten Anschlag des Keyboards und abgeleiteten Starten des Sequenzers</translation>
     </message>
     <message>
         <source>Maximum number of instrument layers</source>
-        <translation type="unfinished"></translation>
+        <translation>Größt möglichste Anzahl von Instrumentenebenen</translation>
     </message>
     <message>
         <source>Maximum number of layers (requires restart of Hydrogen)</source>
-        <translation type="unfinished"></translation>
+        <translation>Größt möglichste Anzahl von Ebenen (erfordert Neustart)</translation>
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Ausgabe</translation>
     </message>
     <message>
         <source>Enable midi feedback</source>
         <translation>Aktiviere Midi Feedback</translation>
+    </message>
+    <message>
+        <source>Language / Γλώσσα / Язык / 言語</source>
+        <translation>Sprache</translation>
+    </message>
+    <message>
+        <source>Hide keyboard input cursor</source>
+        <translation>Keyboard Eingabecursor ausblenden</translation>
+    </message>
+    <message>
+        <source>BBT sync method</source>
+        <translation>BBT Sync. Methode</translation>
+    </message>
+    <message>
+        <source>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</source>
+        <translation>Spezifiziert die Größe, welche über den gesamten Verlauf eine Liedes gleich bleiben muss, um das Funktionen der Synchronization mittels Jack durch einen externen timebase master zu gewährleisten</translation>
+    </message>
+    <message>
+        <source>constant measure</source>
+        <translation>konstanter Takt</translation>
+    </message>
+    <message>
+        <source>constant tempo</source>
+        <translation>konstantes Tempo</translation>
+    </message>
+    <message>
+        <source>matching bars</source>
+        <translation>Übereinstimmende Takte</translation>
+    </message>
+    <message>
+        <source>High-resolution display scaling</source>
+        <translation>Hochauflösende Bildschirmskalierung</translation>
+    </message>
+    <message>
+        <source>Prefer smaller</source>
+        <translation>Bevorzuge Kleinere</translation>
+    </message>
+    <message>
+        <source>Scale to system setting</source>
+        <translation>Skalierung wie unter Systemeinstellungen</translation>
+    </message>
+    <message>
+        <source>Prefer larger</source>
+        <translation>Bevorzuge Größere</translation>
     </message>
 </context>
 <context>
@@ -2751,7 +2820,7 @@ Bist Du sicher?</translation>
     <message>
         <source>Unsaved changes left. These changes will be lost. 
 Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungespeichterte Änderungen. Diese werden verloren gehen. Trotzdem beenden?</translation>
     </message>
 </context>
 <context>
@@ -3191,6 +3260,14 @@ Fortsetzen?</translation>
         <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
         <translation>Die Verwendung der Timeline ist deaktiviert, solange JACK als timebase master verwendet wird.</translation>
     </message>
+    <message>
+        <source> Timeline = Off</source>
+        <translation>Timeline aus</translation>
+    </message>
+    <message>
+        <source> Timeline = On</source>
+        <translation>Timeline an</translation>
+    </message>
 </context>
 <context>
     <name>SongEditorPanelBpmWidget_UI</name>
@@ -3320,15 +3397,19 @@ Soll sie überschrieben werden?</translation>
     </message>
     <message>
         <source>Could not export pattern.</source>
-        <translation type="unfinished">Pattern konnte nicht exportiert werden.</translation>
+        <translation>Pattern konnte nicht exportiert werden.</translation>
     </message>
     <message>
         <source>Could not export sequence.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sequenz konnte nicht exportiert werden.</translation>
     </message>
     <message>
         <source>Pattern saved.</source>
         <translation>Pattern gespeichert.</translation>
+    </message>
+    <message>
+        <source>Could not save pattern to temporary directory.</source>
+        <translation>Pattern konnte nicht in temporären Ordner gespeichert.</translation>
     </message>
 </context>
 <context>
@@ -3386,6 +3467,14 @@ Soll sie überschrieben werden?</translation>
     <message>
         <source>Directory</source>
         <translation>Verzeichnis</translation>
+    </message>
+    <message>
+        <source>Drumkit exported.</source>
+        <translation>Schlagzeug exportiert.</translation>
+    </message>
+    <message>
+        <source>Drumkit not exported. Operation not supported.</source>
+        <translation>Schlagzeugexport fehlgeschlagen. Operation nicht unterstützt.</translation>
     </message>
 </context>
 <context>

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -704,8 +704,6 @@ private:
 	 * audioEngine_checkBPMUpdate() function from doing so.*/
 	void relocateUsingBBT();
 
-	int m_nWaitNCycles;
-
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -452,19 +452,9 @@ public:
      * to TransportInfo::ROLLING.
 	 *
      * The function will check whether a relocation took place by the
-	 * JACK server and (afterwards) whether the current tempo did
-	 * change with respect to the last transport cycle. In case of a
-	 * relocation, #m_frameOffset will be reset to 0,
-	 * TransportInfo::m_nFrames updated to the new value provided by
-	 * JACK, and - if Hydrogen is in Song::PATTERN_MODE - the playback
-	 * moved to the beginning of the pattern. A change in speed, on
-	 * the other hand, depends on the local JACK setup. If there is a
-	 * timebase master, which broadcasts tempo information via JACK,
-	 * and it's not Hydrogen itself, all customizations in the
-	 * Timeline will be disregarded and the tempo of the master will
-	 * be used instead. If Hydrogen is the timebase master or there is
-	 * none at all, Hydrogen::setTimelineBpm() will be used to keep
-	 * the transport tempo aligned the settings in the Timeline.
+	 * JACK server and whether the current tempo did
+	 * change with respect to the last transport cycle and updates the
+	 * transport information accordingly.
 	 *
 	 * If Preferences::USE_JACK_TRANSPORT was not selected in
 	 * Preferences::m_bJackTransportMode, the function will return
@@ -698,10 +688,10 @@ private:
 	 * position.
 	 *
 	 * This type of operation is triggered whenever the transport
-	 * position got relocated using Jack in the presence of an
-	 * external timebase master. In addition, the function also
-	 * updates the current tick size to prevent the
-	 * audioEngine_checkBPMUpdate() function from doing so.*/
+	 * position gets relocated or the tempo is changed using Jack in
+	 * the presence of an external timebase master. In addition, the
+	 * function also updates the current tick size to prevent
+	 * the audioEngine_checkBPMUpdate() function from doing so.*/
 	void relocateUsingBBT();
 
 	/**

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -703,8 +703,6 @@ private:
 	 * the audioEngine_checkBPMUpdate() function from doing so.*/
 	void relocateUsingBBT();
 
-	int m_nWaitNCycles;
-
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -529,15 +529,16 @@ public:
 	/** Stores the latest transport position (for both rolling and
 	 * stopped transport).
 	 *
-	 * In case the user is clicking on the
-	 * SongEditor::mousePressEvent() will trigger both a relocation
-	 * and a change in speed. The change in speed causes the
-	 * audioEngine_checkBPMChange() function to update the ticksize in
-	 * case transported got moved into a region of different tempo and
-	 * triggers the calculateFrameOffset() function. But the latter
-	 * can only work properly if transport is rolling since it has to
-	 * know the frame position prior to the change in tick size and
-	 * there is no up-to-date JACK query providing this information.
+	 * In case the user is clicking on a different location
+	 * SongEditorPositionRuler::mousePressEvent() will trigger both a
+	 * relocation and a (possible) change in speed. The change in
+	 * speed causes the audioEngine_checkBPMChange() function to
+	 * update the ticksize in case playhead got moved into a region of
+	 * different tempo and triggers the calculateFrameOffset()
+	 * function. But the latter can only work properly if transport is
+	 * rolling since it has to know the frame position prior to the
+	 * change in tick size and there is no up-to-date JACK query
+	 * providing this information.
 	 */
 	int m_currentPos;
 	
@@ -685,7 +686,13 @@ protected:
 	void jack_session_callback_impl( jack_session_event_t* event );
 #endif
 
+	static void printJackTransportPos( const jack_position_t* pPos );
+
 private:
+
+	/** Show debugging information.*/
+	void printState() const;
+
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -683,6 +683,15 @@ private:
 	/** Show debugging information.*/
 	void printState() const;
 
+	/** Compares the BBT information stored in #m_JackTransportPos and
+	 * #m_previousJackTransportPos with respect to the tempo and the
+	 * transport position in bars, beats, and ticks.
+	 *
+	 * @return true If #m_JackTransportPos is expected to follow
+	 * #m_previousJackTransportPos.
+	 */
+	bool compareAdjacentBBT() const;
+
 	/** 
 	 * Uses the bar-beat-tick information to relocate the transport
 	 * position.
@@ -870,7 +879,12 @@ private:
 	 * documentation of JackTimebaseCallback() for more information
 	 * about its different members.
 	 */
-	jack_position_t		m_JackTransportPos;
+	jack_position_t			m_JackTransportPos;
+	/** Used for detecting changes in the BBT transport information
+	 * with external timebase master application, which do not
+	 * propagate these changes on time.
+	 */
+	jack_position_t			m_previousJackTransportPos;
 
 	/**
 	 * Specifies whether the default left and right (master) audio

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -703,6 +703,8 @@ private:
 	 * the audioEngine_checkBPMUpdate() function from doing so.*/
 	void relocateUsingBBT();
 
+	int m_nWaitNCycles;
+
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -693,6 +693,17 @@ private:
 	/** Show debugging information.*/
 	void printState() const;
 
+	/** 
+	 * Uses the bar-beat-tick information to relocate the transport
+	 * position.
+	 *
+	 * This type of operation is triggered whenever the transport
+	 * position got relocated using Jack in the presence of an
+	 * external timebase master. In addition, the function also
+	 * updates the current tick size to prevent the
+	 * audioEngine_checkBPMUpdate() function from doing so.*/
+	void relocateUsingBBT();
+
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -704,6 +704,8 @@ private:
 	 * audioEngine_checkBPMUpdate() function from doing so.*/
 	void relocateUsingBBT();
 
+	int m_nWaitNCycles;
+
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -355,13 +355,11 @@ public:
 		/** The measure - could be any - does not change during the
 			song.*/
 		constMeasure = 0,
-		/** The tempo does not change during the song.*/
-		constTempo = 1,
 		/** The length of each pattern must match the measure of the
 			corresponding bar in the timebase master. This way both
 			the pattern position of Hydrogen and the bar information
 			provided by Jack can be assumed to be identical.*/
-		identicalBars = 2 };
+		identicalBars = 1 };
 	/**
 	 * Since Hydrogen uses both fixed pattern lengths and recalculates
 	 * the tick size each time it encounters an alternative tempo, its

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -348,20 +348,20 @@ public:
 
 	/**
 	 * Specifies the variable, which has to remain constant in order
-	 * to guarantee working synchronization and relocation with
+	 * to guarantee a working synchronization and relocation with
 	 * Hydrogen as Jack timebase client.
 	 */
 	enum class JackBBTSyncMethod {
 		/** The measure - could be any - does not change during the
 			song.*/
-		constMeasure,
+		constMeasure = 0,
 		/** The tempo does not change during the song.*/
-		constTempo,
+		constTempo = 1,
 		/** The length of each pattern must match the measure of the
 			corresponding bar in the timebase master. This way both
 			the pattern position of Hydrogen and the bar information
 			provided by Jack can be assumed to be identical.*/
-		identicalBars };
+		identicalBars = 2 };
 	/**
 	 * Since Hydrogen uses both fixed pattern lengths and recalculates
 	 * the tick size each time it encounters an alternative tempo, its

--- a/src/core/include/hydrogen/Preferences.h
+++ b/src/core/include/hydrogen/Preferences.h
@@ -345,6 +345,38 @@ public:
 	bool				m_bJackTrackOuts;
 	int					m_nJackTrackOutputMode;
 	//jack time master
+
+	/**
+	 * Specifies the variable, which has to remain constant in order
+	 * to guarantee working synchronization and relocation with
+	 * Hydrogen as Jack timebase client.
+	 */
+	enum class JackBBTSyncMethod {
+		/** The measure - could be any - does not change during the
+			song.*/
+		constMeasure,
+		/** The tempo does not change during the song.*/
+		constTempo,
+		/** The length of each pattern must match the measure of the
+			corresponding bar in the timebase master. This way both
+			the pattern position of Hydrogen and the bar information
+			provided by Jack can be assumed to be identical.*/
+		identicalBars };
+	/**
+	 * Since Hydrogen uses both fixed pattern lengths and recalculates
+	 * the tick size each time it encounters an alternative tempo, its
+	 * transport is incompatible to the BBT information provided by 
+	 * the Jack server. Only if the length of each pattern corresponds
+	 * to the measure of the respective bar in the timebase master
+	 * application, the bar information provided by Jack can be used
+	 * directly to determine chosen pattern. If this, however, is not
+	 * the case - which can quite easily happen - a complete history 
+	 * of all measure and tempo changes would be required to correctly
+	 * identify the pattern. Since this is not provided by Jack, one
+	 * has to either assume the measure or tempo to be constant or 
+	 * that the user took care of adjusting the lengths properly.
+	 */
+	JackBBTSyncMethod	m_JackBBTSync;
 	/**
 	 * Specifies if Hydrogen should run as JACK time master. It
 	 * has two states: Preferences::USE_JACK_TIME_MASTER and
@@ -353,7 +385,7 @@ public:
 	 * JackAudioDriver::initTimebaseMaster() if Hydrogen couldn't be
 	 * registered as time master.
 	 */
-	int				m_bJackMasterMode;
+	int					m_bJackMasterMode;
 	//~ jack driver properties
 
 	///Default text editor (used by Playlisteditor)

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -1325,6 +1325,7 @@ void JackAudioDriver::printState() const {
 			  << ", m_JackTransportState: " << m_JackTransportState
 			  << ", m_nIsTimebaseMaster: " << m_nIsTimebaseMaster
 			  << ", m_currentPos: " << m_currentPos
+			  << ", m_nWaitNCycles: " << m_nWaitNCycles
 			  << ", pHydrogen->getPatternPos(): " << pHydrogen->getPatternPos()
 			  << "\33[0m" << std::endl;
 }

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -399,7 +399,7 @@ void JackAudioDriver::relocateUsingBBT()
 			// in the pattern.
 			fAdditionalTicks = fTicksPerBeat * 4 *
 				( fNextIncrement - 1 );
-		}		
+		}
 	}
 
 	float fNewTick = static_cast<float>(barTicks) + fAdditionalTicks +
@@ -603,6 +603,9 @@ bool JackAudioDriver::compareAdjacentBBT() const
 		return false;
 	}
 
+	// The rounding is the task of the external timebase master. So,
+	// we need to be a little generous in here to be sure to match its
+	// decision.
 	if ( abs( m_JackTransportPos.tick - nNewTick ) > 1 &&
 		 abs( m_JackTransportPos.tick -
 			  m_JackTransportPos.ticks_per_beat - nNewTick ) > 1 &&

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -364,6 +364,15 @@ void JackAudioDriver::relocateUsingBBT()
 			fAdditionalTicks = fTicksPerBeat * 4 *
 				( fNextIncrement - 1 );
 		}
+
+		// std::cout << "[relocateUsingBBT] "
+		// 		  << "nNumberOfPatternsPassed: " << nNumberOfPatternsPassed
+		// 		  << ", fAdditionalTicks: " << fAdditionalTicks
+		// 		  << ", nBarJack: " << nBarJack
+		// 		  << ", fNumberOfBarsPassed: " << fNumberOfBarsPassed
+		// 		  << ", fBarConversion: " << fBarConversion
+		// 		  << ", barTicks: " << barTicks
+		// 		  << std::endl;
 	}
 
 	float fNewTick = static_cast<float>(barTicks) + fAdditionalTicks +
@@ -525,7 +534,10 @@ bool JackAudioDriver::compareAdjacentBBT() const
 	int32_t nNewTick = m_previousJackTransportPos.tick +
 		floor( expectedTickUpdate );
 
-	if ( nNewTick > m_JackTransportPos.ticks_per_beat ) {
+	// The rounding is the task of the external timebase master. So,
+	// we need to be a little generous in here to be sure to match its
+	// decision.
+	if ( nNewTick + 1 >= m_JackTransportPos.ticks_per_beat ) {
 		nNewTick = remainder( nNewTick, m_JackTransportPos.ticks_per_beat );
 
 		if ( m_previousJackTransportPos.beat + 1 >
@@ -565,9 +577,6 @@ bool JackAudioDriver::compareAdjacentBBT() const
 		return false;
 	}
 
-	// The rounding is the task of the external timebase master. So,
-	// we need to be a little generous in here to be sure to match its
-	// decision.
 	if ( abs( m_JackTransportPos.tick - nNewTick ) > 1 &&
 		 abs( m_JackTransportPos.tick -
 			  m_JackTransportPos.ticks_per_beat - nNewTick ) > 1 &&

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -1267,7 +1267,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 	JackAudioDriver::nWaits = std::max( int(0), JackAudioDriver::nWaits - 1);
 
 	if ( pDriver->m_transport.m_nFrames < 1 ) {
-		pJackPosition->bar = 0;
+		pJackPosition->bar = 1;
 		pJackPosition->beat = 1;
 		pJackPosition->tick = 0;
 		pJackPosition->bar_start_tick = 0;

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -386,29 +386,6 @@ void JackAudioDriver::relocateUsingBBT()
 			ERRORLOG( QString( "Unsupported m_JackBBTSync option [%1]" )
 					  .arg( static_cast<int>(Preferences::get_instance()->m_JackBBTSync) ) );
 		}
-
-		// Position of the resulting pattern in ticks.
-		barTicks = pHydrogen->getTickForPosition( nNumberOfPatternsPassed );
-		if ( barTicks < 0 ) {
-			barTicks = 0;
-		} else if ( fNextIncrement > 1 &&
-					fNumberOfBarsPassed != nBarJack ) {
-			// If pattern is longer than what is considered a bar in
-			// Jack's point of view, some additional ticks have to be
-			// added whenever transport passes the first bar contained
-			// in the pattern.
-			fAdditionalTicks = fTicksPerBeat * 4 *
-				( fNextIncrement - 1 );
-		}
-
-		// std::cout << "[relocateUsingBBT] "
-		// 		  << "nNumberOfPatternsPassed: " << nNumberOfPatternsPassed
-		// 		  << ", fAdditionalTicks: " << fAdditionalTicks
-		// 		  << ", nBarJack: " << nBarJack
-		// 		  << ", fNumberOfBarsPassed: " << fNumberOfBarsPassed
-		// 		  << ", fBarConversion: " << fBarConversion
-		// 		  << ", barTicks: " << barTicks
-		// 		  << std::endl;
 	}
 
 	float fNewTick = static_cast<float>(barTicks) + fAdditionalTicks +

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -400,6 +400,15 @@ void JackAudioDriver::relocateUsingBBT()
 			fAdditionalTicks = fTicksPerBeat * 4 *
 				( fNextIncrement - 1 );
 		}
+
+		// std::cout << "[relocateUsingBBT] "
+		// 		  << "nNumberOfPatternsPassed: " << nNumberOfPatternsPassed
+		// 		  << ", fAdditionalTicks: " << fAdditionalTicks
+		// 		  << ", nBarJack: " << nBarJack
+		// 		  << ", fNumberOfBarsPassed: " << fNumberOfBarsPassed
+		// 		  << ", fBarConversion: " << fBarConversion
+		// 		  << ", barTicks: " << barTicks
+		// 		  << std::endl;
 	}
 
 	float fNewTick = static_cast<float>(barTicks) + fAdditionalTicks +
@@ -603,9 +612,6 @@ bool JackAudioDriver::compareAdjacentBBT() const
 		return false;
 	}
 
-	// The rounding is the task of the external timebase master. So,
-	// we need to be a little generous in here to be sure to match its
-	// decision.
 	if ( abs( m_JackTransportPos.tick - nNewTick ) > 1 &&
 		 abs( m_JackTransportPos.tick -
 			  m_JackTransportPos.ticks_per_beat - nNewTick ) > 1 &&

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -459,7 +459,7 @@ void JackAudioDriver::updateTransportInfo()
 		ERRORLOG( "Unknown jack transport state" );
 	}
 
-	// printState();
+	printState();
 	
 	m_currentPos = m_JackTransportPos.frame;
 	
@@ -497,6 +497,9 @@ void JackAudioDriver::updateTransportInfo()
 
 		if ( m_nIsTimebaseMaster != 0 ) {
 			m_transport.m_nFrames = m_JackTransportPos.frame;
+		} else {
+			relocateUsingBBT();
+		}
 		
 			// There maybe was an offset introduced when passing a
 			// tempo marker.
@@ -1325,7 +1328,6 @@ void JackAudioDriver::printState() const {
 			  << ", m_JackTransportState: " << m_JackTransportState
 			  << ", m_nIsTimebaseMaster: " << m_nIsTimebaseMaster
 			  << ", m_currentPos: " << m_currentPos
-			  << ", m_nWaitNCycles: " << m_nWaitNCycles
 			  << ", pHydrogen->getPatternPos(): " << pHydrogen->getPatternPos()
 			  << "\33[0m" << std::endl;
 }

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -433,9 +433,7 @@ void Preferences::loadPreferences( bool bGlobal )
 					int nBBTSync = LocalFileMng::readXmlInt( jackDriverNode, "jack_bbt_sync", 0 );
 					if ( nBBTSync == 0 ){
 						m_JackBBTSync = JackBBTSyncMethod::constMeasure;
-					} else if ( nBBTSync == 1 ){
-							m_JackBBTSync = JackBBTSyncMethod::constTempo;
-					} else if ( nBBTSync == 2 ) {
+					} else if ( nBBTSync == 1 ) {
 						m_JackBBTSync = JackBBTSyncMethod::identicalBars;
 					} else {
 						ERRORLOG( QString( "Unknown jack_bbt_sync value [%1]. Using JackBBTSyncMethod::constMeasure instead." )
@@ -838,10 +836,8 @@ void Preferences::savePreferences()
 			int nBBTSync = 0;
 			if ( m_JackBBTSync == JackBBTSyncMethod::constMeasure ) {
 				nBBTSync = 0;
-			} else if ( m_JackBBTSync == JackBBTSyncMethod::constTempo ) {
-				nBBTSync = 1;
 			} else if ( m_JackBBTSync == JackBBTSyncMethod::identicalBars ) {
-				nBBTSync = 2;
+				nBBTSync = 1;
 			}
 			LocalFileMng::writeXmlString( jackDriverNode, "jack_bbt_sync",
 										  QString::number( nBBTSync ) );

--- a/src/core/src/preferences.cpp
+++ b/src/core/src/preferences.cpp
@@ -67,6 +67,8 @@ Preferences::Preferences()
 	//Default jack track-outputs are post fader
 	m_nJackTrackOutputMode = POST_FADER;
 	m_bJackTrackOuts = false;
+	m_JackBBTSync = JackBBTSyncMethod::constMeasure;
+	
 	// switch to enable / disable lash, only on h2 startup
 	m_brestartLash = false;
 	m_bsetLash = false;
@@ -426,6 +428,19 @@ void Preferences::loadPreferences( bool bGlobal )
 						m_bJackMasterMode = NO_JACK_TIME_MASTER;
 					} else if ( tmMode == "USE_JACK_TIME_MASTER" ) {
 						m_bJackMasterMode = USE_JACK_TIME_MASTER;
+					}
+
+					int nBBTSync = LocalFileMng::readXmlInt( jackDriverNode, "jack_bbt_sync", 0 );
+					if ( nBBTSync == 0 ){
+						m_JackBBTSync = JackBBTSyncMethod::constMeasure;
+					} else if ( nBBTSync == 1 ){
+							m_JackBBTSync = JackBBTSyncMethod::constTempo;
+					} else if ( nBBTSync == 2 ) {
+						m_JackBBTSync = JackBBTSyncMethod::identicalBars;
+					} else {
+						ERRORLOG( QString( "Unknown jack_bbt_sync value [%1]. Using JackBBTSyncMethod::constMeasure instead." )
+								  .arg( nBBTSync ) );
+						m_JackBBTSync = JackBBTSyncMethod::constMeasure;
 					}
 					//~ jack time master
 
@@ -819,6 +834,18 @@ void Preferences::savePreferences()
 				tmMode = "USE_JACK_TIME_MASTER";
 			}
 			LocalFileMng::writeXmlString( jackDriverNode, "jack_transport_mode_master", tmMode );
+
+			int nBBTSync = 0;
+			if ( m_JackBBTSync == JackBBTSyncMethod::constMeasure ) {
+				nBBTSync = 0;
+			} else if ( m_JackBBTSync == JackBBTSyncMethod::constTempo ) {
+				nBBTSync = 1;
+			} else if ( m_JackBBTSync == JackBBTSyncMethod::identicalBars ) {
+				nBBTSync = 2;
+			}
+			LocalFileMng::writeXmlString( jackDriverNode, "jack_bbt_sync",
+										  QString::number( nBBTSync ) );
+			
 			//~ jack time master
 
 			// jack default connection

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -164,11 +164,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	case Preferences::JackBBTSyncMethod::constMeasure:
 		jackBBTSyncComboBox->setCurrentIndex( 0 );
 		break;
-	case Preferences::JackBBTSyncMethod::constTempo:
-		jackBBTSyncComboBox->setCurrentIndex( 1 );
-		break;
 	case Preferences::JackBBTSyncMethod::identicalBars:
-		jackBBTSyncComboBox->setCurrentIndex( 2 );
+		jackBBTSyncComboBox->setCurrentIndex( 1 );
 		break;
 	default:
 		ERRORLOG( QString( "Unknown Jack BBT synchronization method [%1]" )
@@ -451,9 +448,6 @@ void PreferencesDialog::on_okBtn_clicked()
 		pPref->m_JackBBTSync = Preferences::JackBBTSyncMethod::constMeasure;
 		break;
 	case 1:
-		pPref->m_JackBBTSync = Preferences::JackBBTSyncMethod::constTempo;
-		break;
-	case 2:
 		pPref->m_JackBBTSync = Preferences::JackBBTSyncMethod::identicalBars;
 		break;
 	default:

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include <cstring>
 
 #include "Skin.h"
 #include "PreferencesDialog.h"
@@ -158,6 +159,21 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 
 	connectDefaultsCheckBox->setChecked( pPref->m_bJackConnectDefaults );
 	trackOutputComboBox->setCurrentIndex( pPref->m_nJackTrackOutputMode );
+
+	switch ( pPref->m_JackBBTSync ) {
+	case Preferences::JackBBTSyncMethod::constMeasure:
+		jackBBTSyncComboBox->setCurrentIndex( 0 );
+		break;
+	case Preferences::JackBBTSyncMethod::constTempo:
+		jackBBTSyncComboBox->setCurrentIndex( 1 );
+		break;
+	case Preferences::JackBBTSyncMethod::identicalBars:
+		jackBBTSyncComboBox->setCurrentIndex( 2 );
+		break;
+	default:
+		ERRORLOG( QString( "Unknown Jack BBT synchronization method [%1]" )
+				  .arg( static_cast<int>(pPref->m_JackBBTSync) ) );
+	}
 	//~ JACK
 
 
@@ -429,6 +445,20 @@ void PreferencesDialog::on_okBtn_clicked()
 	} else {
 		pPref->m_nJackTrackOutputMode = Preferences::PRE_FADER;
 	}
+
+	switch ( jackBBTSyncComboBox->currentIndex() ) {
+	case 0:
+		pPref->m_JackBBTSync = Preferences::JackBBTSyncMethod::constMeasure;
+		break;
+	case 1:
+		pPref->m_JackBBTSync = Preferences::JackBBTSyncMethod::constTempo;
+		break;
+	case 2:
+		pPref->m_JackBBTSync = Preferences::JackBBTSyncMethod::identicalBars;
+		break;
+	default:
+		ERRORLOG( QString( "Unexpected Jack BBT synchronization value" ) );
+	}
 	//~ JACK
 
 	pPref->m_nBufferSize = bufferSizeSpinBox->value();
@@ -651,6 +681,15 @@ void PreferencesDialog::updateDriverInfo()
 		sampleRateComboBox->setEnabled( false );
 		trackOutputComboBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled( false );
+
+		if ( std::strcmp( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name(),
+						  "JackAudioDriver" ) == 0 ) {
+			jackBBTSyncComboBox->show();
+			jackBBTSyncLbl->show();
+		} else {
+			jackBBTSyncComboBox->hide();
+			jackBBTSyncLbl->hide();
+		}
 	}
 	else if ( driverComboBox->currentText() == "OSS" ) {	// OSS
 		info += tr("<b>Open Sound System</b><br>Simple audio driver [/dev/dsp]");
@@ -664,6 +703,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		jackBBTSyncComboBox->hide();
+		jackBBTSyncLbl->hide();
 	}
 	else if ( driverComboBox->currentText() == "Jack" ) {	// JACK
 		info += tr("<b>Jack Audio Connection Kit Driver</b><br>Low latency audio driver");
@@ -677,6 +718,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( true );
 		connectDefaultsCheckBox->setEnabled(true);
 		trackOutsCheckBox->setEnabled( true );
+		jackBBTSyncComboBox->show();
+		jackBBTSyncLbl->show();
 	}
 	else if ( driverComboBox->currentText() == "Alsa" ) {	// ALSA
 		info += tr("<b>ALSA Driver</b><br>");
@@ -690,6 +733,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		jackBBTSyncComboBox->hide();
+		jackBBTSyncLbl->hide();
 	}
 	else if ( driverComboBox->currentText() == "PortAudio" ) {
 		info += tr( "<b>PortAudio Driver</b><br>" );
@@ -702,6 +747,8 @@ void PreferencesDialog::updateDriverInfo()
 		sampleRateComboBox->setEnabled(true);
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		jackBBTSyncComboBox->hide();
+		jackBBTSyncLbl->hide();
 	}
 	else if ( driverComboBox->currentText() == "CoreAudio" ) {
 		info += tr( "<b>CoreAudio Driver</b><br>" );
@@ -715,6 +762,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		jackBBTSyncComboBox->hide();
+		jackBBTSyncLbl->hide();
 	}
 	else if ( driverComboBox->currentText() == "PulseAudio" ) {
 		info += tr("<b>PulseAudio Driver</b><br>");
@@ -728,6 +777,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		jackBBTSyncComboBox->hide();
+		jackBBTSyncLbl->hide();
 	}
 	else {
 		QString selectedDriver = driverComboBox->currentText();

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -678,9 +678,13 @@ void PreferencesDialog::updateDriverInfo()
 
 		if ( std::strcmp( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name(),
 						  "JackAudioDriver" ) == 0 ) {
+			connectDefaultsCheckBox->show();
+			trackOutsCheckBox->show();
 			jackBBTSyncComboBox->show();
 			jackBBTSyncLbl->show();
 		} else {
+			connectDefaultsCheckBox->hide();
+			trackOutsCheckBox->hide();
 			jackBBTSyncComboBox->hide();
 			jackBBTSyncLbl->hide();
 		}
@@ -697,6 +701,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		connectDefaultsCheckBox->hide();
+		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
 	}
@@ -712,6 +718,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( true );
 		connectDefaultsCheckBox->setEnabled(true);
 		trackOutsCheckBox->setEnabled( true );
+		connectDefaultsCheckBox->show();
+		trackOutsCheckBox->show();
 		jackBBTSyncComboBox->show();
 		jackBBTSyncLbl->show();
 	}
@@ -727,6 +735,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		connectDefaultsCheckBox->hide();
+		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
 	}
@@ -741,6 +751,8 @@ void PreferencesDialog::updateDriverInfo()
 		sampleRateComboBox->setEnabled(true);
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		connectDefaultsCheckBox->hide();
+		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
 	}
@@ -756,6 +768,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		connectDefaultsCheckBox->hide();
+		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
 	}
@@ -771,6 +785,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled(false);
+		connectDefaultsCheckBox->hide();
+		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
 	}

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -411,6 +411,54 @@
              </property>
             </widget>
            </item>
+		   <item>
+			 <layout class="QGridLayout">
+			   <item row="0" column="0">
+				 <widget class="QLabel" name="jackBBTSyncLbl">
+				   <property name="minimumSize">
+					 <size>
+					   <width>0</width>
+					   <height>22</height>
+					 </size>
+				   </property>
+				   <property name="text">
+					 <string>BBT sync method</string>
+				   </property>
+				   <property name="toolTip">
+					 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+				   </property>
+				 </widget>
+			   </item>
+			   <item row="0" column="1">	 
+				 <widget class="QComboBox" name="jackBBTSyncComboBox">
+				   <property name="minimumSize">
+					 <size>
+					   <width>0</width>
+					   <height>22</height>
+					 </size>
+				   </property>
+				   <property name="toolTip">
+					 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+				   </property>
+				   <item>
+					 <property name="text">
+					   <string>constant measure</string>
+					 </property>
+				   </item>
+				   <item>
+					 <property name="text">
+					   <string>constant tempo</string>
+					 </property>
+				   </item>
+				   <item>
+					 <property name="text">
+					   <string>matching bars</string>
+					 </property>
+				   </item>
+				 </widget>
+			   </item>
+			 </layout>
+		   </item>
           </layout>
          </item>
          <item>

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -447,11 +447,6 @@
 				   </item>
 				   <item>
 					 <property name="text">
-					   <string>constant tempo</string>
-					 </property>
-				   </item>
-				   <item>
-					 <property name="text">
 					   <string>matching bars</string>
 					 </property>
 				   </item>


### PR DESCRIPTION
I reintroduced the original code for updating the transport position on relocation based on the BBT information in the presence of an external Jack timebase master.

This one is on me since I removed it prior to 1.0.0. Conceptional this code is required because otherwise there is no way to sync H2 and Jack if there are tempo markers and the transport got relocated by the user. I didn't thought of this scenario. But the original code was buggy and only worked for patterns of length 8. I fixed this too and it should now work for all lengths.

In addition I introduced two debugging function to the Jack audio driver. Some print statements I have introduced at least 10 times by now and I something tells me that this might was not the last time.

---

Update:

	 * Since Hydrogen uses both fixed pattern lengths and recalculates
	 * the tick size each time it encounters an alternative tempo, its
	 * transport is incompatible to the BBT information provided by 
	 * the Jack server. Only if the length of each pattern corresponds
	 * to the measure of the respective bar in the timebase master
	 * application, the bar information provided by Jack can be used
	 * directly to determine chosen pattern. If this, however, is not
	 * the case - which can quite easily happen - a complete history 
	 * of all measure and tempo changes would be required to correctly
	 * identify the pattern. Since this is not provided by Jack, one
	 * has to either assume the measure or tempo to be constant or 
	 * that the user took care of adjusting the lengths properly.

The user has now the option to either only provide different speeds via the Jack timebase master (TBM) or both speeds and measures but, in addition, has to make sure the length of each pattern matches the measure of the corresponding bar in the TBM. This behavior can be chosen via the Preferences menu 