### PR TITLE
Loading song via core instead of GUI

### DIFF
--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -738,7 +738,9 @@ void AudioEngine::startAudioDrivers()
 		}
 
 #ifdef H2CORE_HAVE_JACK
-		renameJackPorts( pSong );
+		if ( pSong != nullptr ) {
+			renameJackPorts( pSong );
+		}
 #endif
 
 		setupLadspaFX( m_pAudioDriver->getBufferSize() );
@@ -851,8 +853,6 @@ void AudioEngine::processCheckBPMChanged(Song* pSong)
 
 void AudioEngine::setupLadspaFX( unsigned nBufferSize )
 {
-	//___INFOLOG( "buffersize=" + to_string(nBufferSize) );
-
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	Song* pSong = pHydrogen->getSong();
 	if ( ! pSong ) {
@@ -1406,7 +1406,9 @@ void AudioEngine::setSong( Song* pNewSong )
 	}
 
 	// setup LADSPA FX
-	setupLadspaFX( m_pAudioDriver->getBufferSize() );
+	if ( m_pAudioDriver != nullptr ) {
+		setupLadspaFX( m_pAudioDriver->getBufferSize() );
+	}
 
 	// update tick size
 	processCheckBPMChanged( pNewSong );

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -335,9 +335,6 @@ bool CoreActionController::newSong( const QString& sSongPath ) {
 		pHydrogen->sequencer_stop();
 	}
 	
-	// Remove all BPM tags on the Timeline.
-	pHydrogen->getTimeline()->deleteAllTempoMarkers();
-	
 	// Create an empty Song.
 	auto pSong = Song::getEmptySong();
 	
@@ -347,26 +344,21 @@ bool CoreActionController::newSong( const QString& sSongPath ) {
 
 		return false;
 	}
-	
+
+	// Remove all BPM tags on the Timeline.
+	pHydrogen->getTimeline()->deleteAllTempoMarkers();
+	pHydrogen->getTimeline()->deleteAllTags();
+
+	if ( pHydrogen->isUnderSessionManagement() ) {
+		pHydrogen->restartDrivers();
+	}		
+
 	pSong->setFilename( sSongPath );
+
+	pHydrogen->setSong( pSong );
 	
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
-		
-		// Store the prepared Song for the GUI to access after the
-		// EVENT_UPDATE_SONG event was triggered.
-		pHydrogen->setNextSong( pSong );
-		
-		// If the GUI is active, the Song *must not* be set by the
-		// core part itself.
-		// Triggers an update of the Qt5 GUI and tells it to update
-		// the song itself.
 		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
-		
-	} else {
-
-		// Update the Song.
-		pHydrogen->setSong( pSong );
-		
 	}
 	
 	return true;
@@ -422,35 +414,24 @@ bool CoreActionController::setSong( Song* pSong ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	// Remove all BPM tags on the Timeline.
+	// Remove all BPM markers and tags on the Timeline.
 	pHydrogen->getTimeline()->deleteAllTempoMarkers();
+	pHydrogen->getTimeline()->deleteAllTags();
+
+	// Update the Song.
+	pHydrogen->setSong( pSong );
+		
+	if ( pHydrogen->isUnderSessionManagement() ) {
+		pHydrogen->restartDrivers();
+	} else {
+		// Add the new loaded song in the "last used song" vector.
+		// This behavior is prohibited under session management. Only
+		// songs open during normal runs will be listed.
+		Preferences::get_instance()->insertRecentFile( pSong->getFilename() );
+	}
 
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
-		
-		// Store the prepared Song for the GUI to access after the
-		// EVENT_UPDATE_SONG event was triggered.
-		pHydrogen->setNextSong( pSong );
-		
-		int nRestartAudioDriver = 0;
-
-		if ( pHydrogen->isUnderSessionManagement() ) {
-			nRestartAudioDriver = 1;
-		}
-		
-		// If the GUI is active, the Song *must not* be set by the
-		// core part itself.
-		// Triggers an update of the Qt5 GUI and tells it to update
-		// the song itself.
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, nRestartAudioDriver );
-		
-	} else {
-
-		// Update the Song.
-		pHydrogen->setSong( pSong );
-		
-		if ( pHydrogen->isUnderSessionManagement() ) {
-			pHydrogen->restartDrivers();
-		}
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
 	}
 	
 	return true;
@@ -481,7 +462,7 @@ bool CoreActionController::saveSong() {
 	
 	// Update the status bar.
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
 	}
 	
 	return true;
@@ -515,7 +496,7 @@ bool CoreActionController::saveSongAs( const QString& sSongPath ) {
 	
 	// Update the status bar.
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 1 );
 	}
 	
 	return true;
