### PR TITLE
Validity checks

### DIFF
--- a/data/xsd/playlist.xsd
+++ b/data/xsd/playlist.xsd
@@ -31,7 +31,7 @@
 			<xsd:element name="songs">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element ref="h2:song" maxOccurs="1000"/>
+						<xsd:element ref="h2:song" minOccurs="0" maxOccurs="1000"/>
 					</xsd:sequence>
 				</xsd:complexType>
 			</xsd:element>

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -353,7 +353,9 @@ void Drumkit::save_to( XMLNode* node, int component_id )
 			pComponent->save_to( &components_node );
 		}
 	}
-	__instruments->save_to( node, component_id );
+	if ( __instruments != nullptr ) {
+		__instruments->save_to( node, component_id );
+	}
 }
 
 bool Drumkit::save_samples( const QString& dk_dir, bool overwrite )

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -50,7 +50,14 @@ namespace H2Core
 
 const char* Drumkit::__class_name = "Drumkit";
 
-Drumkit::Drumkit() : Object( __class_name ), __samples_loaded( false ), __instruments( nullptr ), __components( nullptr )
+Drumkit::Drumkit() : Object( __class_name ),
+					 __samples_loaded( false ),
+					 __instruments( nullptr ),
+					 __name( "empty" ),
+					 __author( "undefined author" ),
+					 __info( "No information available." ),
+					 __license( "undefined license" ),
+					 __imageLicense( "undefined license" )
 {
 	__components = new std::vector<DrumkitComponent*> ();
 }
@@ -113,7 +120,6 @@ Drumkit* Drumkit::load_file( const QString& dk_path, const bool load_samples )
 	
 	XMLDoc doc;
 	if( !doc.read( dk_path, Filesystem::drumkit_xsd_path() ) ) {
-		
 		//Something went wrong. Lets see how old this drumkit is..
 		
 		//Do we have any components? 
@@ -134,13 +140,12 @@ Drumkit* Drumkit::load_file( const QString& dk_path, const bool load_samples )
 			bReadingSuccessful = false;
 		}
 	}
-	
 	XMLNode root = doc.firstChildElement( "drumkit_info" );
 	if ( root.isNull() ) {
 		ERRORLOG( "drumkit_info node not found" );
 		return nullptr;
 	}
-	
+
 	Drumkit* pDrumkit = Drumkit::load_from( &root, dk_path.left( dk_path.lastIndexOf( "/" ) ) );
 	if ( ! bReadingSuccessful ) {
 		upgrade_drumkit( pDrumkit, dk_path );
@@ -348,13 +353,28 @@ void Drumkit::save_to( XMLNode* node, int component_id )
 
 	if( component_id == -1 ) {
 		XMLNode components_node = node->createNode( "componentList" );
-		for (std::vector<DrumkitComponent*>::iterator it = __components->begin() ; it != __components->end(); ++it) {
-			DrumkitComponent* pComponent = *it;
-			pComponent->save_to( &components_node );
-		}
+		if ( __components->size() > 0 ) {
+			for (std::vector<DrumkitComponent*>::iterator it = __components->begin() ; it != __components->end(); ++it) {
+				DrumkitComponent* pComponent = *it;
+				pComponent->save_to( &components_node );
+			}
+		} else {
+			WARNINGLOG( "Drumkit has no components. Storing an empty one as fallback." );
+			DrumkitComponent* pDrumkitComponent = new DrumkitComponent( 0, "Main" );
+			pDrumkitComponent->save_to( &components_node );
+			delete pDrumkitComponent;
+		}	
 	}
-	if ( __instruments != nullptr ) {
+
+	if ( __instruments != nullptr && __instruments->size() > 0 ) {
 		__instruments->save_to( node, component_id );
+	} else {
+		WARNINGLOG( "Drumkit has no instruments. Storing an InstrumentList with a single empty Instrument as fallback." );
+		InstrumentList* pInstrumentList = new InstrumentList();
+		Instrument* pInstrument = new Instrument();
+		pInstrumentList->insert( 0, pInstrument );
+		pInstrumentList->save_to( node, component_id );
+		delete pInstrumentList;
 	}
 }
 

--- a/src/core/Basics/Playlist.cpp
+++ b/src/core/Basics/Playlist.cpp
@@ -220,4 +220,44 @@ void Playlist::execScript( int index)
 	return;
 }
 
