### PR TITLE
Further OSC commands

### DIFF
--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -189,6 +189,19 @@ class CoreActionController : public H2Core::Object {
 		 * @return bool true on success
 		 */
 		bool activateSongMode( bool bActivate, bool bTriggerEvent );
+	     /**
+		 * Toggle loop mode of playback.
+		 *
+		 * @param bActivate If true - activates loop mode.
+		 * @param bTriggerEvent Setting this variable to true is
+		 * intended for its use as a batch function from within
+		 * Hydrogen's core, which will inform the GUI via an Event
+		 * about the change of mode. When used from the GUI itself,
+		 * this parameter has to be set to false.
+		 *
+		 * @return bool true on success
+		 */
+		bool activateLoopMode( bool bActivate, bool bTriggerEvent );
 		
 		// -----------------------------------------------------------
 		// Helper functions

--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -174,6 +174,21 @@ class CoreActionController : public H2Core::Object {
 		 * @return bool true on success
 		 */
 		bool activateJackTimebaseMaster( bool bActivate );
+
+		/**
+		 * Switches between Song and Pattern mode of playback.
+		 *
+		 * @param bActivate If true - activates Song mode or if false -
+		 * activates Pattern mode.
+		 * @param bTriggerEvent Setting this variable to true is
+		 * intended for its use as a batch function from within
+		 * Hydrogen's core, which will inform the GUI via an Event
+		 * about the change of mode. When used from the GUI itself,
+		 * this parameter has to be set to false.
+		 *
+		 * @return bool true on success
+		 */
+		bool activateSongMode( bool bActivate, bool bTriggerEvent );
 		
 		// -----------------------------------------------------------
 		// Helper functions

--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -202,6 +202,15 @@ class CoreActionController : public H2Core::Object {
 		 * @return bool true on success
 		 */
 		bool activateLoopMode( bool bActivate, bool bTriggerEvent );
+		/** Relocates transport to the beginning of a particular
+		 * Pattern.
+		 * 
+		 * @param nPatternGroup Position of the Song provided as the
+		 * index of a particular pattern group (starting at zero).
+		 *
+		 * @return bool true on success
+		 */
+		bool relocate( int nPatternGroup );
 		
 		// -----------------------------------------------------------
 		// Helper functions

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -135,7 +135,9 @@ enum EventType {
 	/** Toggles the button indicating the usage Jack timebase master.*/
 	EVENT_JACK_TIMEBASE_ACTIVATION,
 	/** Activates either Pattern mode (0) or Song mode (else) of the playback.*/
-	EVENT_SONG_MODE_ACTIVATION
+	EVENT_SONG_MODE_ACTIVATION,
+	/** Toggles the button indicating the usage loop mode.*/
+	EVENT_LOOP_MODE_ACTIVATION
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/event_queue.h
+++ b/src/core/include/hydrogen/event_queue.h
@@ -133,7 +133,9 @@ enum EventType {
 	/** Toggles the button indicating the usage Jack transport.*/
 	EVENT_JACK_TRANSPORT_ACTIVATION,
 	/** Toggles the button indicating the usage Jack timebase master.*/
-	EVENT_JACK_TIMEBASE_ACTIVATION
+	EVENT_JACK_TIMEBASE_ACTIVATION,
+	/** Activates either Pattern mode (0) or Song mode (else) of the playback.*/
+	EVENT_SONG_MODE_ACTIVATION
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -459,7 +459,6 @@ void			previewSample( Sample *pSample );
 #endif
 
 #if defined(H2CORE_HAVE_OSC) || _DOXYGEN_
-	void			startOscServer();
 	void			startNsmClient();
 #endif
 

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -675,6 +675,16 @@ class OscServer : public H2Core::Object
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::activateSongMode().
+		 *
+		 * \param argv The "i" field does contain the value supplied
+		 * by the user. If it is 0, Pattern mode of the playback will
+		 * be activated. Else, Song mode will be activated instead.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
+		static void SONG_MODE_ACTIVATION_Handler(lo_arg **argv, int argc);
+	
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -693,7 +693,15 @@ class OscServer : public H2Core::Object
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc);
-	
+		/**
+		 * Triggers CoreActionController::relocateToPattern().
+		 *
+		 * \param argv The "i" field does contain the desired
+		 * position / number of the pattern group (starting with
+		 * 0).
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
+		static void RELOCATE_Handler(lo_arg **argv, int argc);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -684,6 +684,15 @@ class OscServer : public H2Core::Object
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void SONG_MODE_ACTIVATION_Handler(lo_arg **argv, int argc);
+	/**
+		 * Triggers CoreActionController::activateLoopMode().
+		 *
+		 * \param argv The "i" field does contain the value supplied
+		 * by the user. If it is 0, loop mode will
+		 * be deactivated. Else, it will be activated instead.
+		 * \param argc Unused number of arguments passed by the OSC
+		 * message.*/
+		static void LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc);
 	
 		/** 
 		 * Catches any incoming messages and display them. 

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -586,4 +586,22 @@ bool CoreActionController::activateJackTimebaseMaster( bool bActivate ) {
 	return false;
 #endif
 }
+
+bool CoreActionController::activateSongMode( bool bActivate, bool bTriggerEvent ) {
+
+	auto pHydrogen = Hydrogen::get_instance();
+	pHydrogen->sequencer_stop();
+	if ( bActivate ) {
+		pHydrogen->setPatternPos( 0 );
+		pHydrogen->getSong()->set_mode( Song::SONG_MODE );
+	} else {
+		pHydrogen->getSong()->set_mode( Song::PATTERN_MODE );
+	}
+	
+	if ( bTriggerEvent ) {
+		EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION, static_cast<int>( bActivate ) );
+	}
+	
+	return true;
+}
 }

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -604,4 +604,17 @@ bool CoreActionController::activateSongMode( bool bActivate, bool bTriggerEvent 
 	
 	return true;
 }
+
+bool CoreActionController::activateLoopMode( bool bActivate, bool bTriggerEvent ) {
+
+	auto pSong = Hydrogen::get_instance()->getSong();
+	pSong->set_loop_enabled( bActivate );
+	pSong->set_is_modified( true );
+	
+	if ( bTriggerEvent ) {
+		EventQueue::get_instance()->push_event( EVENT_LOOP_MODE_ACTIVATION, static_cast<int>( bActivate ) );
+	}
+	
+	return true;
+}
 }

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -33,6 +33,7 @@
 
 #include <hydrogen/IO/AlsaMidiDriver.h>
 #include <hydrogen/IO/MidiOutput.h>
+#include <hydrogen/IO/jack_audio_driver.h>
 
 namespace H2Core
 {
@@ -615,6 +616,25 @@ bool CoreActionController::activateLoopMode( bool bActivate, bool bTriggerEvent 
 		EventQueue::get_instance()->push_event( EVENT_LOOP_MODE_ACTIVATION, static_cast<int>( bActivate ) );
 	}
 	
+	return true;
+}
+
+bool CoreActionController::relocate( int nPatternGroup ) {
+
+	auto pHydrogen = Hydrogen::get_instance();
+	pHydrogen->setPatternPos( nPatternGroup );
+	pHydrogen->setTimelineBpm();
+	
+#ifdef H2CORE_HAVE_JACK
+	auto pDriver = pHydrogen->getAudioOutput();
+
+	if ( pHydrogen->haveJackTransport() &&
+		 pDriver->m_transport.m_status != TransportInfo::ROLLING ) {
+	long totalTick = pHydrogen->getTickForPosition( nPatternGroup );
+	static_cast<JackAudioDriver*>(pDriver)->m_currentPos = 
+		totalTick * pDriver->m_transport.m_fTickSize;
+	}
+#endif
 	return true;
 }
 }

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -4103,14 +4103,6 @@ bool Hydrogen::haveJackTimebaseClient() const {
 }
 
 #ifdef H2CORE_HAVE_OSC
-void startOscServer()
-{
-	OscServer* pOscServer = OscServer::get_instance();
-	
-	if( pOscServer ){
-		pOscServer->start();
-	}
-}
 
 void Hydrogen::startNsmClient()
 {

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -153,8 +153,6 @@ int OscServer::generic_handler(const char *	path,
 							   void *		data,
 							   void *		user_data)
 {
-	INFOLOG("GENERIC HANDLER");
-
 	//First we're trying to map TouchOSC messages from multi-fader widgets
 	QString oscPath( path );
 	QRegExp rxStripVol( "/Hydrogen/STRIP_VOLUME_ABSOLUTE/(\\d+)" );
@@ -852,7 +850,6 @@ bool OscServer::start()
 
 	//This handler is responsible for registering clients
 	m_pServerThread->add_method(nullptr, nullptr, [&](lo_message msg){
-									INFOLOG("OSC REGISTER HANDLER");
 									lo_address a = lo_message_get_source(msg);
 
 									bool AddressRegistered = false;
@@ -865,7 +862,6 @@ bool OscServer::start()
 									}
 
 									if( !AddressRegistered ){
-										INFOLOG("REGISTERING CLIENT");
 										lo_address newAddr = lo_address_new_with_proto(	lo_address_get_protocol( a ),
 																						lo_address_get_hostname( a ),
 																						lo_address_get_port( a ) );

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -687,6 +687,16 @@ void OscServer::SONG_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 	}
 }
 
+void OscServer::LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	if ( argv[0]->i != 0 ) {
+		pController->activateLoopMode( true, true );
+	} else {
+		pController->activateLoopMode( false, true );
+	}
+}
+
 // -------------------------------------------------------------------
 // Helper functions
 
@@ -967,6 +977,7 @@ bool OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/JACK_TRANSPORT_ACTIVATION", "i", JACK_TRANSPORT_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/JACK_TIMEBASE_MASTER_ACTIVATION", "i", JACK_TIMEBASE_MASTER_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/SONG_MODE_ACTIVATION", "i", SONG_MODE_ACTIVATION_Handler);
+	m_pServerThread->add_method("/Hydrogen/LOOP_MODE_ACTIVATION", "i", LOOP_MODE_ACTIVATION_Handler);
 	/*
 	 * Start the server.
 	 */

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -677,6 +677,16 @@ void OscServer::JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc)
 	}
 }
 
