### PR TITLE
Dev tweak oscapi

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -3517,24 +3517,6 @@ int Hydrogen::getSelectedPatternNumber()
 }
 
 
-void Hydrogen::setSelectedPatternNumberWithoutGuiEvent( int nPat )
-{
-	Song* pSong = getSong();
-
-	if ( nPat == m_nSelectedPatternNumber
-		 || ( nPat + 1 > pSong->getPatternList()->size() )
-		 ) return;
-
-	if ( Preferences::get_instance()->patternModePlaysSelected() ) {
-		AudioEngine::get_instance()->lock( RIGHT_HERE );
-
-		m_nSelectedPatternNumber = nPat;
-		AudioEngine::get_instance()->unlock();
-	} else {
-		m_nSelectedPatternNumber = nPat;
-	}
-}
-
 void Hydrogen::setSelectedPatternNumber( int nPat )
 {
 	if ( nPat == m_nSelectedPatternNumber )	return;

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -446,10 +446,6 @@ void			previewSample( Sample *pSample );
 	void			setBPM( float fBPM );
 
 	void			restartLadspaFX();
-	/** 
-	 * Same as getSelectedPatternNumber() without pushing an event.
-	 * \param nPat Sets #m_nSelectedPatternNumber*/
-	void			setSelectedPatternNumberWithoutGuiEvent( int nPat );
 	/** \return #m_nSelectedPatternNumber*/
 	int				getSelectedPatternNumber();
 	/**

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -336,7 +336,8 @@ bool MidiActionManager::tap_tempo(Action * , Hydrogen* pEngine, targeted_element
 bool MidiActionManager::select_next_pattern(Action * pAction, Hydrogen* pEngine, targeted_element ) {
 	bool ok;
 	int row = pAction->getParameter1().toInt(&ok,10);
-	if( row > pEngine->getSong()->getPatternList()->size() -1 ) {
+	if( row > pEngine->getSong()->getPatternList()->size() - 1 ||
+		row < 0 ) {
 		return false;
 	}
 	if(Preferences::get_instance()->patternModePlaysSelected()) {
@@ -351,7 +352,8 @@ bool MidiActionManager::select_next_pattern(Action * pAction, Hydrogen* pEngine,
 bool MidiActionManager::select_only_next_pattern(Action * pAction, Hydrogen* pEngine, targeted_element ) {
 	bool ok;
 	int row = pAction->getParameter1().toInt(&ok,10);
-	if( row > pEngine->getSong()->getPatternList()->size() -1 ) {
+	if( row > pEngine->getSong()->getPatternList()->size() -1 ||
+		row < 0 ) {
 		return false;
 	}
 	if(Preferences::get_instance()->patternModePlaysSelected())
@@ -369,7 +371,8 @@ bool MidiActionManager::select_next_pattern_relative(Action * pAction, Hydrogen*
 		return true;
 	}
 	int row = pEngine->getSelectedPatternNumber() + pAction->getParameter1().toInt(&ok,10);
-	if( row > pEngine->getSong()->getPatternList()->size() -1 ) {
+	if( row > pEngine->getSong()->getPatternList()->size() - 1 ||
+		row < 0 ) {
 		return false;
 	}
 
@@ -381,7 +384,8 @@ bool MidiActionManager::select_next_pattern_cc_absolute(Action * pAction, Hydrog
 	bool ok;
 	int row = pAction->getParameter2().toInt(&ok,10);
 	
-	if( row > pEngine->getSong()->getPatternList()->size() -1 ) {
+	if( row > pEngine->getSong()->getPatternList()->size() - 1 ||
+		row < 0 ) {
 		return false;
 	}
 	
@@ -410,13 +414,15 @@ bool MidiActionManager::select_and_play_pattern(Action * pAction, Hydrogen* pEng
 
 bool MidiActionManager::select_instrument(Action * pAction, Hydrogen* pEngine, targeted_element ) {
 	bool ok;
-	int  instrument_number = pAction->getParameter2().toInt(&ok,10) ;
+	int  nInstrumentNumber = pAction->getParameter2().toInt(&ok,10) ;
 	
-	if ( pEngine->getSong()->getInstrumentList()->size() < instrument_number ) {
-		instrument_number = pEngine->getSong()->getInstrumentList()->size() -1;
+	if ( pEngine->getSong()->getInstrumentList()->size() < nInstrumentNumber ) {
+		nInstrumentNumber = pEngine->getSong()->getInstrumentList()->size() -1;
+	} else if ( nInstrumentNumber < 0 ) {
+		nInstrumentNumber = 0;
 	}
 	
-	pEngine->setSelectedInstrumentNumber( instrument_number );
+	pEngine->setSelectedInstrumentNumber( nInstrumentNumber );
 	return true;
 }
 

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -395,11 +395,10 @@ bool MidiActionManager::select_next_pattern_cc_absolute(Action * pAction, Hydrog
 	return true;
 }
 
-bool MidiActionManager::select_and_play_pattern(Action * pAction, Hydrogen* pEngine, targeted_element ) {
-	bool ok;
-	int row = pAction->getParameter1().toInt(&ok,10);
-	pEngine->setSelectedPatternNumber( row );
-	pEngine->sequencer_setNextPattern( row );
+bool MidiActionManager::select_and_play_pattern(Action * pAction, Hydrogen* pEngine, targeted_element t ) {
+	if ( ! select_next_pattern( pAction, pEngine, t ) ) {
+		return false;
+	}
 
 	int nState = pEngine->getState();
 	if ( nState == STATE_READY ) {

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -161,7 +161,6 @@ MidiActionManager::MidiActionManager() : Object( __class_name ) {
 	actionMap.insert(std::make_pair("SELECT_NEXT_PATTERN", std::make_pair(&MidiActionManager::select_next_pattern, empty)));
 	actionMap.insert(std::make_pair("SELECT_ONLY_NEXT_PATTERN", std::make_pair(&MidiActionManager::select_only_next_pattern, empty)));
 	actionMap.insert(std::make_pair("SELECT_NEXT_PATTERN_CC_ABSOLUTE", std::make_pair(&MidiActionManager::select_next_pattern_cc_absolute, empty)));
-	actionMap.insert(std::make_pair("SELECT_NEXT_PATTERN_PROMPTLY", std::make_pair(&MidiActionManager::select_next_pattern_promptly, empty)));
 	actionMap.insert(std::make_pair("SELECT_NEXT_PATTERN_RELATIVE", std::make_pair(&MidiActionManager::select_next_pattern_relative, empty)));
 	actionMap.insert(std::make_pair("SELECT_AND_PLAY_PATTERN", std::make_pair(&MidiActionManager::select_and_play_pattern, empty)));
 	actionMap.insert(std::make_pair("PAN_RELATIVE", std::make_pair(&MidiActionManager::pan_relative, empty)));
@@ -392,15 +391,6 @@ bool MidiActionManager::select_next_pattern_cc_absolute(Action * pAction, Hydrog
 	else {
 		return true;// only usefully in normal pattern mode
 	}
-	
-	return true;
-}
-
-// obsolete, use SELECT_NEXT_PATTERN_CC_ABSOLUT instead
-bool MidiActionManager::select_next_pattern_promptly(Action * pAction, Hydrogen* pEngine, targeted_element ) {
-	bool ok;
-	int row = pAction->getParameter2().toInt(&ok,10);
-	pEngine->setSelectedPatternNumberWithoutGuiEvent( row );
 	
 	return true;
 }

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -129,7 +129,6 @@ class MidiActionManager : public H2Core::Object
 		bool select_next_pattern(Action * , H2Core::Hydrogen * , targeted_element );
 		bool select_only_next_pattern(Action * , H2Core::Hydrogen * , targeted_element );
 		bool select_next_pattern_cc_absolute(Action * , H2Core::Hydrogen * , targeted_element );
-		bool select_next_pattern_promptly(Action * , H2Core::Hydrogen * , targeted_element );
 		bool select_next_pattern_relative(Action * , H2Core::Hydrogen * , targeted_element );
 		bool select_and_play_pattern(Action * , H2Core::Hydrogen * , targeted_element );
 		bool pan_relative(Action * , H2Core::Hydrogen * , targeted_element );

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -170,6 +170,17 @@ int OscServer::generic_handler(const char *	path,
 			}
 		}
 	}
+
+	QRegExp rxStripVolRel( "/Hydrogen/STRIP_VOLUME_RELATIVE/(\\d+)" );
+	pos = rxStripVolRel.indexIn( oscPath );
+	if ( pos > -1 ) {
+		if( argc == 1 ){
+			int nStrip = rxStripVolRel.cap(1).toInt() - 1;
+			if ( nStrip > -1 && nStrip < nNumberOfStrips ) {
+				STRIP_VOLUME_RELATIVE_Handler( QString::number( nStrip ) , QString::number( argv[0]->f, 'f', 0 ) );
+			}
+		}
+	}
 	
 	QRegExp rxStripPanAbs( "/Hydrogen/PAN_ABSOLUTE/(\\d+)" );
 	pos = rxStripPanAbs.indexIn( oscPath );
@@ -456,10 +467,11 @@ void OscServer::STRIP_VOLUME_ABSOLUTE_Handler(int param1, float param2)
 	pController->setStripVolume( param1, param2, false );
 }
 
-void OscServer::STRIP_VOLUME_RELATIVE_Handler(lo_arg **argv,int i)
+void OscServer::STRIP_VOLUME_RELATIVE_Handler(QString param1, QString param2)
 {
 	Action currentAction("STRIP_VOLUME_RELATIVE");
-	currentAction.setParameter2( QString::number( argv[0]->f, 'f', 0 ));
+	currentAction.setParameter1( param1 );
+	currentAction.setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
 	pActionManager->handleAction( &currentAction );
@@ -916,8 +928,6 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/MASTER_VOLUME_ABSOLUTE", "f", MASTER_VOLUME_ABSOLUTE_Handler);
 	m_pServerThread->add_method("/Hydrogen/MASTER_VOLUME_RELATIVE", "f", MASTER_VOLUME_RELATIVE_Handler);
 	
-	m_pServerThread->add_method("/Hydrogen/STRIP_VOLUME_RELATIVE", "f", STRIP_VOLUME_RELATIVE_Handler);
-
 	m_pServerThread->add_method("/Hydrogen/SELECT_NEXT_PATTERN", "f", SELECT_NEXT_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/SELECT_AND_PLAY_PATTERN", "f", SELECT_AND_PLAY_PATTERN_Handler);
 	

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -470,15 +470,6 @@ void OscServer::SELECT_NEXT_PATTERN_Handler(lo_arg **argv,int i)
 	pActionManager->handleAction( &currentAction );
 }
 
-void OscServer::SELECT_NEXT_PATTERN_PROMPTLY_Handler(lo_arg **argv,int i)
-{
-	Action currentAction("SELECT_NEXT_PATTERN_PROMPTLY");
-	currentAction.setParameter1(  QString::number( argv[0]->f, 'f', 0 ) );
-	MidiActionManager* pActionManager = MidiActionManager::get_instance();
-
-	pActionManager->handleAction( &currentAction );
-}
-
 void OscServer::SELECT_AND_PLAY_PATTERN_Handler(lo_arg **argv,int i)
 {
 	Action currentAction("SELECT_AND_PLAY_PATTERN");
@@ -924,7 +915,6 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/STRIP_VOLUME_RELATIVE", "f", STRIP_VOLUME_RELATIVE_Handler);
 
 	m_pServerThread->add_method("/Hydrogen/SELECT_NEXT_PATTERN", "f", SELECT_NEXT_PATTERN_Handler);
-	m_pServerThread->add_method("/Hydrogen/SELECT_NEXT_PATTERN_PROMPTLY", "f", SELECT_NEXT_PATTERN_PROMPTLY_Handler);
 	m_pServerThread->add_method("/Hydrogen/SELECT_AND_PLAY_PATTERN", "f", SELECT_AND_PLAY_PATTERN_Handler);
 	
 	m_pServerThread->add_method("/Hydrogen/BEATCOUNTER", "", BEATCOUNTER_Handler);

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -163,7 +163,6 @@ class OscServer : public H2Core::Object
 		 * - MASTER_VOLUME_RELATIVE_Handler()
 		 * - STRIP_VOLUME_RELATIVE_Handler()
 		 * - SELECT_NEXT_PATTERN_Handler()
-		 * - SELECT_NEXT_PATTERN_PROMPTLY_Handler()
 		 * - SELECT_AND_PLAY_PATTERN_Handler() 
 		 * - PLAYLIST_SONG_Handler()
 		 * - SELECT_INSTRUMENT_Handler()
@@ -454,19 +453,6 @@ class OscServer : public H2Core::Object
 		 * \param i Unused number of arguments passed by the OSC
 		 * message.*/
 		static void SELECT_NEXT_PATTERN_Handler(lo_arg **argv, int i);
-		/**
-		 * Creates an Action of type @b SELECT_NEXT_PATTERN_PROMPTLY
-		 * and passes its references to
-		 * MidiActionManager::handleAction().
-		 *
-		 * The first argument in @a argv will be used to set
-		 * Action::parameter1.
-		 *
-		 * \param argv Pointer to a vector of arguments passed
-		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
-		 * message.*/
-		static void SELECT_NEXT_PATTERN_PROMPTLY_Handler(lo_arg **argv, int i);
 		/**
 		 * Creates an Action of type @b SELECT_AND_PLAY_PATTERN and
 		 * passes its references to MidiActionManager::handleAction().

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -234,6 +234,7 @@ class OscServer : public H2Core::Object
 		 * - \e /Hydrogen/TOGGLE_METRONOME
 		 * - \e /Hydrogen/MUTE_TOGGLE
 		 * - \e /Hydrogen/STRIP_VOLUME_ABSOLUTE/[x]
+		 * - \e /Hydrogen/STRIP_VOLUME_RELATIVE/[x]
 		 * - \e /Hydrogen/PAN_ABSOLUTE/[x]
 		 * - \e /Hydrogen/STRIP_MUTE_TOGGLE/[x]
 		 * - \e /Hydrogen/STRIP_SOLO_TOGGLE/[x]
@@ -424,14 +425,11 @@ class OscServer : public H2Core::Object
 		 * Creates an Action of type @b STRIP_VOLUME_RELATIVE and
 		 * passes its references to MidiActionManager::handleAction().
 		 *
-		 * The first argument in @a argv will be used to set
-		 * Action::parameter2.
-		 *
-		 * \param argv Pointer to a vector of arguments passed
-		 * by the OSC message.
-		 * \param i Unused number of arguments passed by the OSC
-		 * message.*/
-		static void STRIP_VOLUME_RELATIVE_Handler(lo_arg **argv, int i);
+		 * \param param1 Sets Action::parameter1 of the newly created
+		 * Action.
+		 * \param param2 Sets Action::parameter2 of the newly created
+		 * Action.*/
+		static void STRIP_VOLUME_RELATIVE_Handler(QString param1, QString param2);
 		/**
 		 * Calls H2Core::CoreActionController::setStripVolume() with
 		 * both @a param1 and @a param2.


### PR DESCRIPTION
When looking through the OSC commands, I found a couple of issues that had to be addressed before 1.1.

- I found **four** different ways to cause a segfault by providing negative or too large arguments
- I made the `STRIP_VOLUME_RELATIVE` acting on all strips
- I dropped the `SELECT_NEXT_PATTERN_PROMPTLY` which did not work