### PR TITLE
allow pan element in .h2pattern and drumkit

### DIFF
--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -20,6 +20,14 @@
 	</xsd:restriction>
 </xsd:simpleType>
 
+<!-- PSFLOAT - small float [-1.0; 1.0] -->
+<xsd:simpleType name='psfloat_sym'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='-1.0'/>
+		<xsd:maxInclusive value='1.0'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
 <!-- INSTRUMENT COMPONENT -->
 <xsd:element name="instrumentComponent">
 	<xsd:complexType>
@@ -66,8 +74,13 @@
 			<xsd:element name="volume"				type="xsd:decimal"				default="1.0"/>
 			<xsd:element name="isMuted"				type="h2:bool"					default="false"/>
 			<xsd:element name="isSoloed"			type="h2:bool"					default="false"/>
-			<xsd:element name="pan_L"				type="h2:psfloat"				default="1.0"/>
-			<xsd:element name="pan_R"				type="h2:psfloat"				default="1.0"/>
+			<xsd:choice minOccurs="0" maxOccurs="1">
+			  <xsd:sequence>
+				<xsd:element name="pan_L"		type="h2:psfloat"		default="0.5"/>
+				<xsd:element name="pan_R"		type="h2:psfloat"		default="0.5"/>
+			  </xsd:sequence>
+			  <xsd:element name = "pan"		type="h2:psfloat_sym"		default="0.0"/>
+			</xsd:choice>
 			<xsd:element name="pitchOffset"	type="h2:psfloat"				default="0.0"/>
 			<xsd:element name="randomPitchFactor"	type="h2:psfloat"				default="0.0"/>
 			<xsd:element name="gain"				type="xsd:float"				default="1.0"/>

--- a/data/xsd/drumkit_pattern.xsd
+++ b/data/xsd/drumkit_pattern.xsd
@@ -20,6 +20,14 @@
 	</xsd:restriction>
 </xsd:simpleType>
 
+<!-- PSFLOAT - small float [-1.0; 1.0] -->
+<xsd:simpleType name='psfloat_sym'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='-1.0'/>
+		<xsd:maxInclusive value='1.0'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
 <!-- PSFLOAT - positive small float [0.0; 0.5] -->
 <xsd:simpleType name='psfloat5'>
 	<xsd:restriction base='xsd:float'>
@@ -35,8 +43,13 @@
 			<xsd:element name="position"	type="xsd:nonNegativeInteger"	default="0"/>
 			<xsd:element name="leadlag"		type="xsd:float"		default="0.0"/>
 			<xsd:element name="velocity"	type="h2:psfloat"		default="0.8"/>
-			<xsd:element name="pan_L"		type="h2:psfloat5"		default="0.5"/>
-			<xsd:element name="pan_R"		type="h2:psfloat5"		default="0.5"/>
+			<xsd:choice minOccurs="0" maxOccurs="1">
+			  <xsd:sequence>
+				<xsd:element name="pan_L"		type="h2:psfloat5"		default="0.5"/>
+				<xsd:element name="pan_R"		type="h2:psfloat5"		default="0.5"/>
+			  </xsd:sequence>
+			  <xsd:element name = "pan"		type="h2:psfloat_sym"		default="0.0"/>
+			</xsd:choice>
 			<xsd:element name="pitch"		type="xsd:float"		default="0.0"/>
 			<xsd:element name="key"			type="xsd:string"		default="C0"/>
 			<xsd:element name="length"		type="xsd:integer"		default="-1"/>


### PR DESCRIPTION
while keeping backward compatibility.

Now, either `pan` or both `pan_L` and `pan_R` must be present.

@oddtime The pan parameters in the patterns are defined within [-0.5,0.5] while the one in the instruments are within [-1.0,1.0]. I guess you already know this and intend to streamline this one too, right?