### PR TITLE
Fix #1001 upgrade drumkit

### DIFF
--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -203,6 +203,7 @@ Drumkit* Drumkit::load_from( XMLNode* node, const QString& dk_path )
 		pDrumkit->set_instruments( InstrumentList::load_from( &instruments_node, dk_path, drumkit_name ) );
 	}
 	return pDrumkit;
+
 }
 
 void Drumkit::load_samples()
@@ -216,9 +217,17 @@ void Drumkit::load_samples()
 
 void Drumkit::upgrade_drumkit(Drumkit* pDrumkit, const QString& dk_path)
 {
-	if(pDrumkit != nullptr)
-	{
-		WARNINGLOG( QString( "upgrade drumkit %1" ).arg( dk_path ) );
+	if( pDrumkit != nullptr ) {
+		if ( ! Filesystem::file_exists( dk_path, true ) ) {
+			ERRORLOG( QString( "No drumkit found at path %1" ).arg( dk_path ) );
+			return;
+		}
+		QFileInfo fi( dk_path );
+		if ( ! Filesystem::dir_writable( fi.dir().absolutePath(), true ) ) {
+			ERRORLOG( QString( "Drumkit %1 is out of date but can not be upgraded since path is not writable (please copy it to your user's home instead)" ).arg( dk_path ) );
+			return;
+		}
+		WARNINGLOG( QString( "Upgrading drumkit %1" ).arg( dk_path ) );
 		
 		Filesystem::file_copy( dk_path,
 		                       dk_path + ".bak",

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -228,9 +228,30 @@ void Drumkit::upgrade_drumkit(Drumkit* pDrumkit, const QString& dk_path)
 			return;
 		}
 		WARNINGLOG( QString( "Upgrading drumkit %1" ).arg( dk_path ) );
-		
-		Filesystem::file_copy( dk_path,
-		                       dk_path + ".bak",
+
+		QString sBackupPath = dk_path + ".bak";
+		if ( Filesystem::file_exists( sBackupPath, true ) ) {
+			int nnSuffix = 1;
+
+			while ( true ) {
+				if ( ! Filesystem::file_exists( QString( "%1.%2" ).
+												arg( sBackupPath ).
+												arg( nnSuffix ), true ) ) {
+					sBackupPath = QString( "%1.%2" ).arg( sBackupPath ).arg( nnSuffix );
+					break;
+				} else {
+					++nnSuffix;
+				}
+
+				if ( nnSuffix > 100 ) {
+					ERRORLOG( QString( "More than 100 backups written for a single drumkit [%1]? This sounds like a bug. Please report this issue." )
+							  .arg( dk_path ) );
+					return;
+				}
+			}
+		}
+			
+		Filesystem::file_copy( dk_path, sBackupPath,
 		                       false /* do not overwrite existing files */ );
 		
 		pDrumkit->save_file( dk_path, true, -1 );

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -360,6 +360,7 @@ void Instrument::save_to( XMLNode* node, int component_id )
 	InstrumentNode.write_string( "name", __name );
 	InstrumentNode.write_float( "volume", __volume );
 	InstrumentNode.write_bool( "isMuted", __muted );
+	InstrumentNode.write_bool( "isSoloed", __soloed );
 	InstrumentNode.write_float( "pan_L", __pan_l );
 	InstrumentNode.write_float( "pan_R", __pan_r );
 	InstrumentNode.write_float( "randomPitchFactor", __random_pitch_factor );
@@ -376,7 +377,6 @@ void Instrument::save_to( XMLNode* node, int component_id )
 	InstrumentNode.write_int( "midiOutChannel", __midi_out_channel );
 	InstrumentNode.write_int( "midiOutNote", __midi_out_note );
 	InstrumentNode.write_bool( "isStopNote", __stop_notes );
-	InstrumentNode.write_bool( "isSoloed", __soloed );
 
 	switch ( __sample_selection_alg ) {
 	case VELOCITY:

--- a/src/tests/TestHelper.h
+++ b/src/tests/TestHelper.h
@@ -13,6 +13,7 @@ class TestHelper {
 		TestHelper();
 	
 		QString getDataDir() const;
+		QString getTestDataDir() const;
 		QString getTestFile(const QString& file);
 	
 		static void			createInstance();
@@ -27,6 +28,11 @@ inline TestHelper*	TestHelper::get_instance()
 inline QString TestHelper::getDataDir() const 
 { 
 	return m_sDataDir; 
+}
+
+inline QString TestHelper::getTestDataDir() const 
+{ 
+	return m_sTestDataDir;
 }
 
 inline QString TestHelper::getTestFile(const QString& file)

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -64,6 +64,9 @@ void XmlTest::testDrumkit()
 	CPPUNIT_ASSERT( check_samples_data( dk0, false ) );
 	CPPUNIT_ASSERT_EQUAL( 4, dk0->get_instruments()->size() );
 	//dk0->dump();
+
+	// Check if drumkit was valid (what we assume in this test)
+	CPPUNIT_ASSERT( ! H2Core::Filesystem::file_exists( H2TEST_FILE( "/drumkits/baseKit/drumkit.xml.bak" ) ) );
 	
 	// manually load samples
 	dk0->load_samples();
@@ -144,6 +147,15 @@ void XmlTest::testDrumkit_UpgradeInvalidADSRValues()
 		delete pDrumkit;
 	}
 
+	//4. Load the drumkit again to assure updated file is valid
+	pDrumkit = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/invAdsrKit") );
+	CPPUNIT_ASSERT( pDrumkit != nullptr );
+	CPPUNIT_ASSERT( ! H2Core::Filesystem::file_exists( H2TEST_FILE( "/drumkits/invAdsrKit/drumkit.xml.bak.1") ) );
+		 
+	if ( pDrumkit ) {
+		delete pDrumkit;
+	}
+	
 	// Cleanup
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_copy( H2TEST_FILE( "/drumkits/invAdsrKit/drumkit.xml.bak" ), H2TEST_FILE( "/drumkits/invAdsrKit/drumkit.xml" ), true ) );
 	CPPUNIT_ASSERT( H2Core::Filesystem::rm( H2TEST_FILE( "/drumkits/invAdsrKit/drumkit.xml.bak"), false ) );
@@ -171,3 +183,23 @@ void XmlTest::testPattern()
 	delete dk0;
 }
 
+void XmlTest::tearDown() {
+
+	QDirIterator it( TestHelper::get_instance()->getTestDataDir(),
+					 QDirIterator::Subdirectories);
+	QStringList filters;
+	filters << "*.bak*";
+	
+	while ( it.hasNext() ) {
+		it.next();
+		const QDir testFolder( it.next() );
+		const QStringList backupFiles = testFolder.entryList( filters, QDir::NoFilter, QDir::NoSort );
+
+		for ( auto& bbackupFile : backupFiles ) {
+			
+			H2Core::Filesystem::rm( testFolder.absolutePath()
+									.append( "/" )
+									.append( bbackupFile ), false );
+		}
+	}
+}

--- a/src/tests/XmlTest.h
+++ b/src/tests/XmlTest.h
@@ -11,6 +11,8 @@ class XmlTest : public CppUnit::TestCase {
 	CPPUNIT_TEST_SUITE_END();
 
 	public:
+		// Removes all .bak backup files from the test data folder.
+		void tearDown();
 		void testDrumkit();
 		void testDrumkit_UpgradeInvalidADSRValues();
 		void testPattern();


### PR DESCRIPTION
- `Drumkit::upgrade_drumkit` does now check if the drumkit folder is writable. The output does change from 

> (W) Drumkit::upgrade_drumkit upgrade drumkit /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml
(E) Filesystem::check_permissions GMRockKit is not writable
(E) Filesystem::file_copy unable to copy /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml to /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml.bak, /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml.bak is not writable
(I) Drumkit::save_file Saving drumkit definition into /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml
(E) XMLDoc::write Unable to open /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml for writing

to 

> (E) Drumkit::upgrade_drumkit Drumkit /usr/local/share/hydrogen/data/drumkits/GMRockKit/drumkit.xml is out of date but can not be upgraded since path is not writable (please copy it to your user's home instead)

- `Drumkit::upgrade_drumkit` does now check whether there is/are already backup versions and stores the new one into .bak.1, .bak.2 and so on. Previously there was just one single backup file (the first) and all following could not be written. Since the drumkit.xml file is not big it should not harm at all to have several backups (we had in the past quite a number of complaints about drumkits getting bricked)

But this makes Hydrogen vunerable to bricked upgrades adding a backup everytime the application is started (as is happening right now). Therefore

- I added a unit test to check whether upgrading the drumkit does fix the invalid drumkit contained in the test data folder

- I also added a unit test to check whether the valid drumkit used in the unit tests is actually valid.

Both tests currently fail. Which is expected and will be fixed in another PR.
