### PR TITLE
rework JackTrackOutputMode option

### DIFF
--- a/src/core/Preferences.h
+++ b/src/core/Preferences.h
@@ -157,7 +157,6 @@ public:
 	       * #NO_JACK_TIME_MASTER.
 	       */
 	      USE_JACK_TIME_MASTER = 0,
-	      POST_FADER = 0,
 	      SET_PLAY_ON = 0,
 	      BC_ON = 0,/** 
 	       * Specifies whether or not to use JACK transport
@@ -173,7 +172,6 @@ public:
 	       * #USE_JACK_TIME_MASTER.
 	       */
 	      NO_JACK_TIME_MASTER = 1,
-	      PRE_FADER = 1,
 	      SET_PLAY_OFF = 1,
 	      BC_OFF = 1
 	};
@@ -335,6 +333,8 @@ public:
 	 * #USE_JACK_TRANSPORT and #NO_JACK_TRANSPORT.
 	 */
 	int					m_bJackTransportMode;
+	/** Toggles auto-connecting of the main stereo output ports to the
+		system's default ports when starting the JACK server.*/
 	bool				m_bJackConnectDefaults;
 	/** 
 	 * If set to _true_, JackAudioDriver::makeTrackOutputs() will
@@ -343,7 +343,20 @@ public:
 	 * output will be created.
 	 */
 	bool				m_bJackTrackOuts;
