### PR TITLE
Experimental change of visual representation of fixed length notes

### DIFF
--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1127,6 +1127,7 @@ void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 			p.setBrush( color );
 			p.fillRect( x_pos, y_pos +2, width, 3, color );	/// \todo: definire questo colore nelle preferenze
 			p.drawRect( x_pos, y_pos +2, width, 3 );
+			p.drawLine( x_pos+width, y_pos, x_pos+width, y_pos + h);
 		}
 		
 		p.setPen(noteColor);
@@ -1137,6 +1138,7 @@ void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 			p.setPen( movingPen );
 			p.setBrush( Qt::NoBrush );
 			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2 , w + 4, h + 4 );
+			// Moving tail
 			if ( note->get_length() != -1 ) {
 				p.setPen( movingPen );
 				p.setBrush( Qt::NoBrush );

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1054,8 +1054,8 @@ void DrumPatternEditor::__draw_pattern(QPainter& painter)
 ///
 void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 {
-	InstrumentList * pInstrList = Hydrogen::get_instance()->getSong()->getInstrumentList();
-	int nInstrument = pInstrList->index( note->get_instrument() );;
+	InstrumentList *pInstrList = Hydrogen::get_instance()->getSong()->getInstrumentList();
+	int nInstrument = pInstrList->index( note->get_instrument() );
 	if ( nInstrument == -1 ) {
 		ERRORLOG( "Instrument not found..skipping note" );
 		return;

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1104,11 +1104,31 @@ void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 							   delta.y() * m_nGridHeight );
 	}
 
-	if ( note->get_length() == -1 && note->get_note_off() == false ) {	// trigger note
+
+	
+	if ( note->get_note_off() == false ) {	// trigger note
+		int width = w;
 
 		if ( bSelected ) {
 			p.drawEllipse( x_pos -4 -2, y_pos-2, w+4, h+4 );
 		}
+
+		// Draw tail
+		if ( note->get_length() != -1 ) {
+			float fNotePitch = note->get_octave() * 12 + note->get_key();
+			float fStep = pow( 1.0594630943593, ( double )fNotePitch );
+			width = m_nGridWidth * note->get_length() / fStep;
+			width = width - 1;	// lascio un piccolo spazio tra una nota ed un altra
+
+			if ( bSelected ) {
+				p.drawRoundedRect( x_pos-2, y_pos, width+4, 3+4, 4, 4 );
+			}
+			p.setPen(noteColor);
+			p.setBrush( color );
+			p.fillRect( x_pos, y_pos +2, width, 3, color );	/// \todo: definire questo colore nelle preferenze
+			p.drawRect( x_pos, y_pos +2, width, 3 );
+		}
+		
 		p.setPen(noteColor);
 		p.setBrush( color );
 		p.drawEllipse( x_pos -4 , y_pos, w, h );
@@ -1117,6 +1137,12 @@ void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 			p.setPen( movingPen );
 			p.setBrush( Qt::NoBrush );
 			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2 , w + 4, h + 4 );
+			if ( note->get_length() != -1 ) {
+				p.setPen( movingPen );
+				p.setBrush( Qt::NoBrush );
+				p.drawRoundedRect( movingOffset.x() + x_pos-2, movingOffset.y() + y_pos, width+4, 3+4, 4, 4 );
+			}
+
 		}
 
 	}
@@ -1134,31 +1160,6 @@ void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 			p.setBrush( Qt::NoBrush );
 			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2, w + 4, h + 4 );
 		}
