### PR TITLE
fix closing ExportSongDialog

### DIFF
--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -455,8 +455,16 @@ void ExportSongDialog::exportTracks()
     
 }
 
+void ExportSongDialog::closeEvent( QCloseEvent *event ) {
+	UNUSED( event );
+	closeExport();
+}
 void ExportSongDialog::on_closeBtn_clicked()
 {
+	closeExport();
+}
+void ExportSongDialog::closeExport() {
+	
 	m_pEngine->stopExportSong();
 	m_pEngine->stopExportSession();
 	

--- a/src/gui/src/ExportSongDialog.h
+++ b/src/gui/src/ExportSongDialog.h
@@ -51,6 +51,7 @@ class ExportSongDialog : public QDialog, public Ui_ExportSongDialog_UI, public E
 		~ExportSongDialog();
 
 		virtual void progressEvent( int nValue ) override;
+		void closeEvent( QCloseEvent* event ) override;
 
 
 private slots:
@@ -78,6 +79,8 @@ private:
 	void		exportTracks();
 	bool 		validateUserInput();
 	QString		createDefaultFilename();
+
+	void		closeExport();
 	
 	bool					m_bExporting;
 	bool					m_bExportTrackouts;


### PR DESCRIPTION
via pressing ESC or killing the dialog via the window manager instead of pressing the Close button.

Fixes #1185