### PR TITLE
Dev disable timebase

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -234,13 +234,13 @@ int main(int argc, char *argv[])
 			preferences->m_sAudioDriver = "Auto";
 		}
 		else if (sSelectedDriver == "jack") {
-			preferences->m_sAudioDriver = "Jack";
+			preferences->m_sAudioDriver = "JACK";
 		}
 		else if ( sSelectedDriver == "oss" ) {
-			preferences->m_sAudioDriver = "Oss";
+			preferences->m_sAudioDriver = "OSS";
 		}
 		else if ( sSelectedDriver == "alsa" ) {
-			preferences->m_sAudioDriver = "Alsa";
+			preferences->m_sAudioDriver = "ALSA";
 		}
 		else if (sSelectedDriver == "CoreAudio") {
 			preferences->m_sAudioDriver = "CoreAudio";
@@ -277,7 +277,7 @@ int main(int argc, char *argv[])
 			 * here we make it save that hydrogen start in a jacksession case
 			 * every time with jack as audio driver
 			 */
-			preferences->m_sAudioDriver = "Jack";
+			preferences->m_sAudioDriver = "JACK";
 
 		}
 		/* the use of applicationFilePath() make it

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -620,10 +620,10 @@ void				audioEngine_restartAudioDrivers();
  * Which audio driver to use is specified in
  * Preferences::m_sAudioDriver. If "Auto" is selected, it will try to
  * initialize drivers using createDriver() in the following order: 
- * - Windows:  "PortAudio", "Alsa", "CoreAudio", "Jack", "Oss",
+ * - Windows:  "PortAudio", "ALSA", "CoreAudio", "JACK", "OSS",
  *   and "PulseAudio" 
- * - all other systems: "Jack", "Alsa", "CoreAudio", "PortAudio",
- *   "Oss", and "PulseAudio".
+ * - all other systems: "JACK", "ALSA", "CoreAudio", "PortAudio",
+ *   "OSS", and "PulseAudio".
  * If all of them return NULL, #m_pAudioDriver will be initialized
  * with the NullDriver instead. If a specific choice is contained in
  * Preferences::m_sAudioDriver and createDriver() returns NULL, the
@@ -2051,13 +2051,13 @@ AudioOutput* createDriver( const QString& sDriver )
 	Preferences *pPref = Preferences::get_instance();
 	AudioOutput *pDriver = nullptr;
 
-	if ( sDriver == "Oss" ) {
+	if ( sDriver == "OSS" ) {
 		pDriver = new OssDriver( audioEngine_process );
 		if ( pDriver->class_name() == NullDriver::class_name() ) {
 			delete pDriver;
 			pDriver = nullptr;
 		}
-	} else if ( sDriver == "Jack" ) {
+	} else if ( sDriver == "JACK" ) {
 		pDriver = new JackAudioDriver( audioEngine_process );
 		if ( pDriver->class_name() == NullDriver::class_name() ) {
 			delete pDriver;
@@ -2069,7 +2069,7 @@ AudioOutput* createDriver( const QString& sDriver )
 						);
 #endif
 		}
-	} else if ( sDriver == "Alsa" ) {
+	} else if ( sDriver == "ALSA" ) {
 		pDriver = new AlsaAudioDriver( audioEngine_process );
 		if ( pDriver->class_name() == NullDriver::class_name() ) {
 			delete pDriver;
@@ -2150,11 +2150,11 @@ void audioEngine_startAudioDrivers()
 	QString sAudioDriver = preferencesMng->m_sAudioDriver;
 	if ( sAudioDriver == "Auto" ) {
 	#ifndef WIN32
-		if ( ( m_pAudioDriver = createDriver( "Jack" ) ) == nullptr ) {
-			if ( ( m_pAudioDriver = createDriver( "Alsa" ) ) == nullptr ) {
+		if ( ( m_pAudioDriver = createDriver( "JACK" ) ) == nullptr ) {
+			if ( ( m_pAudioDriver = createDriver( "ALSA" ) ) == nullptr ) {
 				if ( ( m_pAudioDriver = createDriver( "CoreAudio" ) ) == nullptr ) {
 					if ( ( m_pAudioDriver = createDriver( "PortAudio" ) ) == nullptr ) {
-						if ( ( m_pAudioDriver = createDriver( "Oss" ) ) == nullptr ) {
+						if ( ( m_pAudioDriver = createDriver( "OSS" ) ) == nullptr ) {
 							if ( ( m_pAudioDriver = createDriver( "PulseAudio" ) ) == nullptr ) {
 								audioEngine_raiseError( Hydrogen::ERROR_STARTING_DRIVER );
 								___ERRORLOG( "Error starting audio driver" );
@@ -2172,10 +2172,10 @@ void audioEngine_startAudioDrivers()
 	#else
 		//On Windows systems, use PortAudio is the prioritized backend
 		if ( ( m_pAudioDriver = createDriver( "PortAudio" ) ) == nullptr ) {
-			if ( ( m_pAudioDriver = createDriver( "Alsa" ) ) == nullptr ) {
+			if ( ( m_pAudioDriver = createDriver( "ALSA" ) ) == nullptr ) {
 				if ( ( m_pAudioDriver = createDriver( "CoreAudio" ) ) == nullptr ) {
-					if ( ( m_pAudioDriver = createDriver( "Jack" ) ) == nullptr ) {
-						if ( ( m_pAudioDriver = createDriver( "Oss" ) ) == nullptr ) {
+					if ( ( m_pAudioDriver = createDriver( "JACK" ) ) == nullptr ) {
+						if ( ( m_pAudioDriver = createDriver( "OSS" ) ) == nullptr ) {
 							if ( ( m_pAudioDriver = createDriver( "PulseAudio" ) ) == nullptr ) {
 								audioEngine_raiseError( Hydrogen::ERROR_STARTING_DRIVER );
 								___ERRORLOG( "Error starting audio driver" );
@@ -2221,7 +2221,7 @@ void audioEngine_startAudioDrivers()
 		m_pMidiDriver->open();
 		m_pMidiDriver->setActive( true );
 #endif
-	} else if ( preferencesMng->m_sMidiDriver == "CoreMidi" ) {
+	} else if ( preferencesMng->m_sMidiDriver == "CoreMIDI" ) {
 #ifdef H2CORE_HAVE_COREMIDI
 		CoreMidiDriver *coreMidiDriver = new CoreMidiDriver();
 		m_pMidiDriver = coreMidiDriver;
@@ -2229,7 +2229,7 @@ void audioEngine_startAudioDrivers()
 		m_pMidiDriver->open();
 		m_pMidiDriver->setActive( true );
 #endif
-	} else if ( preferencesMng->m_sMidiDriver == "JackMidi" ) {
+	} else if ( preferencesMng->m_sMidiDriver == "JACK-MIDI" ) {
 #ifdef H2CORE_HAVE_JACK
 		JackMidiDriver *jackMidiDriver = new JackMidiDriver();
 		m_pMidiDriverOut = jackMidiDriver;

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -288,6 +288,10 @@ void JackAudioDriver::calculateFrameOffset(long long oldFrame)
 
 void JackAudioDriver::relocateUsingBBT()
 {
+	if ( ! Preferences::get_instance()->m_bJackTimebaseEnabled ) {
+		ERRORLOG( "This function should not have been called with JACK timebase disabled in the Preferences" );
+		return;
+	}
 	if ( m_timebaseState != Timebase::Slave ) {
 		ERRORLOG( QString( "Relocation using BBT information can only be used in the presence of another Jack timebase master" ) );
 		return;
@@ -418,6 +422,8 @@ void JackAudioDriver::updateTransportInfo()
 	     Preferences::USE_JACK_TRANSPORT ){
 		return;
 	}
+
+	const bool bTimebaseEnabled = Preferences::get_instance()->m_bJackTimebaseEnabled;
 	
 	// jack_transport_query() (jack/transport.h) queries the
 	// current transport state and position. If called from the
@@ -457,29 +463,31 @@ void JackAudioDriver::updateTransportInfo()
 	// printState();
 	
 	m_currentPos = m_JackTransportPos.frame;
-	
-	// Update the status regrading JACK timebase master.
-	if ( m_JackTransportState != JackTransportStopped ) {
-		if ( m_nTimebaseTracking > 1 ) {
-			m_nTimebaseTracking--;
-		} else if ( m_nTimebaseTracking == 1 ) {
-			// JackTimebaseCallback not called anymore -> timebase client
+
+	if ( bTimebaseEnabled ) {
+		// Update the status regrading JACK timebase master.
+		if ( m_JackTransportState != JackTransportStopped ) {
+			if ( m_nTimebaseTracking > 1 ) {
+				m_nTimebaseTracking--;
+			} else if ( m_nTimebaseTracking == 1 ) {
+				// JackTimebaseCallback not called anymore -> timebase client
+				m_nTimebaseTracking = 0;
+				m_timebaseState = Timebase::Slave;
+			}
+		}
+		if ( m_nTimebaseTracking == 0 && 
+			 !(m_JackTransportPos.valid & JackPositionBBT) ) {
+			// No external timebase master anymore -> regular client
+			m_nTimebaseTracking = -1;
+			m_timebaseState = Timebase::None;
+		} else if ( m_nTimebaseTracking < 0 && 
+					(m_JackTransportPos.valid & JackPositionBBT) ) {
+			// External timebase master detected -> timebase client
 			m_nTimebaseTracking = 0;
 			m_timebaseState = Timebase::Slave;
 		}
 	}
-	if ( m_nTimebaseTracking == 0 && 
-				!(m_JackTransportPos.valid & JackPositionBBT) ) {
-		// No external timebase master anymore -> regular client
-		m_nTimebaseTracking = -1;
-		m_timebaseState = Timebase::None;
-	} else if ( m_nTimebaseTracking < 0 && 
-				(m_JackTransportPos.valid & JackPositionBBT) ) {
-		// External timebase master detected -> timebase client
-		m_nTimebaseTracking = 0;
-		m_timebaseState = Timebase::Slave;
-	}
-
+		
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	
 	// The relocation could be either triggered by an user interaction
@@ -490,7 +498,7 @@ void JackAudioDriver::updateTransportInfo()
 		// is in pattern mode.
 		pHydrogen->resetPatternStartTick();
 
-		if ( m_timebaseState != Timebase::Slave ) {
+		if ( !bTimebaseEnabled || m_timebaseState != Timebase::Slave ) {
 			m_transport.m_nFrames = m_JackTransportPos.frame;
 		
 			// There maybe was an offset introduced when passing a
@@ -501,7 +509,7 @@ void JackAudioDriver::updateTransportInfo()
 		}
 	}
 
-	if ( m_timebaseState == Timebase::Slave ){
+	if ( bTimebaseEnabled && m_timebaseState == Timebase::Slave ){
 		// There is a JACK timebase master and it's not us. If it
 		// provides a tempo that differs from the local one, we will
 		// use the former instead.
@@ -517,13 +525,17 @@ void JackAudioDriver::updateTransportInfo()
 		pHydrogen->setTimelineBpm();
 	}
 
-	if ( m_timebaseState == Timebase::Slave ) {
+	if ( bTimebaseEnabled && m_timebaseState == Timebase::Slave ) {
 		m_previousJackTransportPos = m_JackTransportPos;
 	}
 }
 
 bool JackAudioDriver::compareAdjacentBBT() const
 {
+	if ( ! Preferences::get_instance()->m_bJackTimebaseEnabled ) {
+		ERRORLOG( "This function should not have been called with JACK timebase disabled in the Preferences" );
+	}
+	
 	if ( m_JackTransportPos.beats_per_minute !=
 		 m_previousJackTransportPos.beats_per_minute ) {
 		INFOLOG( QString( "Change in tempo from [%1] to [%2]" )
@@ -874,7 +886,8 @@ int JackAudioDriver::init( unsigned bufferSize )
 #endif
 
 	if ( pPreferences->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT &&
-		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ){
+		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER &&
+		 pPreferences->m_bJackTimebaseEnabled ){
 		initTimebaseMaster();
 	}
 	
@@ -1142,6 +1155,11 @@ void JackAudioDriver::initTimebaseMaster()
 	if ( m_pClient == nullptr ) {
 		return;
 	}
+	
+	if ( ! Preferences::get_instance()->m_bJackTimebaseEnabled ) {
+		ERRORLOG( "This function should not have been called with JACK timebase disabled in the Preferences" );
+		return;
+	}
 
 	Preferences* pPreferences = Preferences::get_instance();
 	if ( pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER) {
@@ -1193,6 +1211,11 @@ void JackAudioDriver::releaseTimebaseMaster()
 		return;
 	}
 
+	if ( ! Preferences::get_instance()->m_bJackTimebaseEnabled ) {
+		ERRORLOG( "This function should not have been called with JACK timebase disabled in the Preferences" );
+		return;
+	}
+	
 	jack_release_timebase( m_pClient );
 	
 	if ( m_JackTransportPos.valid & JackPositionBBT ) {
@@ -1324,6 +1347,14 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
     
 	// Tell Hydrogen it is still timebase master.
 	pDriver->m_nTimebaseTracking = 2;
+}
+
+	
+JackAudioDriver::Timebase JackAudioDriver::getTimebaseState() const {
+	if ( Preferences::get_instance()->m_bJackTimebaseEnabled ) {
+		return m_timebaseState;
+	}
+	return Timebase::None;
 }
 
 void JackAudioDriver::printState() const {

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -930,10 +930,6 @@ private:
 	Timebase m_timebaseState;
 
 };
-	
-inline JackAudioDriver::Timebase JackAudioDriver::getTimebaseState() const {
-	return m_timebaseState;
-}
 
 
 

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -168,7 +168,8 @@ Preferences::Preferences()
 	m_bJackTransportMode = true;
 	m_bJackConnectDefaults = true;
 	m_bJackTrackOuts = false;
-	m_bJackMasterMode = false ;
+	m_bJackTimebaseEnabled = true;
+	m_bJackMasterMode = NO_JACK_TIME_MASTER;
 	m_JackTrackOutputMode = JackTrackOutputMode::postFader;
 	m_JackBBTSync = JackBBTSyncMethod::constMeasure;
 
@@ -436,6 +437,7 @@ void Preferences::loadPreferences( bool bGlobal )
 					}
 
 					//jack time master
+					m_bJackTimebaseEnabled = LocalFileMng::readXmlBool( jackDriverNode, "jack_timebase_enabled", true );
 					QString tmMode = LocalFileMng::readXmlString( jackDriverNode, "jack_transport_mode_master", "NO_JACK_TIME_MASTER" );
 					if ( tmMode == "NO_JACK_TIME_MASTER" ) {
 						m_bJackMasterMode = NO_JACK_TIME_MASTER;
@@ -861,6 +863,7 @@ void Preferences::savePreferences()
 			LocalFileMng::writeXmlString( jackDriverNode, "jack_transport_mode", sMode );
 
 			//jack time master
+			LocalFileMng::writeXmlBool( jackDriverNode, "jack_timebase_enabled", m_bJackTimebaseEnabled );
 			QString tmMode;
 			if ( m_bJackMasterMode == NO_JACK_TIME_MASTER ) {
 				tmMode = "NO_JACK_TIME_MASTER";

--- a/src/core/Preferences.h
+++ b/src/core/Preferences.h
@@ -353,7 +353,7 @@ public:
 	bool				m_bJackTrackOuts;
 
 	/** Specifies which audio settings will be applied to the sample
-		supplied in the Jack per track output ports.*/
+		supplied in the JACK per track output ports.*/
 	enum class JackTrackOutputMode {
 		/** Applies layer, component, and instrument gain, note and
 		instrument pan, note velocity, and main component and
@@ -363,14 +363,22 @@ public:
 		preFader = 1 };
 
 	/** Specifies which audio settings will be applied to the sample
-		supplied in the Jack per track output ports.*/
+		supplied in the JACK per track output ports.*/
 	JackTrackOutputMode		m_JackTrackOutputMode;
 	//jack time master
 
 	/**
+	 * External applications with a faulty JACK timebase master
+	 * implementation can mess up the transport within Hydrogen. To
+	 * guarantee the basic functionality, the user can disable
+	 * timebase support and make Hydrogen only listen to the frame
+	 * number broadcast by the JACK server.
+	 */
+	bool				m_bJackTimebaseEnabled;
+	/**
 	 * Specifies the variable, which has to remain constant in order
 	 * to guarantee a working synchronization and relocation with
-	 * Hydrogen as Jack timebase client.
+	 * Hydrogen as JACK timebase client.
 	 */
 	enum class JackBBTSyncMethod {
 		/** The measure - could be any - does not change during the
@@ -379,19 +387,19 @@ public:
 		/** The length of each pattern must match the measure of the
 			corresponding bar in the timebase master. This way both
 			the pattern position of Hydrogen and the bar information
-			provided by Jack can be assumed to be identical.*/
+			provided by JACK can be assumed to be identical.*/
 		identicalBars = 1 };
 	/**
 	 * Since Hydrogen uses both fixed pattern lengths and recalculates
 	 * the tick size each time it encounters an alternative tempo, its
 	 * transport is incompatible to the BBT information provided by 
-	 * the Jack server. Only if the length of each pattern corresponds
+	 * the JACK server. Only if the length of each pattern corresponds
 	 * to the measure of the respective bar in the timebase master
-	 * application, the bar information provided by Jack can be used
+	 * application, the bar information provided by JACK can be used
 	 * directly to determine chosen pattern. If this, however, is not
 	 * the case - which can quite easily happen - a complete history 
 	 * of all measure and tempo changes would be required to correctly
-	 * identify the pattern. Since this is not provided by Jack, one
+	 * identify the pattern. Since this is not provided by JACK, one
 	 * has to either assume the measure or tempo to be constant or 
 	 * that the user took care of adjusting the lengths properly.
 	 */

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -432,12 +432,14 @@ PlayerControl::PlayerControl(QWidget *parent)
 	);
 	m_pJackMasterBtn->hide();
 	if ( m_pJackTransportBtn->isPressed() &&
-		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER ) {
+		 pPreferences->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER &&
+		 pPreferences->m_bJackTimebaseEnabled ) {
 		m_pJackMasterBtn->setPressed( true );
 	} else {
 		m_pJackMasterBtn->setPressed( false );
 	}