@@ -568,7 +549,7 @@ bool CoreActionController::isSongPathValid( const QString& sSongPath ) {
 		if ( !songFileInfo.isWritable() ) {
 			WARNINGLOG( QString( "You don't have permissions to write to the Song found in path [%1]. It will be opened as read-only (no autosave)." )
 						.arg( sSongPath.toLocal8Bit().data() ));
-			EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 3 );
+			EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
 		}
 	}
 	

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -127,12 +127,10 @@ enum EventType {
 	 * or and OSC command.
 	 *
 	 * If the value of the event is 
-	 * - 0 - Hydrogen::m_pNextSong will be loaded.
-	 * - 1 - Hydrogen::m_pNextSong will be loaded and the audio
-	 *       drivers will be restarted via Hydrogen::restartDrivers()
-	 * - 2 - triggered whenever the Song was saved via the core part
+	 * - 0 - update the GUI to represent the song loaded by the core.
+	 * - 1 - triggered whenever the Song was saved via the core part
 	 *       (updated the title and status bar).
-	 * - 3 - Song is not writable (inform the user via a QMessageBox)
+	 * - 2 - Song is not writable (inform the user via a QMessageBox)
 	 */
 	EVENT_UPDATE_SONG,
 	/**

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -116,7 +116,6 @@ Hydrogen::Hydrogen()
 	INFOLOG( "[Hydrogen]" );
 
 	__song = nullptr;
-	m_pNextSong = nullptr;
 
 	m_bExportSessionIsActive = false;
 	m_pTimeline = new Timeline();
@@ -1763,44 +1762,6 @@ void Hydrogen::startNsmClient()
 #endif
 }
 
-void Hydrogen::setInitialSong( Song *pSong )
-{
-	AudioEngine* pAudioEngine = m_pAudioEngine;
-
-	// Since the function is only intended to set a Song prior to the
-	// initial creation of the audio driver, it will cause the
-	// application to get out of sync if used elsewhere. The following
-	// checks ensure it is called in the right context.
-	if ( pSong == nullptr ) {
-		return;
-	}
-	if ( __song != nullptr ) {
-		return;
-	}
-	if ( pAudioEngine->getAudioDriver() != nullptr ) {
-		return;
-	}
-	
-	// Just to be sure.
-	pAudioEngine->lock( RIGHT_HERE );
-
-	// Find the first pattern and set as current.
-	if ( pSong->getPatternList()->size() > 0 ) {
-		m_pAudioEngine->getPlayingPatterns()->add( pSong->getPatternList()->get( 0 ) );
-	}
-
-	pAudioEngine->unlock();
-
-	// Move to the beginning.
-	setSelectedPatternNumber( 0 );
-
-	__song = pSong;
-
-	// Push current state of Hydrogen to attached control interfaces,
-	// like OSC clients.
-	m_pCoreActionController->initExternalControlInterfaces();
-}
-
 QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 
 	QString s = Object::sPrintIndention;
@@ -1829,13 +1790,7 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2m_bOldLoopEnabled: %3\n" ).arg( sPrefix ).arg( s ).arg( m_bOldLoopEnabled ) )
 			.append( QString( "%1%2m_bExportSessionIsActive: %3\n" ).arg( sPrefix ).arg( s ).arg( m_bExportSessionIsActive ) )
 			.append( QString( "%1%2m_GUIState: %3\n" ).arg( sPrefix ).arg( s ).arg( static_cast<int>( m_GUIState ) ) )
-			.append( QString( "%1%2m_pNextSong: " ).arg( sPrefix ).arg( s ) );
-		if ( m_pNextSong != nullptr ) {
-			sOutput.append( QString( "%1" ).arg( m_pNextSong->toQString( sPrefix + s, bShort ) ) );
-		} else {
-			sOutput.append( QString( "nullptr\n" ) );
-		}
-		sOutput.append( QString( "%1%2m_pTimeline:\n" ).arg( sPrefix ).arg( s ) );
+			.append( QString( "%1%2m_pTimeline:\n" ).arg( sPrefix ).arg( s ) );
 		if ( m_pTimeline != nullptr ) {
 			sOutput.append( QString( "%1" ).arg( m_pTimeline->toQString( sPrefix + s, bShort ) ) );
 		} else {
@@ -1885,13 +1840,7 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", m_oldEngineMode: %1" ).arg( m_oldEngineMode ) )
 			.append( QString( ", m_bOldLoopEnabled: %1" ).arg( m_bOldLoopEnabled ) )
 			.append( QString( ", m_bExportSessionIsActive: %1" ).arg( m_bExportSessionIsActive ) )
-			.append( QString( ", m_GUIState: %1" ).arg( static_cast<int>( m_GUIState ) ) )
-			.append( QString( ", m_pNextSong: " ) );
-		if ( m_pNextSong != nullptr ) {
-			sOutput.append( QString( "%1" ).arg( m_pNextSong->toQString( sPrefix + s, bShort ) ) );
-		} else {
-			sOutput.append( QString( "nullptr" ) );
-		}
+			.append( QString( ", m_GUIState: %1" ).arg( static_cast<int>( m_GUIState ) ) );
 		sOutput.append( QString( ", m_pTimeline: " ) );
 		if ( m_pTimeline != nullptr ) {
 			sOutput.append( QString( "%1" ).arg( m_pTimeline->toQString( sPrefix + s, bShort ) ) );

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -266,7 +266,6 @@ void Hydrogen::setSong( Song *pSong )
 		return;
 	}
 
-	QString sCurrentSongFilename;
 	if ( pCurrentSong != nullptr ) {
 		/* NOTE: 
 		 *       - this is actually some kind of cleanup 
@@ -274,6 +273,9 @@ void Hydrogen::setSong( Song *pSong )
 		 */
 		
 		if ( isUnderSessionManagement() ) {
+			// When under session management Hydrogen is only allowed
+			// to replace the content of the session song but not to
+			// write to a different location.
 			pSong->setFilename( pCurrentSong->getFilename() );
 		}
 		removeSong();
@@ -305,7 +307,7 @@ void Hydrogen::setSong( Song *pSong )
 
 	if ( isUnderSessionManagement() ) {
 #ifdef H2CORE_HAVE_OSC
-		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath.toLocal8Bit().data(), true );
+		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, true );
 #endif
 	} else {		
 		Preferences::get_instance()->setLastSongFilename( pSong->getFilename() );
@@ -949,7 +951,7 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool conditional )
 	// management.
 	if ( isUnderSessionManagement() ) {
 #ifdef H2CORE_HAVE_OSC
-		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath.toLocal8Bit().data(), false );
+		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, false );
 #endif
 	}
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -861,13 +861,6 @@ inline PatternList * Hydrogen::getNextPatterns()
 {
 	return m_pAudioEngine->getNextPatterns();
 }
