### PR TITLE
Fix Bug #1184

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -151,7 +151,11 @@ int PatternEditor::getColumn( int x, bool bUseFineGrained ) const
 	int nWidth = m_nGridWidth * nGranularity;
 	int nColumn = ( x - m_nMargin + (nWidth / 2) ) / nWidth;
 	nColumn = nColumn * nGranularity;
-	return nColumn;
+	if ( nColumn < 0 ) {
+		return 0;
+	} else {
+		return nColumn;
+	}
 }
 
 void PatternEditor::selectNone()


### PR DESCRIPTION
in function `getColumn()` which returns the position (in ticks) of the nearest grid line to the position of click event,
added constraint: output >= 0 ticks