+void OscServer::SONG_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	if ( argv[0]->i != 0 ) {
+		pController->activateSongMode( true, true );
+	} else {
+		pController->activateSongMode( false, true );
+	}
+}
+
 // -------------------------------------------------------------------
 // Helper functions
 
@@ -956,6 +966,7 @@ bool OscServer::start()
 
 	m_pServerThread->add_method("/Hydrogen/JACK_TRANSPORT_ACTIVATION", "i", JACK_TRANSPORT_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/JACK_TIMEBASE_MASTER_ACTIVATION", "i", JACK_TIMEBASE_MASTER_ACTIVATION_Handler);
+	m_pServerThread->add_method("/Hydrogen/SONG_MODE_ACTIVATION", "i", SONG_MODE_ACTIVATION_Handler);
 	/*
 	 * Start the server.
 	 */

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -695,6 +695,11 @@ void OscServer::LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 	}
 }
 
+void OscServer::RELOCATE_Handler(lo_arg **argv, int argc) {
+
+	H2Core::Hydrogen::get_instance()->getCoreActionController()->relocate( argv[0]->i );
+}
+
 // -------------------------------------------------------------------
 // Helper functions
 
@@ -974,6 +979,7 @@ bool OscServer::start()
 	m_pServerThread->add_method("/Hydrogen/JACK_TIMEBASE_MASTER_ACTIVATION", "i", JACK_TIMEBASE_MASTER_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/SONG_MODE_ACTIVATION", "i", SONG_MODE_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/LOOP_MODE_ACTIVATION", "i", LOOP_MODE_ACTIVATION_Handler);