+QString Playlist::toQString( const QString& sPrefix, bool bShort ) const {
+	QString s = Object::sPrintIndention;
+	QString sOutput;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[Playlist]\n" ).arg( sPrefix )
+			.append( QString( "%1%2filename: %3\n" ).arg( sPrefix ).arg( s ).arg( __filename ) )
+			.append( QString( "%1%2m_nSelectedSongNumber: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nSelectedSongNumber ) )
+			.append( QString( "%1%2m_nActiveSongNumber: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nActiveSongNumber ) )
+			.append( QString( "%1%2entries:\n" ).arg( sPrefix ).arg( s ) );
+		if ( size() > 0 ) {
+			for ( auto ii : __entries ) {
+				sOutput.append( QString( "%1%2Entry:\n" ).arg( sPrefix ).arg( s + s ) )
+					.append( QString( "%1%2filePath: %3\n" ).arg( sPrefix ).arg( s + s + s ).arg( ii->filePath ) )
+					.append( QString( "%1%2fileExists: %3\n" ).arg( sPrefix ).arg( s + s + s ).arg( ii->fileExists ) )
+					.append( QString( "%1%2scriptPath: %3\n" ).arg( sPrefix ).arg( s + s + s ).arg( ii->scriptPath ) )
+					.append( QString( "%1%2scriptEnabled: %3\n" ).arg( sPrefix ).arg( s + s + s ).arg( ii->scriptEnabled ) );
+			}
+		}
+		sOutput.append( QString( "%1%2m_bIsModified: %3\n" ).arg( sPrefix ).arg( s ).arg( m_bIsModified ) );
+	} else {
+		sOutput = QString( "[Playlist]" )
+			.append( QString( " filename: %1" ).arg( __filename ) )
+			.append( QString( ", m_nSelectedSongNumber: %1" ).arg( m_nSelectedSongNumber ) )
+			.append( QString( ", m_nActiveSongNumber: %1" ).arg( m_nActiveSongNumber ) )
+			.append( ", entries: {" );
+		if ( size() > 0 ) {
+			for ( auto ii : __entries ) {
+				sOutput.append( QString( "[filePath: %1" ).arg( ii->filePath ) )
+					.append( QString( ", fileExists: %1" ).arg( ii->fileExists ) )
+					.append( QString( ", scriptPath: %1" ).arg( ii->scriptPath ) )
+					.append( QString( ", scriptEnabled: %1] " ).arg( ii->scriptEnabled ) );
+										
+										
+			}
+		}
+		sOutput.append( QString( "}, m_bIsModified: %1\n" ).arg( m_bIsModified ) );
+	}
+	
+	return sOutput;
+}
 };

--- a/src/core/Basics/Playlist.h
+++ b/src/core/Basics/Playlist.h
@@ -85,6 +85,15 @@ class Playlist : public H2Core::Object
 		static Playlist* load( const QString& filename, bool useRelativePaths );
 		static Playlist* load_file( const QString& pl_path, bool useRelativePaths );
 		bool save_file( const QString& pl_path, const QString& name, bool overwrite, bool useRelativePaths );
+		/** Formatted string version for debugging purposes.
+		 * \param sPrefix String prefix which will be added in front of
+		 * every new line
+		 * \param bShort Instead of the whole content of all classes
+		 * stored as members just a single unique identifier will be
+		 * displayed without line breaks.
+		 *
+		 * \return String presentation of current object.*/
+		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
 
 	private:
 		/**

--- a/src/tests/FunctionalTests.cpp
+++ b/src/tests/FunctionalTests.cpp
@@ -39,6 +39,7 @@
 #include <core/Basics/PatternList.h>
 #include <core/Basics/Sample.h>
 #include <core/Basics/Song.h>
+#include <core/Basics/Playlist.h>
 #include <core/Smf/SMF.h>
 #include "TestHelper.h"
 #include "assertions/File.h"
@@ -151,6 +152,10 @@ class FunctionalTest : public CppUnit::TestCase {
 		auto pNote = pPattern->find_note( 0, -1, pInstrument, false );
 		auto pDrumkit = Drumkit::load( sDrumkitFile, true );
 		auto pDrumkitComponent = (*pDrumkit->get_components())[ 0 ];
+		auto pPlaylist = Playlist::get_instance();
+		auto entry = Playlist::Entry{ "/tmp", true, "/usr/", false };
+		pPlaylist->add( &entry );
+		pPlaylist->add( &entry );
 
 		std::cout << std::endl;
 		std::cout << pVelocityAutomationPath << std::endl;
@@ -166,6 +171,7 @@ class FunctionalTest : public CppUnit::TestCase {
 		std::cout << pDrumkitComponent << std::endl;
 		std::cout << pDrumkit << std::endl;
 		std::cout << pSong << std::endl;
+		std::cout << pPlaylist << std::endl;
 		std::cout << Hydrogen::get_instance() << std::endl;
  
 		qDebug() << pVelocityAutomationPath;
@@ -181,6 +187,7 @@ class FunctionalTest : public CppUnit::TestCase {
 		qDebug() << pDrumkitComponent;
 		qDebug() << pDrumkit;
 		qDebug() << pSong;
+		qDebug() << pPlaylist;
 		qDebug() << Hydrogen::get_instance();
  
 		// 	std::cout << std::endl;
@@ -197,6 +204,7 @@ class FunctionalTest : public CppUnit::TestCase {
 		// 	std::cout << pDrumkitComponent->toQString( "", false ).toLocal8Bit().data() << std::endl;
 		// 	std::cout << pDrumkit->toQString( "", false ).toLocal8Bit().data() << std::endl;
 		// 	std::cout << pSong->toQString( "", false ).toLocal8Bit().data() << std::endl;
+		// std::cout << pPlaylist->toQString( "", false ).toLocal8Bit().data();
 
 	}
 

--- a/src/tests/MidiNoteTest.cpp
+++ b/src/tests/MidiNoteTest.cpp
@@ -7,6 +7,8 @@
 
 #include <QFileInfo>
 
+#include "TestHelper.h"
+
 #include <iostream>
 #include <stdexcept>
 
@@ -82,7 +84,7 @@ class MidiNoteTest : public CppUnit::TestCase {
 		 * preserving legacy behavior. */
 
 		SongReader reader;
-		auto song = reader.readSong( get_test_file("song/test_song_0.9.6.h2song") );
+		auto song = reader.readSong( H2TEST_FILE( "song/test_song_0.9.6.h2song" ) );
 		CPPUNIT_ASSERT( song != nullptr );
 
 		auto instruments = song->getInstrumentList();
@@ -103,7 +105,7 @@ class MidiNoteTest : public CppUnit::TestCase {
 		 * change that mapping */
 
 		SongReader reader;
-		auto song = reader.readSong( get_test_file("song/test_song_0.9.7.h2song") );
+		auto song = reader.readSong( H2TEST_FILE( "song/test_song_0.9.7.h2song" ) );
 		CPPUNIT_ASSERT( song != nullptr );
 
 		auto instruments = song->getInstrumentList();

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -184,9 +184,10 @@ void XmlTest::testDrumkit_UpgradeInvalidADSRValues()
 
 void XmlTest::testPattern()
 {
-	QString pat_path = H2Core::Filesystem::tmp_dir()+"/pat";
+	QString pat_path = H2Core::Filesystem::tmp_dir()+"pat";
 
 	H2Core::Pattern* pat0 = nullptr;
+	H2Core::Pattern* pat1 = nullptr;
 	H2Core::Drumkit* dk0 = nullptr;
 	H2Core::InstrumentList* instruments = nullptr;
 
@@ -198,10 +199,25 @@ void XmlTest::testPattern()
 	pat0 = H2Core::Pattern::load_file( H2TEST_FILE( "/pattern/pat.h2pattern" ), instruments );
 	CPPUNIT_ASSERT( pat0 );
 
-	pat0->save_file( "dk_name", "author", "license", pat_path );
+	CPPUNIT_ASSERT( pat0->save_file( "dk_name", "author", "license", pat_path, true ) );
 
+	H2Core::XMLDoc doc;
+	CPPUNIT_ASSERT( doc.read( pat_path, H2Core::Filesystem::pattern_xsd_path() ) );
+
+	pat1 = H2Core::Pattern::load_file( pat_path, instruments );
+
+	CPPUNIT_ASSERT( pat1 != nullptr );
+
+	delete pat1;
 	delete pat0;
 	delete dk0;
+}
+
+void XmlTest::checkTestPatterns()
+{
+	H2Core::XMLDoc doc;
+	CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/pattern/pat.h2pattern" ),
+							  H2Core::Filesystem::pattern_xsd_path() ) );
 }
 
 void XmlTest::tearDown() {

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -52,7 +52,7 @@ static bool check_samples_data( H2Core::Drumkit* dk, bool loaded )
 
 void XmlTest::testDrumkit()
 {
-	QString dk_path = H2Core::Filesystem::tmp_dir()+"/dk0";
+	QString dk_path = H2Core::Filesystem::tmp_dir()+"dk0";
 
 	H2Core::Drumkit* dk0 = nullptr;
 	H2Core::Drumkit* dk1 = nullptr;
@@ -88,7 +88,6 @@ void XmlTest::testDrumkit()
 	CPPUNIT_ASSERT( check_samples_data( dk0, false ) );
 	//dk0->dump();
 	
-	/*
 	// save drumkit elsewhere
 	dk0->set_name( "dk0" );
 	CPPUNIT_ASSERT( dk0->save( dk_path, false ) );
@@ -97,21 +96,30 @@ void XmlTest::testDrumkit()
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/hh.wav" ) );
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/kick.wav" ) );
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/snare.wav" ) );
+
+	// Check whether the generated drumkit is valid.
+	H2Core::XMLDoc doc;
+	CPPUNIT_ASSERT( doc.read( dk_path + "/drumkit.xml",
+							  H2Core::Filesystem::drumkit_xsd_path() ) );
+	
 	// load file
 	dk1 = H2Core::Drumkit::load_file( dk_path+"/drumkit.xml" );
 	CPPUNIT_ASSERT( dk1!=nullptr );
 	//dk1->dump();
+	
 	// copy constructor
 	dk2 = new H2Core::Drumkit( dk1 );
-	dk2->set_name( "COPY" );
 	CPPUNIT_ASSERT( dk2!=nullptr );
 	// save file
+	dk2->set_name( "COPY" );
 	CPPUNIT_ASSERT( dk2->save_file( dk_path+"/drumkit.xml", true ) );
-	*/
 	
 	delete dk0;
-	//delete dk1;
-	//delete dk2;
+	delete dk1;
+	delete dk2;
+
+	// Cleanup
+	H2Core::Filesystem::rm( dk_path, true );
 }
 
 void XmlTest::testShippedDrumkits()

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -9,6 +9,7 @@
 #include <core/Basics/InstrumentLayer.h>
 #include <core/Basics/InstrumentComponent.h>
 #include <core/Basics/Sample.h>
+#include <core/Basics/Playlist.h>
 
 #include <core/Helpers/Filesystem.h>
 #include <core/Helpers/Xml.h>
@@ -242,6 +243,23 @@ void XmlTest::checkTestPatterns()
 	H2Core::XMLDoc doc;
 	CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/pattern/pat.h2pattern" ),
 							  H2Core::Filesystem::pattern_xsd_path() ) );
