### PR TITLE
Build Windows release mode binaries, keep artifacts on any tag build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,12 +10,20 @@ environment:
       job_group: 'Mac OS X'
       appveyor_build_worker_image: macos
 
-    - job_name: 'WindowsDebug64'
+    - job_name: 'Windows64'
       job_group: 'Windows'
       MSYS: 'C:\msys64\mingw64'
       MSYS_REPO: 'mingw64/mingw-w64-x86_64'
-      BUILD_TYPE: "Debug"
-      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=ON -DWIN64:BOOL=ON"
+      BUILD_TYPE: "Release"
+      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
+      appveyor_build_worker_image: Visual Studio 2019
+
+    - job_name: 'Windows32'
+      job_group: 'Windows'
+      MSYS: 'C:\msys64\mingw32'
+      MSYS_REPO: 'mingw-w64-i686'
+      BUILD_TYPE: "Release"
+      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
       appveyor_build_worker_image: Visual Studio 2019
 
 
@@ -62,7 +70,7 @@ for:
       ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg
 
       #deploy dmg only on branch appveyor-build-with-artifacts
-      if [ "$APPVEYOR_REPO_BRANCH" = appveyor-build-with-artifacts ]; then appveyor PushArtifact Hydrogen*.dmg -DeploymentName Installer; fi
+      if [ "$APPVEYOR_REPO_TAG" = true ]; then appveyor PushArtifact Hydrogen*.dmg -DeploymentName Installer; fi
 
     test_script: |-
       TMPDIR=/tmp src/tests/tests --appveyor || true
@@ -115,7 +123,7 @@ for:
           set PATH=%CORE_PATH%;%PATH%
           src\tests\tests.exe --appveyor || cmd /c "exit /b 0"
           7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen
-          if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
+          if %APPVEYOR_REPO_TAG%==true appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
 
           mkdir %APPVEYOR_BUILD_FOLDER%\windows\extralibs
 
@@ -137,10 +145,10 @@ for:
           %PYTHON% -m pytest %APPVEYOR_BUILD_FOLDER%\windows\ci\test_installation.py --junitxml=test_installation.xml
 
 on_finish:
-  - cmd: if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
-  - cmd: if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
-  - cmd: if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
-  - cmd: if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.0-win64.exe
+  - cmd: if %APPVEYOR_REPO_TAG%==true appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
+  - cmd: if %APPVEYOR_REPO_TAG%==true appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
+  - cmd: if %APPVEYOR_REPO_TAG%==true appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
+  - cmd: if %APPVEYOR_REPO_TAG%==true FOR %%F IN (%APPVEYOR_BUILD_FOLDER%\build\Hydrogen-*.exe) DO appveyor PushArtifact %%F
 
   - cmd: |
-      if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts curl -F file=@%APPVEYOR_BUILD_FOLDER%\build\test_installation.xml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%
+      if %APPVEYOR_REPO_TAG%==true curl -F file=@%APPVEYOR_BUILD_FOLDER%\build\test_installation.xml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%


### PR DESCRIPTION
Having tested the 32-bit release mode Windows builds, it seems that there's no longer an issue with Appveyor's 32-bit release builds immediately crashing. So enable release-mode builds for both 32-bit and 64-bit Windows so these can be used as release packages.

Also, changes the condition of whether or not to keep build artifacts from the specific branch name, to whether or not the build is started by pushing a tag. Since this only generally happens with releases or release candidates, that seems a good compromise to avoid excessive branch maintenance and chopping and changing.