+	m_pServerThread->add_method("/Hydrogen/RELOCATE", "i", RELOCATE_Handler);
 	/*
 	 * Start the server.
 	 */

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -50,6 +50,7 @@ class EventListener
 		virtual void timelineUpdateEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void jackTransportActivationEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void jackTimebaseActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void songModeActivationEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -51,6 +51,7 @@ class EventListener
 		virtual void jackTransportActivationEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void jackTimebaseActivationEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void songModeActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void loopModeActivationEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -597,6 +597,10 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->songModeActivationEvent( event.value );
 				break;
 				
+			case EVENT_LOOP_MODE_ACTIVATION:
+				pListener->loopModeActivationEvent( event.value );
+				break;
+				
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -593,6 +593,10 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->jackTimebaseActivationEvent( event.value );
 				break;
 				
+			case EVENT_SONG_MODE_ACTIVATION:
+				pListener->songModeActivationEvent( event.value );
+				break;
+				
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1264,8 +1264,8 @@ void MainForm::onPlayStopAccelEvent()
 
 void MainForm::onRestartAccelEvent()
 {
-	Hydrogen* pEngine = Hydrogen::get_instance();
-	pEngine->setPatternPos( 0 );
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getCoreActionController()->relocate( 0 );
 }
 
 
@@ -1584,7 +1584,7 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 		// qDebug( "Got key press for instrument '%c'", k->ascii() );
 		//int songnumber = 0;
 		HydrogenApp* app = HydrogenApp::get_instance();
