### PR TITLE
Fix memory mgmt. problems in instrument_component / instrument_layer

### DIFF
--- a/src/core/src/basics/instrument_component.cpp
+++ b/src/core/src/basics/instrument_component.cpp
@@ -63,7 +63,7 @@ InstrumentComponent::InstrumentComponent( InstrumentComponent* other )
 	for ( int i = 0; i < m_nMaxLayers; i++ ) {
 		InstrumentLayer* other_layer = other->get_layer( i );
 		if ( other_layer ) {
-			__layers[i] = new InstrumentLayer( other_layer, other_layer->get_sample());
+			__layers[i] = new InstrumentLayer( other_layer );
 		} else {
 			__layers[i] = nullptr;
 		}

--- a/src/core/src/basics/instrument_layer.cpp
+++ b/src/core/src/basics/instrument_layer.cpp
@@ -53,7 +53,7 @@ InstrumentLayer::InstrumentLayer( InstrumentLayer* other, Sample* sample ) : Obj
 	__end_velocity( other->get_end_velocity() ),
 	__pitch( other->get_pitch() ),
 	__gain( other->get_gain() ),
-	__sample( new Sample( sample ) )
+	__sample( sample )
 {
 }
 


### PR DESCRIPTION
Fix for #958: 

instrument_component: Use regular copy constructor to copy instrument layer. Otherwise, the sample is not copyied.

instrument_layer.cpp: fix memory leak in copy constructor