### PR TITLE
Fix issues causing warnings from clang

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -429,6 +429,9 @@ int main(int argc, char *argv[])
 							 // corresponding OSC message.
 				quit = true;
 				break;
+			default:
+				// EVENT_STATE, EVENT_PATTERN_CHANGED, etc are ignored
+				break;
 			}
 		}
 

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -213,16 +213,16 @@ class Pattern : public H2Core::Object
 };
 
 #define FOREACH_NOTE_CST_IT_BEGIN_END(_notes,_it) \
-	for( Pattern::notes_cst_it_t (_it)=(_notes)->begin(); (_it)!=(_notes)->end(); (_it)++ )
+	for( Pattern::notes_cst_it_t _it=(_notes)->begin(); (_it)!=(_notes)->end(); (_it)++ )
 
 #define FOREACH_NOTE_CST_IT_BOUND(_notes,_it,_bound) \
-	for( Pattern::notes_cst_it_t (_it)=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->upper_bound((_bound)); (_it)++ )
+	for( Pattern::notes_cst_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound); (_it)++ )
 
 #define FOREACH_NOTE_IT_BEGIN_END(_notes,_it) \
-	for( Pattern::notes_it_t (_it)=(_notes)->begin(); (_it)!=(_notes)->end(); (_it)++ )
+	for( Pattern::notes_it_t _it=(_notes)->begin(); (_it)!=(_notes)->end(); (_it)++ )
 
 #define FOREACH_NOTE_IT_BOUND(_notes,_it,_bound) \
-	for( Pattern::notes_it_t (_it)=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->upper_bound((_bound)); (_it)++ )
+	for( Pattern::notes_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound); (_it)++ )
 
 // DEFINITIONS
 

--- a/src/core/LocalFileMgr.cpp
+++ b/src/core/LocalFileMgr.cpp
@@ -331,8 +331,9 @@ SongWriter::~SongWriter()
 int SongWriter::writeSong( Song * pSong, const QString& filename )
 {
 	QFileInfo fi( filename );
-	if ( Filesystem::file_exists( filename, true ) && ! Filesystem::file_writable( filename, true ) ||
-		 ! Filesystem::file_exists( filename, true ) && ! Filesystem::dir_writable( fi.dir().absolutePath(), true ) ) {
+	if ( ( Filesystem::file_exists( filename, true ) && ! Filesystem::file_writable( filename, true ) ) ||
+		 ( ! Filesystem::file_exists( filename, true ) &&
+		   ! Filesystem::dir_writable( fi.dir().absolutePath(), true ) ) ) {
 		// In case a read-only file is loaded by Hydrogen. Beware:
 		// .isWritable() will return false if the song does not exist.
 		ERRORLOG( QString( "Unable to save song to %1. Path is not writable!" )

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -168,15 +168,15 @@ void Logger::log( unsigned level, const QString& class_name, const char* func_na
 
 unsigned Logger::parse_log_level( const char* level ) {
 	unsigned log_level = Logger::None;
-	if( 0 == strncasecmp( level, __levels[0], sizeof( __levels[0] ) ) ) {
+	if( 0 == strncasecmp( level, __levels[0], strlen( __levels[0] ) ) ) {
 		log_level = Logger::None;
-	} else if ( 0 == strncasecmp( level, __levels[1], sizeof( __levels[1] ) ) ) {
+	} else if ( 0 == strncasecmp( level, __levels[1], strlen( __levels[1] ) ) ) {
 		log_level = Logger::Error;
-	} else if ( 0 == strncasecmp( level, __levels[2], sizeof( __levels[2] ) ) ) {
+	} else if ( 0 == strncasecmp( level, __levels[2], strlen( __levels[2] ) ) ) {
 		log_level = Logger::Error | Logger::Warning;
-	} else if ( 0 == strncasecmp( level, __levels[3], sizeof( __levels[3] ) ) ) {
+	} else if ( 0 == strncasecmp( level, __levels[3], strlen( __levels[3] ) ) ) {
 		log_level = Logger::Error | Logger::Warning | Logger::Info;
-	} else if ( 0 == strncasecmp( level, __levels[4], sizeof( __levels[4] ) ) ) {
+	} else if ( 0 == strncasecmp( level, __levels[4], strlen( __levels[4] ) ) ) {
 		log_level = Logger::Error | Logger::Warning | Logger::Info | Logger::Debug;
 	} else {
 #ifdef HAVE_SSCANF

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1119,6 +1119,9 @@ void MainForm::action_instruments_clearAll()
 	case QMessageBox::Cancel:
 		// cancel btn pressed
 		return;
+	default:
+		// Not reached
+		return;
 	}
 
 	// Remove all instruments


### PR DESCRIPTION
Fixes a few warnings from clang on macOS.
  - missing default cases 
  - bug where `strncmp` size argument was set to `sizeof(char*)` so would only compare first 4 characters on 32-bit systems (but would compare the full string on 64-bit systems since all the strings are smaller than 8 characters)
  - almost-unnecessary parentheses around iterator name in FOREACH macros.
      - also changes the terminating condition for 'bound' foreach constructs, since really these are iterating over map entries where the key is strictly equal to the 'bound'. Comparing against 'upper_bound' unnecessarily performs a log(n) search on every iteration, making the whole iterator m.log(n) rather than log(n)+m. 

        Doesn't make much difference in practice since in this case "m" is the number of notes in a pattern in the same position (on any instrument) which should be expected to be small.