-		Hydrogen* engine = Hydrogen::get_instance();
+		Hydrogen* pHydrogen = Hydrogen::get_instance();
 		switch (k->key()) {
 		case Qt::Key_Space:
 			onPlayStopAccelEvent();
@@ -1592,7 +1592,7 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 
 
 		case Qt::Key_Comma:
-			engine->handleBeatCounter();
+			pHydrogen->handleBeatCounter();
 			return true; // eat even
 			break;
 
@@ -1612,7 +1612,7 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 			break;
 
 		case Qt::Key_Backslash:
-			engine->onTapTempoAccelEvent();
+			pHydrogen->onTapTempoAccelEvent();
 			return true; // eat event
 			break;
 
@@ -1636,23 +1636,23 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 			break;
 
 		case  Qt::Key_F12 : //panic button stop all playing notes
-			engine->__panic();
+			pHydrogen->__panic();
 			//QMessageBox::information( this, "Hydrogen", tr( "Panic" ) );
 			return true;
 			break;
 
 		case  Qt::Key_F9 : // Qt::Key_Left do not work. Some ideas ?
-			engine->setPatternPos( Hydrogen::get_instance()->getPatternPos() - 1 );
+			pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() - 1 );
 			return true;
 			break;
 
 		case  Qt::Key_F10 : // Qt::Key_Right do not work. Some ideas ?
-			engine->setPatternPos( Hydrogen::get_instance()->getPatternPos() + 1 );
+			pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() + 1 );
 			return true;
 			break;
 
 		case Qt::Key_L :
-			engine->togglePlaysSelected();
+			pHydrogen->togglePlaysSelected();
 			QString msg = Preferences::get_instance()->patternModePlaysSelected() ? "Single pattern mode" : "Stacked pattern mode";
 			app->setStatusBarMessage( msg, 5000 );
 			app->getSongEditorPanel()->setModeActionBtn( Preferences::get_instance()->patternModePlaysSelected() );
@@ -1673,7 +1673,7 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 			float pan_L = 0.5f;
 			float pan_R = 0.5f;
 
-			engine->addRealtimeNote (row, velocity, pan_L, pan_R, 0, false, false , row + 36);
+			pHydrogen->addRealtimeNote (row, velocity, pan_L, pan_R, 0, false, false , row + 36);
 
 			return true; // eat event
 		}

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -742,15 +742,10 @@ void PlayerControl::songModeBtnClicked(Button* ref)
 {
 	UNUSED( ref );
 
-	m_pEngine->sequencer_stop();
-	m_pEngine->setPatternPos( 0 );	// from start
-	m_pEngine->getSong()->set_mode( Song::SONG_MODE );
-	m_pSongModeBtn->setPressed(true);
-	m_pLiveModeBtn->setPressed(false);
-	(HydrogenApp::get_instance())->setStatusBarMessage(tr("Song mode selected."), 5000);
+	Hydrogen::get_instance()->getCoreActionController()->activateSongMode( true, false );
+
+	songModeActivationEvent( 1 );
 }
-
-
 
 
 ///Set Live mode
