### PR TITLE
Use radio buttons for View > Timeline and View > Playback Track

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -380,15 +380,18 @@ void MainForm::createMenuBar()
 	m_pViewAutomationPathAction->setCheckable( true );
 	update_automation_checkbox();
 
+	m_pViewMenu->addSeparator();				// -----
+
 	m_pViewTimelineAction = m_pViewMenu->addAction( tr("&Timeline"), this, SLOT( action_window_showTimeline() ), QKeySequence( "" ) );
 	m_pViewTimelineAction->setCheckable( true );
-	m_pViewTimelineAction->setChecked( true );
-	update_automation_checkbox();
 	
 	m_pViewPlaybackTrackAction = m_pViewMenu->addAction( tr("&Playback Track"), this, SLOT( action_window_showPlaybackTrack() ), QKeySequence( "" ) );
 	m_pViewPlaybackTrackAction->setCheckable( true );
-	m_pViewPlaybackTrackAction->setChecked( false );
-	update_automation_checkbox();
+
+	m_pViewPlaybackTrackActionGroup = new QActionGroup( this );
+	m_pViewPlaybackTrackActionGroup->addAction( m_pViewTimelineAction );
+	m_pViewPlaybackTrackActionGroup->addAction( m_pViewPlaybackTrackAction );
+	update_playback_track_group();
 
 	m_pViewMenu->addSeparator();				// -----
 
@@ -1053,16 +1056,12 @@ void MainForm::action_window_showSongEditor()
 void MainForm::action_window_showTimeline()
 {
 	h2app->getSongEditorPanel()->showTimeline();
-	m_pViewPlaybackTrackAction->setChecked( false );	
-	m_pViewTimelineAction->setChecked( true );	
 }
 
 
 void MainForm::action_window_showPlaybackTrack()
 {
 	h2app->getSongEditorPanel()->showPlaybackTrack();
-	m_pViewPlaybackTrackAction->setChecked( true );	
-	m_pViewTimelineAction->setChecked( false );	
 }
 
 void MainForm::action_window_showAutomationArea()
@@ -1322,6 +1321,18 @@ void MainForm::update_automation_checkbox()
 		m_pViewAutomationPathAction->setChecked(true);	
 	} else {
 		m_pViewAutomationPathAction->setChecked(false);
+	}
+}
+
+void MainForm::update_playback_track_group()
+{
+	Preferences *pPref = Preferences::get_instance();
+
+	// Note that the ActionGroup unchecks the other menu item automatically
+	if ( pPref->getShowPlaybackTrack() ) {
+		m_pViewPlaybackTrackAction->setChecked( true );
+	} else {
+		m_pViewTimelineAction->setChecked( true );
 	}
 }
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -164,6 +164,7 @@ public slots:
 		void update_mixer_checkbox();
 		void update_instrument_checkbox( bool show );
 		void update_automation_checkbox();
+		void update_playback_track_group();
 		void update_director_checkbox();
 		void update_playlist_checkbox();
 
@@ -240,6 +241,7 @@ public slots:
 		QAction *	m_pViewAutomationPathAction;
 		QAction *	m_pViewTimelineAction;
 		QAction *	m_pViewPlaybackTrackAction;
+		QActionGroup *	m_pViewPlaybackTrackActionGroup;
 		QAction *	m_pInstrumentAction;
 		QAction *	m_pDrumkitAction;
 


### PR DESCRIPTION
Previously, the Timeline and Playback Track items in the View menu were shown as checkboxes, but they functioned as radio buttons.  Also, while the actual state was saved in the preferences, the Timeline menu item was always shown as checked on startup.

This PR changes the menu items to be a radio button group, with an extra separator above them to set them apart from the checkboxes further.  It also correctly loads the state on program startup so that the correct item is shown as selected.