### PR TITLE
fix #959 involuntary change of instrumments

### DIFF
--- a/src/core/include/hydrogen/core_action_controller.h
+++ b/src/core/include/hydrogen/core_action_controller.h
@@ -36,8 +36,20 @@ class CoreActionController : public H2Core::Object {
 		~CoreActionController();
 	
 		void setMasterVolume( float masterVolumeValue );
-		void setStripVolume( int nStrip, float masterVolumeValue );
-		void setStripPan( int nStrip, float panValue );
+		/**
+		 * \param nStrip Instrument which to set the volume for.
+		 * \param fVolumeValue New volume.
+		 * \param bSelectedStrip Whether the corresponding instrument
+		 * should be selected.
+		 */
+		void setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip );
+		/**
+		 * \param nStrip Instrument which to set the volume for.
+		 * \param fPanValue New pan.
+		 * \param bSelectedStrip Whether the corresponding instrument
+		 * should be selected.
+		 */
+		void setStripPan( int nStrip, float fPanValue, bool bSelectStrip );
 		void setMetronomeIsActive( bool isActive );
 		void setMasterIsMuted( bool isMuted );
 		void setStripIsMuted( int nStrip, bool isMuted );

--- a/src/core/include/hydrogen/midi_action.h
+++ b/src/core/include/hydrogen/midi_action.h
@@ -42,15 +42,15 @@ class Action : public H2Core::Object {
 			parameter2 = text;
 		}
 