-
-	}
-	else {
-		float fNotePitch = note->get_octave() * 12 + note->get_key();
-		float fStep = pow( 1.0594630943593, ( double )fNotePitch );
-
-		uint x = m_nMargin + (pos * m_nGridWidth);
-		int w = m_nGridWidth * note->get_length() / fStep;
-		w = w - 1;	// lascio un piccolo spazio tra una nota ed un altra
-
-		int y = (int) ( ( nInstrument ) * m_nGridHeight  + (m_nGridHeight / 100.0 * 30.0) );
-		int h = (int) (m_nGridHeight - ((m_nGridHeight / 100.0 * 30.0) * 2.0) );
-		if ( bSelected ) {
-			p.drawRoundedRect( x-2, y+1-2, w+4, h+1+4, 4, 4 );
-		}
-		p.setPen(noteColor);
-		p.setBrush( color );
-		p.fillRect( x, y + 1, w, h + 1, color );	/// \todo: definire questo colore nelle preferenze
-		p.drawRect( x, y + 1, w, h + 1 );
-		if ( bMoving ) {
-			p.setPen( movingPen );
-			p.setBrush( Qt::NoBrush );
-			p.drawRoundedRect( movingOffset.x() + x-2, movingOffset.y() + y+1-2, w+4, h+1+4, 4, 4 );
-		}
-
 	}
 }
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1054,115 +1054,17 @@ void DrumPatternEditor::__draw_pattern(QPainter& painter)
 ///
 void DrumPatternEditor::__draw_note( Note *note, QPainter& p )
 {
-	static const UIStyle *pStyle = Preferences::get_instance()->getDefaultUIStyle();
-	static const QColor noteColor( pStyle->m_patternEditor_noteColor.getRed(), pStyle->m_patternEditor_noteColor.getGreen(), pStyle->m_patternEditor_noteColor.getBlue() );
-	static const QColor noteoffColor( pStyle->m_patternEditor_noteoffColor.getRed(), pStyle->m_patternEditor_noteoffColor.getGreen(), pStyle->m_patternEditor_noteoffColor.getBlue() );
-
-	p.setRenderHint( QPainter::Antialiasing );
-
-	int nInstrument = -1;
 	InstrumentList * pInstrList = Hydrogen::get_instance()->getSong()->getInstrumentList();
-	for ( uint nInstr = 0; nInstr < pInstrList->size(); ++nInstr ) {
-		Instrument *pInstr = pInstrList->get( nInstr );
-		if ( pInstr == note->get_instrument() ) {
- 			nInstrument = nInstr;
-			break;
-		}
-	}
+	int nInstrument = pInstrList->index( note->get_instrument() );;
 	if ( nInstrument == -1 ) {
 		ERRORLOG( "Instrument not found..skipping note" );
 		return;
 	}
 
-	uint pos = note->get_position();
+	QPoint pos ( m_nMargin + note->get_position() * m_nGridWidth,
+				 ( nInstrument * m_nGridHeight) + (m_nGridHeight / 2) - 3 );
 
-	QColor color = computeNoteColor( note->get_velocity() );
-
-	uint w = 8;
-	uint h =  m_nGridHeight / 3;
-	uint x_pos = m_nMargin + (pos * m_nGridWidth);
-	uint y_pos = ( nInstrument * m_nGridHeight) + (m_nGridHeight / 2) - 3;
-
-	bool bSelected = m_selection.isSelected( note );
-
-	if ( bSelected ) {
-		QPen selectedPen( selectedNoteColor( pStyle ) );
-		selectedPen.setWidth( 2 );
-		p.setPen( selectedPen );
-		p.setBrush( Qt::NoBrush );
-	}
-
-	bool bMoving = bSelected && m_selection.isMoving();
-	QPen movingPen( noteColor );
-	QPoint movingOffset;
-
-	if ( bMoving ) {
-		movingPen.setStyle( Qt::DotLine );
-		movingPen.setWidth( 2 );
-		QPoint delta = movingGridOffset();
-		movingOffset = QPoint( delta.x() * m_nGridWidth,
-							   delta.y() * m_nGridHeight );
-	}
-
-
-	
-	if ( note->get_note_off() == false ) {	// trigger note
-		int width = w;
-
-		if ( bSelected ) {
-			p.drawEllipse( x_pos -4 -2, y_pos-2, w+4, h+4 );
-		}
-
-		// Draw tail
-		if ( note->get_length() != -1 ) {
-			float fNotePitch = note->get_octave() * 12 + note->get_key();
-			float fStep = pow( 1.0594630943593, ( double )fNotePitch );
-			width = m_nGridWidth * note->get_length() / fStep;
-			width = width - 1;	// lascio un piccolo spazio tra una nota ed un altra
-
-			if ( bSelected ) {
-				p.drawRoundedRect( x_pos-2, y_pos, width+4, 3+4, 4, 4 );
-			}
-			p.setPen(noteColor);
-			p.setBrush( color );
-			p.fillRect( x_pos, y_pos +2, width, 3, color );	/// \todo: definire questo colore nelle preferenze
-			p.drawRect( x_pos, y_pos +2, width, 3 );
-			p.drawLine( x_pos+width, y_pos, x_pos+width, y_pos + h);
-		}
-		
-		p.setPen(noteColor);
-		p.setBrush( color );
-		p.drawEllipse( x_pos -4 , y_pos, w, h );
-
-		if ( bMoving ) {
-			p.setPen( movingPen );
-			p.setBrush( Qt::NoBrush );
-			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2 , w + 4, h + 4 );
-			// Moving tail
-			if ( note->get_length() != -1 ) {
-				p.setPen( movingPen );
-				p.setBrush( Qt::NoBrush );
-				p.drawRoundedRect( movingOffset.x() + x_pos-2, movingOffset.y() + y_pos, width+4, 3+4, 4, 4 );
-			}
-
-		}
-
-	}
-	else if ( note->get_length() == 1 && note->get_note_off() == true ){
-
-		if ( bSelected ) {
-			p.drawEllipse( x_pos -4 -2, y_pos-2, w+4, h+4 );
-		}
-		p.setPen( noteoffColor );
-		p.setBrush(QColor( noteoffColor));
-		p.drawEllipse( x_pos -4 , y_pos, w, h );
-
-		if ( bMoving ) {
-			p.setPen( movingPen );
-			p.setBrush( Qt::NoBrush );
-			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2, w + 4, h + 4 );
-		}
-	}
+	drawNoteSymbol( p, pos, note );
 }
 
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -154,8 +154,7 @@ void PatternEditor::drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote
 
 	QColor color = computeNoteColor( pNote->get_velocity() );
 
