### PR TITLE
fix drumkit load under NSM + error messages

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1521,14 +1521,6 @@ void audioEngine_renameJackPorts(Song * pSong)
 	if ( ! pSong ) return;
 
 	if ( Hydrogen::get_instance()->haveJackAudioDriver() ) {
-
-		// When restarting the audio driver after loading a new song under
-		// Non session management all ports have to be registered _prior_
-		// to the activation of the client.
-		if ( Hydrogen::get_instance()->isUnderSessionManagement() ) {
-			return;
-		}
-		
 		static_cast< JackAudioDriver* >( m_pAudioDriver )->makeTrackOutputs( pSong );
 	}
 #endif
@@ -2563,7 +2555,7 @@ void Hydrogen::setSong( Song *pSong )
 
 	if ( isUnderSessionManagement() ) {
 #ifdef H2CORE_HAVE_OSC
-		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath.toLocal8Bit().data() );
+		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath.toLocal8Bit().data(), true );
 #endif
 	} else {		
 		Preferences::get_instance()->setLastSongFilename( pSong->get_filename() );
@@ -3372,7 +3364,7 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool conditional )
 	// management.
 	if ( isUnderSessionManagement() ) {
 #ifdef H2CORE_HAVE_OSC
-		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath.toLocal8Bit().data() );
+		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath.toLocal8Bit().data(), false );
 #endif
 	}
 

--- a/src/core/NsmClient.h
+++ b/src/core/NsmClient.h
@@ -142,8 +142,11 @@ class NsmClient : public H2Core::Object
 	 * the local drumkits present in the user's home.
 	 *
 	 * \param name Absolute path to the session folder.
+	 * \param bCheckLinkage Whether or not the linked drumkit should
+	 * be verified to correspond to @a name. If set to none, the
+	 * drumkit will always be relinked.
 	 */
-	static void linkDrumkit( const char* name );
+	static void linkDrumkit( const char* name, bool bCheckLinkage );
 	/** Custom function to print a colored error message.
 	 *
 	 * Since the OpenCallback() and SaveCallback() functions will be


### PR DESCRIPTION
the individual JACK ports were not properly renamed

even when explicitly loading a new drumkit an error was displayed saying the old and new drumkit did not match.