### PR TITLE
GMKit -> GMRockKit (MainForm.cpp)

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1842,7 +1842,7 @@ void MainForm::action_file_export_lilypond()
 		"Hydrogen",
 		tr( "\nThe LilyPond export is an experimental feature.\n"
 		"It should work like a charm provided that you use the "
-		"GM-kit, and that you do not use triplet.\n" ),
+		"GMRockKit, and that you do not use triplet.\n" ),
 		QMessageBox::Ok ); 
 
 	QFileDialog fd( this );


### PR DESCRIPTION
There is no "GMKit" anymore. This looks to be an leftover from the time we switched from the GMKit to the GMRockKit. This could confusing or users.

I don't have any knowledge about using this lilypond converter so I'm not sure if the exports are still corrects. Hence I'm not merging this PR myself.