### PR TITLE
Fix #250 by selecting instrument when 'mute' button is clicked.

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -192,12 +192,13 @@ void InstrumentLine::setSamplesMissing( bool bSamplesMissing )
 
 void InstrumentLine::muteClicked()
 {
-	Hydrogen *pEngine = Hydrogen::get_instance();
-	Song *pSong = pEngine->getSong();
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	Song *pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	Instrument *pInstr = pInstrList->get( m_nInstrumentNumber );
+	pHydrogen->setSelectedInstrumentNumber( m_nInstrumentNumber );
 
-	CoreActionController* pCoreActionController = pEngine->getCoreActionController();
+	CoreActionController* pCoreActionController = pHydrogen->getCoreActionController();
 	pCoreActionController->setStripIsMuted( m_nInstrumentNumber, !pInstr->is_muted() );
 }
 


### PR DESCRIPTION
This should be a reasonable expectation since the mute button is
contained entirely within the area of the selectable instrument
line, and the 'solo' button changes instrument as well.