### PR TITLE
add denominator to pattern xsd

### DIFF
--- a/data/xsd/drumkit_pattern.xsd
+++ b/data/xsd/drumkit_pattern.xsd
@@ -54,6 +54,7 @@
 			<xsd:element name="info"		type="xsd:string"/>
 			<xsd:element name="category"	type="xsd:string"		default="unknown"/>
 			<xsd:element name="size"		type="xsd:nonNegativeInteger"/>
+			<xsd:element name="denominator"	type="xsd:nonNegativeInteger"/>
 			<xsd:element name="noteList">
 				<xsd:complexType>
 					<xsd:sequence>


### PR DESCRIPTION
#999 did not include an update of the Pattern XSD file causing the lint to consider all patterns as invalid.

One consequence was that the legacy loading code was triggered when loading a temporary pattern. Due to this the name of a copied pattern got lost during copying.