@@ -758,14 +753,23 @@ void PlayerControl::liveModeBtnClicked(Button* ref)
 {
 	UNUSED( ref );
 
-	m_pEngine->sequencer_stop();
-	m_pEngine->getSong()->set_mode( Song::PATTERN_MODE );
-	m_pSongModeBtn->setPressed(false);
-	m_pLiveModeBtn->setPressed(true);
-	(HydrogenApp::get_instance())->setStatusBarMessage(tr("Pattern mode selected."), 5000);
+	Hydrogen::get_instance()->getCoreActionController()->activateSongMode( false, false );
+
+	songModeActivationEvent( 0 );
 }
 
-
+void PlayerControl::songModeActivationEvent( int nValue )
+{
+	if ( nValue != 0 ) {
+		m_pSongModeBtn->setPressed(true);
+		m_pLiveModeBtn->setPressed(false);
+		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Song mode selected."), 5000);
+	} else {
+		m_pSongModeBtn->setPressed(false);
+		m_pLiveModeBtn->setPressed(true);
+		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Pattern mode selected."), 5000);
+	}
+}
 
 void PlayerControl::bpmChanged() {
 	float fNewBpmValue = m_pLCDBPMSpinbox->getValue();

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -727,11 +727,12 @@ void PlayerControl::playBtnClicked(Button* ref) {
 void PlayerControl::stopBtnClicked(Button* ref)
 {
 	UNUSED( ref );
+
+	auto pHydrogen = Hydrogen::get_instance();
 	m_pPlayBtn->setPressed(false);
-	m_pEngine->sequencer_stop();
-	m_pEngine->setPatternPos( 0 );
+	pHydrogen->sequencer_stop();
+	pHydrogen->getCoreActionController()->relocate( 0 );
 	(HydrogenApp::get_instance())->setStatusBarMessage(tr("Stopped."), 5000);
-	Hydrogen::get_instance()->setTimelineBpm();
 }
 
 
@@ -993,9 +994,9 @@ void PlayerControl::bpmButtonClicked( Button* pBtn )
 void PlayerControl::FFWDBtnClicked( Button* )
 {
 	WARNINGLOG( "relocate via button press" );
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->setPatternPos( pEngine->getPatternPos() + 1 );
-	Hydrogen::get_instance()->setTimelineBpm();
+
+	auto pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() + 1 );
 }
 
 
@@ -1003,9 +1004,9 @@ void PlayerControl::FFWDBtnClicked( Button* )
 void PlayerControl::RewindBtnClicked( Button* )
 {
 	WARNINGLOG( "relocate via button press" );
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->setPatternPos( pEngine->getPatternPos() - 1 );
-	Hydrogen::get_instance()->setTimelineBpm();
+	
+	auto pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() - 1 );
 }
 
 

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -1009,18 +1009,26 @@ void PlayerControl::RewindBtnClicked( Button* )
 }
 
 
-void PlayerControl::songLoopBtnClicked( Button* )
+void PlayerControl::songLoopBtnClicked( Button* pButton )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	Song *song = pEngine->getSong();
-	song->set_loop_enabled( ! song->is_loop_enabled() );
-	song->set_is_modified( true );
+	Hydrogen::get_instance()->getCoreActionController()->activateLoopMode( pButton->isPressed(), false );
 
-	if ( song->is_loop_enabled() ) {
-		HydrogenApp::get_instance()->setStatusBarMessage(tr("Loop song = On"), 5000);
+	if ( pButton->isPressed() ){
+		loopModeActivationEvent( 1 );
+	} else {
+		loopModeActivationEvent( 0 );
+	}
+}
+
+void PlayerControl::loopModeActivationEvent( int nValue ) {
+
+	if ( nValue == 0 ) {
+		m_pSongLoopBtn->setPressed( false );
+		HydrogenApp::get_instance()->setStatusBarMessage(tr("Loop song = Off"), 5000);
 	}
 	else {
-		HydrogenApp::get_instance()->setStatusBarMessage(tr("Loop song = Off"), 5000);
+		m_pSongLoopBtn->setPressed( true );
+		HydrogenApp::get_instance()->setStatusBarMessage(tr("Loop song = On"), 5000);
 	}
 }
 

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -142,6 +142,13 @@ class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 		 * Song mode will be activated instead.
 		 */
 		void songModeActivationEvent( int nValue );