-	m_pJackMasterBtn->setToolTip( tr("JACK Timebase master on/off") );
+	m_sJackMasterModeToolTip = tr("JACK Timebase master on/off");
+	m_pJackMasterBtn->setToolTip( m_sJackMasterModeToolTip );
 	connect(m_pJackMasterBtn, SIGNAL(clicked(Button*)), this, SLOT(jackMasterBtnClicked(Button*)));
 	m_pJackMasterBtn->move(56, 26);
 	//~ jack time master
@@ -606,6 +608,14 @@ void PlayerControl::updatePlayerControl()
 					m_pJackMasterBtn->setPressed( true );
 				} else {
 					m_pJackMasterBtn->setPressed( false );
+				}
+
+				if ( pPref->m_bJackTimebaseEnabled ) {
+					m_pJackMasterBtn->setDisabled( false );
+					m_pJackMasterBtn->setToolTip( m_sJackMasterModeToolTip );
+				} else {
+					m_pJackMasterBtn->setDisabled( true );
+					m_pJackMasterBtn->setToolTip( tr( "JACK timebase support is disabled in the Preferences" ) );
 				}
 
 				if ( m_pEngine->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -181,6 +181,7 @@ class PlayerControl : public QLabel, public EventListener, public H2Core::Object
 		ToggleButton *m_pJackTransportBtn;
 		//jack time master
 		ToggleButton *m_pJackMasterBtn;
+		QString m_sJackMasterModeToolTip;
 		//~ jack time master
 		Button *m_pBPMUpBtn;
 		Button *m_pBPMDownBtn;

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -68,7 +68,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	driverComboBox->clear();
 	driverComboBox->addItem( "Auto" );
 #ifdef H2CORE_HAVE_JACK
-	driverComboBox->addItem( "Jack" );
+	driverComboBox->addItem( "JACK" );
 #endif
 #ifdef H2CORE_HAVE_ALSA
 	driverComboBox->addItem( "ALSA" );
@@ -433,14 +433,14 @@ void PreferencesDialog::on_okBtn_clicked()
 		pPref->m_sAudioDriver = "Auto";
 	}
 	else if (driverComboBox->currentText() == "JACK" ) {
-		pPref->m_sAudioDriver = "Jack";
+		pPref->m_sAudioDriver = "JACK";
 	}
 	else if (driverComboBox->currentText() == "ALSA" ) {
-		pPref->m_sAudioDriver = "Alsa";
+		pPref->m_sAudioDriver = "ALSA";
 		pPref->m_sAlsaAudioDevice = m_pAudioDeviceTxt->text();
 	}
 	else if (driverComboBox->currentText() == "OSS" ) {
-		pPref->m_sAudioDriver = "Oss";
+		pPref->m_sAudioDriver = "OSS";
 		pPref->m_sOSSDevice = m_pAudioDeviceTxt->text();
 	}
 	else if (driverComboBox->currentText() == "PortAudio" ) {
@@ -511,10 +511,10 @@ void PreferencesDialog::on_okBtn_clicked()
 		pPref->m_sMidiDriver = "PortMidi";
 	}
 	else if ( m_pMidiDriverComboBox->currentText() == "CoreMIDI" ) {
-		pPref->m_sMidiDriver = "CoreMidi";
+		pPref->m_sMidiDriver = "CoreMIDI";
 	}
 	else if ( m_pMidiDriverComboBox->currentText() == "JACK-MIDI" ) {
-		pPref->m_sMidiDriver = "JackMidi";
+		pPref->m_sMidiDriver = "JACK-MIDI";
 	}
 
 

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -68,7 +68,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	driverComboBox->clear();
 	driverComboBox->addItem( "Auto" );
 #ifdef H2CORE_HAVE_JACK
