### PR TITLE
Fix issue with loading drumkits causing inconsistent instrument ids

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -3136,6 +3136,7 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool conditional )
 	
 	//needed for the new delete function
 	int instrumentDiff =  pSongInstrList->size() - pDrumkitInstrList->size();
+	int nMaxID = -1;
 	
 	for ( unsigned nInstr = 0; nInstr < pDrumkitInstrList->size(); ++nInstr ) {
 		Instrument *pInstr = nullptr;
@@ -3159,8 +3160,17 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool conditional )
 				 .arg( pDrumkitInstrList->size() )
 				 .arg( pNewInstr->get_name() ) );
 
+		// Preserve instrument IDs. Where the new drumkit has more instruments than the song does, new
+		// instruments need new ids.
+		int nID = pInstr->get_id();
+		if ( nID == EMPTY_INSTR_ID ) {
+			nID = nMaxID + 1;
+		}
+		nMaxID = std::max( nID, nMaxID );
+
 		// Moved code from here right into the Instrument class - Jakob Lund.
 		pInstr->load_from( pDrumkitInfo, pNewInstr );
+		pInstr->set_id( nID );
 	}
 
 	//wolke: new delete function


### PR DESCRIPTION
When loading a new drumkit, the instruments are overwritted by the new instruments, including their 'id' fields. This causes existing notes to have their instrument_id field out of sync with the instrument's actual id. A few places do rely on these being consistent, potentially causing crashes.

This PR fixes this by mapping the new instrument ids to the corresponding old instrument ids. 

An alternative would be to go over all the notes in the song after loading the kit and reset their instrument_ids to the new instrument_ids, but this doesn't handle the case where loading a drumkit keeps some old instruments (due to existing notes) which might have duplicate IDs in the new drumkit.