### PR TITLE
Jack tweaks

### DIFF
--- a/src/core/include/hydrogen/IO/AudioOutput.h
+++ b/src/core/include/hydrogen/IO/AudioOutput.h
@@ -40,8 +40,7 @@ public:
 	TransportInfo m_transport;
 
 	AudioOutput( const char* class_name )
-			: Object( class_name )
-			, __track_out_enabled( false ) { }
+			: Object( class_name ) { }
 
 	virtual ~AudioOutput() { }
 
@@ -58,26 +57,6 @@ public:
 	virtual void stop() = 0;
 	virtual void locate( unsigned long nFrame ) = 0;
 	virtual void setBpm( float fBPM ) = 0;
-
-	/** Accesses the per-track output port settings of a driver.
-	 * \return __track_out_enabled */
-	bool has_track_outs() {
-		return __track_out_enabled;
-	}
-
-protected:
-	/**
-	 * Whether the JackAudioDriver is ordered to create per-track
-	 * audio output ports (true). The order comes from the
-	 * variable Preferences::m_bJackTrackOuts. It will be used by
-	 * the Sampler and Hydrogen itself to probe the behavior of
-	 * the JackAudioDriver.
-	 *
-	 * In all other drivers this variable isn't used. It gets
-	 * initialized to false.
-	 */
-	bool __track_out_enabled;
-
 };
 
 };

--- a/src/core/include/hydrogen/IO/TransportInfo.h
+++ b/src/core/include/hydrogen/IO/TransportInfo.h
@@ -72,7 +72,7 @@ public:
 	 *
 	 * A tick is the most fine-grained time scale handled by the
 	 * AudioEngine. The notes won't be processed frame by frame but,
-	 * instead, tick by tick. Therefore, #m_nTickSize represents the
+	 * instead, tick by tick. Therefore, #m_fTickSize represents the
 	 * minimum duration of a Note as well as the minimum distance
 	 * between two of them.
 	 * 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -220,9 +220,6 @@ public:
 	 * callback function.
 	 */
 	void clearPerTrackAudioBuffers( uint32_t nFrames );
-
-	/** @return #m_bUsePerTrackOutputs */
-	bool getUsePerTrackOutputs() const;
 	
 	/**
 	 * Creates per component output ports for each instrument.
@@ -787,12 +784,6 @@ private:
 	 */
 	int				m_trackMap[MAX_INSTRUMENTS][MAX_COMPONENTS];
 	/**
-	 * Whether to create per-track audio output ports. The choice of
-	 * the user queried from Preferences::m_bJackTrackOuts and stored
-	 * in this variable at the moment of creation of an instance.
-	 */
-	bool			m_bUsePerTrackOutputs;
-	/**
 	 * Total number of output ports currently in use. It gets updated
 	 * by makeTrackOutputs().
 	 */
@@ -920,9 +911,6 @@ private:
 	
 inline JackAudioDriver::Timebase JackAudioDriver::getTimebaseState() const {
 	return m_timebaseState;
-}
-inline bool JackAudioDriver::getUsePerTrackOutputs() const {
-	return m_bUsePerTrackOutputs;
 }
 
 