-	driverComboBox->addItem( "JACK" );
+	driverComboBox->addItem( "Jack" );
 #endif
 #ifdef H2CORE_HAVE_ALSA
 	driverComboBox->addItem( "ALSA" );
@@ -160,6 +160,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	connect(trackOutsCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleTrackOutsCheckBox( bool )));
 
 	connectDefaultsCheckBox->setChecked( pPref->m_bJackConnectDefaults );
+	enableTimebaseCheckBox->setChecked( pPref->m_bJackTimebaseEnabled );
 
 	switch ( pPref->m_JackTrackOutputMode ) {
 	case Preferences::JackTrackOutputMode::postFader:
@@ -457,6 +458,7 @@ void PreferencesDialog::on_okBtn_clicked()
 
 	// JACK
 	pPref->m_bJackConnectDefaults = connectDefaultsCheckBox->isChecked();
+	pPref->m_bJackTimebaseEnabled = enableTimebaseCheckBox->isChecked();
 
 	switch ( trackOutputComboBox->currentIndex() ) {
 	case 0: 
@@ -691,28 +693,43 @@ void PreferencesDialog::updateDriverInfo()
 				.append( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name() )
 				.append( "</b> " ).append( tr( "selected") );
 		}
-		m_pAudioDeviceTxt->setEnabled(false);
+		m_pAudioDeviceTxt->setEnabled( true );
 		m_pAudioDeviceTxt->setText( "" );
-		bufferSizeSpinBox->setEnabled( false );
-		sampleRateComboBox->setEnabled( false );
+		bufferSizeSpinBox->setEnabled( true );
+		sampleRateComboBox->setEnabled( true );
 		trackOutputComboBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled( false );
+		enableTimebaseCheckBox->setEnabled( false );
 		trackOutsCheckBox->setEnabled( false );
 		jackBBTSyncComboBox->setEnabled( false );
 		jackBBTSyncLbl->setEnabled( false );
 
 		if ( std::strcmp( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name(),
 						  "JackAudioDriver" ) == 0 ) {
+			trackOutputComboBox->setEnabled( true );
+			connectDefaultsCheckBox->setEnabled( true );
+			enableTimebaseCheckBox->setEnabled( true );
+			trackOutsCheckBox->setEnabled( true );
+			jackBBTSyncComboBox->setEnabled( true );
+			jackBBTSyncLbl->setEnabled( true );
 			trackOutputComboBox->show();
 			trackOutputLbl->show();
 			connectDefaultsCheckBox->show();
 			trackOutsCheckBox->show();
+			enableTimebaseCheckBox->show();
 			jackBBTSyncComboBox->show();
 			jackBBTSyncLbl->show();
 		} else {
+			trackOutputComboBox->setEnabled( false );
+			connectDefaultsCheckBox->setEnabled( false );
+			enableTimebaseCheckBox->setEnabled( false );
+			trackOutsCheckBox->setEnabled( false );
+			jackBBTSyncComboBox->setEnabled( false );
+			jackBBTSyncLbl->setEnabled( false );
 			trackOutputComboBox->hide();
 			trackOutputLbl->hide();
 			connectDefaultsCheckBox->hide();
+			enableTimebaseCheckBox->hide();
 			trackOutsCheckBox->hide();
 			jackBBTSyncComboBox->hide();
 			jackBBTSyncLbl->hide();
@@ -734,6 +751,7 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->hide();
 		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
+		enableTimebaseCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
@@ -754,11 +772,13 @@ void PreferencesDialog::updateDriverInfo()
 		bufferSizeSpinBox->setEnabled(false);
 		sampleRateComboBox->setEnabled(false);
 		trackOutputComboBox->setEnabled( true );
-		connectDefaultsCheckBox->setEnabled(true);
+		connectDefaultsCheckBox->setEnabled( true );
+		enableTimebaseCheckBox->setEnabled( true );
 		trackOutsCheckBox->setEnabled( true );
 		trackOutputComboBox->show();
 		trackOutputLbl->show();
 		connectDefaultsCheckBox->show();
+		enableTimebaseCheckBox->show();
 		trackOutsCheckBox->show();
 		jackBBTSyncComboBox->show();
 		jackBBTSyncLbl->show();
@@ -779,6 +799,7 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->hide();
 		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
+		enableTimebaseCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
@@ -799,6 +820,7 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutsCheckBox->hide();
 		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
+		enableTimebaseCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
@@ -819,6 +841,7 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->hide();
 		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
+		enableTimebaseCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();
@@ -839,6 +862,7 @@ void PreferencesDialog::updateDriverInfo()
 		trackOutputComboBox->hide();
 		trackOutputLbl->hide();
 		connectDefaultsCheckBox->hide();
+		enableTimebaseCheckBox->hide();
 		trackOutsCheckBox->hide();
 		jackBBTSyncComboBox->hide();
 		jackBBTSyncLbl->hide();

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -10,9 +10,6 @@
     <height>555</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form1</string>
-  </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
     <widget class="QTabWidget" name="TabWidget2">
@@ -32,7 +29,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab_1">
       <attribute name="title">
@@ -62,7 +59,7 @@
           </size>
          </property>
          <property name="text">
-          <string>&amp;Reopen last used song</string>
+          <string>Reopen last used &amp;song</string>
          </property>
          <property name="shortcut">
           <string>Alt+R</string>
@@ -78,7 +75,7 @@
           </size>
          </property>
          <property name="text">
-          <string>&amp;Reopen last used playlist</string>
+          <string>Reopen last used &amp;playlist</string>
          </property>
          <property name="shortcut">
           <string>Alt+R</string>
@@ -88,21 +85,21 @@
        <item>
         <widget class="QCheckBox" name="useRelativePlaylistPathsCheckbox">
          <property name="text">
-          <string>Use relative paths for playlist</string>
+          <string>Use &amp;relative paths for playlist</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="hideKeyboardCursor">
          <property name="text">
-          <string>Hide keyboard input cursor</string>
+          <string>&amp;Hide keyboard input cursor</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="useLashCheckbox">
          <property name="text">
-          <string>Use LASH</string>
+          <string>Use &amp;LASH</string>
          </property>
         </widget>
        </item>
@@ -433,7 +430,7 @@
            <item>
             <widget class="QCheckBox" name="connectDefaultsCheckBox">
              <property name="text">
-              <string>Connect to &amp;Default Output Pair</string>
+              <string>Connect to &amp;default JACK output ports</string>
              </property>
              <property name="shortcut">
               <string>Alt+D</string>
@@ -443,10 +440,17 @@
            <item>
             <widget class="QCheckBox" name="trackOutsCheckBox">
              <property name="text">
-              <string>Create per-instrument outputs</string>
+              <string>Create &amp;per-instrument JACK output ports</string>
              </property>
              <property name="shortcut">
               <string>Alt+D</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="enableTimebaseCheckBox">
+             <property name="text">
+              <string>Enable JACK &amp;timebase master support</string>
              </property>
             </widget>
            </item>
@@ -781,7 +785,7 @@
            <item>
             <widget class="QCheckBox" name="m_pIgnoreNoteOffCheckBox">
              <property name="text">
-              <string>Ignore note-off</string>
+              <string>&amp;Ignore note-off</string>
              </property>
             </widget>
            </item>
@@ -790,14 +794,14 @@
          <item>
           <widget class="QCheckBox" name="m_pEnableMidiFeedbackCheckBox">
            <property name="text">
-            <string>Enable MIDI feedback</string>
+            <string>&amp;Enable MIDI feedback</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="m_pDiscardMidiMsgCheckbox">
            <property name="text">
-            <string>Discard MIDI messages after action has been triggered</string>
+            <string>&amp;Discard MIDI messages after action has been triggered</string>
            </property>
           </widget>
          </item>
@@ -806,7 +810,7 @@
            <item>
             <widget class="QCheckBox" name="m_pFixedMapping">
              <property name="text">
-              <string>Use output note as input note</string>
+              <string>&amp;Use output note as input note</string>
              </property>
             </widget>
            </item>

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -334,13 +334,13 @@ int main(int argc, char *argv[])
 			pPref->m_sAudioDriver = "Auto";
 		}
 		else if (sSelectedDriver == "jack") {
-			pPref->m_sAudioDriver = "Jack";
+			pPref->m_sAudioDriver = "JACK";
 		}
 		else if ( sSelectedDriver == "oss" ) {
-			pPref->m_sAudioDriver = "Oss";
+			pPref->m_sAudioDriver = "OSS";
 		}
 		else if ( sSelectedDriver == "alsa" ) {
-			pPref->m_sAudioDriver = "Alsa";
+			pPref->m_sAudioDriver = "ALSA";
 		}
 
 		// Bootstrap is complete, start GUI
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
 			 * here we make it save that hydrogen start in a jacksession case
 			 * every time with jack as audio driver
 			 */
-			pPref->m_sAudioDriver = "Jack";
+			pPref->m_sAudioDriver = "JACK";
 
 		}
 


### PR DESCRIPTION
Sometimes (but unfortunately hard to reproduce) the BBT information sent by JACK do some really weird stuff. while the frame number gets incremented as usual, the BBT information shows very large and cyclic jumps e.g. beat 5 => 7 => 12 => 5. This messes up Hydrogen and makes it unusuable.

Up to now I only had this problem with Non-timeline and it went away when pressing the J.MASTER button in the GUI once or twice. But I now had a reproducible instance were it was just messed up with nothing that could be done about it. Curiously, when removing all the timebase support from Non-timeline this bug does still show. So, this is maybe a problem of Jack2 itself?

Anyway, there seems to be things in the JACK timebase ecosystem that to wild and mess up with the transport of Hydrogen. Previously there would be nothing the user could do about but to change to another driver. Hydrogen would always be in slave mode in case there was an external timebase master registered to the JACK server.

I introduced an option in the Preferences to disable the timebase support altogether. This way the basic JACK transport will always be usable.

Also, I updated some shortcuts in the PreferencesDialog