-	int					m_nJackTrackOutputMode;
+
+	/** Specifies which audio settings will be applied to the sample
+		supplied in the Jack per track output ports.*/
+	enum class JackTrackOutputMode {
+		/** Applies layer, component, and instrument gain, note and
+		instrument pan, note velocity, and main component and
+		instrument volume to the samples. */
+		postFader = 0,
+		/** Only layer gain and note velocity will be applied to the samples.*/
+		preFader = 1 };
+
+	/** Specifies which audio settings will be applied to the sample
+		supplied in the Jack per track output ports.*/
+	JackTrackOutputMode		m_JackTrackOutputMode;
 	//jack time master
 
 	/**

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -594,8 +594,7 @@ bool Sampler::renderNote( Note* pNote, unsigned nBufferSize, Song* pSong )
 		if ( isMutedForExport || pInstr->is_muted() || pSong->__is_muted || pMainCompo->is_muted() || isMutedBecauseOfSolo) {	
 			cost_L = 0.0;
 			cost_R = 0.0;
-			if ( Preferences::get_instance()->m_nJackTrackOutputMode == 0 ) {
-				// Post-Fader
+			if ( Preferences::get_instance()->m_JackTrackOutputMode == Preferences::JackTrackOutputMode::postFader ) {
 				cost_track_L = 0.0;
 				cost_track_R = 0.0;
 			}
@@ -614,9 +613,8 @@ bool Sampler::renderNote( Note* pNote, unsigned nBufferSize, Song* pSong )
 			cost_L = cost_L * pMainCompo->get_volume(); // Component volument
 
 			cost_L = cost_L * pInstr->get_volume();		// instrument volume
-			if ( Preferences::get_instance()->m_nJackTrackOutputMode == 0 ) {
-			// Post-Fader
-			cost_track_L = cost_L * 2;
+			if ( Preferences::get_instance()->m_JackTrackOutputMode == Preferences::JackTrackOutputMode::postFader ) {
+				cost_track_L = cost_L * 2;
 			}
 			cost_L = cost_L * pSong->get_volume();	// song volume
 			cost_L = cost_L * 2; // max pan is 0.5
@@ -630,16 +628,15 @@ bool Sampler::renderNote( Note* pNote, unsigned nBufferSize, Song* pSong )
 			cost_R = cost_R * pMainCompo->get_volume(); // Component volument
 
 			cost_R = cost_R * pInstr->get_volume();		// instrument volume
-			if ( Preferences::get_instance()->m_nJackTrackOutputMode == 0 ) {
-			// Post-Fader
-			cost_track_R = cost_R * 2;
+			if ( Preferences::get_instance()->m_JackTrackOutputMode == Preferences::JackTrackOutputMode::postFader ) {
+				cost_track_R = cost_R * 2;
 			}
 			cost_R = cost_R * pSong->get_volume();	// song pan
 			cost_R = cost_R * 2; // max pan is 0.5
 		}
 
 		// direct track outputs only use velocity
-		if ( Preferences::get_instance()->m_nJackTrackOutputMode == 1 ) {
+		if ( Preferences::get_instance()->m_JackTrackOutputMode == Preferences::JackTrackOutputMode::preFader ) {
 			cost_track_L = cost_track_L * pNote->get_velocity();
 			cost_track_L = cost_track_L * fLayerGain;
 			cost_track_R = cost_track_L;

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -158,7 +158,18 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	connect(trackOutsCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleTrackOutsCheckBox( bool )));
 
 	connectDefaultsCheckBox->setChecked( pPref->m_bJackConnectDefaults );
-	trackOutputComboBox->setCurrentIndex( pPref->m_nJackTrackOutputMode );
+
+	switch ( pPref->m_JackTrackOutputMode ) {
+	case Preferences::JackTrackOutputMode::postFader:
+ 		trackOutputComboBox->setCurrentIndex( 0 );
+		break;
+	case Preferences::JackTrackOutputMode::preFader:
+		trackOutputComboBox->setCurrentIndex( 1 );
+		break;
+	default:
+		ERRORLOG( QString( "Unknown Jack track output mode [%1]" )
+				  .arg( static_cast<int>( pPref->m_JackTrackOutputMode ) ) );
+	}
 
 	switch ( pPref->m_JackBBTSync ) {
 	case Preferences::JackBBTSyncMethod::constMeasure:
@@ -431,16 +442,15 @@ void PreferencesDialog::on_okBtn_clicked()
 	// JACK
 	pPref->m_bJackConnectDefaults = connectDefaultsCheckBox->isChecked();
 
-	/*
-	 * 0: Post-Fader
-	 * 1: Pre-Fader
-	 */
-
-	if (trackOutputComboBox->currentIndex() == Preferences::POST_FADER)
-	{
-		pPref->m_nJackTrackOutputMode = Preferences::POST_FADER;
-	} else {
-		pPref->m_nJackTrackOutputMode = Preferences::PRE_FADER;
+	switch ( trackOutputComboBox->currentIndex() ) {
+	case 0: 
+		pPref->m_JackTrackOutputMode = Preferences::JackTrackOutputMode::postFader;
+		break;
+	case 1:
+		pPref->m_JackTrackOutputMode = Preferences::JackTrackOutputMode::preFader;
+		break;
+	default:
+		ERRORLOG( QString( "Unexpected track output value" ) );
 	}
 
 	switch ( jackBBTSyncComboBox->currentIndex() ) {
@@ -671,14 +681,21 @@ void PreferencesDialog::updateDriverInfo()
 		sampleRateComboBox->setEnabled( false );
 		trackOutputComboBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled( false );
+		trackOutsCheckBox->setEnabled( false );
+		jackBBTSyncComboBox->setEnabled( false );
+		jackBBTSyncLbl->setEnabled( false );
 
 		if ( std::strcmp( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name(),
 						  "JackAudioDriver" ) == 0 ) {
+			trackOutputComboBox->show();
+			trackOutputLbl->show();
 			connectDefaultsCheckBox->show();
 			trackOutsCheckBox->show();
 			jackBBTSyncComboBox->show();
 			jackBBTSyncLbl->show();
 		} else {
+			trackOutputComboBox->hide();
+			trackOutputLbl->hide();
 			connectDefaultsCheckBox->hide();
 			trackOutsCheckBox->hide();
 			jackBBTSyncComboBox->hide();
@@ -694,9 +711,8 @@ void PreferencesDialog::updateDriverInfo()
 		m_pAudioDeviceTxt->setText( pPref->m_sOSSDevice );
 		bufferSizeSpinBox->setEnabled(true);
 		sampleRateComboBox->setEnabled(true);
-		trackOutputComboBox->setEnabled( false );
-		trackOutsCheckBox->setEnabled( false );
-		connectDefaultsCheckBox->setEnabled(false);
+		trackOutputComboBox->hide();
+		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
@@ -714,6 +730,8 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->setEnabled( true );
 		connectDefaultsCheckBox->setEnabled(true);
 		trackOutsCheckBox->setEnabled( true );
+		trackOutputComboBox->show();
+		trackOutputLbl->show();
 		connectDefaultsCheckBox->show();
 		trackOutsCheckBox->show();
 		jackBBTSyncComboBox->show();
@@ -728,9 +746,8 @@ void PreferencesDialog::updateDriverInfo()
 		m_pAudioDeviceTxt->setText( pPref->m_sAlsaAudioDevice );
 		bufferSizeSpinBox->setEnabled(true);
 		sampleRateComboBox->setEnabled(true);
-		trackOutputComboBox->setEnabled( false );
-		trackOutsCheckBox->setEnabled( false );
-		connectDefaultsCheckBox->setEnabled(false);
+		trackOutputComboBox->hide();
+		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
@@ -745,8 +762,8 @@ void PreferencesDialog::updateDriverInfo()
 		m_pAudioDeviceTxt->setText( "" );
 		bufferSizeSpinBox->setEnabled(true);
 		sampleRateComboBox->setEnabled(true);
-		trackOutsCheckBox->setEnabled( false );
-		connectDefaultsCheckBox->setEnabled(false);
+		trackOutsCheckBox->hide();
+		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
@@ -761,9 +778,8 @@ void PreferencesDialog::updateDriverInfo()
 		m_pAudioDeviceTxt->setText( "" );
 		bufferSizeSpinBox->setEnabled(true);
 		sampleRateComboBox->setEnabled(true);
-		trackOutputComboBox->setEnabled( false );
-		trackOutsCheckBox->setEnabled( false );
-		connectDefaultsCheckBox->setEnabled(false);
+		trackOutputComboBox->hide();
+		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
@@ -778,9 +794,8 @@ void PreferencesDialog::updateDriverInfo()
 		m_pAudioDeviceTxt->setText("");
 		bufferSizeSpinBox->setEnabled(true);
 		sampleRateComboBox->setEnabled(true);
-		trackOutputComboBox->setEnabled( false );
-		trackOutsCheckBox->setEnabled( false );
-		connectDefaultsCheckBox->setEnabled(false);
+		trackOutputComboBox->hide();
+		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -372,7 +372,7 @@
             </widget>
            </item>
            <item row="3" column="0">
-            <widget class="QLabel" name="trackOutLbl">
+            <widget class="QLabel" name="trackOutputLbl">
              <property name="minimumSize">
               <size>
                <width>0</width>
@@ -384,6 +384,45 @@
              </property>
             </widget>
            </item>
+		   <item row="4" column="0">
+			 <widget class="QLabel" name="jackBBTSyncLbl">
+			   <property name="minimumSize">
+				 <size>
+				   <width>0</width>
+				   <height>22</height>
+				 </size>
+			   </property>
+			   <property name="text">
+				 <string>BBT sync method</string>
+			   </property>
+			   <property name="toolTip">
+				 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+			   </property>
+			 </widget>
+		   </item>
+		   <item row="4" column="1">	 
+			 <widget class="QComboBox" name="jackBBTSyncComboBox">
+			   <property name="minimumSize">
+				 <size>
+				   <width>0</width>
+				   <height>22</height>
+				 </size>
+			   </property>
+			   <property name="toolTip">
+				 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+			   </property>
+			   <item>
+				 <property name="text">
+				   <string>constant measure</string>
+				 </property>
+			   </item>
+			   <item>
+				 <property name="text">
+				   <string>matching bars</string>
+				 </property>
+			   </item>
+			 </widget>
+		   </item>
           </layout>
          </item>
          <item>
@@ -411,49 +450,6 @@
              </property>
             </widget>
            </item>
-		   <item>
-			 <layout class="QGridLayout">
-			   <item row="0" column="0">
-				 <widget class="QLabel" name="jackBBTSyncLbl">
-				   <property name="minimumSize">
-					 <size>
-					   <width>0</width>
-					   <height>22</height>
-					 </size>
-				   </property>
-				   <property name="text">
-					 <string>BBT sync method</string>
-				   </property>
-				   <property name="toolTip">
-					 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
-				   </property>
-				 </widget>
-			   </item>
-			   <item row="0" column="1">	 
-				 <widget class="QComboBox" name="jackBBTSyncComboBox">
-				   <property name="minimumSize">
-					 <size>
-					   <width>0</width>
-					   <height>22</height>
-					 </size>
-				   </property>
-				   <property name="toolTip">
-					 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
-				   </property>
-				   <item>
-					 <property name="text">
-					   <string>constant measure</string>
-					 </property>
-				   </item>
-				   <item>
-					 <property name="text">
-					   <string>matching bars</string>
-					 </property>
-				   </item>
-				 </widget>
-			   </item>
-			 </layout>
-		   </item>
           </layout>
          </item>
          <item>


### PR DESCRIPTION
    making the meaning of the individual options more explicit by converting the enum into a enum class.

    the option does now only gets displayed when in case the Jack driver was selected/choosen by the Auto driver.