### PR TITLE
Fix1052 timeline export song

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -160,8 +160,11 @@ void AudioEngine::calculateElapsedTime( const unsigned sampleRate, const unsigne
 	}
 	
 	const unsigned long currentTick = static_cast<unsigned long>(static_cast<float>(nFrame) / fTickSize );
+
+	const auto tempoMarkers = pHydrogen->getTimeline()->getAllTempoMarkers();
 	
-	if ( !Preferences::get_instance()->getUseTimelineBpm() ){
+	if ( !Preferences::get_instance()->getUseTimelineBpm() ||
+		 tempoMarkers.size() == 0 ){
 		
 		int nPatternStartInTicks;
 		const int nCurrentPatternNumber = pHydrogen->getPosForTick( currentTick, &nPatternStartInTicks );
@@ -183,8 +186,6 @@ void AudioEngine::calculateElapsedTime( const unsigned sampleRate, const unsigne
 		long previousTicks = 0;
 		float fPreviousTickSize;
 
-		auto tempoMarkers = pHydrogen->getTimeline()->getAllTempoMarkers();
-		
 		// TODO: how to handle the BPM before the first marker?
 		fPreviousTickSize = compute_tick_size( static_cast<int>(sampleRate), 
 											   tempoMarkers[0]->fBpm, nResolution );
@@ -208,7 +209,6 @@ void AudioEngine::calculateElapsedTime( const unsigned sampleRate, const unsigne
 												   mmarker->fBpm, nResolution );
 			previousTicks = totalTicks;
 		}
-		
 		const int nCurrentPatternNumber = pHydrogen->getPosForTick( currentTick, &nPatternStartInTicks );
 		totalTicks = pHydrogen->getTickForPosition( nCurrentPatternNumber );
 		

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -216,14 +216,18 @@ void ExportSongDialog::restoreSettingsFromPreferences()
 	exportTypeCombo->setCurrentIndex( m_pPreferences->getExportModeIdx() );
 	
 	int nExportSampleRateIdx = m_pPreferences->getExportSampleRateIdx();
-	if( nExportSampleRateIdx >= 0 ) {
+	if( nExportSampleRateIdx > 0 ) {
 		sampleRateCombo->setCurrentIndex( nExportSampleRateIdx );
+	} else {
+		sampleRateCombo->setCurrentIndex( 0 );
 	}
 	
 	
 	int nExportBithDepthIdx = m_pPreferences->getExportSampleDepthIdx();
-	if( nExportBithDepthIdx >= 0 ) {
+	if( nExportBithDepthIdx > 0 ) {
 		sampleDepthCombo->setCurrentIndex( nExportBithDepthIdx );
+	} else {
+		sampleDepthCombo->setCurrentIndex( 0 );
 	}
 }
 
@@ -337,7 +341,7 @@ void ExportSongDialog::on_okBtn_clicked()
 		for (auto i = 0; i < pInstrumentList->size(); i++) {
 			pInstrumentList->get(i)->set_currently_exported( true );
 		}
-		
+
 		m_pEngine->startExportSession( sampleRateCombo->currentText().toInt(), sampleDepthCombo->currentText().toInt());
 		m_pEngine->startExportSong( filename );
 

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -122,14 +122,9 @@ ExportSongDialog::ExportSongDialog(QWidget* parent)
 	}
 
 	// use of timeline
-	if( m_pEngine->getTimeline()->getAllTempoMarkers().size() > 0 ){
-		toggleTimeLineBPMCheckBox->setChecked(m_pPreferences->getUseTimelineBpm());
-		m_bOldTimeLineBPMMode = m_pPreferences->getUseTimelineBpm();
-		connect(toggleTimeLineBPMCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleTimeLineBPMMode( bool )));
-	} else {
-		m_bOldTimeLineBPMMode = m_pPreferences->getUseTimelineBpm();
-		toggleTimeLineBPMCheckBox->setEnabled( false );
-	}
+	toggleTimeLineBPMCheckBox->setChecked(m_pPreferences->getUseTimelineBpm());
+	m_bOldTimeLineBPMMode = m_pPreferences->getUseTimelineBpm();
+	connect(toggleTimeLineBPMCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleTimeLineBPMMode( bool )));
 
 	// use of interpolation mode
 	m_OldInterpolationMode = AudioEngine::get_instance()->get_sampler()->getInterpolateMode();

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -35,6 +35,7 @@
 #include <core/Basics/Instrument.h>
 #include <core/LocalFileMng.h>
 #include <core/Timeline.h>
+#include <core/IO/DiskWriterDriver.h>
 using namespace H2Core;
 
 #include "UndoActions.h"
@@ -1418,6 +1419,15 @@ void SongEditorPatternList::patternChangedEvent() {
 		return;
 	}
 #endif
+
+	// The disk writer runs at it's own pace. Due to the following
+	// lines of code the GUI, instead, just sets the speed to 0 BPM.
+	auto pDriver = pHydrogen->getAudioOutput();
+	if ( pDriver != nullptr ) {
+		if ( DiskWriterDriver::class_name() == pDriver->class_name() ) {
+			return;
+		}
+	}
 	
 	Timeline* pTimeline = pHydrogen->getTimeline();
 	if ( ( Preferences::get_instance()->getUseTimelineBpm() ) &&


### PR DESCRIPTION
- I am not quite sure how that is possible but I ended up with   <exportDialogSampleRate>-1</exportDialogSampleRate> in my config file causing SampleRate in the ExportSongDialog to be not set, and the DiskWriterDriver to be initialized with 0 sample rate.

  Whenever <exportDialogSampleRate> is now smaller than one 0 will be assigned instead.

- The DiskWriterDriver does query the Timeline and the TempoMarker itself. But in addition, the SongEditor also tries to set the BPM but somehow messes up and sets the speed to 0 BPM instead. I have not looked into why it does but simply prevented it from doing so.