-	uint w = 8;
-	uint h =  m_nGridHeight / 3;
+	uint w = 8, h =  8;
 	uint x_pos = pos.x(), y_pos = pos.y();
 
 	bool bSelected = m_selection.isSelected( pNote );

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -114,7 +114,7 @@ void PatternEditor::zoomOut()
 	}
 }
 
-QColor PatternEditor::computeNoteColor( float velocity ){
+QColor PatternEditor::computeNoteColor( float velocity ) {
 	int red;
 	int green;
 	int blue;
@@ -141,6 +141,103 @@ QColor PatternEditor::computeNoteColor( float velocity ){
 	//qDebug() << "R " << red << "G " << green << "blue " << blue;
 	return QColor( red, green, blue );
 }
+
+
+void PatternEditor::drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote ) const
+{
+	static const UIStyle *pStyle = Preferences::get_instance()->getDefaultUIStyle();
+	static const QColor noteColor( pStyle->m_patternEditor_noteColor.getRed(), pStyle->m_patternEditor_noteColor.getGreen(), pStyle->m_patternEditor_noteColor.getBlue() );
+	static const QColor noteoffColor( pStyle->m_patternEditor_noteoffColor.getRed(), pStyle->m_patternEditor_noteoffColor.getGreen(), pStyle->m_patternEditor_noteoffColor.getBlue() );
+
+	p.setRenderHint( QPainter::Antialiasing );
+
+
+	QColor color = computeNoteColor( pNote->get_velocity() );
+
+	uint w = 8;
+	uint h =  m_nGridHeight / 3;
+	uint x_pos = pos.x(), y_pos = pos.y();
+
+	bool bSelected = m_selection.isSelected( pNote );
+
+	if ( bSelected ) {
+		QPen selectedPen( selectedNoteColor( pStyle ) );
+		selectedPen.setWidth( 2 );
+		p.setPen( selectedPen );
+		p.setBrush( Qt::NoBrush );
+	}
+
+	bool bMoving = bSelected && m_selection.isMoving();
+	QPen movingPen( noteColor );
+	QPoint movingOffset;
+
+	if ( bMoving ) {
+		movingPen.setStyle( Qt::DotLine );
+		movingPen.setWidth( 2 );
+		QPoint delta = movingGridOffset();
+		movingOffset = QPoint( delta.x() * m_nGridWidth,
+							   delta.y() * m_nGridHeight );
+	}
+
+	if ( pNote->get_note_off() == false ) {	// trigger note
+		int width = w;
+
+		if ( bSelected ) {
+			p.drawEllipse( x_pos -4 -2, y_pos-2, w+4, h+4 );
+		}
+
+		// Draw tail
+		if ( pNote->get_length() != -1 ) {
+			float fNotePitch = pNote->get_octave() * 12 + pNote->get_key();
+			float fStep = pow( 1.0594630943593, ( double )fNotePitch );
+			width = m_nGridWidth * pNote->get_length() / fStep;
+			width = width - 1;	// lascio un piccolo spazio tra una nota ed un altra
+
+			if ( bSelected ) {
+				p.drawRoundedRect( x_pos-2, y_pos, width+4, 3+4, 4, 4 );
+			}
+			p.setPen( noteColor );
+			p.setBrush( color );
+			p.fillRect( x_pos, y_pos +2, width, 3, color );	/// \todo: definire questo colore nelle preferenze
+			p.drawRect( x_pos, y_pos +2, width, 3 );
+			p.drawLine( x_pos+width, y_pos, x_pos+width, y_pos + h );
+		}
+
+		p.setPen( noteColor );
+		p.setBrush( color );
+		p.drawEllipse( x_pos -4 , y_pos, w, h );
+
+		if ( bMoving ) {
+			p.setPen( movingPen );
+			p.setBrush( Qt::NoBrush );
+			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2 , w + 4, h + 4 );
+			// Moving tail
+			if ( pNote->get_length() != -1 ) {
+				p.setPen( movingPen );
+				p.setBrush( Qt::NoBrush );
+				p.drawRoundedRect( movingOffset.x() + x_pos-2, movingOffset.y() + y_pos, width+4, 3+4, 4, 4 );
+			}
+
+		}
+
+	}
+	else if ( pNote->get_length() == 1 && pNote->get_note_off() == true ) {
+
+		if ( bSelected ) {
+			p.drawEllipse( x_pos -4 -2, y_pos-2, w+4, h+4 );
+		}
+ 		p.setPen( noteoffColor );
+		p.setBrush( QColor( noteoffColor ) );
+		p.drawEllipse( x_pos -4 , y_pos, w, h );
+
+		if ( bMoving ) {
+			p.setPen( movingPen );
+			p.setBrush( Qt::NoBrush );
+			p.drawEllipse( movingOffset.x() + x_pos -4 -2, movingOffset.y() + y_pos -2, w + 4, h + 4 );
+		}
+	}
+}
+
 
 int PatternEditor::getColumn( int x, bool bUseFineGrained ) const
 {
@@ -402,7 +499,7 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 }
 
 
-QColor PatternEditor::selectedNoteColor( const UIStyle *pStyle ) {
+QColor PatternEditor::selectedNoteColor( const UIStyle *pStyle ) const {
 	if ( hasFocus() ) {
 		static const QColor selectHilightColor( pStyle->m_selectionHighlightColor.getRed(),
 												pStyle->m_selectionHighlightColor.getGreen(),

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -173,7 +173,10 @@ protected:
 	void drawGridLines( QPainter &p, Qt::PenStyle style = Qt::SolidLine ) const;
 
 	//! Colour to use for outlining selected notes
-	QColor selectedNoteColor( const H2Core::UIStyle *pStyle );
+	QColor selectedNoteColor( const H2Core::UIStyle *pStyle ) const;
+
+	//! Draw a note
+	void drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote ) const;
 
 	//! Update current pattern information
 	void updatePatternInfo();

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -325,102 +325,12 @@ void PianoRollEditor::drawPattern()
 
 void PianoRollEditor::drawNote( Note *pNote, QPainter *pPainter )
 {
-	static const UIStyle *pStyle = Preferences::get_instance()->getDefaultUIStyle();
-	static const QColor noteColor( pStyle->m_patternEditor_noteColor.getRed(), pStyle->m_patternEditor_noteColor.getGreen(), pStyle->m_patternEditor_noteColor.getBlue() );
-	static const QColor noteoffColor( pStyle->m_patternEditor_noteoffColor.getRed(), pStyle->m_patternEditor_noteoffColor.getGreen(), pStyle->m_patternEditor_noteoffColor.getBlue() );
-
-	int nInstrument = -1;
-	InstrumentList * pInstrList = Hydrogen::get_instance()->getSong()->getInstrumentList();
-	for ( uint nInstr = 0; nInstr < pInstrList->size(); ++nInstr ) {
-		Instrument *pInstr = pInstrList->get( nInstr );
-		if ( pInstr == pNote->get_instrument() ) {
-			nInstrument = nInstr;
-			break;
-		}
-	}
-	if ( nInstrument == -1 ) {
-		//ERRORLOG( "Instrument not found..skipping note" );
-		return;
-	}
-
-	if ( nInstrument != Hydrogen::get_instance()->getSelectedInstrumentNumber() ) {
-		return;
-	}
-
-	uint start_x = m_nMargin + pNote->get_position() * m_nGridWidth;
-	uint start_y = m_nGridHeight * pitchToLine( pNote->get_notekey_pitch() ) + 1;
-	uint w = 8;
-	uint h = m_nGridHeight - 2;
-
-	QColor color = computeNoteColor( pNote->get_velocity() );
-
-	bool bSelected = m_selection.isSelected( pNote );
-	if ( bSelected ) {
-		QPen selectedPen( selectedNoteColor( pStyle ) );
-		selectedPen.setWidth( 2 );
-		pPainter->setPen( selectedPen );
-		pPainter->setBrush( Qt::NoBrush );
-	}
-
-	bool bMoving = bSelected && m_selection.isMoving();
-	QPen movingPen( noteColor );
-	QPoint movingOffset;
-
-	if ( bMoving ) {
-		movingPen.setStyle( Qt::DotLine );
-		movingPen.setWidth( 2 );
-		QPoint delta = movingGridOffset();
-		movingOffset = QPoint( delta.x() * m_nGridWidth,
-							   delta.y() * m_nGridHeight );
-	}
-
-	pPainter->setRenderHint( QPainter::Antialiasing );
-
-	if ( pNote->get_length() == -1 && pNote->get_note_off() == false ) {
-		if ( bSelected ) {
-			pPainter->drawEllipse( start_x -4 -2 , start_y -2, w+4, h+4 );
-		}
-		pPainter->setPen( noteColor );
-		pPainter->setBrush( color );
-		pPainter->drawEllipse( start_x -4 , start_y, w, h );
-		if ( bMoving ) {
-			pPainter->setPen( movingPen );
-			pPainter->setBrush( Qt::NoBrush );
-			pPainter->drawEllipse( start_x -4 -2 + movingOffset.x(), start_y -2 + movingOffset.y(), w+4, h+4 );
-		}
-	}
-	else if ( pNote->get_length() == 1 && pNote->get_note_off() == true ){
-		if ( bSelected ) {
-			pPainter->drawEllipse( start_x -4 -2 , start_y -2, w+4, h+4 );
-		}
-		pPainter->setPen( noteoffColor );
-		pPainter->setBrush( noteoffColor );
-		pPainter->drawEllipse( start_x -4 , start_y, w, h );
-		if ( bMoving ) {
-			pPainter->setPen( movingPen );
-			pPainter->setBrush( Qt::NoBrush );
-			pPainter->drawEllipse( start_x -4 -2 + movingOffset.x(), start_y -2 + movingOffset.y(), w+4, h+4 );
-		}
-	}
-	else {
-		float fNotePitch = pNote->get_notekey_pitch();
-		float fStep = pow( 1.0594630943593, ( double )fNotePitch );
-
-		int nend = m_nGridWidth * pNote->get_length() / fStep;
-		nend = nend - 1;	// lascio un piccolo spazio tra una nota ed un altra
-		if ( bSelected ) {
-			pPainter->drawRoundedRect( start_x-2, start_y-2, nend+4, h+4, 4, 4 );
-		}
-		pPainter->setPen( noteColor );
-		pPainter->setBrush( color );
-		pPainter->fillRect( start_x, start_y, nend, h, color );
-		pPainter->drawRect( start_x, start_y, nend, h );
-		if ( bMoving ) {
-			pPainter->setPen( movingPen );
-			pPainter->setBrush( Qt::NoBrush );
-			pPainter->drawRoundedRect( start_x-2 + movingOffset.x(), start_y -2 + movingOffset.y(), nend+4, h+4, 4, 4 );
-		}
-
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	InstrumentList * pInstrList = pHydrogen->getSong()->getInstrumentList();
+	if ( pInstrList->index( pNote->get_instrument() ) == pHydrogen->getSelectedInstrumentNumber() ) {
+		QPoint pos ( m_nMargin + pNote->get_position() * m_nGridWidth,
+					 m_nGridHeight * pitchToLine( pNote->get_notekey_pitch() ) + 1);
+		drawNoteSymbol( *pPainter, pos, pNote );
 	}
 }
 

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -316,7 +316,7 @@ public:
 	}
 
 	//! Is an element in the set of currently selected elements? 
-	bool isSelected( Elem e ) {
+	bool isSelected( Elem e ) const {
 		return m_pSelectionGroup->m_selectedElements.find( e ) != m_pSelectionGroup->m_selectedElements.end();
 	}
 


### PR DESCRIPTION
I've long been a bit dissatisfied with the way fixed-length notes are displayed in the pattern editors. The transition from round note marker to rectangle is jarring and abrupt. 

  * Suddenly going from round to having corners. 
  * Gives more visual emphasis to longer notes, which doesn't necessarily represent the aural impact.
  * Usually the *start* of the note is the most important thing, with time spent in the 'sustain' of the note less significant.

So, as a proposal and a request for comment (and not completely implemented -- only in the Drum Pattern Editor, not the Piano Roll Editor), I've tried a few things and like this representation more: a round note like the usual notes, but with a tail representing the length of the note:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/768466/109399328-1a39ed00-793a-11eb-990a-eed621496a9f.png">

Any thoughts or opinions?