-
-inline QString Hydrogen::getNextSongPath() {
-	return m_sNextSongPath;
-}
-inline void Hydrogen::setNextSongPath( const QString sSongPath ) {
-	m_sNextSongPath = sSongPath;
-}
 };
 
 #endif

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -783,22 +783,6 @@ private:
 	 * Only one Hydrogen object is allowed to exist. If the
 	 * #__instance object is present, the constructor will throw
 	 * an error.
-	 *
-	 * - Sets the current #__song to NULL
-	 * - Sets #m_bExportSessionIsActive to false
-	 * - Creates a new Timeline #m_pTimeline 
-	 * - Creates a new CoreActionController
-	 *   #m_pCoreActionController, 
-	 * - Calls initBeatcounter(), audioEngine_init(), and
-	 *   audioEngine_startAudioDrivers() 
-	 * - Sets InstrumentComponent::m_nMaxLayers to
-	 *   Preferences::m_nMaxLayers via
-	 *   InstrumentComponent::setMaxLayers() and
-	 *   Preferences::getMaxLayers() 
-	 * - Starts the OscServer using OscServer::start() if
-	 *   #H2CORE_HAVE_OSC was set during compilation.
-	 * - Fills #m_nInstrumentLookupTable with the corresponding
-	 *   index of each element.
 	 */
 	Hydrogen();
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -600,8 +600,6 @@ void			previewSample( Sample *pSample );
 	/**\param pNextSong Sets #m_pNextSong. Song which is about to be
 	   loaded by the GUI.*/
 	void			setNextSong( Song* pNextSong );
-	void			setNextSongPath( const QString sSongPath );
-	QString			getNextSongPath();
 	/** Calculates the lookahead for a specific tick size.
 	 *
 	 * During the humanization the onset of a Note will be moved
@@ -760,7 +758,6 @@ private:
 	 * Set by setNextSong() and accessed via getNextSong().
 	 */
 	Song*			m_pNextSong;
-	QString			m_sNextSongPath;
 
 	/**
 	 * Local instance of the Timeline object.

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -595,11 +595,6 @@ void			previewSample( Sample *pSample );
 	   #m_GUIState.*/
 	void			setGUIState( const GUIState state );
 	
-	/**\return #m_pNextSong*/
-	Song*			getNextSong() const;
-	/**\param pNextSong Sets #m_pNextSong. Song which is about to be
-	   loaded by the GUI.*/
-	void			setNextSong( Song* pNextSong );
 	/** Calculates the lookahead for a specific tick size.
 	 *
 	 * During the humanization the onset of a Note will be moved
@@ -653,20 +648,6 @@ void			previewSample( Sample *pSample );
 	/** \return NsmClient::m_bUnderSessionManagement if NSM is
 		supported.*/
 	bool			isUnderSessionManagement() const;
-	/** Sets the first Song to be loaded under session management.
-	 *
-	 * Enables the creation of a JACK client with all per track output
-	 * ports present right from the start. This is necessary to ensure
-	 * their connection can be properly restored by external tools.
-	 *
-	 * The function will only work if no audio driver is present
-	 * (since this is the intended use case and the function will be
-	 * harmful if used otherwise. Use setSong() instead.) and fails if
-	 * there is already a Song present.
-	 *
-	 * \param pSong Song to be loaded.
-	 */
-	void			setInitialSong( Song* pSong );
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
@@ -747,18 +728,6 @@ private:
 	 */
 	GUIState		m_GUIState;
 	
