### PR TITLE
Show a full-height cursor for song position

### DIFF
--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -824,9 +824,9 @@ void SongEditor::paintEvent( QPaintEvent *ev )
 			// nessun pattern, uso la grandezza di default
 			fPos += (float)pHydrogen->getTickPosition() / (float)MAX_NOTES;
 		}
-		uint x = (int)( m_nMargin + fPos * m_nGridWidth - 11 / 2 );
+		uint x = (int)( m_nMargin + fPos * m_nGridWidth );
 		painter.setPen( QColor(35, 39, 51) );
-		painter.drawLine( x + 5 , 0, x + 5 , height() );
+		painter.drawLine( x, 0, x, height() );
 
 		// Update the position ruler to redraw the cursor there as well.
 		// Without this they can get separated from each other if e.g. user
@@ -2116,11 +2116,11 @@ SongEditorPositionRuler::SongEditorPositionRuler( QWidget *parent )
 
 	createBackground();	// create m_backgroundPixmap pixmap
 
-	// create tick position pixmap
-	bool ok = m_tickPositionPixmap.load( Skin::getImagePath() + "/patternEditor/tickPosition.png" );
-	if( ok == false ){
-		ERRORLOG( "Error loading pixmap" );
-	}
+	// Create tick position QPainterPath
+	m_tickPositionPath = QPainterPath( QPointF( 0, 6 ) );
+	m_tickPositionPath.lineTo( -4, 2 );
+	m_tickPositionPath.lineTo( 4, 2 );
+	m_tickPositionPath.closeSubpath();
 
 	update();
 
@@ -2360,10 +2360,13 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	painter.drawPixmap( ev->rect(), *m_pBackgroundPixmap, srcRect );
 
 	if (fPos != -1) {
-		uint x = (int)( m_nMargin + fPos * m_nGridWidth - 11 / 2 );
+		uint x = (int)( m_nMargin + fPos * m_nGridWidth );
 		painter.setPen( QColor(35, 39, 51) );
-		painter.drawLine( x + 5 , 0, x + 5 , height() );
-		painter.drawPixmap( QRect( x, height() / 2, 11, 8), m_tickPositionPixmap, QRect(0, 0, 11, 8) );
+		painter.drawLine( x, 0, x, height() );
+		painter.translate( x, height() / 2 );
+		painter.fillPath( m_tickPositionPath, Qt::black );
+		painter.drawPath( m_tickPositionPath );
+		painter.resetTransform();
 	}
 
 	if ( pIPos <= pOPos ) {

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -317,7 +317,7 @@ class SongEditorPositionRuler : public QWidget, public H2Core::Object
 		const int m_nMargin = 10;
 
 		QPixmap *			m_pBackgroundPixmap;
-		QPixmap				m_tickPositionPixmap;
+		QPainterPath		m_tickPositionPath;
 		bool				m_bRightBtnPressed;
 		
 		virtual void mouseMoveEvent(QMouseEvent *ev);

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -550,6 +550,7 @@ void SongEditorPanel::updatePlaybackTrackIfNecessary()
 void SongEditorPanel::updatePositionRuler()
 {
 	m_pPositionRuler->createBackground();
+	m_pPositionRuler->update();
 }
 
 ///


### PR DESCRIPTION
Previously, Hydrogen had only a small marker on the song editor position ruler to indicate the playback head position in the song.  This PR extends the line all the way down the song editor, as discussed in #192 (item 1 in the first comment).

![Screenshot from 2021-01-18 22-51-46](https://user-images.githubusercontent.com/320472/104985793-c4d7fb00-59df-11eb-82f5-34bff8adaa63.png)

Still a work-in-progress, as I know of a few minor issues it has still.

- [x] The line is offset by half a (logical) pixel from the arrow on my HiDPI monitor.
- [ ] Occasionally, and mostly at very high BPM, the line will get slightly out-of-sync between the ruler and the song editor.
- [x] The arrow and line are different colors, which is more obvious now that the line is bigger.
- [ ] The cursor's movement is quite jerky, but that's not new; ideally we would change the update timer's tick rate based on the amount of time represented by one pixel on the song editor.
- [ ] The line still needs to be extended over the automation path, though the dark line won't show up very well on its dark background.