### PR TITLE
Prefer CoreAudio driver when available in the 'Auto' order.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,8 @@
 	* Instrument main pitch shift offset
 	* Custom pattern size support with representation in note values
 	* Custom pan law support in mixer
+	* Attempt to find fallback Audio drivers if user preferred
+	  driver fails
 
 2021-04-11 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.0.2

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,7 @@
 	* Custom pattern size support with representation in note values
 	* Custom pan law support in mixer
 	* Attempt to find fallback Audio drivers if user preferred
-	  driver fails
+	  driver fails, as if the "Auto" driver option were selected
 
 2021-04-11 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.0.2

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -2120,15 +2120,18 @@ void audioEngine_startAudioDrivers()
 
 
 	QString sAudioDriver = preferencesMng->m_sAudioDriver;
-	QStringList drivers = { "CoreAudio", "JACK", "ALSA", "OSS", "PulseAudio" };
-
-#ifdef WIN32
-	drivers.removeAll( "PortAudio" );
-	drivers.push_front( "PortAudio" );
+#if defined(WIN32)
+    QStringList drivers = { "PortAudio", "JACK" };
+#elif defined(__APPLE__)
+    QStringList drivers = { "CoreAudio", "JACK", "PulseAudio", "PortAudio" };
+#else /* Linux */
+    QStringList drivers = { "JACK", "ALSA", "OSS", "PulseAudio", "PortAudio" };
 #endif
+
+
 	if ( sAudioDriver != "Auto" ) {
 		drivers.removeAll( sAudioDriver );
-		drivers.push_front( sAudioDriver );
+		drivers.prepend( sAudioDriver );
 	}
 	for ( QString sDriver : drivers ) {
 		if ( ( m_pAudioDriver = createDriver( sDriver ) ) != nullptr ) {


### PR DESCRIPTION
Also, small refactor to remove duplication, and also use the "Auto"
list as a fallback when a user's preferred driver isn't available.