+}
+
+void XmlTest::testPlaylist()
+{
+	QString sPath = H2Core::Filesystem::tmp_dir()+"playlist.h2playlist";
+
+	H2Core::Playlist* pPlaylistCurrent = H2Core::Playlist::get_instance();
+	H2Core::Playlist* pPlaylistLoaded = nullptr;
+	H2Core::XMLDoc doc;
+
+	CPPUNIT_ASSERT( pPlaylistCurrent->save_file( sPath, "ladida", true, false ) );
+	CPPUNIT_ASSERT( doc.read( sPath, H2Core::Filesystem::playlist_xsd_path() ) );
+	pPlaylistLoaded = H2Core::Playlist::load_file( sPath, false );
+	CPPUNIT_ASSERT( pPlaylistLoaded != nullptr );
+
+	delete pPlaylistLoaded;
+	delete pPlaylistCurrent;
 }
 
 void XmlTest::tearDown() {

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -89,7 +89,7 @@ void XmlTest::testDrumkit()
 	
 	// save drumkit elsewhere
 	pDrumkitLoaded->set_name( "pDrumkitLoaded" );
-	CPPUNIT_ASSERT( pDrumkitLoaded->save( sDrumkitPath, false ) );
+	CPPUNIT_ASSERT( pDrumkitLoaded->save( sDrumkitPath, true ) );
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/drumkit.xml" ) );
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/crash.wav" ) );
 	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/hh.wav" ) );
@@ -110,7 +110,6 @@ void XmlTest::testDrumkit()
 	// save file
 	pDrumkitCopied->set_name( "COPY" );
 	CPPUNIT_ASSERT( pDrumkitCopied->save_file( sDrumkitPath+"/drumkit.xml", true ) );
-		CPPUNIT_ASSERT( pDrumkitCopied->save_file( sDrumkitPath+"/drumkit.xml", true ) );
 
 	delete pDrumkitReloaded;
 

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -52,74 +52,83 @@ static bool check_samples_data( H2Core::Drumkit* dk, bool loaded )
 
 void XmlTest::testDrumkit()
 {
-	QString dk_path = H2Core::Filesystem::tmp_dir()+"dk0";
+	QString sDrumkitPath = H2Core::Filesystem::tmp_dir()+"dk0";
 
-	H2Core::Drumkit* dk0 = nullptr;
-	H2Core::Drumkit* dk1 = nullptr;
-	H2Core::Drumkit* dk2 = nullptr;
+	H2Core::Drumkit* pDrumkitLoaded = nullptr;
+	H2Core::Drumkit* pDrumkitReloaded = nullptr;
+	H2Core::Drumkit* pDrumkitCopied = nullptr;
+	H2Core::Drumkit* pDrumkitNew = nullptr;
+	H2Core::XMLDoc doc;
 
 	// load without samples
-	dk0 = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/baseKit") );
-	CPPUNIT_ASSERT( dk0!=nullptr );
-	CPPUNIT_ASSERT( dk0->samples_loaded()==false );
-	CPPUNIT_ASSERT( check_samples_data( dk0, false ) );
-	CPPUNIT_ASSERT_EQUAL( 4, dk0->get_instruments()->size() );
-	//dk0->dump();
+	pDrumkitLoaded = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/baseKit") );
+	CPPUNIT_ASSERT( pDrumkitLoaded!=nullptr );
+	CPPUNIT_ASSERT( pDrumkitLoaded->samples_loaded()==false );
+	CPPUNIT_ASSERT( check_samples_data( pDrumkitLoaded, false ) );
+	CPPUNIT_ASSERT_EQUAL( 4, pDrumkitLoaded->get_instruments()->size() );
 
 	// Check if drumkit was valid (what we assume in this test)
 	CPPUNIT_ASSERT( ! H2Core::Filesystem::file_exists( H2TEST_FILE( "/drumkits/baseKit/drumkit.xml.bak" ) ) );
 	
 	// manually load samples
-	dk0->load_samples();
-	CPPUNIT_ASSERT( dk0->samples_loaded()==true );
-	CPPUNIT_ASSERT( check_samples_data( dk0, true ) );
-	//dk0->dump();
+	pDrumkitLoaded->load_samples();
+	CPPUNIT_ASSERT( pDrumkitLoaded->samples_loaded()==true );
+	CPPUNIT_ASSERT( check_samples_data( pDrumkitLoaded, true ) );
 	
 	// load with samples
-	dk0 = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/baseKit" ), true );
-	CPPUNIT_ASSERT( dk0!=nullptr );
-	CPPUNIT_ASSERT( dk0->samples_loaded()==true );
-	CPPUNIT_ASSERT( check_samples_data( dk0, true ) );
-	//dk0->dump();
+	pDrumkitLoaded = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/baseKit" ), true );
+	CPPUNIT_ASSERT( pDrumkitLoaded!=nullptr );
+	CPPUNIT_ASSERT( pDrumkitLoaded->samples_loaded()==true );
+	CPPUNIT_ASSERT( check_samples_data( pDrumkitLoaded, true ) );
 	
 	// unload samples
-	dk0->unload_samples();
-	CPPUNIT_ASSERT( dk0->samples_loaded()==false );
-	CPPUNIT_ASSERT( check_samples_data( dk0, false ) );
-	//dk0->dump();
+	pDrumkitLoaded->unload_samples();
+	CPPUNIT_ASSERT( pDrumkitLoaded->samples_loaded()==false );
+	CPPUNIT_ASSERT( check_samples_data( pDrumkitLoaded, false ) );
 	
 	// save drumkit elsewhere
-	dk0->set_name( "dk0" );
-	CPPUNIT_ASSERT( dk0->save( dk_path, false ) );
-	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/drumkit.xml" ) );
-	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/crash.wav" ) );
-	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/hh.wav" ) );
-	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/kick.wav" ) );
-	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( dk_path+"/snare.wav" ) );
+	pDrumkitLoaded->set_name( "pDrumkitLoaded" );
+	CPPUNIT_ASSERT( pDrumkitLoaded->save( sDrumkitPath, false ) );
+	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/drumkit.xml" ) );
+	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/crash.wav" ) );
+	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/hh.wav" ) );
+	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/kick.wav" ) );
+	CPPUNIT_ASSERT( H2Core::Filesystem::file_readable( sDrumkitPath+"/snare.wav" ) );
 
 	// Check whether the generated drumkit is valid.
-	H2Core::XMLDoc doc;
-	CPPUNIT_ASSERT( doc.read( dk_path + "/drumkit.xml",
+	CPPUNIT_ASSERT( doc.read( sDrumkitPath + "/drumkit.xml",
 							  H2Core::Filesystem::drumkit_xsd_path() ) );
 	
 	// load file
-	dk1 = H2Core::Drumkit::load_file( dk_path+"/drumkit.xml" );
-	CPPUNIT_ASSERT( dk1!=nullptr );
-	//dk1->dump();
+	pDrumkitReloaded = H2Core::Drumkit::load_file( sDrumkitPath+"/drumkit.xml" );
+	CPPUNIT_ASSERT( pDrumkitReloaded!=nullptr );
 	
 	// copy constructor
-	dk2 = new H2Core::Drumkit( dk1 );
-	CPPUNIT_ASSERT( dk2!=nullptr );
+	pDrumkitCopied = new H2Core::Drumkit( pDrumkitReloaded );
+	CPPUNIT_ASSERT( pDrumkitCopied!=nullptr );
 	// save file
-	dk2->set_name( "COPY" );
-	CPPUNIT_ASSERT( dk2->save_file( dk_path+"/drumkit.xml", true ) );
-	
-	delete dk0;
-	delete dk1;
-	delete dk2;
+	pDrumkitCopied->set_name( "COPY" );
+	CPPUNIT_ASSERT( pDrumkitCopied->save_file( sDrumkitPath+"/drumkit.xml", true ) );
+		CPPUNIT_ASSERT( pDrumkitCopied->save_file( sDrumkitPath+"/drumkit.xml", true ) );
+
+	delete pDrumkitReloaded;
+
+	// Check whether blank drumkits are valid.
+	pDrumkitNew = new H2Core::Drumkit();
+	CPPUNIT_ASSERT( pDrumkitNew != nullptr );
+	CPPUNIT_ASSERT( pDrumkitNew->save_file( sDrumkitPath+"/drumkit.xml", true ) );
+	CPPUNIT_ASSERT( doc.read( sDrumkitPath + "/drumkit.xml",
+							  H2Core::Filesystem::drumkit_xsd_path() ) );
+	pDrumkitReloaded = H2Core::Drumkit::load_file( sDrumkitPath+"/drumkit.xml" );
+	CPPUNIT_ASSERT( pDrumkitReloaded!=nullptr );
+
+	delete pDrumkitLoaded;
+	delete pDrumkitReloaded;
+	delete pDrumkitCopied;
+	delete pDrumkitNew;
 
 	// Cleanup
-	H2Core::Filesystem::rm( dk_path, true );
+	H2Core::Filesystem::rm( sDrumkitPath, true );
 }
 
 void XmlTest::testShippedDrumkits()
@@ -184,33 +193,48 @@ void XmlTest::testDrumkit_UpgradeInvalidADSRValues()
 
 void XmlTest::testPattern()
 {
-	QString pat_path = H2Core::Filesystem::tmp_dir()+"pat";
+	QString sPatternPath = H2Core::Filesystem::tmp_dir()+"pat.h2pattern";
 
-	H2Core::Pattern* pat0 = nullptr;
-	H2Core::Pattern* pat1 = nullptr;
-	H2Core::Drumkit* dk0 = nullptr;
-	H2Core::InstrumentList* instruments = nullptr;
-
-	dk0 = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/baseKit" ) );
-	CPPUNIT_ASSERT( dk0!=nullptr );
-	instruments = dk0->get_instruments();
-	CPPUNIT_ASSERT( instruments->size()==4 );
-
-	pat0 = H2Core::Pattern::load_file( H2TEST_FILE( "/pattern/pat.h2pattern" ), instruments );
-	CPPUNIT_ASSERT( pat0 );
-
-	CPPUNIT_ASSERT( pat0->save_file( "dk_name", "author", "license", pat_path, true ) );
-
+	H2Core::Pattern* pPatternLoaded = nullptr;
+	H2Core::Pattern* pPatternReloaded = nullptr;
+	H2Core::Pattern* pPatternCopied = nullptr;
+	H2Core::Pattern* pPatternNew = nullptr;
+	H2Core::Drumkit* pDrumkit = nullptr;
+	H2Core::InstrumentList* pInstrumentList = nullptr;
 	H2Core::XMLDoc doc;
-	CPPUNIT_ASSERT( doc.read( pat_path, H2Core::Filesystem::pattern_xsd_path() ) );
 
-	pat1 = H2Core::Pattern::load_file( pat_path, instruments );
+	pDrumkit = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/baseKit" ) );
+	CPPUNIT_ASSERT( pDrumkit!=nullptr );
+	pInstrumentList = pDrumkit->get_instruments();
+	CPPUNIT_ASSERT( pInstrumentList->size()==4 );
 
-	CPPUNIT_ASSERT( pat1 != nullptr );
+	pPatternLoaded = H2Core::Pattern::load_file( H2TEST_FILE( "/pattern/pat.h2pattern" ), pInstrumentList );
+	CPPUNIT_ASSERT( pPatternLoaded );
 
-	delete pat1;
-	delete pat0;
-	delete dk0;
+	CPPUNIT_ASSERT( pPatternLoaded->save_file( "dk_name", "author", "license", sPatternPath, true ) );
+
+	// Check for double freeing when destructing both copy and original.
+	pPatternCopied = new H2Core::Pattern( pPatternLoaded );
+
+	// Is stored pattern valid?
+	CPPUNIT_ASSERT( doc.read( sPatternPath, H2Core::Filesystem::pattern_xsd_path() ) );
+	pPatternReloaded = H2Core::Pattern::load_file( sPatternPath, pInstrumentList );
+	CPPUNIT_ASSERT( pPatternReloaded != nullptr );
+
+	delete pPatternReloaded;
+
+	// Check whether the constructor produces valid patterns.
+	pPatternNew = new H2Core::Pattern( "test", "ladida", "", 1, 1 );
+	CPPUNIT_ASSERT( pPatternLoaded->save_file( "dk_name", "author", "license", sPatternPath, true ) );
+	CPPUNIT_ASSERT( doc.read( sPatternPath, H2Core::Filesystem::pattern_xsd_path() ) );
+	pPatternReloaded = H2Core::Pattern::load_file( sPatternPath, pInstrumentList );
+	CPPUNIT_ASSERT( pPatternReloaded != nullptr );
+
+	delete pPatternReloaded;
+	delete pPatternLoaded;
+	delete pPatternCopied;
+	delete pPatternNew;
+	delete pDrumkit;
 }
 
 void XmlTest::checkTestPatterns()

--- a/src/tests/XmlTest.h
+++ b/src/tests/XmlTest.h
@@ -8,6 +8,7 @@ class XmlTest : public CppUnit::TestCase {
 	CPPUNIT_TEST(testDrumkit);
 	CPPUNIT_TEST(testDrumkit_UpgradeInvalidADSRValues);
 	CPPUNIT_TEST(testPattern);
+	CPPUNIT_TEST(testPlaylist);
 	CPPUNIT_TEST(testShippedDrumkits);
 	CPPUNIT_TEST(checkTestPatterns);
 	CPPUNIT_TEST_SUITE_END();
@@ -18,6 +19,7 @@ class XmlTest : public CppUnit::TestCase {
 		void testDrumkit();
 		void testDrumkit_UpgradeInvalidADSRValues();
 		void testPattern();
+		void testPlaylist();
 		// Check whether the drumkits provided alongside this repo can
 		// be validated against the drumkit XSD.
 		void testShippedDrumkits();

--- a/src/tests/XmlTest.h
+++ b/src/tests/XmlTest.h
@@ -9,6 +9,7 @@ class XmlTest : public CppUnit::TestCase {
 	CPPUNIT_TEST(testDrumkit_UpgradeInvalidADSRValues);
 	CPPUNIT_TEST(testPattern);
 	CPPUNIT_TEST(testShippedDrumkits);
+	CPPUNIT_TEST(checkTestPatterns);
 	CPPUNIT_TEST_SUITE_END();
 
 	public:
@@ -20,6 +21,9 @@ class XmlTest : public CppUnit::TestCase {
 		// Check whether the drumkits provided alongside this repo can
 		// be validated against the drumkit XSD.
 		void testShippedDrumkits();
+		// Check whether the pattern used in the unit test is valid
+		// with respect to the shipped XSD file.
+		void checkTestPatterns();
 	
 };
 

--- a/src/tests/data/pattern/pat.h2pattern
+++ b/src/tests/data/pattern/pat.h2pattern
@@ -1,278 +1,274 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<drumkit_pattern
-    xmlns="http://www.hydrogen-music.org/drumkit_pattern"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    >
- <drumkit_name>GMkit</drumkit_name>
+<drumkit_pattern xmlns="http://www.hydrogen-music.org/drumkit_pattern" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+ <drumkit_name>GMRockKit</drumkit_name>
+ <author>Hydrogen dev team</author>
+ <license>Public Domain</license>
  <pattern>
-  <name>1</name>
-  <info/>
+  <name>pat</name>
+  <info></info>
   <category>unknown</category>
   <size>192</size>
+  <denominator>4</denominator>
   <noteList>
    <note>
     <position>0</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>0</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>0</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>1</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>24</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>3</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>24</position>
     <leadlag>0</leadlag>
     <velocity>0.98</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>2</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>36</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>3</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>36</position>
     <leadlag>0</leadlag>
     <velocity>0.42</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>0</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>48</position>
     <leadlag>0</leadlag>
     <velocity>0.54</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>0</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>72</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>1</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>72</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>1</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>72</position>
     <leadlag>0</leadlag>
     <velocity>0.68</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>2</instrument>
     <note_off>true</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>84</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>0</instrument>
     <note_off>true</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>96</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>0</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>96</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>2</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>108</position>
     <leadlag>0</leadlag>
     <velocity>0.5</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>3</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>120</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>3</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>132</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>2</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>132</position>
     <leadlag>0</leadlag>
     <velocity>0.54</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>1</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>144</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>1</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>156</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>0</instrument>
     <note_off>false</note_off>
+    <probability>1</probability>
    </note>
    <note>
     <position>168</position>
     <leadlag>0</leadlag>
     <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
+    <pan_L>0.5</pan_L>
+    <pan_R>0.5</pan_R>
     <pitch>0</pitch>
     <key>C0</key>
     <length>-1</length>
     <instrument>3</instrument>
     <note_off>false</note_off>
-   </note>
-   <note>
-    <position>168</position>
-    <leadlag>0</leadlag>
-    <velocity>0.58</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
-    <pitch>0</pitch>
-    <key>C0</key>
-    <length>-1</length>
-    <instrument>69</instrument>
-    <note_off>false</note_off>
-   </note>
-   <note>
-    <position>180</position>
-    <leadlag>0</leadlag>
-    <velocity>0.8</velocity>
-    <pan_L>1</pan_L>
-    <pan_R>1</pan_R>
-    <pitch>0</pitch>
-    <key>C0</key>
-    <length>-1</length>
-    <instrument>666</instrument>
-    <note_off>false</note_off>
+    <probability>1</probability>
    </note>
   </noteList>
  </pattern>


### PR DESCRIPTION
I added a couple of unit tests to check for the validity of saved files (and some other stuff) since there was a bug during the development of 1.1 due to new patterns not being valid with respect to the XSD file.

~Please note that some tests are **not** passing. This is because the constructors of `Drumkit` and `Playlist` yield objects that when written to disk do not produce `drumkit.xml` and `.h2playlist` files valid with respect to their XSD files. I think they should.~

There was also a segfault when saving an empty drumkit. But this seems not to occur via the GUI since it ensures one instrument will always be present.

Update: 

I fixed the constructor of `Playlist` and the `Drumkit::save_file` method. Now, they produce valid .h2playlist and drumkit.xml files for empty/new objects.