-	/**
-	 * Stores a new Song which is about of the loaded by the GUI.
-	 *
-	 * If #m_GUIState is true, the core part of must not load a new
-	 * Song itself. Instead, the new Song is prepared and stored in
-	 * this object to be loaded by HydrogenApp::updateSongEvent() if
-	 * H2Core::EVENT_UPDATE_SONG is pushed with a '1'.
-	 *
-	 * Set by setNextSong() and accessed via getNextSong().
-	 */
-	Song*			m_pNextSong;
-
 	/**
 	 * Local instance of the Timeline object.
 	 */
@@ -897,14 +866,6 @@ inline Hydrogen::GUIState Hydrogen::getGUIState() const {
 
 inline void Hydrogen::setGUIState( const Hydrogen::GUIState state ) {
 	m_GUIState = state;
-}
-
-inline Song* Hydrogen::getNextSong() const {
-	return m_pNextSong;
-}
-
-inline void Hydrogen::setNextSong( Song* pNextSong ) {
-	m_pNextSong = pNextSong;
 }
 
 inline PatternList* Hydrogen::getCurrentPatternList()

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -200,7 +200,6 @@ int NsmClient::OpenCallback( const char *name,
 
 		// The opening of the Song will be done asynchronously.
 		pHydrogen->setNextSong( pSong );
-		pHydrogen->setNextSongPath( sSongPath );
 		
 		bool bSuccess;
 		if ( songFileInfo.exists() ) {

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -69,7 +69,7 @@ int NsmClient::OpenCallback( const char *name,
 							 const char *clientID,
 							 char **outMsg,
 							 void *userData ) {
-	
+
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 	auto pPref = H2Core::Preferences::get_instance();
 	auto pController = pHydrogen->getCoreActionController();
@@ -94,11 +94,11 @@ int NsmClient::OpenCallback( const char *name,
 			NsmClient::printError( "Folder could not created." );
 		}
 	}
-	
+
 	// At this point the GUI can be assumed to have to be fully
 	// initialized.
 	NsmClient::copyPreferences( name );
-	
+
 	NsmClient::get_instance()->m_sSessionFolderPath = name;
 	
 	const QFileInfo sessionPath( name );
@@ -145,14 +145,13 @@ int NsmClient::OpenCallback( const char *name,
 		pSong->setFilename( sSongPath );
 	}
 
-	// The opening of the Song will be done asynchronously.
 	if ( ! pController->openSong( pSong ) ) {
 			NsmClient::printError( "Unable to handle opening action!" );
 			return ERR_LAUNCH_FAILED;
 	}
 	
 	NsmClient::printMessage( "Song loaded!" );
-			
+
 	return ERR_OK;
 }
 
@@ -402,9 +401,9 @@ void NsmClient::createInitialClient()
 				// H2 is under session management, the variable will
 				// be set here.
 				m_bUnderSessionManagement = true;
-				
+
 				nsm_send_announce( pNsm, "Hydrogen", ":dirty:switch:", byteArray.data() );
-						
+
 				if ( pthread_create( &m_NsmThread, nullptr, NsmClient::ProcessEvent, pNsm ) ) {
 					___ERRORLOG("Error creating NSM thread\n	");
 					m_bUnderSessionManagement = false;
@@ -419,7 +418,7 @@ void NsmClient::createInitialClient()
 				int nCheck = 0;
 				
 				while ( true ) {
-					if ( pHydrogen->getAudioOutput() != nullptr ) {
+					if ( pHydrogen->getSong() != nullptr ) {
 						break;
 					}
 					// Don't wait indefinitely.
@@ -427,7 +426,7 @@ void NsmClient::createInitialClient()
 						break;
 				   }
 					nCheck++;
-					sleep(1);
+					sleep( 1 );
 				}			
 
 			} else {

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -95,8 +95,6 @@ int NsmClient::OpenCallback( const char *name,
 		}
 	}
 
-	// At this point the GUI can be assumed to have to be fully
-	// initialized.
 	NsmClient::copyPreferences( name );
 
 	NsmClient::get_instance()->m_sSessionFolderPath = name;
@@ -109,7 +107,7 @@ int NsmClient::OpenCallback( const char *name,
 	
 	const QFileInfo songFileInfo = QFileInfo( sSongPath );
 
-	// When restarting the JACK client (later in this function) the
+	// When restarting the JACK client (during song loading) the
 	// clientID will be used as the name of the freshly created
 	// instance.
 	if ( pPref != nullptr ){
@@ -201,7 +199,7 @@ void NsmClient::copyPreferences( const char* name ) {
 	NsmClient::printMessage( "Preferences loaded!" );
 }
 
-void NsmClient::linkDrumkit( const char* name, bool bCheckLinkage ) {	
+void NsmClient::linkDrumkit( const QString& sName, bool bCheckLinkage ) {	
 	
 	const auto pHydrogen = H2Core::Hydrogen::get_instance();
 	
@@ -210,7 +208,7 @@ void NsmClient::linkDrumkit( const char* name, bool bCheckLinkage ) {
 	const QString sDrumkitName = pHydrogen->getCurrentDrumkitName();
 	
 	const QString sLinkedDrumkitPath = QString( "%1/%2" )
-		.arg( name ).arg( "drumkit" );
+		.arg( sName ).arg( "drumkit" );
 	const QFileInfo linkedDrumkitPathInfo( sLinkedDrumkitPath );
 
 	if ( bCheckLinkage ) {
@@ -271,7 +269,7 @@ void NsmClient::linkDrumkit( const char* name, bool bCheckLinkage ) {
 				// renamed to 'drumkit' manually again.
 				QDir oldDrumkitFolder( sLinkedDrumkitPath );
 				if ( ! oldDrumkitFolder.rename( sLinkedDrumkitPath,
-												QString( "%1/drumkit_old" ).arg( name ) ) ) {
+												QString( "%1/drumkit_old" ).arg( sName ) ) ) {
 					NsmClient::printError( QString( "Unable to rename drumkit folder [%1]." )
 										   .arg( sLinkedDrumkitPath ) );
 					return;

--- a/src/core/NsmClient.h
+++ b/src/core/NsmClient.h
@@ -41,17 +41,14 @@
 * Linux systems as well as for the actual application - the
 * non-session-manager - implementing it.
 *
-* Hydrogen is compliant with the standard, send dirty flag to the NSM
+* Hydrogen is compliant with the standard, sends dirty flag to the NSM
 * server to indicate unsaved changes, and is able to switch between
 * different sessions without restarting the entire
 * application. However, Hydrogen does use several files to store all
 * options the user is able to customize and not all of them are stored
-* inside the folder provided by the NSM server. While the song file
-* will be kept there, both the drumkit and preferences are stored
-* elsewhere. Altering either of them can very well affect the state of
-* the individual session, e.g. by disabling a prior set the per track
-* output option of the JACK driver outside of the session and
-* restarting it. So, be very careful. 
+* inside the folder provided by the NSM server. Both the song and a
+* custom copy of the preferences will be stored in the session
+* folder. But the drumkit used in the song will only be linked into it.
 *
 * @author Sebastian Moors
 *
@@ -126,12 +123,11 @@ class NsmClient : public H2Core::Object
 		 * Sets #NsmShutdown to true.*/
 		void shutdown();
 	/**
-	 * Part of OpenCallback() responsible for linking and loading of
-	 * the drumkit samples.
+	 * Responsible for linking and loading of the drumkit samples.
 	 *
 	 * Upon first invocation of this function in a new project, a
 	 * symbolic link to the folder containing the samples of the
-	 * current drumkit will be created in @name /`drumkit`. In all
+	 * current drumkit will be created in @a sName `drumkit`. In all
 	 * following runs of the session the linked samples will be used
 	 * over the default ones.
 	 *
@@ -141,12 +137,12 @@ class NsmClient : public H2Core::Object
 	 * ensure portability of Hydrogen within a session regardless of
 	 * the local drumkits present in the user's home.
 	 *
-	 * \param name Absolute path to the session folder.
+	 * \param sName Absolute path to the session folder.
 	 * \param bCheckLinkage Whether or not the linked drumkit should
-	 * be verified to correspond to @a name. If set to none, the
+	 * be verified to correspond to @a sName. If set to none, the
 	 * drumkit will always be relinked.
 	 */
-	static void linkDrumkit( const char* name, bool bCheckLinkage );
+	static void linkDrumkit( const QString& sName, bool bCheckLinkage );
 	/** Custom function to print a colored error message.
 	 *
 	 * Since the OpenCallback() and SaveCallback() functions will be
@@ -184,14 +180,11 @@ class NsmClient : public H2Core::Object
 		
 		/**
 		 * Stores the current instance of the NSM client.
-		 *
-		 * Used in sendDirtyState() to establish a communication to
-		 * the NSM server.
 		 */
 		nsm_client_t* m_pNsm;
 	
 		/**
-		 * To determine whether Hydrogen is under Non session management,
+		 * To determine whether Hydrogen is under NON session management,
 		 * it is not sufficient to check whether the NSM_URL environmental
 		 * variable is set but also whether the NSM server did respond
 		 * to the announce message appropriately. Therefore,
@@ -203,36 +196,14 @@ class NsmClient : public H2Core::Object
 	 * Callback function for the NSM server to tell Hydrogen to open a
 	 * H2Core::Song.
 	 *
-	 * This function has two separate purposes: 
-	 * 1. it is used to load the
-	 * initial session including its H2Core::Song and to set up the audio
-	 * driver when started via the NSM server. 
-	 * 2. It handles the switching
-	 * between sessions by loading the H2Core::Song, the
-	 * H2Core::Preferences, and the H2Core::Drumkit of the new session
-	 * without the need to restart the whole application.
+	 * It also handles the switching between sessions by loading the
+	 * H2Core::Song, the H2Core::Preferences, and the H2Core::Drumkit
+	 * of the new session without the need to restart the whole
+	 * application.
 	 *
-	 * To fulfill the 1. purpose, it is important to know that the
+	 * It is important to know that the
 	 * core part of H2Core::Hydrogen is already initialized when this
-	 * function is called, but the GUI isn't. In order to allow for a
-	 * rewiring of all per track JACK output ports, the
-	 * H2Core::JackAudioDriver::init() function _must_ register them
-	 * alongside the main left and right output ports in the very
-	 * initialization and not at a later stage. Therefore, the
-	 * starting of the audio driver is prohibited whenever the
-	 * "NSM_URL" environmental variable is set,
-	 *  and H2Core::Hydrogen::restartDrivers() to start
-	 * the audio driver and - if JACK is chosen - to create all per
-	 * track output ports right away. In addition, is also calls
-	 * H2Core::Hydrogen::restartLadspaFX() and
-	 * H2Core::Sampler::reinitialize_playback_track() to set up the
-	 * missing core parts of Hydrogen.
-	 *
-	 * In the 2. case of switching between session the function will
-	 * construct an Action of type "OPEN_SONG" - or "NEW_SONG" if no file
-	 * exists with the provided file path - triggering
-	 * MidiActionManager::open_song() or
-	 * MidiActionManager::new_song().
+	 * function is called, but the GUI isn't.
 	 *
 	 * All files and symbolic links will be stored in a folder created
 	 * by this function and named according to @a name.
@@ -271,9 +242,6 @@ class NsmClient : public H2Core::Object
 	/**
 	 * Callback function for the NSM server to tell Hydrogen to save the
 	 * current session.
-	 *
-	 * It will construct an Action of type "SAVE_ALL" triggering
-	 * MidiActionManager::save_all().
 	 *
 	 * \param outMsg Unused argument. Kept for API compatibility.
 	 * \param userData Unused argument. Kept for API compatibility.

--- a/src/core/NsmClient.h
+++ b/src/core/NsmClient.h
@@ -221,8 +221,7 @@ class NsmClient : public H2Core::Object
 	 * initialization and not at a later stage. Therefore, the
 	 * starting of the audio driver is prohibited whenever the
 	 * "NSM_URL" environmental variable is set,
-	 * H2Core::Hydrogen::setInitialSong() is used to store the loaded
-	 * H2Core::Song, and H2Core::Hydrogen::restartDrivers() to start
+	 *  and H2Core::Hydrogen::restartDrivers() to start
 	 * the audio driver and - if JACK is chosen - to create all per
 	 * track output ports right away. In addition, is also calls
 	 * H2Core::Hydrogen::restartLadspaFX() and
@@ -234,12 +233,6 @@ class NsmClient : public H2Core::Object
 	 * exists with the provided file path - triggering
 	 * MidiActionManager::open_song() or
 	 * MidiActionManager::new_song().
-	 *
-	 * If the GUI is present, it waits - up to 11 seconds - until the
-	 * H2Core::Song was asynchronously set by the GUI (as a response
-	 * to the action). This (regular) procedure is only done if a GUI
-	 * is present and fully loaded and thus
-	 * H2Core::Hydrogen::m_GUIState is set to H2Core::Hydrogen::GUIState::ready.
 	 *
 	 * All files and symbolic links will be stored in a folder created
 	 * by this function and named according to @a name.

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -64,7 +64,7 @@ using namespace H2Core;
 HydrogenApp* HydrogenApp::m_pInstance = nullptr;
 const char* HydrogenApp::__class_name = "HydrogenApp";
 
-HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
+HydrogenApp::HydrogenApp( MainForm *pMainForm )
  : Object( __class_name )
  , m_pMainForm( pMainForm )
  , m_pMixer( nullptr )
@@ -85,12 +85,6 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 	connect( m_pEventQueueTimer, SIGNAL( timeout() ), this, SLOT( onEventQueueTimer() ) );
 	m_pEventQueueTimer->start( QUEUE_TIMER_PERIOD );
 
-	if ( ! Hydrogen::get_instance()->isUnderSessionManagement() ) {
-		// When under Non Session Management the new Song will be
-		// loaded by the corresponding NSM client instance.
-		Hydrogen::get_instance()->setSong( pFirstSong );
-	} 
-	
 	SoundLibraryDatabase::create_instance();
 
 	//setup the undo stack
@@ -796,31 +790,17 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();	
 	
-	if ( nValue == 0 || nValue == 1 ) {
-
-		// Set a Song prepared by the core part.
-		Song* pNextSong = pHydrogen->getNextSong();
-		
-		pHydrogen->setSong( pNextSong );
-
+	if ( nValue == 0 ) {
 		// Cleanup
 		closeFXProperties();
 		m_pUndoStack->clear();
 		
-		// Add the new loaded song in the "last used song" vector.
-		// This behavior is prohibited under session management. Only
-		// songs open during normal runs will be listed.
-		if ( ! pHydrogen->isUnderSessionManagement() ) {
-			Preferences::get_instance()->insertRecentFile( pNextSong->getFilename() );
-		}
-
 		// Update GUI components
 		m_pSongEditorPanel->updateAll();
 		m_pPatternEditorPanel->updateSLnameLabel();
 		updateWindowTitle();
 		getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
 		getSongEditorPanel()->updatePositionRuler();
-		pHydrogen->getTimeline()->deleteAllTags();
 	
 		// Trigger a reset of the Director and MetronomeWidget.
 		EventQueue::get_instance()->push_event( EVENT_METRONOME, 2 );
@@ -830,11 +810,7 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		m_pPatternEditorPanel->updateSLnameLabel();
 		updateWindowTitle();
 		
-		if ( nValue == 1 ) {	
-			pHydrogen->restartDrivers();
-		}
-		
-	} else if ( nValue == 2 ) {
+	} else if ( nValue == 1 ) {
 		
 		QString filename = pHydrogen->getSong()->getFilename();
 		
@@ -843,7 +819,7 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		updateWindowTitle();
 		EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
 		
-	} else if ( nValue == 3 ) {
+	} else if ( nValue == 2 ) {
 
 		// The event was triggered before the Song was fully loaded by
 		// the core. It's most likely to be present by now, but it's

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -800,10 +800,6 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 
 		// Set a Song prepared by the core part.
 		Song* pNextSong = pHydrogen->getNextSong();
-
-		if ( ! pHydrogen->getNextSongPath().isEmpty() ) {
-			pNextSong->setFilename( pHydrogen->getNextSongPath() );
-		}
 		
 		pHydrogen->setSong( pNextSong );
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -74,7 +74,7 @@ class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 		H2_OBJECT
 	Q_OBJECT
 	public:
-		HydrogenApp( MainForm* pMainForm, H2Core::Song *pFirstSong );
+		HydrogenApp( MainForm* pMainForm );
 
 		/// Returns the instance of HydrogenApp class
 		static HydrogenApp* get_instance();
@@ -245,12 +245,11 @@ class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 		 * an OSC message, this command will get core and GUI in sync
 		 * again. 
 		 *
-		 * \param nValue If 0 or 1, loads the Song stored in
-		 *     H2Core::Hydrogen::m_pNextSong. If 1, also restarts the
-		 *     audio driver via H2Core::Hydrogen::restartDrivers(). If
-		 *     2, a message in the status bar will be displayed
-		 *     notifying the user about the saving of the current Song
-		 *     to the config file.
+		 * \param nValue If 0, update the GUI to represent the new song. If
+		 *     1, a message in the status bar will be displayed
+		 *     notifying the user about the saving of the current
+		 *     Song. If 2, notifies the user that the current song is
+		 *     opened in read-only mode.
 		 */
 		virtual void updateSongEvent( int nValue ) override;
 		/**

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -87,7 +87,7 @@ int MainForm::sigusr1Fd[2];
 
 const char* MainForm::__class_name = "MainForm";
 
-MainForm::MainForm( QApplication * pQApplication, const QString& songFilename, const bool bLoadSong )
+MainForm::MainForm( QApplication * pQApplication )
 	: QMainWindow( nullptr )
 	, Object( __class_name )
 {
@@ -106,57 +106,8 @@ MainForm::MainForm( QApplication * pQApplication, const QString& songFilename, c
 
 	m_pQApp->processEvents();
 
-	Song *pSong = nullptr;
-	
-	if ( bLoadSong ) {
-		if ( !songFilename.isEmpty() ) {
-			pSong = Song::load( songFilename );
-
-			/*
-			 * If the song could not be loaded, create
-			 * a new one with the specified filename
-			 */
-			if ( pSong == nullptr ) {
-				pSong = Song::getEmptySong();
-				pSong->setFilename( songFilename );
-			}
-		}
-		else {
-			Preferences *pref = Preferences::get_instance();
-			bool restoreLastSong = pref->isRestoreLastSongEnabled();
-			QString filename = pref->getLastSongFilename();
-			if ( restoreLastSong && ( !filename.isEmpty() )) {
-				pSong = Song::load( filename );
-				if ( pSong == nullptr ) {
-					//QMessageBox::warning( this, "Hydrogen", tr("Error restoring last song.") );
-					pSong = Song::getEmptySong();
-					pSong->setFilename( "" );
-				}
-			}
-			else {
-				pSong = Song::getEmptySong();
-				pSong->setFilename( "" );
-			}
-		}
-	} else {
-		// When under Non Session Management the new Song will be
-		// prepared by the corresponding NSM client instance and in
-		// here we will just obtain and handed to the HydrogenApp but
-		// not load there.
-		pSong = Hydrogen::get_instance()->getSong();
-
-		// In case something went wrong when setting the Song to the
-		// loaded by the GUI via an OSC command, load the default Song
-		// instead.
-		if ( pSong == nullptr ) {
-			pSong = Song::getEmptySong();
-			pSong->setFilename( songFilename );
-		}
-		
-	}
-
 	showDevelWarning();
-	h2app = new HydrogenApp( this, pSong );
+	h2app = new HydrogenApp( this );
 	h2app->addEventListener( this );
 	createMenuBar();
 	checkMidiSetup();

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1460,10 +1460,6 @@ void MainForm::updateRecentUsedSongList()
 
 void MainForm::action_file_open_recent(QAction *pAction)
 {
-	// When under session management the filename of the current Song
-	// has to be preserved.
-	const bool bUnderSessionManagement = H2Core::Hydrogen::get_instance()->isUnderSessionManagement();
-	
 	HydrogenApp::get_instance()->openSong( pAction->text() );
 }
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -48,7 +48,7 @@ class MainForm : public QMainWindow, public EventListener, public H2Core::Object
 	public:
 		QApplication* m_pQApp;
 
-		MainForm( QApplication * pQApplication, const QString& songFilename, const bool bLoadSong );
+		MainForm( QApplication * pQApplication );
 		~MainForm();
 
 		void updateRecentUsedSongList();

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -800,14 +800,6 @@ void SoundLibraryPanel::on_songLoadAction()
 {
 	QString sFilename = Filesystem::song_path( __sound_library_tree->currentItem()->text( 0 ) );
 
-	if ( H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ) {
-		// The current path needs to be preserved. This will be done
-		// using an auxiliary variable since the GUI opens the song
-		// via the core, which in turn opens it asynchronously via the
-		// GUI.
-		H2Core::Hydrogen::get_instance()->setNextSongPath( H2Core::Hydrogen::get_instance()->getSong()->getFilename() );
-	}
-	
 	HydrogenApp::get_instance()->openSong( sFilename );
 }
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -127,8 +127,9 @@ static void handleFatalSignal( int nSignal )
 
 	// Allow logger to complete
 	H2Core::Logger* pLogger = H2Core::Logger::get_instance();
-	if ( pLogger )
+	if ( pLogger ) {
 		delete pLogger;
+	}
 
 	raise( nSignal );
 }

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -390,10 +390,6 @@ int main(int argc, char *argv[])
 		pQApp->setApplicationName( "Hydrogen" );
 		pQApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );
 
-		// Process any pending events before showing splash screen. This allows macOS to show previous-crash
-		// warning dialogs before they are covered by the splash screen.
-		pQApp->processEvents();
-
 		QString family = pPref->getApplicationFontFamily();
 		pQApp->setFont( QFont( family, pPref->getApplicationFontPointSize() ) );
 
@@ -510,20 +506,31 @@ int main(int argc, char *argv[])
 		// Tell Hydrogen it was started via the QT5 GUI.
 		H2Core::Hydrogen::get_instance()->setGUIState( H2Core::Hydrogen::GUIState::notReady );
 		
-		// Whether or not to load a default song or supplied one when
-		// constructing the MainForm object.
-		bool bLoadSong = true;
-
 		H2Core::Hydrogen::get_instance()->startNsmClient();
-		
-		if ( H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ){
-			
-			// When using the Non Session Management system, the new
-			// Song will be loaded by the NSM client singleton itself
-			// and not by the MainForm. The latter will just access
-			// the already loaded Song.
-			bLoadSong = false;
-			
+
+		// When using the Non Session Management system, the new Song
+		// will be loaded by the NSM client singleton itself and not
+		// by the MainForm. The latter will just access the already
+		// loaded Song.
+		if ( ! H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ){
+			H2Core::Song *pSong = nullptr;
+
+			if ( sSongFilename.isEmpty() ) {
+				if ( pPref->isRestoreLastSongEnabled() ) {
+					sSongFilename = pPref->getLastSongFilename();
+				}
+			}
+
+			if ( !sSongFilename.isEmpty() ) {
+				pSong = H2Core::Song::load( sSongFilename );
+			}
+
+			if ( pSong == nullptr ) {
+				pSong = H2Core::Song::getEmptySong();
+				pSong->setFilename( sSongFilename );
+			}
+
+			H2Core::Hydrogen::get_instance()->getCoreActionController()->openSong( pSong );
 		}
 
 		// If the NSM_URL variable is present, Hydrogen will not
@@ -536,7 +543,7 @@ int main(int argc, char *argv[])
 			H2Core::Hydrogen::get_instance()->restartDrivers();
 		}
 
-		MainForm *pMainForm = new MainForm( pQApp, sSongFilename, bLoadSong );
+		MainForm *pMainForm = new MainForm( pQApp );
 		pMainForm->show();
 		
 		pSplash->finish( pMainForm );


### PR DESCRIPTION
Proper fix of #1040, reverts ~#1262~ #1258, and covers #1041.

The proper fix moves all the code required for loading a song into the core part and performs the loading in the `main.cpp` after the core was successfully initialized and before the GUI initialization.

Since it not only affects instances running within NSM sessions and is "just" a cleaner version of ~#1262~ #1258, I did not want to merge it into `master` right between the beta and the release but in `development` instead.