+		/**
+		 * Shared GUI update when activating loop mode via button
+		 * click or via OSC command.
+		 *
+		 * @param nValue If 0, loop mode will be deactivate.
+		 */
+		void loopModeActivationEvent( int nValue );
 		H2Core::Hydrogen *m_pEngine;
 		QPixmap m_background;
 

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -134,6 +134,14 @@ class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 		void rubberbandButtonToggle(Button* ref);
 
 	private:
+		/**
+		 * Shared GUI update when activating Song or Pattern mode via
+		 * button click or via OSC command.
+		 *
+		 * @param nValue If 0, Pattern mode will be activate. Else,
+		 * Song mode will be activated instead.
+		 */
+		void songModeActivationEvent( int nValue );
 		H2Core::Hydrogen *m_pEngine;
 		QPixmap m_background;
 

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -783,21 +783,21 @@ void PlaylistDialog::nodeStopBTN( Button* ref )
 	UNUSED( ref );
 	m_pPlayBtn->setPressed(false);
 	Hydrogen::get_instance()->sequencer_stop();
-	Hydrogen::get_instance()->setPatternPos ( 0 );
+	Hydrogen::get_instance()->getCoreActionController()->relocate( 0 );
 }
 
 void PlaylistDialog::ffWDBtnClicked( Button* ref)
 {
 	UNUSED( ref );
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->setPatternPos( pEngine->getPatternPos() + 1 );
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() + 1 );
 }
 
 void PlaylistDialog::rewindBtnClicked( Button* ref )
 {
 	UNUSED( ref );
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->setPatternPos( pEngine->getPatternPos() - 1 );
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() - 1 );
 }
 
 void PlaylistDialog::on_m_pPlaylistTree_itemDoubleClicked ()

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -35,7 +35,6 @@
 #include <hydrogen/basics/instrument.h>
 #include <hydrogen/LocalFileMng.h>
 #include <hydrogen/timeline.h>
-#include <hydrogen/IO/jack_audio_driver.h>
 using namespace H2Core;
 
 #include "UndoActions.h"
@@ -2454,32 +2453,14 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 		if ( pHydrogen->getSong()->get_mode() == Song::PATTERN_MODE ) {
 			return;
 		}
-		AudioOutput* pDriver = pHydrogen->getAudioOutput();
 
 		int nPatternPos = pHydrogen->getPatternPos();
 		if ( nPatternPos != column ) {
 			WARNINGLOG( "relocate via mouse click" );
-			pHydrogen->setPatternPos( column );
+			
+			pHydrogen->getCoreActionController()->relocate( column );
 			update();
-
-#ifdef H2CORE_HAVE_JACK
-			if ( pHydrogen->haveJackTransport() ) {
-				long totalTick = pHydrogen->getTickForPosition( column );
-				static_cast<JackAudioDriver*>(pDriver)->m_currentPos = 
-					totalTick * pDriver->m_transport.m_fTickSize;
-			}
-#endif
 		}
-
-		//time line test
-	
-#ifdef H2CORE_HAVE_JACK
-		if ( !pHydrogen->haveJackTimebaseClient() ) {
-			pHydrogen->setTimelineBpm();
-		}
-#else
-		pHydrogen->setTimelineBpm();
-#endif
 
 	} else if (ev->button() == Qt::MidButton && ev->y() >= 26) {
 		int column = (ev->x() / m_nGridWidth);


### PR DESCRIPTION
I introduced some more OSC commands which will be handy for some debugging I do plan during the next week.

- (De)activating loop mode
- Switching between Song and Pattern mode
- Relocating to a particular pattern group

I made sure to move all the engine-related code into the CoreActionController. E.g. there were numerous occasions of the GUI relocating the transport position without taking care of adjusting the tempo according to the timeline. Since the actions of the GUI do happen not at a fixed position in the process cycle of the audio engine, this could very well produce some minor (probably inaudible) glitches with the tempo getting only adjusted in the next process cycle.