### PR TITLE
Make the swing humanization code more explicit

### DIFF
--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -680,7 +680,7 @@ MasterMixerLine::MasterMixerLine(QWidget* parent)
 	m_pHumanizeTimeRotary->move( 74, 125 );
 	connect( m_pHumanizeTimeRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 
-	m_pSwingRotary = new Rotary( this,  Rotary::TYPE_NORMAL, tr( "Swing" ), false, true );
+	m_pSwingRotary = new Rotary( this,  Rotary::TYPE_NORMAL, tr( "16th-note Swing" ), false, true );
 	m_pSwingRotary->move( 74, 162 );
 	connect( m_pSwingRotary, SIGNAL( valueChanged(Rotary*) ), this, SLOT( rotaryChanged(Rotary*) ) );
 


### PR DESCRIPTION
Basically this makes clear that the Swing is applied on upbeat 16th notes, rather than 8th notes, both in the GUI and in the code for developers to maintain it.
And now the swing offset is proportional to MAX_RESOLUTION.