### PR TITLE
remove shortcut bound to "l"

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1773,15 +1773,6 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 			pHydrogen->getCoreActionController()->relocate( pHydrogen->getPatternPos() + 1 );
 			return true;
 			break;
-
-		case Qt::Key_L :
-			pHydrogen->togglePlaysSelected();
-			QString msg = Preferences::get_instance()->patternModePlaysSelected() ? "Single pattern mode" : "Stacked pattern mode";
-			app->setStatusBarMessage( msg, 5000 );
-			app->getSongEditorPanel()->setModeActionBtn( Preferences::get_instance()->patternModePlaysSelected() );
-			app->getSongEditorPanel()->updateAll();
-			return true;
-			break;
 		}
 
 		// virtual keyboard handling


### PR DESCRIPTION
I discovered that there is a shortcut bound to "l" which does exactly the same as pressing the stack mode button in the SongEditorPanel. But it will only work in PATTERN_MODE.

I am not quite sure what was its former intention but since no other button is bound to a shortcut, it will not work in SONG_MODE, and it is not documented, I would suggest to remove it.