### PR TITLE
Use a condition variable for logger sleep/wake.

### DIFF
--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -27,14 +27,6 @@
 #include <QtCore/QDir>
 #include <QtCore/QString>
 
-#ifdef WIN32
-#include <windows.h>
-#define LOGGER_SLEEP Sleep( 100 )
-#else
-#include <unistd.h>
-#define LOGGER_SLEEP do { usleep( 500000 ); usleep( 500000 ); } while (0)
-#endif
-
 namespace H2Core {
 
 unsigned Logger::__bit_msk = 0;
@@ -69,7 +61,8 @@ void* loggerThread_func( void* param ) {
 	Logger::queue_t::iterator it, last;
 
 	while ( logger->__running ) {
-		LOGGER_SLEEP;
+		pthread_cond_wait( &logger->__messages_available, &logger->__mutex );
+		pthread_mutex_unlock( &logger->__mutex );
 		if( !queue->empty() ) {
 			for( it = last = queue->begin() ; it != queue->end() ; ++it ) {
 				last = it;
@@ -94,7 +87,7 @@ void* loggerThread_func( void* param ) {
 #ifdef WIN32
 	::FreeConsole();
 #endif
-	LOGGER_SLEEP;
+
 	pthread_exit( nullptr );
 	return nullptr;
 }
@@ -114,11 +107,13 @@ Logger::Logger() : __use_file( true ), __running( true ) {
 	pthread_attr_t attr;
 	pthread_attr_init( &attr );
 	pthread_mutex_init( &__mutex, nullptr );
+        pthread_cond_init( &__messages_available, nullptr );
 	pthread_create( &loggerThread, &attr, loggerThread_func, this );
 }
 
 Logger::~Logger() {
 	__running = false;
+        pthread_cond_broadcast ( &__messages_available );
 	pthread_join( loggerThread, nullptr );
 }
 
@@ -164,6 +159,7 @@ void Logger::log( unsigned level, const QString& class_name, const char* func_na
 	pthread_mutex_lock( &__mutex );
 	__msg_queue.push_back( tmp );
 	pthread_mutex_unlock( &__mutex );
+	pthread_cond_broadcast( &__messages_available );
 }
 
 unsigned Logger::parse_log_level( const char* level ) {

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -111,13 +111,13 @@ Logger::Logger() : __use_file( true ), __running( true ) {
 	pthread_attr_t attr;
 	pthread_attr_init( &attr );
 	pthread_mutex_init( &__mutex, nullptr );
-        pthread_cond_init( &__messages_available, nullptr );
+	pthread_cond_init( &__messages_available, nullptr );
 	pthread_create( &loggerThread, &attr, loggerThread_func, this );
 }
 
 Logger::~Logger() {
 	__running = false;
-        pthread_cond_broadcast ( &__messages_available );
+	pthread_cond_broadcast ( &__messages_available );
 	pthread_join( loggerThread, nullptr );
 }
 

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -27,6 +27,10 @@
 #include <QtCore/QDir>
 #include <QtCore/QString>
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 namespace H2Core {
 
 unsigned Logger::__bit_msk = 0;

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -132,6 +132,7 @@ class Logger {
 		queue_t __msg_queue;            ///< the message queue
 		static unsigned __bit_msk;      ///< the bitmask of log_level_t
 		static const char* __levels[];  ///< levels strings
+		pthread_cond_t __messages_available;
 
 		/** constructor */
 		Logger();


### PR DESCRIPTION
Logger previously used wall clock time to sleep / wake. This had
two(ish) unpleasant side effects.

  1. logger traffic would be excessively bursty, which makes it
     harder to read the log on the console in real time, and
     particularly makes it harder to associate particular log lines
     with user actions.
  2. quitting Hydrogen had to wait for the thread to wake up and
     terminate itself before quitting. This adds on average 0.5s
     to the time taken to quit. Not annoying for most users, but
     probably fairly annoying for developers (hi).
     The sleep period was for some reason only 0.1 seconds on
     Windows, but 1.0 everywhere else. I suspect this was a typo.
     Actually there also seems to have been a pointless extra 1s
     wait (0.1s on Windows) after flushing the log. I think this
     is probably a historical artefact.

It also wasted a very tiny bit of CPU time by waking the thread up
every second to check the queue, but it would be tiny.

This change uses a condition variable instead to block the logger,
so it only wakes up when messages are present, and it does so
immediately. It also wakes up immediately to terminate and flush
buffers.