--- a/src/core/include/hydrogen/IO/jack_audio_driver.h
+++ b/src/core/include/hydrogen/IO/jack_audio_driver.h
@@ -214,7 +214,7 @@ public:
 	unsigned getSampleRate();
 
 	/** Resets the buffers contained in #m_pTrackOutputPortsL and
-	 * #m_pTrackOutputPortR.
+	 * #m_pTrackOutputPortsR.
 	 * 
 	 * @param nFrames Size of the buffers used in the audio process
 	 * callback function.
@@ -360,8 +360,8 @@ public:
 	 * them in #jackServerSampleRate, Preferences::m_nSampleRate,
 	 * #jackServerBufferSize, and Preferences::m_nBufferSize. In
 	 * addition, it also registers JackAudioDriver::m_processCallback,
-	 * H2Core::jackDriverSampleRate, H2Core::jackDriverBufferSize, and
-	 * H2Core::jackDriverShutdown using _jack_set_process_callback()_,
+	 * jackDriverSampleRate, jackDriverBufferSize, and
+	 * jackDriverShutdown using _jack_set_process_callback()_,
 	 * _jack_set_sample_rate_callback()_,
 	 * _jack_set_buffer_size_callback()_, and _jack_on_shutdown()_
 	 * (all in jack/jack.h).
@@ -584,7 +584,7 @@ public:
 	static int					nWaits;
 	/**
 	 * Callback function for the JACK audio server to set the sample
-	 * rate #H2Core::jackServerSampleRate and prints a message to the
+	 * rate #jackServerSampleRate and prints a message to the
 	 * #__INFOLOG, which has to be included via a Logger instance in
 	 * the provided @a param.
 	 *
@@ -603,7 +603,7 @@ public:
 	
 	/**
 	 * Callback function for the JACK audio server to set the buffer
-	 * size #H2Core::jackServerBufferSize.
+	 * size #jackServerBufferSize.
 	 *
 	 * It gets registered as a callback function of the JACK server in
 	 * JackAudioDriver::init() using

--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -134,7 +134,7 @@ class CoreActionController : public H2Core::Object {
 		 * (De)activates the usage of the Timeline.
 		 *
 		 * Note that this function will fail in the presence of the
-		 * Jack audio driver and an external timebase master (see Hydrogen::haveJackTimebaseClient()).
+		 * Jack audio driver and an external timebase master (see Hydrogen::getJackTimebaseState()).
 		 *
 		 * @param bActivate If true - activate or if false -
 		 * deactivate.

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -32,6 +32,7 @@
 #include <hydrogen/IO/AudioOutput.h>
 #include <hydrogen/IO/MidiInput.h>
 #include <hydrogen/IO/MidiOutput.h>
+#include <hydrogen/IO/jack_audio_driver.h>
 #include <hydrogen/basics/drumkit.h>
 #include <hydrogen/core_action_controller.h>
 #include <cassert>
@@ -647,9 +648,9 @@ void			previewSample( Sample *pSample );
 	 * \return Whether we haveJackTransport() and there is an external
 	 * JACK timebase master broadcasting us tempo information and
 	 * making use disregard Hydrogen's Timeline information (see
-	 * #JackAudioDriver::m_nIsTimebaseMaster).
+	 * #JackAudioDriver::m_timebaseState).
 	 */
