### PR TITLE
fix #960 responsible OSC settings

### DIFF
--- a/src/core/include/hydrogen/hydrogen.h
+++ b/src/core/include/hydrogen/hydrogen.h
@@ -459,6 +459,12 @@ void			previewSample( Sample *pSample );
 #endif
 
 #if defined(H2CORE_HAVE_OSC) || _DOXYGEN_
+	/** Starts/stops the OSC server
+	 * \param bEnable `true` = start, `false` = stop.*/
+	void			toggleOscServer( bool bEnable );
+	/** Destroys and recreates the OscServer singleton in order to
+		adopt a new OSC port.*/
+	void			recreateOscServer();
 	void			startNsmClient();
 #endif
 

--- a/src/core/include/hydrogen/osc_server.h
+++ b/src/core/include/hydrogen/osc_server.h
@@ -141,8 +141,7 @@ class OscServer : public H2Core::Object
 		static QString qPrettyPrint(lo_type type,void * data);
 		
 		/**
-		 * Registers all handler functions defined for this class
-		 * starts the OscServer.
+		 * Registers all handler functions.
 		 *
 		 * The path the handlers will be registered at always starts
 		 * with \e /Hydrogen/ followed by the name of the handler
@@ -186,13 +185,20 @@ class OscServer : public H2Core::Object
 		 * clients. This will happen each time the state of Hydrogen
 		 * does change.
 		 *
-		 * This function will only be processed if the created server
-		 * thread #m_pServerThread is valid.
-		 *
-		 * \return `true` if #m_pServerThread could be successfully
-		 *   created..
+		 * \return `true` on success.
 		 */
+		bool init();
+		/** Starts the OSC server and makes it available to handle
+		 * commands.
+		 *
+		 * If the server was not properly initialized, this function
+		 * will do so.
+		 *
+		 * \return `true` on success*/
 		bool start();
+		/** Stops the OSC server and makes it unavailable.
+		 * \return `true` on success*/
+		bool stop();
 		/**
 		 * Function called by
 		 * H2Core::CoreActionController::initExternalControlInterfaces()
@@ -234,7 +240,7 @@ class OscServer : public H2Core::Object
 		 * \param pAction Action to be sent to all registered
 		 * clients. 
 		 */
-		static void handleAction(Action* pAction);
+		void handleAction(Action* pAction);
 
 		/**
 		 * Creates an Action of type @b PLAY and passes its
@@ -750,7 +756,11 @@ class OscServer : public H2Core::Object
 		 * H2Core::Preferences::get_instance(), this is an appetizer
 		 * for internal changes happening after the 1.0 release.*/
 		H2Core::Preferences*			m_pPreferences;
-		
+		/**
+		 * Used to determine whether the callback methods were already
+		 * added to #m_pServerThread.
+		 */
+		bool m_bInitialized;
 		/**
 		 * Object containing the actual thread with an OSC server
 		 * running in.
@@ -769,7 +779,7 @@ class OscServer : public H2Core::Object
 		 * will be added to it and the current state Hydrogen will be
 		 * propagated to all registered clients.
 		 */
-		static std::list<lo_address>	m_pClientRegistry;
+		std::list<lo_address>	m_pClientRegistry;
 };
 
 #endif /* H2CORE_HAVE_OSC */

