### PR TITLE
UX tweaks (as discussed in #1097 )

### DIFF
--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -165,7 +165,7 @@ void DrumPatternEditor::mouseClickEvent( QMouseEvent *ev )
 	if (row >= nInstruments) {
 		return;
 	}
-	int nColumn = getColumn( ev->x() );
+	int nColumn = getColumn( ev->x(), /* bUseFineGrained=*/ true );
 	int nRealColumn = 0;
 	if( ev->x() > m_nMargin ) {
 		nRealColumn = ev->x() / static_cast<float>(m_nGridWidth) - m_nMargin;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -142,11 +142,15 @@ QColor PatternEditor::computeNoteColor( float velocity ){
 	return QColor( red, green, blue );
 }
 
-int PatternEditor::getColumn( int x ) const
+int PatternEditor::getColumn( int x, bool bUseFineGrained ) const
 {
-	int nWidth = m_nGridWidth * granularity();
+	int nGranularity = 1;
+	if ( !( bUseFineGrained && m_bFineGrained ) ) {
+		nGranularity = granularity();
+	}
+	int nWidth = m_nGridWidth * nGranularity;
 	int nColumn = ( x - m_nMargin + (nWidth / 2) ) / nWidth;
-	nColumn = nColumn * granularity();
+	nColumn = nColumn * nGranularity;
 	return nColumn;
 }
 

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -166,7 +166,7 @@ protected:
 	PatternEditorPanel *m_pPatternEditorPanel;
 	QMenu *m_pPopupMenu;
 
-	int getColumn( int x ) const;
+	int getColumn( int x, bool bUseFineGrained = false ) const;
 	QPoint movingGridOffset() const;
 
 	//! Draw lines for note grid.

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -504,7 +504,7 @@ void PianoRollEditor::mouseClickEvent( QMouseEvent *ev ) {
 		return;
 	}
 
-	int nColumn = getColumn( ev->x() );
+	int nColumn = getColumn( ev->x(), /* bUseFineGrained=*/ true );
 
 	if ( nColumn >= (int)m_pPattern->get_length() ) {
 		update( 0, 0, width(), height() );


### PR DESCRIPTION
UX tweaks for the pattern editors.
  - alt + up/down arrows to fine-tune note properties 
  - alt + click in pattern editors for fine-grained placement of notes
  - show messages on LCD for note properties edited with the arrow keys (but not for multiple notes)
  - Also fix (theoretical) bugs with qBound argument ordering.