-	bool			haveJackTimebaseClient() const;
+	JackAudioDriver::Timebase		getJackTimebaseState() const;
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -51,145 +51,53 @@
 
 namespace H2Core {
 
-	/**
-	 * Sample rate of the JACK audio server.
-	 *
-	 * It is set by the callback function jackDriverSampleRate()
-	 * registered in the JACK server and accessed via
-	 * JackAudioDriver::getSampleRate(). Its initialization is handled by
-	 * JackAudioDriver::init(), which sets it to the sample rate of the
-	 * Hydrogen's external JACK client via _jack_get_sample_rate()_
-	 * (jack/jack.h).
-	 */
-	unsigned long		jackServerSampleRate = 0;
-	/**
-	 * Buffer size of the JACK audio server.
-	 *
-	 * It is set by the callback function jackDriverBufferSize()
-	 * registered in the JACK server and accessed via
-	 * JackAudioDriver::getBufferSize(). Its initialization is handled by
-	 * JackAudioDriver::init(), which sets it to the buffer size of the
-	 * Hydrogen's external JACK client via _jack_get_buffer_size()_
-	 * (jack/jack.h).
-	 */
-	jack_nframes_t		jackServerBufferSize = 0;
-	/**
-	 * Instance of the JackAudioDriver.
-	 */
-	JackAudioDriver*	pJackDriverInstance = nullptr;
-
-/**
- * Callback function for the JACK audio server to set the sample rate
- * #H2Core::jackServerSampleRate and prints a message to
- * the #__INFOLOG, which has to be included via a Logger instance in
- * the provided @a param.
- *
- * It gets registered as a callback function of the JACK server in
- * JackAudioDriver::init() using _jack_set_sample_rate_callback()_.
- *
- * \param nframes New sample rate. The object has to be of type
- * _jack_nframes_t_, which is defined in the jack/types.h header.
- * \param param Object containing a Logger member to display the
- * change in the sample rate in its INFOLOG.
- *
- * @return 0 on success
- */
-int jackDriverSampleRate( jack_nframes_t nframes, void* param ){
+int JackAudioDriver::jackDriverSampleRate( jack_nframes_t nframes, void* param ){
 	// Used for logging.
 	Object* __object = ( Object* )param;
-	QString msg = QString("Jack SampleRate changed: the sample rate is now %1/sec").arg( QString::number( (int) nframes ) );
+	QString msg = QString("Jack SampleRate changed: the sample rate is now %1/sec").arg( QString::number( static_cast<int>(nframes) ) );
 	// The __INFOLOG macro uses the Object *__object and not the
 	// Object instance as INFOLOG does. It will call
 	// __object->logger()->log( H2Core::Logger::Info, ..., msg )
 	// (see object.h).
 	__INFOLOG( msg );
-	jackServerSampleRate = nframes;
+	JackAudioDriver::jackServerSampleRate = nframes;
 	return 0;
 }
-/**
- * Callback function for the JACK audio server to set the buffer size
- * #H2Core::jackServerBufferSize.
- *
- * It gets registered as a callback function of the JACK server in
- * JackAudioDriver::init() using _jack_set_buffer_size_callback()_.
- *
- * \param nframes New buffer size. The object has to be of type @a
- * jack_nframes_t, which is defined in the jack/types.h header.
- * \param arg Not used within the function but kept for compatibility
- * reasons since the _JackBufferSizeCallback_ (jack/types.h) requires a
- * second input argument @a arg of type _void_, which is a pointer
- * supplied by the jack_set_buffer_size_callback() function.
- *
- * @return 0 on success
- */
-int jackDriverBufferSize( jack_nframes_t nframes, void* arg ){
+
+int JackAudioDriver::jackDriverBufferSize( jack_nframes_t nframes, void* arg ){
 	// This function does _NOT_ have to be realtime safe.
-	jackServerBufferSize = nframes;
+	JackAudioDriver::jackServerBufferSize = nframes;
 	return 0;
 }
-/**
- * Callback function for the JACK audio server to shutting down the
- * JACK driver.
- *
- * The JackAudioDriver::m_pClient pointer stored in the current
- * instance of the JACK audio driver #pJackDriverInstance is set to
- * the nullptr and a Hydrogen::JACK_SERVER_SHUTDOWN error is raised
- * using Hydrogen::raiseError().
- *
- * It gets registered as a callback function of the JACK server in
- * JackAudioDriver::init() using _jack_on_shutdown()_.
- *
- * \param arg Not used within the function but kept for compatibility
- * reasons since _jack_shutdown()_ (jack/jack.h) the argument @a arg
- * of type void.
- */	
-void jackDriverShutdown( void* arg )
+	
+void JackAudioDriver::jackDriverShutdown( void* arg )
 {
 	UNUSED( arg );
 
-	pJackDriverInstance->m_pClient = nullptr;
+	JackAudioDriver::pJackDriverInstance->m_pClient = nullptr;
 	Hydrogen::get_instance()->raiseError( Hydrogen::JACK_SERVER_SHUTDOWN );
 }
 
-/**
- * Required in JackTimebaseCallback() to keep the sync between the
- * timebase master and all other JACK clients.
- *
- * Whenever a relocation takes place in Hydrogen as timebase master,
- * the speed of the timeline at the destination frame must not be sent
- * in the timebase callback. Instead, Hydrogen must wait two full
- * cycles of the audioEngine before broadcasting the new tempo
- * again. This is because the Hydrogen (as timebase master) requires
- * two full cycles to set the tempo itself and there is a rather
- * intricate dependence on values calculate in various other
- * functions.
- *
- * TODO: Kill this variable and make the relocation behavior way more 
- * straight forward.
- */
-int nWaits = 0;
-
 const char* JackAudioDriver::__class_name = "JackAudioDriver";
+unsigned long JackAudioDriver::jackServerSampleRate = 0;
+jack_nframes_t JackAudioDriver::jackServerBufferSize = 0;
+JackAudioDriver* JackAudioDriver::pJackDriverInstance = nullptr;
+int JackAudioDriver::nWaits = 0;
 
 JackAudioDriver::JackAudioDriver( JackProcessCallback m_processCallback )
-	: AudioOutput( __class_name )
+	: AudioOutput( __class_name ),
+	  m_bUsePerTrackOutputs( Preferences::get_instance()->m_bJackTrackOuts )
 {
 	INFOLOG( "INIT" );
 	
 	auto pPreferences = Preferences::get_instance();
-	
-	// __track_out_enabled is inherited from AudioOutput and
-	// instantiated with false. It will be used by the Sampler and
-	// Hydrogen itself to check whether JackAudioDriver does create
-	// per-track audio output ports.
-	__track_out_enabled = pPreferences->m_bJackTrackOuts;
 
 	m_transport.m_status = TransportInfo::STOPPED;
 	m_transport.m_nFrames = 0;
 	m_transport.m_fTickSize = 100;
 	m_transport.m_fBPM = 120;
 
-	pJackDriverInstance = this;
+	JackAudioDriver::pJackDriverInstance = this;
 	this->m_processCallback = m_processCallback;
 
 	m_frameOffset = 0;
@@ -338,12 +246,30 @@ void JackAudioDriver::deactivate()
 
 unsigned JackAudioDriver::getBufferSize()
 {
-	return jackServerBufferSize;
+	return JackAudioDriver::jackServerBufferSize;
 }
 
 unsigned JackAudioDriver::getSampleRate()
 {
-	return jackServerSampleRate;
+	return JackAudioDriver::jackServerSampleRate;
+}
+
+void JackAudioDriver::clearPerTrackAudioBuffers( uint32_t nFrames )
+{
+	if ( m_pClient != nullptr && m_bUsePerTrackOutputs ) {
+		float* pBuffer;
+		
+		for ( int ii = 0; ii < m_nTrackPortCount; ++ii ) {
+			pBuffer = getTrackOut_L( ii );
+			if ( pBuffer != nullptr ) {
+				memset( pBuffer, 0, nFrames * sizeof( float ) );
+			}
+			pBuffer = getTrackOut_R( ii );
+			if ( pBuffer != nullptr ) {
+				memset( pBuffer, 0, nFrames * sizeof( float ) );
+			}
+		}
+	}
 }
 
 void JackAudioDriver::calculateFrameOffset(long long oldFrame)
@@ -439,7 +365,7 @@ void JackAudioDriver::updateTransportInfo()
 		// There is a JACK timebase master and it's not us. If it
 		// provides a tempo that differs from the local one, we will
 		// use the former instead.
-		float fBPM = ( float )m_JackTransportPos.beats_per_minute;
+		float fBPM = static_cast<float>(m_JackTransportPos.beats_per_minute);
 
 		if ( m_transport.m_fBPM != fBPM ) {
 			setBpm( fBPM );
@@ -464,40 +390,40 @@ float* JackAudioDriver::getOut_L()
 	 * or zero-filled. if there are multiple inbound connections,
 	 * the data will be mixed appropriately.
 	 */
-	jack_default_audio_sample_t *out = ( jack_default_audio_sample_t * ) jack_port_get_buffer ( m_pOutputPort1, jackServerBufferSize );
+	jack_default_audio_sample_t *out = static_cast<jack_default_audio_sample_t*>(jack_port_get_buffer( m_pOutputPort1, JackAudioDriver::jackServerBufferSize ));
 	return out;
 }
 
 float* JackAudioDriver::getOut_R()
 {
-	jack_default_audio_sample_t *out = ( jack_default_audio_sample_t * ) jack_port_get_buffer ( m_pOutputPort2, jackServerBufferSize );
+	jack_default_audio_sample_t *out = static_cast<jack_default_audio_sample_t*>(jack_port_get_buffer( m_pOutputPort2, JackAudioDriver::jackServerBufferSize ));
 	return out;
 }
 
 float* JackAudioDriver::getTrackOut_L( unsigned nTrack )
 {
-	if ( nTrack > (unsigned)m_nTrackPortCount ) {
+	if ( nTrack > static_cast<unsigned>(m_nTrackPortCount) ) {
 		return nullptr;
 	}
 	
 	jack_port_t* pPort = m_pTrackOutputPortsL[nTrack];
 	jack_default_audio_sample_t* out = nullptr;
 	if( pPort ) {
-		out = (jack_default_audio_sample_t*) jack_port_get_buffer( pPort, jackServerBufferSize);
+		out = static_cast<jack_default_audio_sample_t*>(jack_port_get_buffer( pPort, JackAudioDriver::jackServerBufferSize));
 	}
 	return out;
 }
 
 float* JackAudioDriver::getTrackOut_R( unsigned nTrack )
 {
-	if( nTrack > (unsigned)m_nTrackPortCount ) {
+	if( nTrack > static_cast<unsigned>(m_nTrackPortCount) ) {
 		return nullptr;
 	}
 	
 	jack_port_t* pPort = m_pTrackOutputPortsR[nTrack];
 	jack_default_audio_sample_t* out = nullptr;
 	if( pPort ) {
-		out = (jack_default_audio_sample_t*) jack_port_get_buffer( pPort, jackServerBufferSize);
+		out = static_cast<jack_default_audio_sample_t*>(jack_port_get_buffer( pPort, JackAudioDriver::jackServerBufferSize));
 	}
 	return out;
 }
@@ -658,11 +584,11 @@ int JackAudioDriver::init( unsigned bufferSize )
 		return -1;
 	}
 
-	jackServerSampleRate = jack_get_sample_rate( m_pClient );
-	jackServerBufferSize = jack_get_buffer_size( m_pClient );
+	JackAudioDriver::jackServerSampleRate = jack_get_sample_rate( m_pClient );
+	JackAudioDriver::jackServerBufferSize = jack_get_buffer_size( m_pClient );
 
-	pPreferences->m_nSampleRate = jackServerSampleRate;
-	pPreferences->m_nBufferSize = jackServerBufferSize;
+	pPreferences->m_nSampleRate = JackAudioDriver::jackServerSampleRate;
+	pPreferences->m_nBufferSize = JackAudioDriver::jackServerBufferSize;
 
 	/* tell the JACK server to call `process()' whenever
 	   there is work to be done.
@@ -739,7 +665,7 @@ void JackAudioDriver::makeTrackOutputs( Song* pSong )
 
 	InstrumentList* pInstrumentList = pSong->get_instrument_list();
 	Instrument* pInstrument;
-	int nInstruments = ( int ) pInstrumentList->size();
+	int nInstruments = static_cast<int>(pInstrumentList->size());
 
 	WARNINGLOG( QString( "Creating / renaming %1 ports" ).arg( nInstruments ) );
 
@@ -859,7 +785,7 @@ void JackAudioDriver::locate( unsigned long frame )
 			jack_transport_locate( m_pClient, frame );
 		}
 	} else {
-		m_transport.m_nFrames = (long long)frame;
+		m_transport.m_nFrames = static_cast<long long>(frame);
 	}
 }
 
@@ -896,9 +822,9 @@ void JackAudioDriver::jack_session_callback_impl(jack_session_event_t* event)
 	Preferences* pPreferences = Preferences::get_instance();
 	EventQueue* pEventQueue = EventQueue::get_instance();
 
-	jack_session_event_t* ev = (jack_session_event_t *) event;
+	jack_session_event_t* ev = static_cast<jack_session_event_t*>(event);
 
-	QString sJackSessionDirectory = (QString) ev->session_dir;
+	QString sJackSessionDirectory = static_cast<QString>(ev->session_dir);
 	QString sRetval = pPreferences->getJackSessionApplicationPath() + 
 		" --jacksessionid " + ev->client_uuid;
 
@@ -1101,31 +1027,31 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		return;
 	}
 
-	pJackPosition->ticks_per_beat = (double)ticksPerBar / 4;
+	pJackPosition->ticks_per_beat = static_cast<double>(ticksPerBar) / 4;
 	pJackPosition->valid = JackPositionBBT;
 	// Time signature "numerator"
 	pJackPosition->beats_per_bar = 
-		((float)ticksPerBar /  (float)pSong->__resolution);
+		(static_cast<float>(ticksPerBar) /  static_cast<float>(pSong->__resolution));
 	// Time signature "denominator"
 	pJackPosition->beat_type = 4.0;
 	
 	if ( pDriver->m_transport.m_nFrames + pDriver->m_frameOffset != pJackPosition->frame ) {
 		// In case of a relocation, wait two full cycles till the new
 		// tempo will be broadcast.
-		nWaits = 2;
+		JackAudioDriver::nWaits = 2;
 	}
 
-	if ( nWaits == 0 ) {
+	if ( JackAudioDriver::nWaits == 0 ) {
 		// Average tempo in BPM for the block corresponding to
 		// pJackPosition. In Hydrogen is guaranteed to be constant within
 		// a block.
 		pJackPosition->beats_per_minute = 
-			(double)pHydrogen->getTimelineBpm( nNextPatternInternal );
+			static_cast<double>(pHydrogen->getTimelineBpm( nNextPatternInternal ));
 	} else {
-		pJackPosition->beats_per_minute = (double)pDriver->m_transport.m_fBPM;
+		pJackPosition->beats_per_minute = static_cast<double>(pDriver->m_transport.m_fBPM);
 	}
 		
-	nWaits = std::max( int(0), nWaits - 1);
+	JackAudioDriver::nWaits = max( int(0), JackAudioDriver::nWaits - 1);
 
 	if ( pDriver->m_transport.m_nFrames < 1 ) {
 		pJackPosition->bar = 0;
@@ -1137,7 +1063,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		pJackPosition->bar = nNextPattern + 1;
 		
 		/* how many ticks elapsed from last bar ( where bar == pattern ) */
-		int32_t nTicksFromBar = ( nextTick % (int32_t) ticksPerBar );
+		int32_t nTicksFromBar = ( nextTick % static_cast<int32_t>(ticksPerBar) );
 
 		// Number of ticks that have elapsed between frame 0 and the
 		// first beat of the next measure.
@@ -1148,7 +1074,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		pJackPosition->beat++;
 
 		// Counting ticks starts at 0.
-		pJackPosition->tick = nTicksFromBar % (int32_t) pJackPosition->ticks_per_beat;
+		pJackPosition->tick = nTicksFromBar % static_cast<int32_t>(pJackPosition->ticks_per_beat);
 				
 	}
     

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -184,6 +184,11 @@ JackAudioDriver::JackAudioDriver( JackProcessCallback m_processCallback )
 	// per-track audio output ports.
 	__track_out_enabled = pPreferences->m_bJackTrackOuts;
 
+	m_transport.m_status = TransportInfo::STOPPED;
+	m_transport.m_nFrames = 0;
+	m_transport.m_fTickSize = 100;
+	m_transport.m_fBPM = 120;
+
 	pJackDriverInstance = this;
 	this->m_processCallback = m_processCallback;
 
@@ -202,6 +207,8 @@ JackAudioDriver::JackAudioDriver( JackProcessCallback m_processCallback )
 	
 	memset( m_pTrackOutputPortsL, 0, sizeof(m_pTrackOutputPortsL) );
 	memset( m_pTrackOutputPortsR, 0, sizeof(m_pTrackOutputPortsR) );
+
+	m_JackTransportState  = JackTransportStopped;
 }
 
 JackAudioDriver::~JackAudioDriver()
@@ -349,7 +356,6 @@ void JackAudioDriver::calculateFrameOffset(long long oldFrame)
 
 void JackAudioDriver::updateTransportInfo()
 {
-	
 	if ( Preferences::get_instance()->m_bJackTransportMode !=
 	     Preferences::USE_JACK_TRANSPORT ){
 		return;
@@ -360,7 +366,7 @@ void JackAudioDriver::updateTransportInfo()
 	// process thread, the second argument, which is a pointer to
 	// a structure for returning current transport, corresponds to
 	// the first frame of the current cycle and the state returned
-	// is valid for the entire cycle. #m_JackTransportPos->valid
+	// is valid for the entire cycle. #m_JackTransportPos.valid
 	// will show which fields contain valid data. If
 	// #m_JackTransportPos is NULL, do not return position
 	// information.
@@ -1011,6 +1017,7 @@ void JackAudioDriver::initTimebaseMaster()
 void JackAudioDriver::releaseTimebaseMaster()
 {
 	if ( m_pClient == nullptr ) {
+		ERRORLOG( QString( "Not fully initialized yet" ) );
 		return;
 	}
 

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -27,6 +27,7 @@
 #include <unistd.h>
 #include <cstdlib>
 #include <cassert>
+#include <algorithm>
 #include <hydrogen/hydrogen.h>
 #include <hydrogen/audio_engine.h>
 #include <hydrogen/basics/drumkit_component.h>
@@ -1051,7 +1052,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 		pJackPosition->beats_per_minute = static_cast<double>(pDriver->m_transport.m_fBPM);
 	}
 		
-	JackAudioDriver::nWaits = max( int(0), JackAudioDriver::nWaits - 1);
+	JackAudioDriver::nWaits = std::max( int(0), JackAudioDriver::nWaits - 1);
 
 	if ( pDriver->m_transport.m_nFrames < 1 ) {
 		pJackPosition->bar = 0;

--- a/src/core/src/IO/jack_audio_driver.cpp
+++ b/src/core/src/IO/jack_audio_driver.cpp
@@ -85,8 +85,7 @@ JackAudioDriver* JackAudioDriver::pJackDriverInstance = nullptr;
 int JackAudioDriver::nWaits = 0;
 
 JackAudioDriver::JackAudioDriver( JackProcessCallback m_processCallback )
-	: AudioOutput( __class_name ),
-	  m_bUsePerTrackOutputs( Preferences::get_instance()->m_bJackTrackOuts )
+	: AudioOutput( __class_name )
 {
 	INFOLOG( "INIT" );
 	
@@ -256,7 +255,8 @@ unsigned JackAudioDriver::getSampleRate()
 
 void JackAudioDriver::clearPerTrackAudioBuffers( uint32_t nFrames )
 {
-	if ( m_pClient != nullptr && m_bUsePerTrackOutputs ) {
+	if ( m_pClient != nullptr &&
+		 Preferences::get_instance()->m_bJackTrackOuts ) {
 		float* pBuffer;
 		
 		for ( int ii = 0; ii < m_nTrackPortCount; ++ii ) {

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -504,7 +504,7 @@ bool CoreActionController::isSongPathValid( const QString& songPath ) {
 bool CoreActionController::activateTimeline( bool bActivate ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	if ( pHydrogen->haveJackTimebaseClient() ) {
+	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		ERRORLOG( "Timeline usage is disabled in the presence of an external JACK timebase master." );
 		return false;
 	}

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -1224,24 +1224,7 @@ inline void audioEngine_process_clearAudioBuffers( uint32_t nFrames )
 	}
 
 #ifdef H2CORE_HAVE_JACK
-	JackAudioDriver * jo = dynamic_cast<JackAudioDriver*>(m_pAudioDriver);
-	// Check whether the Preferences::m_bJackTrackOuts option was
-	// set. It enables a per-track creation of the output
-	// ports. All of them have to be reset as well.
-	if( jo && jo->has_track_outs() ) {
-		float* buf;
-		int k;
-		for( k=0 ; k<jo->getNumTracks() ; ++k ) {
-			buf = jo->getTrackOut_L(k);
-			if( buf ) {
-				memset( buf, 0, nFrames * sizeof( float ) );
-			}
-			buf = jo->getTrackOut_R(k);
-			if( buf ) {
-				memset( buf, 0, nFrames * sizeof( float ) );
-			}
-		}
-	}
+	dynamic_cast<JackAudioDriver*>(m_pAudioDriver)->clearPerTrackAudioBuffers( nFrames );
 #endif
 
 	mx.unlock();

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -3642,7 +3642,7 @@ void Hydrogen::setBPM( float fBPM )
 		return;
 	}
 
-	if ( haveJackTimebaseClient() ) {
+	if ( getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		ERRORLOG( "Unable to change tempo directly in the presence of an external JACK timebase master. Press 'J.MASTER' get tempo control." );
 		return;
 	}
@@ -4043,7 +4043,7 @@ float Hydrogen::getTimelineBpm( int nBar )
 void Hydrogen::setTimelineBpm()
 {
 	if ( ! Preferences::get_instance()->getUseTimelineBpm() ||
-		 haveJackTimebaseClient() ) {
+		 getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		return;
 	}
 
@@ -4096,16 +4096,14 @@ bool Hydrogen::haveJackTransport() const {
 #endif	
 }
 
-bool Hydrogen::haveJackTimebaseClient() const {
+JackAudioDriver::Timebase Hydrogen::getJackTimebaseState() const {
 #ifdef H2CORE_HAVE_JACK
 	if ( haveJackTransport() ) {
-		if ( static_cast<JackAudioDriver*>(m_pAudioDriver)->getIsTimebaseMaster() == 0 ) {
-			return true;
-		}
+		return static_cast<JackAudioDriver*>(m_pAudioDriver)->getTimebaseState();
 	} 
-	return false;
+	return JackAudioDriver::Timebase::None;
 #else
-	return false;
+	return JackAudioDriver::Timebase::None;
 #endif	
 }
 

--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -898,11 +898,11 @@ bool Sampler::__render_note_no_resample(
 
 
 #ifdef H2CORE_HAVE_JACK
-	auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput);
 	float *		pTrackOutL = nullptr;
 	float *		pTrackOutR = nullptr;
 
-	if ( pJackAudioDriver->getUsePerTrackOutputs() ) {
+	if ( Preferences::get_instance()->m_bJackTrackOuts ) {
+		auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput);
 		 pTrackOutL = pJackAudioDriver->getTrackOut_L( pNote->get_instrument(), pCompo );
 		 pTrackOutR = pJackAudioDriver->getTrackOut_R( pNote->get_instrument(), pCompo );
 	}
@@ -1056,11 +1056,11 @@ bool Sampler::__render_note_resample(
 
 
 #ifdef H2CORE_HAVE_JACK
-	auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput);
 	float *		pTrackOutL = nullptr;
 	float *		pTrackOutR = nullptr;
 
-	if ( pJackAudioDriver->getUsePerTrackOutputs() ) {
+	if ( Preferences::get_instance()->m_bJackTrackOuts ) {
+		auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput);
 		pTrackOutL = pJackAudioDriver->getTrackOut_L( pNote->get_instrument(), pCompo );
 		pTrackOutR = pJackAudioDriver->getTrackOut_R( pNote->get_instrument(), pCompo );
 	}

--- a/src/core/src/sampler/sampler.cpp
+++ b/src/core/src/sampler/sampler.cpp
@@ -898,14 +898,13 @@ bool Sampler::__render_note_no_resample(
 
 
 #ifdef H2CORE_HAVE_JACK
-	JackAudioDriver* pJackAudioDriver = nullptr;
+	auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput);
 	float *		pTrackOutL = nullptr;
 	float *		pTrackOutR = nullptr;
 
-	if( pAudioOutput->has_track_outs()
-	&& (pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput)) ) {
+	if ( pJackAudioDriver->getUsePerTrackOutputs() ) {
 		 pTrackOutL = pJackAudioDriver->getTrackOut_L( pNote->get_instrument(), pCompo );
-		pTrackOutR = pJackAudioDriver->getTrackOut_R( pNote->get_instrument(), pCompo );
+		 pTrackOutR = pJackAudioDriver->getTrackOut_R( pNote->get_instrument(), pCompo );
 	}
 #endif
 
@@ -1057,14 +1056,13 @@ bool Sampler::__render_note_resample(
 
 
 #ifdef H2CORE_HAVE_JACK
-	JackAudioDriver* pJackAudioDriver = nullptr;
+	auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput);
 	float *		pTrackOutL = nullptr;
 	float *		pTrackOutR = nullptr;
 
-	if( pAudioOutput->has_track_outs()
-	&& (pJackAudioDriver = dynamic_cast<JackAudioDriver*>(pAudioOutput)) ) {
-				pTrackOutL = pJackAudioDriver->getTrackOut_L( pNote->get_instrument(), pCompo );
-				pTrackOutR = pJackAudioDriver->getTrackOut_R( pNote->get_instrument(), pCompo );
+	if ( pJackAudioDriver->getUsePerTrackOutputs() ) {
+		pTrackOutL = pJackAudioDriver->getTrackOut_L( pNote->get_instrument(), pCompo );
+		pTrackOutR = pJackAudioDriver->getTrackOut_R( pNote->get_instrument(), pCompo );
 	}
 #endif
 

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -589,8 +589,6 @@ void PlayerControl::updatePlayerControl()
 
 
 #ifdef H2CORE_HAVE_JACK
-	AudioOutput *p_Driver = m_pEngine->getAudioOutput();
-
 	if ( m_pEngine->haveJackAudioDriver() ) {
 		m_pJackTransportBtn->show();
 		m_pJackMasterBtn->show();
@@ -604,7 +602,7 @@ void PlayerControl::updatePlayerControl()
 			case Preferences::USE_JACK_TRANSPORT:
 				m_pJackTransportBtn->setPressed(true);
 				
-				if ( static_cast<JackAudioDriver*>(p_Driver)->getIsTimebaseMaster() > 0 ) {
+				if ( m_pEngine->getJackTimebaseState() == JackAudioDriver::Timebase::Master ) {
 					m_pJackMasterBtn->setPressed( true );
 				} else {
 					m_pJackMasterBtn->setPressed( false );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2459,7 +2459,7 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 			pHydrogen->getCoreActionController()->relocate( column );
 			update();
 		}
-
+		
 	} else if (ev->button() == Qt::MidButton && ev->y() >= 26) {
 		int column = (ev->x() / m_nGridWidth);
 		SongEditorPanelTagWidget dialog( this , column );

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -42,6 +42,8 @@
 #include <hydrogen/audio_engine.h>
 #include <hydrogen/basics/instrument_component.h>
 #include <hydrogen/basics/pattern_list.h>
+#include <hydrogen/IO/jack_audio_driver.h>
+
 #ifdef WIN32
 #include <time.h>
 #endif
@@ -83,7 +85,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	connect( m_pTimeLineToggleBtn, SIGNAL( clicked( Button* ) ), this, SLOT( timeLineBtnPressed(Button* ) ) );
 	
 	if ( pPref->getUseTimelineBpm() &&
-		 !pEngine->haveJackTimebaseClient() ) {
+		 pEngine->getJackTimebaseState() != JackAudioDriver::Timebase::Slave ) {
 		m_pTimeLineToggleBtn->setPressed( true );
 		m_pTimeLineToggleBtn->setToolTip( trUtf8( "Enable time line edit") );
 
@@ -723,7 +725,7 @@ void SongEditorPanel::updateTimelineUsage() {
 
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	if ( pHydrogen->haveJackTimebaseClient() ) {
+	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		m_pTimeLineToggleBtn->setToolTip( trUtf8( "Timeline usage is disabled in the presence of an external JACK timebase master") );
 		m_pTimeLineToggleBtn->setPressed( false );
 		m_pTimeLineToggleBtn->setDisabled( true );
@@ -744,7 +746,7 @@ void SongEditorPanel::timeLineBtnPressed( Button* pBtn )
 	
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	if ( pHydrogen->haveJackTimebaseClient() ) {
+	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		m_pTimeLineToggleBtn->setToolTip( trUtf8( "Timeline usage is disabled in the presence of an external JACK timebase master") );
 		return;
 	} else {


### PR DESCRIPTION
Some minor code cleanups regarding the Jack audio driver which were on my todo list.

- the `has_tracks_out` method and the corresponding private member was removed from the AudioOutput class and inserted into just the JackAudioDriver. All other children did not use it anyway and it does only make sense in the context of Jack.
- using explicit static_casts in JackAudioDriver
- make all Jack callback functions and the corresponding variables static members of the JackAudioDriver class in order to not litter the global namespace.
- move clearing of the per track audio output ports into the JackAudioDriver class to make the audio engine routines more concise and focused.
- previously this option has been stored in a variable inherited by the AudioOutput and written once the class instance was created. But the `makeTrackOutput` function did use the underlying option in the Preferences all along. This could potentially lead to errors in the clean up of the audio engine buffers and in the sampling. Thus, this inconsistency has been removed in favor for the Preferences variable.
- convert Jack timebase state to enum
- initialize more data members