--- a/src/core/src/core_action_controller.cpp
+++ b/src/core/src/core_action_controller.cpp
@@ -59,7 +59,7 @@ void CoreActionController::setMasterVolume( float masterVolumeValue )
 #ifdef H2CORE_HAVE_OSC
 	Action FeedbackAction( "MASTER_VOLUME_ABSOLUTE" );
 	FeedbackAction.setParameter2( QString("%1").arg( masterVolumeValue ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 	
 	MidiMap*	pMidiMap = MidiMap::get_instance();
@@ -88,7 +88,7 @@ void CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool 
 	
 	FeedbackAction.setParameter1( QString("%1").arg( nStrip + 1 ) );
 	FeedbackAction.setParameter2( QString("%1").arg( fVolumeValue ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 
 	MidiMap*	pMidiMap = MidiMap::get_instance();
@@ -108,7 +108,7 @@ void CoreActionController::setMetronomeIsActive( bool isActive )
 	Action FeedbackAction( "TOGGLE_METRONOME" );
 	
 	FeedbackAction.setParameter1( QString("%1").arg( (int) isActive ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 	
 	MidiMap*	pMidiMap = MidiMap::get_instance();
@@ -127,7 +127,7 @@ void CoreActionController::setMasterIsMuted( bool isMuted )
 	Action FeedbackAction( "MUTE_TOGGLE" );
 	
 	FeedbackAction.setParameter1( QString("%1").arg( (int) isMuted ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 
 	MidiMap*	pMidiMap = MidiMap::get_instance();
@@ -151,7 +151,7 @@ void CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
 	
 	FeedbackAction.setParameter1( QString("%1").arg( nStrip + 1 ) );
 	FeedbackAction.setParameter2( QString("%1").arg( (int) isMuted ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 
 	MidiMap*	pMidiMap = MidiMap::get_instance();
@@ -184,7 +184,7 @@ void CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
 	
 	FeedbackAction.setParameter1( QString("%1").arg( nStrip + 1 ) );
 	FeedbackAction.setParameter2( QString("%1").arg( (int) isSoloed ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 	
 	MidiMap*	pMidiMap = MidiMap::get_instance();
@@ -227,7 +227,7 @@ void CoreActionController::setStripPan( int nStrip, float fPanValue, bool bSelec
 	
 	FeedbackAction.setParameter1( QString("%1").arg( nStrip + 1 ) );
 	FeedbackAction.setParameter2( QString("%1").arg( fPanValue ) );
-	OscServer::handleAction( &FeedbackAction );
+	OscServer::get_instance()->handleAction( &FeedbackAction );
 #endif
 	
 	MidiMap*	pMidiMap = MidiMap::get_instance();

--- a/src/core/src/hydrogen.cpp
+++ b/src/core/src/hydrogen.cpp
@@ -2396,8 +2396,7 @@ Hydrogen::Hydrogen()
 #ifdef H2CORE_HAVE_OSC
 	if( Preferences::get_instance()->getOscServerEnabled() )
 	{
-		OscServer* pOscServer = OscServer::get_instance();
-		pOscServer->start();
+		toggleOscServer( true );
 	}
 #endif
 }
@@ -4111,6 +4110,27 @@ bool Hydrogen::haveJackTimebaseClient() const {
 }
 
 #ifdef H2CORE_HAVE_OSC
+
+void Hydrogen::toggleOscServer( bool bEnable ) {
+	if ( bEnable ) {
+		OscServer::get_instance()->start();
+	} else {
+		OscServer::get_instance()->stop();
+	}
+}
+
+void Hydrogen::recreateOscServer() {
+	OscServer* pOscServer = OscServer::get_instance();
+	if( pOscServer ) {
+		delete pOscServer;
+	}
+
+	OscServer::create_instance( Preferences::get_instance() );
+	
+	if ( Preferences::get_instance()->getOscServerEnabled() ) {
+		toggleOscServer( true );
+	}
+}
 
 void Hydrogen::startNsmClient()
 {

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -505,9 +505,15 @@ void PreferencesDialog::on_okBtn_clicked()
 	pPref->m_nMidiChannelFilter = midiPortChannelComboBox->currentIndex() - 1;
 
 	//OSC tab
-	pPref->setOscServerEnabled( enableOscCheckbox->isChecked() );
+	if ( enableOscCheckbox->isChecked() != pPref->getOscServerEnabled() ) {
+		pPref->setOscServerEnabled( enableOscCheckbox->isChecked() );
+		H2Core::Hydrogen::get_instance()->toggleOscServer( enableOscCheckbox->isChecked() );
+	}
 	pPref->setOscFeedbackEnabled( enableOscFeedbackCheckbox->isChecked() );
-	pPref->setOscServerPort( incomingOscPortSpinBox->value() );
+	if ( incomingOscPortSpinBox->value() != pPref->getOscServerPort() ) {
+		pPref->setOscServerPort( incomingOscPortSpinBox->value() );
+		H2Core::Hydrogen::get_instance()->recreateOscServer();
+	}
 	
 	// General tab
 	pPref->setRestoreLastSongEnabled( restoreLastUsedSongCheckbox->isChecked() );


### PR DESCRIPTION
Both the enabling and the port of the OSC server can now be altered (and take effect) without restarting Hydrogen.

To do so I made the following changes:

- introduce the `Hydrogen::toggleOscServer()` and `Hydrogen::recreateOscServer()` functions to allow for the two behaviors mentioned above
- split `OscServer::start()` into `::init()` and `::start()` as well as introducing a `::stop()` function
- make both the `OscServer::handleAction()` and `OscServer::m_pClientRegistry` members of the class. They handling would become less straight forward ones it was possible to recreate the `OscServer`
- make the corresponding `PreferencesDialog` section call the functions listed in the first bullet point 