### PR TITLE
Set midiOutChannel to standard 10 by default

### DIFF
--- a/data/drumkits/GMRockKit/drumkit.xml
+++ b/data/drumkits/GMRockKit/drumkit.xml
@@ -36,7 +36,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>36</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -105,7 +105,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>37</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -174,7 +174,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>38</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -243,7 +243,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>39</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -284,7 +284,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>40</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -353,7 +353,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>41</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -422,7 +422,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>42</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -491,7 +491,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>43</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -560,7 +560,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>44</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -629,7 +629,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>45</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -698,7 +698,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>46</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -767,7 +767,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>56</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -836,7 +836,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>51</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -905,7 +905,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>49</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -974,7 +974,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>59</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -1043,7 +1043,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>57</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -1112,7 +1112,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>82</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
@@ -1181,7 +1181,7 @@ p, li { white-space: pre-wrap; }
    <Sustain>1</Sustain>
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
+   <midiOutChannel>10</midiOutChannel>
    <midiOutNote>81</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>


### PR DESCRIPTION
Setting to 10 by default allow MIDI TX to work by default.
(It would be nice if there was a global parameter instead of having to fix each instrument in each DrumKit.)