-		QString getParameter1(){
+		QString getParameter1() const {
 			return parameter1;
 		}
 
-		QString getParameter2(){
+		QString getParameter2() const {
 			return parameter2;
 		}
 
-		QString getType(){
+		QString getType() const {
 			return type;
 		}
 

--- a/src/core/include/hydrogen/midi_map.h
+++ b/src/core/include/hydrogen/midi_map.h
@@ -76,8 +76,8 @@ class MidiMap : public H2Core::Object
 		Action* getCCAction( int parameter );
 		Action* getPCAction();
 		
-		int findCCValueByActionParam1( QString actionType, QString param1 );
-		int findCCValueByActionType( QString actionType );
+		int findCCValueByActionParam1( QString actionType, QString param1 ) const;
+		int findCCValueByActionType( QString actionType ) const;
 
 		void setupNoteArray();
 	private:

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -53,8 +53,8 @@ CoreActionController::~CoreActionController() {
 
 void CoreActionController::setMasterVolume( float masterVolumeValue )
 {
-	Hydrogen* pEngine = Hydrogen::get_instance();
-	pEngine->getSong()->set_volume( masterVolumeValue );
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getSong()->set_volume( masterVolumeValue );
 	
 #ifdef H2CORE_HAVE_OSC
 	Action FeedbackAction( "MASTER_VOLUME_ABSOLUTE" );
@@ -69,22 +69,25 @@ void CoreActionController::setMasterVolume( float masterVolumeValue )
 	handleOutgoingControlChange( ccParamValue, (masterVolumeValue / 1.5) * 127 );
 }
 
-void CoreActionController::setStripVolume( int nStrip, float masterVolumeValue )
+void CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->setSelectedInstrumentNumber( nStrip );
-	
-	Song *pSong = pEngine->getSong();
-	InstrumentList *instrList = pSong->get_instrument_list();
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
 
-	Instrument *pInstr = instrList->get( nStrip );
-	pInstr->set_volume( masterVolumeValue );
+	if ( bSelectStrip ) {
+		pHydrogen->setSelectedInstrumentNumber( nStrip );
+	}
+	
+	Song *pSong = pHydrogen->getSong();
+	InstrumentList *pInstrList = pSong->get_instrument_list();
+
+	Instrument *pInstr = pInstrList->get( nStrip );
+	pInstr->set_volume( fVolumeValue );
 	
 #ifdef H2CORE_HAVE_OSC
 	Action FeedbackAction( "STRIP_VOLUME_ABSOLUTE" );
 	
 	FeedbackAction.setParameter1( QString("%1").arg( nStrip + 1 ) );
-	FeedbackAction.setParameter2( QString("%1").arg( masterVolumeValue ) );
+	FeedbackAction.setParameter2( QString("%1").arg( fVolumeValue ) );
 	OscServer::handleAction( &FeedbackAction );
 #endif
 
@@ -93,7 +96,7 @@ void CoreActionController::setStripVolume( int nStrip, float masterVolumeValue )
 	int ccParamValue = pMidiMap->findCCValueByActionParam1( QString("STRIP_VOLUME_ABSOLUTE"), QString("%1").arg( nStrip ) );
 	
 
-	handleOutgoingControlChange( ccParamValue, (masterVolumeValue / 1.5) * 127 );
+	handleOutgoingControlChange( ccParamValue, (fVolumeValue / 1.5) * 127 );
 
 }
 
@@ -117,8 +120,8 @@ void CoreActionController::setMetronomeIsActive( bool isActive )
 
 void CoreActionController::setMasterIsMuted( bool isMuted )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->getSong()->__is_muted = isMuted;
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	pHydrogen->getSong()->__is_muted = isMuted;
 	
 #ifdef H2CORE_HAVE_OSC
 	Action FeedbackAction( "MUTE_TOGGLE" );
@@ -136,8 +139,8 @@ void CoreActionController::setMasterIsMuted( bool isMuted )
 
 void CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	Song *pSong = pEngine->getSong();
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	Song *pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->get_instrument_list();
 
 	Instrument *pInstr = pInstrList->get( nStrip );
@@ -160,8 +163,8 @@ void CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
 
 void CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	Song *pSong = pEngine->getSong();
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	Song *pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->get_instrument_list();
 	
 	if ( isSoloed ) {
@@ -193,37 +196,37 @@ void CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
 
 
 
-void CoreActionController::setStripPan( int nStrip, float panValue )
+void CoreActionController::setStripPan( int nStrip, float fPanValue, bool bSelectStrip )
 {
-	float	pan_L;
-	float	pan_R;
+	float	fPan_L;
+	float	fPan_R;
 
-	if (panValue >= 0.5) {
-		pan_L = (1.0 - panValue) * 2;
-		pan_R = 1.0;
+	if ( fPanValue >= 0.5 ) {
+		fPan_L = (1.0 - fPanValue) * 2;
+		fPan_R = 1.0;
 	}
 	else {
-		pan_L = 1.0;
-		pan_R = panValue * 2;
+		fPan_L = 1.0;
+		fPan_R = fPanValue * 2;
 	}
 
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->setSelectedInstrumentNumber( nStrip );
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	if ( bSelectStrip ) {
+		pHydrogen->setSelectedInstrumentNumber( nStrip );
+	}
 	
-	Song *pSong = pEngine->getSong();
+	Song *pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->get_instrument_list();
 
 	Instrument *pInstr = pInstrList->get( nStrip );
-	pInstr->set_pan_l( pan_L );
-	pInstr->set_pan_r( pan_R );
-
-	pEngine->setSelectedInstrumentNumber( nStrip );
+	pInstr->set_pan_l( fPan_L );
+	pInstr->set_pan_r( fPan_R );
 	
 #ifdef H2CORE_HAVE_OSC
 	Action FeedbackAction( "PAN_ABSOLUTE" );
 	
 	FeedbackAction.setParameter1( QString("%1").arg( nStrip + 1 ) );
-	FeedbackAction.setParameter2( QString("%1").arg( panValue ) );
+	FeedbackAction.setParameter2( QString("%1").arg( fPanValue ) );
 	OscServer::handleAction( &FeedbackAction );
 #endif
 	
@@ -232,14 +235,14 @@ void CoreActionController::setStripPan( int nStrip, float panValue )
 	int ccParamValue = pMidiMap->findCCValueByActionParam1( QString("PAN_ABSOLUTE"), QString("%1").arg( nStrip ) );
 	
 
-	handleOutgoingControlChange( ccParamValue, panValue * 127 );
+	handleOutgoingControlChange( ccParamValue, fPanValue * 127 );
 }
 
 void CoreActionController::handleOutgoingControlChange(int param, int value)
 {
 	Preferences *pPref = Preferences::get_instance();
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	MidiOutput *pMidiDriver = pEngine->getMidiOutput();
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	MidiOutput *pMidiDriver = pHydrogen->getMidiOutput();
 	
 	if(	pMidiDriver 
 		&& pPref->m_bEnableMidiFeedback 
@@ -255,8 +258,8 @@ void CoreActionController::initExternalControlInterfaces()
 	 */
 	
 	//MASTER_VOLUME_ABSOLUTE
-	Hydrogen* pEngine = Hydrogen::get_instance();
-	Song *pSong = pEngine->getSong();
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Song *pSong = pHydrogen->getSong();
 	setMasterVolume( pSong->get_volume() );
 	
 	//PER-INSTRUMENT/STRIP STATES
@@ -265,7 +268,7 @@ void CoreActionController::initExternalControlInterfaces()
 		
 			//STRIP_VOLUME_ABSOLUTE
 			Instrument *pInstr = pInstrList->get( i );
-			setStripVolume( i, pInstr->get_volume() );
+			setStripVolume( i, pInstr->get_volume(), false );
 			
 			float fPan_L = pInstr->get_pan_l();
 			float fPan_R = pInstr->get_pan_r();
@@ -279,7 +282,7 @@ void CoreActionController::initExternalControlInterfaces()
 				fPanValue = fPan_R / 2.0;
 			}
 		
-			setStripPan( i, fPanValue );
+			setStripPan( i, fPanValue, false );
 			
 			//STRIP_MUTE_TOGGLE
 			setStripIsMuted( i, pInstr->is_muted() );

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -226,9 +226,15 @@ int				m_nSongPos; // TODO: rename it to something more
  */
 int				m_nSelectedPatternNumber;
 /**
+ * Instrument currently focused/selected in the GUI. 
  *
+ * Within the core it is relevant for the MIDI input. Using
+ * Preferences::__playselectedinstrument incoming MIDI signals can be
+ * used to play back only the selected instrument or the whole
+ * drumkit.
  *
- * Initialized to 0 in audioEngine_init().
+ * Queried using Hydrogen::getSelectedInstrumentNumber() and set by
+ * Hydrogen::setSelectedInstrumentNumber().
  */
 int				m_nSelectedInstrumentNumber;
 /**
@@ -3703,7 +3709,9 @@ int Hydrogen::getSelectedInstrumentNumber()
 
 void Hydrogen::setSelectedInstrumentNumber( int nInstrument )
 {
-	if ( m_nSelectedInstrumentNumber == nInstrument )	return;
+	if ( m_nSelectedInstrumentNumber == nInstrument ) {
+		return;
+	}
 
 	m_nSelectedInstrumentNumber = nInstrument;
 	EventQueue::get_instance()->push_event( EVENT_SELECTED_INSTRUMENT_CHANGED, -1 );

--- a/src/core/src/midi_map.cpp
+++ b/src/core/src/midi_map.cpp
@@ -163,7 +163,7 @@ void MidiMap::registerCCEvent( int parameter , Action * pAction ){
 	}
 }
 
-int MidiMap::findCCValueByActionParam1( QString actionType, QString param1 )
+int MidiMap::findCCValueByActionParam1 ( QString actionType, QString param1 ) const
 {
 	int nParam = -1;
 
@@ -180,7 +180,7 @@ int MidiMap::findCCValueByActionParam1( QString actionType, QString param1 )
 	return nParam;
 }
 
-int MidiMap::findCCValueByActionType( QString actionType )
+int MidiMap::findCCValueByActionType( QString actionType ) const
 {
 	int nParam = -1;
 

--- a/src/core/src/osc_server.cpp
+++ b/src/core/src/osc_server.cpp
@@ -173,7 +173,7 @@ int OscServer::generic_handler(const char *	path,
 			H2Core::Hydrogen *pEngine = H2Core::Hydrogen::get_instance();
 			H2Core::CoreActionController* pController = pEngine->getCoreActionController();
 		
-			pController->setStripPan( value, argv[0]->f );
+			pController->setStripPan( value, argv[0]->f, false );
 		}
 	}
 	
@@ -453,7 +453,7 @@ void OscServer::STRIP_VOLUME_ABSOLUTE_Handler(int param1, float param2)
 	H2Core::Hydrogen *pEngine = H2Core::Hydrogen::get_instance();
 	H2Core::CoreActionController* pController = pEngine->getCoreActionController();
 
-	pController->setStripVolume( param1, param2 );
+	pController->setStripVolume( param1, param2, false );
 }
 
 void OscServer::STRIP_VOLUME_RELATIVE_Handler(lo_arg **argv,int i)

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -403,7 +403,7 @@ void Mixer::volumeChanged(MixerLine* ref)
 	CoreActionController* pController = pEngine->getCoreActionController();
 
 	int nLine = findMixerLineByRef(ref);
-	pController->setStripVolume( nLine, ref->getVolume() );
+	pController->setStripVolume( nLine, ref->getVolume(), true );
 }
 
 void Mixer::masterVolumeChanged(MasterMixerLine* ref)
@@ -762,7 +762,7 @@ void Mixer::panChanged(MixerLine* ref) {
 	Hydrogen *pEngine = Hydrogen::get_instance();
 	CoreActionController* pController = pEngine->getCoreActionController();
 
-	pController->setStripPan( nLine, panValue );
+	pController->setStripPan( nLine, panValue, true );
 }
 
 


### PR DESCRIPTION
the methods `CoreActionController::setStripVolume` and `CoreActionController::setStripPan` do now only select the corresponding strip if explizitly indicated using another input argument.

This way the calls from OSC commands do not trigger the selection of another instrument while calls from the Mixer will do so.