### PR TITLE
Fix cmake find helper's behaviour with cached variables

### DIFF
--- a/cmake/FindHelper.cmake
+++ b/cmake/FindHelper.cmake
@@ -48,5 +48,8 @@ macro(FIND_HELPER prefix pkg_name header lib)
         if(NOT "${PC_${prefix}_INCLUDE_DIRS}" STREQUAL "")
             set(${prefix}_INCLUDE_DIRS "${${prefix}_INCLUDE_DIRS};${PC_${prefix}_INCLUDE_DIRS}")
         endif()
+        # Update variables in the cache (these are set by find_path/find_library) after modifying
+        set(${prefix}_INCLUDE_DIRS "${${prefix}_INCLUDE_DIRS}" CACHE PATH "Path to ${pkg_name} include files" FORCE)
+        set(${prefix}_LIBRARIES "${${prefix}_LIBRARIES}" CACHE FILEPATH "Path to ${pkg_name} libraries" FORCE)
     endif()
 endmacro()


### PR DESCRIPTION
FindHelper was finding package paths with find_path/find_library, and then
modifying them afterwards with pkgconf configuration variables if they were
there. That results in the local variables in the first run of cmake being
different from the cached values (which will be used in subsequent runs
of cmake).

There's two potential fixes: either update the cached value once the value
to be used is finally calculated, or post-process the cached variables in
the same way when they're used.

This fixes the annoying error:

```
/usr/include/lrdf.h:8:10: fatal error: raptor.h: No such file or directory
 #include <raptor.h>
          ^~~~~~~~~~
compilation terminated.
```