### PR TITLE
Import song in session using aux variable

### DIFF
--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -630,6 +630,8 @@ void			previewSample( Sample *pSample );
 	/**\param pNextSong Sets #m_pNextSong. Song which is about to be
 	   loaded by the GUI.*/
 	void			setNextSong( Song* pNextSong );
+	void			setNextSongPath( const QString sSongPath );
+	QString			getNextSongPath();
 	/** Calculates the lookahead for a specific tick size.
 	 *
 	 * During the humanization the onset of a Note will be moved
@@ -778,6 +780,7 @@ private:
 	 * Set by setNextSong() and accessed via getNextSong().
 	 */
 	Song*			m_pNextSong;
+	QString			m_sNextSongPath;
 
 	/**
 	 * Local instance of the Timeline object.
@@ -893,7 +896,12 @@ inline Song* Hydrogen::getNextSong() const {
 inline void Hydrogen::setNextSong( Song* pNextSong ) {
 	m_pNextSong = pNextSong;
 }
-
+inline QString Hydrogen::getNextSongPath() {
+	return m_sNextSongPath;
+}
+inline void Hydrogen::setNextSongPath( const QString sSongPath ) {
+	m_sNextSongPath = sSongPath;
+}
 };
 
 #endif

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -200,6 +200,7 @@ int NsmClient::OpenCallback( const char *name,
 
 		// The opening of the Song will be done asynchronously.
 		pHydrogen->setNextSong( pSong );
+		pHydrogen->setNextSongPath( sSongPath );
 		
 		bool bSuccess;
 		if ( songFileInfo.exists() ) {

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -798,6 +798,10 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 
 		// Set a Song prepared by the core part.
 		Song* pNextSong = pHydrogen->getNextSong();
+
+		if ( ! pHydrogen->getNextSongPath().isEmpty() ) {
+			pNextSong->setFilename( pHydrogen->getNextSongPath() );
+		}
 		
 		pHydrogen->setSong( pNextSong );
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -825,10 +825,13 @@ void MainForm::action_file_export_pattern_as()
 }
 
 void MainForm::action_file_open() {
-	const bool bUnderSessionManagement = H2Core::Hydrogen::get_instance()->isUnderSessionManagement();
+
+	H2Core::Hydrogen* pHydrogen = H2Core::Hydrogen::get_instance();
+	
+	const bool bUnderSessionManagement = pHydrogen->isUnderSessionManagement();
 		
-	if ( Hydrogen::get_instance()->getState() == STATE_PLAYING ) {
-		Hydrogen::get_instance()->sequencer_stop();
+	if ( pHydrogen->getState() == STATE_PLAYING ) {
+		pHydrogen->sequencer_stop();
 	}
 
 	bool bProceed = handleUnsavedChanges();
@@ -857,22 +860,15 @@ void MainForm::action_file_open() {
 
 	// When under session management the filename of the current Song
 	// has to be preserved.
-	QString sCurrentFilename;
 	if ( bUnderSessionManagement ) {
-		sCurrentFilename = H2Core::Hydrogen::get_instance()->getSong()->getFilename();
+		// The current path needs to be preserved. This will be done
+		// using an auxiliary variable since the GUI opens the song
+		// via the core, which in turn opens it asynchronously via the
+		// GUI.
+		pHydrogen->setNextSongPath( pHydrogen->getSong()->getFilename() );
 	}
 	if ( !sFilename.isEmpty() ) {
 		HydrogenApp::get_instance()->openSong( sFilename );
-	}
-
-	if ( bUnderSessionManagement ) {
-		
-		Song* pSong = H2Core::Hydrogen::get_instance()->getSong();
-		if ( pSong == nullptr ) {
-			ERRORLOG( QString( "No song present while under session management" ) );
-			return;
-		}
-		pSong->setFilename( sCurrentFilename );
 	}
 
 	HydrogenApp::get_instance()->getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
@@ -1526,20 +1522,15 @@ void MainForm::updateRecentUsedSongList()
 
 void MainForm::action_file_open_recent(QAction *pAction)
 {
-	// When under session management the filename of the current Song
-	// has to be preserved.
-	const bool bUnderSessionManagement = H2Core::Hydrogen::get_instance()->isUnderSessionManagement();
-	
-	QString currentFilename;
-	if ( bUnderSessionManagement ) {
-		currentFilename = H2Core::Hydrogen::get_instance()->getSong()->getFilename();
+	if ( H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ) {
+		// The current path needs to be preserved. This will be done
+		// using an auxiliary variable since the GUI opens the song
+		// via the core, which in turn opens it asynchronously via the
+		// GUI.
+		H2Core::Hydrogen::get_instance()->setNextSongPath( H2Core::Hydrogen::get_instance()->getSong()->getFilename() );
 	}
 	
 	HydrogenApp::get_instance()->openSong( pAction->text() );
-	
-	if ( bUnderSessionManagement ) {
-		H2Core::Hydrogen::get_instance()->getSong()->setFilename( currentFilename );
-	}
 }
 
 void MainForm::checkMissingSamples()

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -800,6 +800,14 @@ void SoundLibraryPanel::on_songLoadAction()
 {
 	QString sFilename = Filesystem::song_path( __sound_library_tree->currentItem()->text( 0 ) );
 
+	if ( H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ) {
+		// The current path needs to be preserved. This will be done
+		// using an auxiliary variable since the GUI opens the song
+		// via the core, which in turn opens it asynchronously via the
+		// GUI.
+		H2Core::Hydrogen::get_instance()->setNextSongPath( H2Core::Hydrogen::get_instance()->getSong()->getFilename() );
+	}
+	
 	HydrogenApp::get_instance()->openSong( sFilename );
 }
 


### PR DESCRIPTION
In order to not touch any essential code parts between the beta and final release, I introduced a auxiliary member variable in the Hydrogen class which allows for the import of songs into an NSM session.

Addresses #1040.

The proper version of the fix will move all the parts for loading a song into the core/main.cpp. This way the GUI does not need to be called asynchronously when setting a song and a number of helper variables can be removed to. I am working on this fix and will make a PR against `development` soon.