### PR TITLE
Fix hidden NULL linstrument

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -3452,8 +3452,6 @@ void Hydrogen::removeInstrument( int instrumentNumber, bool conditional )
 	// delete the instrument from the instruments list
 	AudioEngine::get_instance()->lock( RIGHT_HERE );
 	getSong()->getInstrumentList()->del( instrumentNumber );
-	// Ensure the selected instrument is not a deleted one
-	setSelectedInstrumentNumber( instrumentNumber - 1 );
 	getSong()->setIsModified( true );
 	AudioEngine::get_instance()->unlock();
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1621,10 +1621,10 @@ void DrumPatternEditor::functionMoveInstrumentAction( int nSourceInstrument,  in
 
 void  DrumPatternEditor::functionDropInstrumentUndoAction( int nTargetInstrument, std::vector<int>* AddedComponents )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	pEngine->removeInstrument( nTargetInstrument, false );
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	pHydrogen->removeInstrument( nTargetInstrument, false );
 
-	std::vector<DrumkitComponent*>* pDrumkitComponents = pEngine->getSong()->getComponents();
+	std::vector<DrumkitComponent*>* pDrumkitComponents = pHydrogen->getSong()->getComponents();
 
 	for (std::vector<int>::iterator it = AddedComponents->begin() ; it != AddedComponents->end(); ++it) {
 		int p_compoID = *it;
@@ -1640,8 +1640,8 @@ void  DrumPatternEditor::functionDropInstrumentUndoAction( int nTargetInstrument
 
 	AudioEngine::get_instance()->lock( RIGHT_HERE );
 #ifdef H2CORE_HAVE_JACK
-	Song *pSong = pEngine->getSong();
-	pEngine->renameJackPorts(pSong);
+	Song *pSong = pHydrogen->getSong();
+	pHydrogen->renameJackPorts( pSong );
 #endif
 	AudioEngine::get_instance()->unlock();
 	updateEditor();
@@ -1771,22 +1771,23 @@ int DrumPatternEditor::findExistingCompo( QString SourceName )
 
 
 
-void DrumPatternEditor::functionDeleteInstrumentUndoAction( std::list< H2Core::Note* > noteList, int nSelectedInstrument, QString instrumentName, QString drumkitName )
+void DrumPatternEditor::functionDeleteInstrumentUndoAction( std::list< H2Core::Note* > noteList, int nSelectedInstrument, QString sInstrumentName, QString sDrumkitName )
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	Instrument *pNewInstrument;
-	if( drumkitName == "" ){
-		pNewInstrument = new Instrument( pEngine->getSong()->getInstrumentList()->size() -1, instrumentName );
-	}else
-	{
-		pNewInstrument = Instrument::load_instrument( drumkitName, instrumentName );
+	if( sDrumkitName == "" ){
+		pNewInstrument = new Instrument( pHydrogen->getSong()->getInstrumentList()->size() -1, sInstrumentName );
+	} else {
+		pNewInstrument = Instrument::load_instrument( sDrumkitName, sInstrumentName );
 	}
-	if( pNewInstrument == nullptr ) return;
+	if( pNewInstrument == nullptr ) {
+		return;
+	}
 
 	// create a new valid ID for this instrument
 	int nID = -1;
-	for ( uint i = 0; i < pEngine->getSong()->getInstrumentList()->size(); ++i ) {
-		Instrument* pInstr = pEngine->getSong()->getInstrumentList()->get( i );
+	for ( uint i = 0; i < pHydrogen->getSong()->getInstrumentList()->size(); ++i ) {
+		Instrument* pInstr = pHydrogen->getSong()->getInstrumentList()->get( i );
 		if ( pInstr->get_id() > nID ) {
 			nID = pInstr->get_id();
 		}
@@ -1797,22 +1798,22 @@ void DrumPatternEditor::functionDeleteInstrumentUndoAction( std::list< H2Core::N
 //	pNewInstrument->set_adsr( new ADSR( 0, 0, 1.0, 1000 ) );
 
 	AudioEngine::get_instance()->lock( RIGHT_HERE );
-	pEngine->getSong()->getInstrumentList()->add( pNewInstrument );
+	pHydrogen->getSong()->getInstrumentList()->add( pNewInstrument );
 
 	#ifdef H2CORE_HAVE_JACK
-	pEngine->renameJackPorts( pEngine->getSong() );
+	pHydrogen->renameJackPorts( pHydrogen->getSong() );
 	#endif
 
 	AudioEngine::get_instance()->unlock();	// unlock the audio engine
 
 	//move instrument to the position where it was dropped
-	functionMoveInstrumentAction(pEngine->getSong()->getInstrumentList()->size() - 1 , nSelectedInstrument );
+	functionMoveInstrumentAction(pHydrogen->getSong()->getInstrumentList()->size() - 1 , nSelectedInstrument );
 
 	// select the new instrument
-	pEngine->setSelectedInstrumentNumber( nSelectedInstrument );
+	pHydrogen->setSelectedInstrumentNumber( nSelectedInstrument );
 
 	H2Core::Pattern *pPattern;
-	PatternList *pPatternList = pEngine->getSong()->getPatternList();
+	PatternList *pPatternList = pHydrogen->getSong()->getPatternList();
 
 	updateEditor();
 	EventQueue::get_instance()->push_event( EVENT_SELECTED_INSTRUMENT_CHANGED, -1 );

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -510,18 +510,17 @@ void InstrumentLine::functionRenameInstrument()
 
 void InstrumentLine::functionDeleteInstrument()
 {
-	Hydrogen * pEngine = Hydrogen::get_instance();
-	Instrument *pSelectedInstrument = pEngine->getSong()->getInstrumentList()->get( m_nInstrumentNumber );
-
+	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	Song* pSong = pHydrogen->getSong();
+		
+	Instrument *pSelectedInstrument = pSong->getInstrumentList()->get( m_nInstrumentNumber );
 	std::list< Note* > noteList;
-	Song* song = pEngine->getSong();
-	PatternList *patList = song->getPatternList();
 
-	QString instrumentName =  pSelectedInstrument->get_name();
-	QString drumkitName = pEngine->getCurrentDrumkitname();
+	QString sInstrumentName =  pSelectedInstrument->get_name();
+	QString sDrumkitName = pHydrogen->getCurrentDrumkitname();
 
-	for ( int i = 0; i < patList->size(); i++ ) {
-		H2Core::Pattern *pPattern = song->getPatternList()->get(i);
+	for ( int i = 0; i < pSong->getPatternList()->size(); i++ ) {
+		H2Core::Pattern *pPattern = pSong->getPatternList()->get(i);
 		const Pattern::notes_t* notes = pPattern->get_notes();
 		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
 			Note *pNote = it->second;
@@ -532,7 +531,7 @@ void InstrumentLine::functionDeleteInstrument()
 			}
 		}
 	}
-	SE_deleteInstrumentAction *action = new SE_deleteInstrumentAction( noteList, drumkitName, instrumentName, m_nInstrumentNumber );
+	SE_deleteInstrumentAction *action = new SE_deleteInstrumentAction( noteList, sDrumkitName, sInstrumentName, m_nInstrumentNumber );
 	HydrogenApp::get_instance()->m_pUndoStack->push( action );
 }
 

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -906,7 +906,7 @@ private:
 class SE_deleteInstrumentAction : public QUndoCommand
 {
 public:
-	SE_deleteInstrumentAction(  std::list<  H2Core::Note* > noteList, QString drumkitName, QString instrumentName, int nSelectedInstrument ){
+	SE_deleteInstrumentAction(  std::list<  H2Core::Note* > noteList, QString sDrumkitName, QString sInstrumentName, int nSelectedInstrument ){
 		setText( QString( "Delete instrument " ) );
 
 		std::list < H2Core::Note *>::iterator pos;
@@ -916,8 +916,8 @@ public:
 			assert( pNote );
 			__noteList.push_back( pNote );
 		}
-		__drumkitName = drumkitName;
-		__instrumentName = instrumentName;
+		__drumkitName = sDrumkitName;
+		__instrumentName = sInstrumentName;
 		__nSelectedInstrument = nSelectedInstrument;
 	}
 


### PR DESCRIPTION
In `Hydrogen::removeInstrument` the instrument number was decremented causing Hydrogen to break when removing the first instrument.

fixes #1140 