### PR TITLE
allow read-only access of songs

### DIFF
--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -388,19 +388,13 @@ bool CoreActionController::openSong( const QString& sSongPath ) {
 		return false;
 	}
 	
-	QFileInfo songFileInfo = QFileInfo( sSongPath );
-	if ( !songFileInfo.exists() ) {
-		ERRORLOG( QString( "Selected song [%1] does not exist." )
-				 .arg( sSongPath ) );
-		return false;
-	}
-	
 	// Create an empty Song.
 	auto pSong = Song::load( sSongPath );
 
 	if ( pSong == nullptr ) {
 		ERRORLOG( QString( "Unable to open song [%1]." )
 				  .arg( sSongPath ) );
+		return false;
 	}
 	
 	return setSong( pSong );
@@ -566,10 +560,15 @@ bool CoreActionController::isSongPathValid( const QString& sSongPath ) {
 	}
 	
 	if ( songFileInfo.exists() ) {
-		if ( !songFileInfo.isWritable() ) {
-			ERRORLOG( QString( "Error: Unable to handle path [%1]. You must have permissions to write the file!" )
+		if ( !songFileInfo.isReadable() ) {
+			ERRORLOG( QString( "Error: Unable to handle path [%1]. You must have permissions to read the file!" )
 						.arg( sSongPath.toLocal8Bit().data() ));
 			return false;
+		}
+		if ( !songFileInfo.isWritable() ) {
+			WARNINGLOG( QString( "You don't have permissions to write to the Song found in path [%1]. It will be opened as read-only (no autosave)." )
+						.arg( sSongPath.toLocal8Bit().data() ));
+			EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 3 );
 		}
 	}
 	

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -132,6 +132,7 @@ enum EventType {
 	 *       drivers will be restarted via Hydrogen::restartDrivers()
 	 * - 2 - triggered whenever the Song was saved via the core part
 	 *       (updated the title and status bar).
+	 * - 3 - Song is not writable (inform the user via a QMessageBox)
 	 */
 	EVENT_UPDATE_SONG,
 	/**

--- a/src/core/LocalFileMgr.cpp
+++ b/src/core/LocalFileMgr.cpp
@@ -330,12 +330,23 @@ SongWriter::~SongWriter()
 // Returns 0 on success, passes the TinyXml error code otherwise.
 int SongWriter::writeSong( Song * pSong, const QString& filename )
 {
+	QFileInfo fi( filename );
+	if ( Filesystem::file_exists( filename, true ) && ! Filesystem::file_writable( filename, true ) ||
+		 ! Filesystem::file_exists( filename, true ) && ! Filesystem::dir_writable( fi.dir().absolutePath(), true ) ) {
+		// In case a read-only file is loaded by Hydrogen. Beware:
+		// .isWritable() will return false if the song does not exist.
+		ERRORLOG( QString( "Unable to save song to %1. Path is not writable!" )
+				  .arg( filename ) );
+		return 1;
+	}
+	
 	INFOLOG( "Saving song " + filename );
 	int rv = 0; // return value
 
-	// FIXME: has the file write-permssion?
+	// ???
 	// FIXME: verificare che il file non sia gia' esistente
 	// FIXME: effettuare copia di backup per il file gia' esistente
+	// ???
 
 
 	QDomDocument doc;

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -833,8 +833,14 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		updateWindowTitle();
 		EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
 		
-	}
+	} else if ( nValue == 3 ) {
 
+		// The event was triggered before the Song was fully loaded by
+		// the core. It's most likely to be present by now, but it's
+		// probably better to avoid displaying its path just to be
+		// sure.
+		QMessageBox::information( m_pMainForm, "Hydrogen", tr("Song is read-only.\nUse 'Save as' to enable autosave." ) );
+	}
 }
 
 void HydrogenApp::quitEvent( int nValue ) {

--- a/src/tests/CoreActionControllerTest.cpp
+++ b/src/tests/CoreActionControllerTest.cpp
@@ -1,4 +1,5 @@
 #include "CoreActionControllerTest.h"
+#include <core/Helpers/Filesystem.h>
 
 #include <stdio.h>
 
@@ -8,6 +9,9 @@ void CoreActionControllerTest::setUp() {
 	
 	m_pHydrogen = Hydrogen::get_instance();
 	m_pController = m_pHydrogen->getCoreActionController();
+	m_sFileName = Filesystem::tmp_dir().append( "test1.h2song" );
+	m_sFileName2 = Filesystem::tmp_dir().append( "test2.h2song" );
+	m_sFileNameImproper = Filesystem::tmp_dir().append( "test3.h2song" );
 	
 	m_pHydrogen->setSong( Song::get_empty_song() );
 }

--- a/src/tests/FilesystemTest.cpp
+++ b/src/tests/FilesystemTest.cpp
@@ -6,9 +6,13 @@
 using namespace H2Core;
 
 void FilesystemTest::setUp() {
-#if !defined(Q_OS_MACX) || !defined(WIN32) 
+#if !defined(WIN32) 
 	m_sNotExistingPath = QDir::homePath().append( "aFunnyNameYouWouldNotExpectInYourHomeFolder.h2song" );
+#ifdef Q_OS_MACX
+	m_sNoAccessPath = "/etc/master.passwd";
+#else
 	m_sNoAccessPath = "/etc/shadow";
+#endif
 	m_sReadOnlyPath = "/etc/profile";
 	m_sFullAccessPath = Filesystem::usr_data_path().append( "test.h2song"  );
 	m_sTmpPath = Filesystem::tmp_file_path( "test.h2song" );
@@ -16,13 +20,13 @@ void FilesystemTest::setUp() {
 }
 
 void FilesystemTest::tearDown() {
-#if !defined(Q_OS_MACX) || !defined(WIN32) 
+#ifndef WIN32
 	CPPUNIT_ASSERT( Filesystem::rm( m_sTmpPath, false ) );
 #endif
 }
 
 void FilesystemTest::testPermissions(){
-#if !defined(Q_OS_MACX) || !defined(WIN32) 
+#ifndef WIN32
 	CPPUNIT_ASSERT( ! Filesystem::file_exists( m_sNotExistingPath, true ) );
 	CPPUNIT_ASSERT( Filesystem::file_exists( m_sNoAccessPath, true ) );
 	CPPUNIT_ASSERT( ! Filesystem::file_readable( m_sNoAccessPath, true ) );

--- a/src/tests/FilesystemTest.cpp
+++ b/src/tests/FilesystemTest.cpp
@@ -1,0 +1,37 @@
+#include "FilesystemTest.h"
+#include <core/Preferences.h>
+
+#include <QTest>
+
+using namespace H2Core;
+
+void FilesystemTest::setUp() {
+#if !defined(Q_OS_MACX) || !defined(WIN32) 
+	m_sNotExistingPath = QDir::homePath().append( "aFunnyNameYouWouldNotExpectInYourHomeFolder.h2song" );
+	m_sNoAccessPath = "/etc/shadow";
+	m_sReadOnlyPath = "/etc/profile";
+	m_sFullAccessPath = Filesystem::usr_data_path().append( "test.h2song"  );
+	m_sTmpPath = Filesystem::tmp_file_path( "test.h2song" );
+#endif
+}
+
+void FilesystemTest::tearDown() {
+#if !defined(Q_OS_MACX) || !defined(WIN32) 
+	CPPUNIT_ASSERT( Filesystem::rm( m_sTmpPath, false ) );
+#endif
+}
+
+void FilesystemTest::testPermissions(){
+#if !defined(Q_OS_MACX) || !defined(WIN32) 
+	CPPUNIT_ASSERT( ! Filesystem::file_exists( m_sNotExistingPath, true ) );
+	CPPUNIT_ASSERT( Filesystem::file_exists( m_sNoAccessPath, true ) );
+	CPPUNIT_ASSERT( ! Filesystem::file_readable( m_sNoAccessPath, true ) );
+	CPPUNIT_ASSERT( Filesystem::file_readable( m_sReadOnlyPath, true ) );
+	CPPUNIT_ASSERT( ! Filesystem::file_writable( m_sReadOnlyPath, true ) );
+	CPPUNIT_ASSERT( Filesystem::file_writable( m_sFullAccessPath, true ) );
+
+	CPPUNIT_ASSERT( Filesystem::file_exists( m_sTmpPath, true ) );
+	CPPUNIT_ASSERT( Filesystem::file_readable( m_sTmpPath, true ) );
+	CPPUNIT_ASSERT( Filesystem::file_writable( m_sTmpPath, true ) );
+#endif
+}

--- a/src/tests/FilesystemTest.h
+++ b/src/tests/FilesystemTest.h
@@ -1,0 +1,26 @@
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <core/Helpers/Filesystem.h>
+
+class FilesystemTest : public CppUnit::TestFixture {
+	CPPUNIT_TEST_SUITE( FilesystemTest );
+	CPPUNIT_TEST( testPermissions );
+	CPPUNIT_TEST_SUITE_END();
+	
+	
+public:
+	void setUp();
+	void tearDown();
+	
+	void testPermissions();
+
+private:
+	QString m_sNotExistingPath;
+	QString m_sNoAccessPath;
+	QString m_sReadOnlyPath;
+	QString m_sFullAccessPath;
+	// To ensure Qt does handle the temporary files consistently.
+	QString m_sTmpPath;
+	QString m_sDemoSongSysPath;
+};
+CPPUNIT_TEST_SUITE_REGISTRATION( FilesystemTest );


### PR DESCRIPTION
Fixes #996 

Allows for accessing read-only songs (was broken with the introduction of a uniform loading function) and displays a warning informing the user to run "Save as" in order to enable the autosave again.