### PR TITLE
display temporary OSC port

### DIFF
--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -260,8 +260,10 @@ OscServer::OscServer( H2Core::Preferences* pPreferences ) : Object( __class_name
 			tmpPort = m_pServerThread->port();
 			
 			ERRORLOG( QString("Could not start OSC server on port %1, using port %2 instead.").arg(port).arg(tmpPort));
+
+			m_pPreferences->m_nOscTemporaryPort = tmpPort;
 			
-			H2Core::EventQueue::get_instance()->push_event( H2Core::EVENT_ERROR, H2Core::Hydrogen::OSC_CANNOT_CONNECT_TO_PORT );		
+			H2Core::EventQueue::get_instance()->push_event( H2Core::EVENT_ERROR, H2Core::Hydrogen::OSC_CANNOT_CONNECT_TO_PORT );
 		} else {
 			INFOLOG( QString( "OSC server running on port %1" ).arg( port ) );
 		}

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -176,6 +176,7 @@ Preferences::Preferences()
 	m_bOscServerEnabled = false;
 	m_bOscFeedbackEnabled = true;
 	m_nOscServerPort = 9000;
+	m_nOscTemporaryPort = -1;
 
 	//___ General properties ___
 	m_bPatternModePlaysSelected = true;

--- a/src/core/Preferences.h
+++ b/src/core/Preferences.h
@@ -314,6 +314,14 @@ public:
 	 */
 	bool				m_bOscFeedbackEnabled;
 	/**
+	 * In case #m_nOscServerPort is already occupied by another
+	 * client, the alternative - random - port number provided by the
+	 * OSC server will be stored in this variable. If the connection
+	 * using the default port succeeded, the variable will be set to
+	 * -1.
+	 */
+	int					m_nOscTemporaryPort;
+	/**
 	 * Port number the OscServer will be started at.
 	 
 	 * Set by setOscServerPort() and queried by

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1906,7 +1906,7 @@ void MainForm::errorEvent( int nErrorCode )
 		break;
 		
 	case Hydrogen::OSC_CANNOT_CONNECT_TO_PORT:
-		msg = tr( "OSC Server: Cannot connect to given port, using temporary port instead" );
+		msg = QString( tr( "OSC Server: Cannot connect to given port, using port %1 instead" ) ).arg( Preferences::get_instance()->m_nOscTemporaryPort );
 		break;
 
 	default:

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -50,6 +50,8 @@ using namespace H2Core;
 
 const char* PreferencesDialog::__class_name = "PreferencesDialog";
 
+QString PreferencesDialog::m_sColorRed = "#ca0003";
+
 PreferencesDialog::PreferencesDialog(QWidget* parent)
  : QDialog( parent )
  , Object( __class_name )
@@ -334,7 +336,21 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	
 	incomingOscPortSpinBox->setValue( pPref->getOscServerPort() );
 	oscWidget->setEnabled( pPref->getOscServerEnabled() );
-	
+
+	if ( pPref->m_nOscTemporaryPort != -1 ) {
+		oscTemporaryPortLabel->show();
+		oscTemporaryPortLabel->setText( QString( "<b><i><font color=" )
+										.append( m_sColorRed )
+										.append( ">" )
+										.append( tr( "The select port is unavailable. This instance uses the following temporary port instead:" ) )
+										.append( "</font></i></b>" ) );
+		oscTemporaryPort->show();
+		oscTemporaryPort->setEnabled( false );
+		oscTemporaryPort->setText( QString::number( pPref->m_nOscTemporaryPort ) );
+	} else {
+		oscTemporaryPortLabel->hide();
+		oscTemporaryPort->hide();
+	}
 
 	// General tab
 	restoreLastUsedSongCheckbox->setChecked( pPref->isRestoreLastSongEnabled() );
@@ -721,7 +737,10 @@ void PreferencesDialog::updateDriverInfo()
 	else if ( driverComboBox->currentText() == "Jack" ) {	// JACK
 		info += tr("<b>Jack Audio Connection Kit Driver</b><br>Low latency audio driver");
 		if ( !bJack_support ) {
-			info += tr("<br><b><font color=\"red\">Not compiled</font></b>");
+			info += QString("<br><b><font color=")
+				.append( m_sColorRed ).append( ">")
+				.append( tr( "Not compiled" ) )
+				.append( "</font></b>" );
 		}
 		m_pAudioDeviceTxt->setEnabled(false);
 		m_pAudioDeviceTxt->setText( "" );
@@ -740,7 +759,10 @@ void PreferencesDialog::updateDriverInfo()
 	else if ( driverComboBox->currentText() == "Alsa" ) {	// ALSA
 		info += tr("<b>ALSA Driver</b><br>");
 		if ( !bAlsa_support ) {
-			info += tr("<br><b><font color=\"red\">Not compiled</font></b>");
+			info += QString("<br><b><font color=")
+				.append( m_sColorRed ).append( ">")
+				.append( tr( "Not compiled" ) )
+				.append( "</font></b>" );
 		}
 		m_pAudioDeviceTxt->setEnabled(true);
 		m_pAudioDeviceTxt->setText( pPref->m_sAlsaAudioDevice );
@@ -756,7 +778,10 @@ void PreferencesDialog::updateDriverInfo()
 	else if ( driverComboBox->currentText() == "PortAudio" ) {
 		info += tr( "<b>PortAudio Driver</b><br>" );
 		if ( !bPortAudio_support ) {
-			info += tr("<br><b><font color=\"red\">Not compiled</font></b>");
+			info += QString("<br><b><font color=")
+				.append( m_sColorRed ).append( ">")
+				.append( tr( "Not compiled" ) )
+				.append( "</font></b>" );
 		}
 		m_pAudioDeviceTxt->setEnabled(false);
 		m_pAudioDeviceTxt->setText( "" );
@@ -772,7 +797,10 @@ void PreferencesDialog::updateDriverInfo()
 	else if ( driverComboBox->currentText() == "CoreAudio" ) {
 		info += tr( "<b>CoreAudio Driver</b><br>" );
 		if ( !bCoreAudio_support ) {
-			info += tr("<br><b><font color=\"red\">Not compiled</font></b>");
+			info += QString("<br><b><font color=")
+				.append( m_sColorRed ).append( ">")
+				.append( tr( "Not compiled" ) )
+				.append( "</font></b>" );
 		}
 		m_pAudioDeviceTxt->setEnabled(false);
 		m_pAudioDeviceTxt->setText( "" );
@@ -788,7 +816,10 @@ void PreferencesDialog::updateDriverInfo()
 	else if ( driverComboBox->currentText() == "PulseAudio" ) {
 		info += tr("<b>PulseAudio Driver</b><br>");
 		if ( !bPulseAudio_support ) {
-			info += tr("<br><b><font color=\"red\">Not compiled</font></b>");
+			info += QString("<br><b><font color=")
+				.append( m_sColorRed ).append( ">")
+				.append( tr( "Not compiled" ) )
+				.append( "</font></b>" );
 		}
 		m_pAudioDeviceTxt->setEnabled(false);
 		m_pAudioDeviceTxt->setText("");

--- a/src/gui/src/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog.h
@@ -38,7 +38,8 @@ class PreferencesDialog : public QDialog, private Ui_PreferencesDialog_UI, publi
 	public:
 		explicit PreferencesDialog( QWidget* parent );
 		~PreferencesDialog();
-
+		static QString m_sColorRed;
+							  
 	private slots:
 		void on_okBtn_clicked();
 		void on_cancelBtn_clicked();

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -32,7 +32,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">
@@ -384,45 +384,45 @@
              </property>
             </widget>
            </item>
-		   <item row="4" column="0">
-			 <widget class="QLabel" name="jackBBTSyncLbl">
-			   <property name="minimumSize">
-				 <size>
-				   <width>0</width>
-				   <height>22</height>
-				 </size>
-			   </property>
-			   <property name="text">
-				 <string>BBT sync method</string>
-			   </property>
-			   <property name="toolTip">
-				 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
-			   </property>
-			 </widget>
-		   </item>
-		   <item row="4" column="1">	 
-			 <widget class="QComboBox" name="jackBBTSyncComboBox">
-			   <property name="minimumSize">
-				 <size>
-				   <width>0</width>
-				   <height>22</height>
-				 </size>
-			   </property>
-			   <property name="toolTip">
-				 <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
-			   </property>
-			   <item>
-				 <property name="text">
-				   <string>constant measure</string>
-				 </property>
-			   </item>
-			   <item>
-				 <property name="text">
-				   <string>matching bars</string>
-				 </property>
-			   </item>
-			 </widget>
-		   </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="jackBBTSyncLbl">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+             </property>
+             <property name="text">
+              <string>BBT sync method</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QComboBox" name="jackBBTSyncComboBox">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+             </property>
+             <item>
+              <property name="text">
+               <string>constant measure</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>matching bars</string>
+              </property>
+             </item>
+            </widget>
+           </item>
           </layout>
          </item>
          <item>
@@ -823,104 +823,129 @@
       <attribute name="title">
        <string>&amp;OSC</string>
       </attribute>
-      <widget class="QWidget" name="oscWidget" native="true">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>30</y>
-         <width>441</width>
-         <height>121</height>
-        </rect>
-       </property>
-       <widget class="QWidget" name="gridLayoutWidget">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>30</y>
-          <width>441</width>
-          <height>41</height>
-         </rect>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_4">
-           <property name="text">
-            <string>Incoming port</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="1" column="3">
-          <widget class="QSpinBox" name="incomingOscPortSpinBox">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port which will be used to receive incoming OSC messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="maximum">
-            <number>20000</number>
-           </property>
-           <property name="value">
-            <number>9000</number>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QCheckBox" name="enableOscFeedbackCheckbox">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>10</y>
-          <width>441</width>
-          <height>25</height>
-         </rect>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Enable OSC &amp;feedback</string>
-        </property>
-        <property name="shortcut">
-         <string>Alt+R</string>
-        </property>
-       </widget>
-      </widget>
-      <widget class="QCheckBox" name="enableOscCheckbox">
+      <widget class="QWidget" name="oscWidget">
        <property name="geometry">
         <rect>
          <x>10</x>
          <y>10</y>
-         <width>441</width>
-         <height>22</height>
+         <width>541</width>
+         <height>141</height>
         </rect>
        </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>&amp;Enable OSC support</string>
-       </property>
-       <property name="shortcut">
-        <string>Alt+R</string>
-       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_8">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <widget class="QCheckBox" name="enableOscCheckbox">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>&amp;Enable OSC support</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+R</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="enableOscFeedbackCheckbox">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Enable OSC &amp;feedback</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+R</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <property name="verticalSpacing">
+             <number>0</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Incoming port</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QSpinBox" name="incomingOscPortSpinBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port which will be used to receive incoming OSC messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="maximum">
+               <number>20000</number>
+              </property>
+              <property name="value">
+               <number>9000</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="spacing">
+             <number>6</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="oscTemporaryPortLabel">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="oscTemporaryPort">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>68</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </widget>
      </widget>
      <widget class="QWidget" name="tab_4">


### PR DESCRIPTION
in case the default OSC port is already registered to another client, the OSC server will choose a random port for Hydrogen. Beforehand this port was only once shown at the beginning of the log. Now, it is shown both in the popup window and in the OSC preference tab.

![OSC_window](https://user-images.githubusercontent.com/14164547/103663709-aef32080-4f71-11eb-8d53-67b16163449e.png)

Note: I already changed the spelling to "This instance uses.." in the code.

In addition, I changed the red color in Preferences to something more readable.

Old: 
![old_red](https://user-images.githubusercontent.com/14164547/103663739-b9adb580-4f71-11eb-9b27-9b198383c1d3.png)

New:
![new_red](https://user-images.githubusercontent.com/14164547/103663758-bf0b0000-4f71-11eb-8667-8d9a4fb71c14.png)


