### PR TITLE
Improve handling of pattern naming/renaming

### DIFF
--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -195,21 +195,21 @@ void PatternList::virtual_pattern_del( Pattern* pattern )
 	for( int i=0; i<__patterns.size(); i++ ) __patterns[i]->virtual_patterns_del( pattern );
 }
 
-bool PatternList::check_name( QString patternName )
+bool PatternList::check_name( QString patternName, Pattern* ignore )
 {
 	if (patternName == "") {
 		return false;
 	}
 
 	for (uint i = 0; i < __patterns.size(); i++) {
-		if ( __patterns[i]->get_name() == patternName) {
+		if ( __patterns[i] != ignore && __patterns[i]->get_name() == patternName ) {
 			return false;
 		}
 	}
 	return true;
 }
 
-QString PatternList::find_unused_pattern_name( QString sourceName )
+QString PatternList::find_unused_pattern_name( QString sourceName, Pattern* ignore )
 {
 	QString unusedPatternNameCandidate;
 
@@ -233,7 +233,7 @@ QString PatternList::find_unused_pattern_name( QString sourceName )
 		unusedPatternNameCandidate = match.captured(1);
 	}
 
-	while( !check_name( unusedPatternNameCandidate + suffix ) ) {
+	while( !check_name( unusedPatternNameCandidate + suffix, ignore ) ) {
 		suffix = " #" + QString::number(i);
 		i++;
 	}

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -221,6 +221,18 @@ QString PatternList::find_unused_pattern_name( QString sourceName )
 	QString suffix = "";
 	unusedPatternNameCandidate = sourceName;
 
+	// Check if the sourceName already has a number suffix, and if so, start
+	// searching for an unused name from that number.
+	QRegularExpression numberSuffixRe("(.+) #(\\d+)$");
+	QRegularExpressionMatch match = numberSuffixRe.match(sourceName);
+	if (match.hasMatch()) {
+		QString numberSuffix = match.captured(2);
+
+		i = numberSuffix.toInt();
+		suffix = " #" + QString::number(i);
+		unusedPatternNameCandidate = match.captured(1);
+	}
+
 	while( !check_name( unusedPatternNameCandidate + suffix ) ) {
 		suffix = " #" + QString::number(i);
 		i++;

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -144,13 +144,15 @@ class AudioEngineLocking;
 		/**
 		 * check if a pattern with name patternName already exists in this list
 		 * \param patternName name of a pattern to check
+		 * \param ignore optional pattern in the list to ignore
 		 */
-		bool check_name( QString patternName );
+		bool check_name( QString patternName, Pattern* ignore = NULL );
 		/**
 		 * find unused patternName
 		 * \param sourceName base name to start with
+		 * \param ignore optional pattern in the list to ignore
 		 */
-		QString find_unused_pattern_name( QString sourceName );
+		QString find_unused_pattern_name( QString sourceName, Pattern* ignore = NULL );
 
 		/**
 		 * Get the length of the longest pattern in the list

--- a/src/gui/src/PatternPropertiesDialog.cpp
+++ b/src/gui/src/PatternPropertiesDialog.cpp
@@ -128,7 +128,9 @@ void PatternPropertiesDialog::defaultNameCheck( QString pattName, bool savepatte
 {
 	if ( savepattern && !nameCheck(pattName) )
 	{
-		defaultNameCheck( tr( "%1#2").arg(pattName), savepattern );
+		PatternList *pPatternList = Hydrogen::get_instance()->getSong()->get_pattern_list();
+		QString newPattName = pPatternList->find_unused_pattern_name(pattName);
+		patternNameTxt->setText( tr( "%1").arg(newPattName) );
 	}
 	else
 	{
@@ -139,17 +141,9 @@ void PatternPropertiesDialog::defaultNameCheck( QString pattName, bool savepatte
 
 bool PatternPropertiesDialog::nameCheck( QString pattName )
 {
-	if (pattName == "") {
-		return false;
-	}
-	PatternList *patternList = Hydrogen::get_instance()->getSong()->get_pattern_list();
+	PatternList *pPatternList = Hydrogen::get_instance()->getSong()->get_pattern_list();
 	
-	for (uint i = 0; i < patternList->size(); i++) {
-		if ( patternList->get(i)->get_name() == pattName) {
-			return false;
-		}
-	}
-	return true;
+	return pPatternList->check_name(pattName);
 }
 
 

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1507,7 +1507,7 @@ void SongEditorPatternList::inlineEditingEntered()
 	 * If it is not, use an unused patten name.
 	 */
 	
-	QString patternName = pPatternList->find_unused_pattern_name( m_pLineEdit->text() );
+	QString patternName = pPatternList->find_unused_pattern_name( m_pLineEdit->text(), m_pPatternBeingEdited );
 
 	int nSelectedPattern = pEngine->getSelectedPatternNumber();
 


### PR DESCRIPTION
I noticed a few annoying quirks with how Hydrogen avoided duplicate pattern names, so I thought I'd try my hand at fixing them.  When editing a pattern name inline in the song editor, if the user pressed Enter without changing the pattern name, it would get a `" #1"` suffix added to the end.  Repeating this would result in a second `" #1"` suffix being appended  Also, the pattern properties dialog used a different procedure for avoiding name collisions, appending `"#2"` until the name was unique.

To address these issues, this merge request:

* Enhances `PatternList::find_unused_pattern_name` to detect if a `" #[number]"` suffix has already been added to a pattern's name, and if so, increment the number instead of adding a new suffix.
* Makes the pattern properties dialog use functions from the core for detecting and avoiding pattern name collisions, instead of reimplementing that functionality in a different way in the GUI code.
* Adds an optional pattern to ignore in `PatternList::find_unused_pattern_name` and `PatternList::check_name` so that when renaming a pattern, its own previous name can be ignored.