### PR TITLE
Fix1057 consistent bpm

### DIFF
--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -133,6 +133,20 @@ void Song::purgeInstrument( Instrument* pInstr )
 	}
 }
 
+void Song::setBpm( float fBpm ) {
+	if ( fBpm > MAX_BPM ) {
+		m_fBpm = MAX_BPM;
+		WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
+					.arg( fBpm ).arg( MAX_BPM ) );
+	} else if ( fBpm < MIN_BPM ) {
+		m_fBpm = MIN_BPM;
+		WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
+					.arg( fBpm ).arg( MIN_BPM ) );
+	} else {
+		m_fBpm = fBpm;
+	}
+}
+	
 ///Load a song from file
 Song* Song::load( const QString& sFilename )
 {

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -196,7 +196,7 @@ class Song : public H2Core::Object
 		 * One of its purposes is an intermediate storage of the
 		 * tempo at the current transport position in
 		 * Hydrogen::setTimelineBpm() in order to detect local changes
-		 * in speed (set by the user).
+		 * in speed (set by the user). Bounded by [#MIN_BPM,#MAX_BPM].
 		 */
 		float m_fBpm;
 		
@@ -282,11 +282,6 @@ inline void Song::setResolution( unsigned resolution )
 inline float Song::getBpm() const
 {
 	return m_fBpm;
-}
-
-inline void Song::setBpm( float fBpm )
-{
-	m_fBpm = fBpm;
 }
 
 inline void Song::setName( const QString& sName )

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -3660,6 +3660,16 @@ void Hydrogen::setBPM( float fBPM )
 	if ( ! m_pAudioDriver || ! pSong ){
 		return;
 	}
+	
+	if ( fBPM > MAX_BPM ) {
+		fBPM = MAX_BPM;
+		WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
+					.arg( fBPM ).arg( MAX_BPM ) );
+	} else if ( fBPM < MIN_BPM ) {
+		fBPM = MIN_BPM;
+		WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
+					.arg( fBPM ).arg( MIN_BPM ) );
+	}
 
 	if ( getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		ERRORLOG( "Unable to change tempo directly in the presence of an external JACK timebase master. Press 'J.MASTER' get tempo control." );

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -3808,35 +3808,35 @@ void Hydrogen::handleBeatCounter()
 
 	m_nEventCount++;
 
-	// Set wm_LastTime to wm_CurrentTime to remind the time:
-	m_LastTime = m_CurrentTime;
+	// Set lastTime to m_CurrentTime to remind the time:
+	timeval lastTime = m_CurrentTime;
 
 	// Get new time:
 	gettimeofday(&m_CurrentTime,nullptr);
 
 
 	// Build doubled time difference:
-	m_nLastBeatTime = (double)(
-				m_LastTime.tv_sec
-				+ (double)(m_LastTime.tv_usec * US_DIVIDER)
+	double lastBeatTime = (double)(
+				lastTime.tv_sec
+				+ (double)(lastTime.tv_usec * US_DIVIDER)
 				+ (int)m_nCoutOffset * .0001
 				);
-	m_nCurrentBeatTime = (double)(
+	double currentBeatTime = (double)(
 				m_CurrentTime.tv_sec
 				+ (double)(m_CurrentTime.tv_usec * US_DIVIDER)
 				);
-	m_nBeatDiff = m_nBeatCount == 1 ? 0 : m_nCurrentBeatTime - m_nLastBeatTime;
+	double beatDiff = m_nBeatCount == 1 ? 0 : currentBeatTime - lastBeatTime;
 
 	//if differences are to big reset the beatconter
-	if( m_nBeatDiff > 3.001 * 1/m_ntaktoMeterCompute ) {
+	if( beatDiff > 3.001 * 1/m_ntaktoMeterCompute ) {
 		m_nEventCount = 1;
 		m_nBeatCount = 1;
 		return;
 	}
 	// Only accept differences big enough
-	if (m_nBeatCount == 1 || m_nBeatDiff > .001) {
+	if (m_nBeatCount == 1 || beatDiff > .001) {
 		if (m_nBeatCount > 1) {
-			m_nBeatDiffs[m_nBeatCount - 2] = m_nBeatDiff ;
+			m_nBeatDiffs[m_nBeatCount - 2] = beatDiff ;
 		}
 		// Compute and reset:
 		if (m_nBeatCount == m_nbeatsToCount){
@@ -3845,20 +3845,18 @@ void Hydrogen::handleBeatCounter()
 			for(int i = 0; i < (m_nbeatsToCount - 1); i++) {
 				beatTotalDiffs += m_nBeatDiffs[i];
 			}
-			double m_nBeatDiffAverage =
+			double nBeatDiffAverage =
 					beatTotalDiffs
 					/ (m_nBeatCount - 1)
 					* m_ntaktoMeterCompute ;
-			m_fBeatCountBpm	 =
-					(float) ((int) (60 / m_nBeatDiffAverage * 100))
+			float fBeatCountBpm	 =
+					(float) ((int) (60 / nBeatDiffAverage * 100))
 					/ 100;
-			AudioEngine::get_instance()->lock( RIGHT_HERE );
-			if ( m_fBeatCountBpm > MAX_BPM) {
-				m_fBeatCountBpm = MAX_BPM;
-			}
 			
-			setBPM( m_fBeatCountBpm );
+			AudioEngine::get_instance()->lock( RIGHT_HERE );
+			setBPM( fBeatCountBpm );
 			AudioEngine::get_instance()->unlock();
+			
 			if (Preferences::get_instance()->m_mmcsetplay
 					== Preferences::SET_PLAY_OFF) {
 				m_nBeatCount = 1;
@@ -3871,13 +3869,13 @@ void Hydrogen::handleBeatCounter()
 					if ( m_ntaktoMeterCompute <= 1){
 						rtstartframe =
 								bcsamplerate
-								* m_nBeatDiffAverage
+								* nBeatDiffAverage
 								* ( 1/ m_ntaktoMeterCompute );
 					}else
 					{
 						rtstartframe =
 								bcsamplerate
-								* m_nBeatDiffAverage
+								* nBeatDiffAverage
 								/ m_ntaktoMeterCompute ;
 					}
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -747,11 +747,6 @@ private:
 	int			m_nBeatCount;		///< beatcounter beat to count
 	double			m_nBeatDiffs[16];	///< beat diff
 	timeval 		m_CurrentTime;		///< timeval
-	timeval			m_LastTime;		///< timeval
-	double			m_nLastBeatTime;	///< timediff
-	double			m_nCurrentBeatTime;	///< timediff
-	double			m_nBeatDiff;		///< timediff
-	float			m_fBeatCountBpm;	///< bpm
 	int			m_nCoutOffset;		///ms default 0
 	int			m_nStartOffset;		///ms default 0
 	//~ beatcounter

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -1024,7 +1024,15 @@ void JackAudioDriver::locate( unsigned long frame )
 
 void JackAudioDriver::setBpm( float fBPM )
 {
-	if ( fBPM >= 1 ) {
+	if ( fBPM > MAX_BPM ) {
+		m_transport.m_fBPM = MAX_BPM;
+		ERRORLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
+					.arg( fBPM ).arg( MAX_BPM ) );
+	} else if ( fBPM < MIN_BPM ) {
+		m_transport.m_fBPM = fBPM;
+		ERRORLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
+					.arg( fBPM ).arg( MIN_BPM ) );
+	} else {
 		m_transport.m_fBPM = fBPM;
 	}
 }

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -877,9 +877,8 @@ bool MidiActionManager::bpm_increase(Action * pAction, Hydrogen* pEngine, target
 	int mult = pAction->getParameter1().toInt(&ok,10);
 
 	Song* pSong = pEngine->getSong();
-	if ( pSong->getBpm()  < 300) {
-		pEngine->setBPM( pSong->getBpm() + 1*mult );
-	}
+	pEngine->setBPM( pSong->getBpm() + 1*mult );
+
 	AudioEngine::get_instance()->unlock();
 	
 	EventQueue::get_instance()->push_event( EVENT_TEMPO_CHANGED, -1 );
@@ -894,9 +893,8 @@ bool MidiActionManager::bpm_decrease(Action * pAction, Hydrogen* pEngine, target
 	int mult = pAction->getParameter1().toInt(&ok,10);
 
 	Song* pSong = pEngine->getSong();
-	if (pSong->getBpm()  > 40 ) {
-		pEngine->setBPM( pSong->getBpm() - 1*mult );
-	}
+	pEngine->setBPM( pSong->getBpm() - 1*mult );
+	
 	AudioEngine::get_instance()->unlock();
 	
 	EventQueue::get_instance()->push_event( EVENT_TEMPO_CHANGED, -1 );

--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -39,10 +39,14 @@ namespace H2Core
 
 	void Timeline::addTempoMarker( int nBar, float fBpm ) {
 		
-		if ( fBpm < 30.0 ) {
-			fBpm = 30.0;
-		} else if ( fBpm > 500.0 ) {
-			fBpm = 500.0;
+		if ( fBpm < MIN_BPM ) {
+			fBpm = MIN_BPM;
+			WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
+						.arg( fBpm ).arg( MIN_BPM ) );
+		} else if ( fBpm > MAX_BPM ) {
+			fBpm = MAX_BPM;
+			WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
+						.arg( fBpm ).arg( MAX_BPM ) );
 		}
 
 		std::shared_ptr<TempoMarker> pTempoMarker( new TempoMarker );

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1423,9 +1423,7 @@ void MainForm::onBPMPlusAccelEvent()
 	AudioEngine::get_instance()->lock( RIGHT_HERE );
 
 	Song* pSong = pEngine->getSong();
-	if ( pSong->getBpm() < MAX_BPM ) {
-		pEngine->setBPM( pSong->getBpm() + 0.1 );
-	}
+	pEngine->setBPM( pSong->getBpm() + 0.1 );
 	AudioEngine::get_instance()->unlock();
 }
 
@@ -1437,9 +1435,7 @@ void MainForm::onBPMMinusAccelEvent()
 	AudioEngine::get_instance()->lock( RIGHT_HERE );
 
 	Song* pSong = pEngine->getSong();
-	if ( pSong->getBpm() > MIN_BPM ) {
-		pEngine->setBPM( pSong->getBpm() - 0.1 );
-	}
+	pEngine->setBPM( pSong->getBpm() - 0.1 );
 	AudioEngine::get_instance()->unlock();
 }
 

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -329,7 +329,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	hbox->addWidget( pBPMPanel );
 
 	// LCD BPM SpinBox
-	m_pLCDBPMSpinbox = new LCDSpinBox( pBPMPanel, 6, LCDSpinBox::FLOAT, 30, 400 );
+	m_pLCDBPMSpinbox = new LCDSpinBox( pBPMPanel, 6, LCDSpinBox::FLOAT, MIN_BPM, MAX_BPM );
 	m_pLCDBPMSpinbox->move( 43, 6 );
 	connect( m_pLCDBPMSpinbox, SIGNAL(changed(LCDSpinBox*)), this, SLOT(bpmChanged()));
 	connect( m_pLCDBPMSpinbox, SIGNAL(spinboxClicked()), this, SLOT(bpmClicked()));
@@ -767,12 +767,6 @@ void PlayerControl::songModeActivationEvent( int nValue )
 
 void PlayerControl::bpmChanged() {
 	float fNewBpmValue = m_pLCDBPMSpinbox->getValue();
-	if (fNewBpmValue < 30) {
-		fNewBpmValue = 30;
-	}
-	else if (fNewBpmValue > 400 ) {
-		fNewBpmValue = 400;
-	}
 
 	m_pEngine->getSong()->setIsModified( true );
 
@@ -955,11 +949,8 @@ void PlayerControl::jackMasterBtnClicked( Button* )
 void PlayerControl::bpmClicked()
 {
 	bool bIsOkPressed;
-	double fNewVal= QInputDialog::getDouble( this, "Hydrogen", tr( "New BPM value" ),  m_pLCDBPMSpinbox->getValue(), 10, 400, 2, &bIsOkPressed );
+	double fNewVal= QInputDialog::getDouble( this, "Hydrogen", tr( "New BPM value" ),  m_pLCDBPMSpinbox->getValue(), MIN_BPM, MAX_BPM, 2, &bIsOkPressed );
 	if ( bIsOkPressed  ) {
-		if ( fNewVal < 30 ) {
-			return;
-		}
 
 		m_pEngine->getSong()->setIsModified( true );
 

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -91,6 +91,20 @@ void SongEditorPanelBpmWidget::on_CancelBtn_clicked()
 
 void SongEditorPanelBpmWidget::on_okBtn_clicked()
 {
+	float fNewBpm = lineEditBpm->text().toFloat( nullptr );
+
+	// In case the input text can not be parsed by Qt `fNewBpm' is 0
+	// and also covered by the warning below.
+	if ( fNewBpm > MAX_BPM || fNewBpm < MIN_BPM ){
+		QMessageBox::warning( this, "Hydrogen",
+							  QString( tr( "Please enter a number within the range of " )
+									   .append( QString( "[%1,%2]" )
+												.arg( MIN_BPM )
+												.arg( MAX_BPM ) ) ),
+							  tr("&Cancel") );
+		return;
+	}
+	
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	Timeline* pTimeline = pHydrogen->getTimeline();
 	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();


### PR DESCRIPTION
fixes #1057

- the global constants MIN_BPM and MAX_BPM have been adopted everywhere
- bound checks were introduced in the BPM setter function of Hydrogen, Song and JackAudioDriver (not the other drivers, since only the Jack one is called with something else than the Song->getBpm())
- existing bound checks in the GUI were dropped in favor of the core ones
- when adding/editing a tempo marker the entered BPM value is checked and a warning dialog prompts if either not a number or out of range.

 fix beatcounter variable signature. some of them were only used locally but defined as member variables of the Hydrogen class



