### PR TITLE
Fix #1275 - CoreAudio assumes nFrames equivalent to buffer len

### DIFF
--- a/src/core/Basics/Sample.cpp
+++ b/src/core/Basics/Sample.cpp
@@ -461,7 +461,7 @@ void Sample::apply_rubberband( const Rubberband& rb )
 	DEBUGLOG( QString( "on %1\n\toptions\t\t: %2\n\ttime ratio\t: %3\n\tpitch\t\t: %4" ).arg( get_filename() ).arg( options ).arg( time_ratio ).arg( pitch_scale ) );
 
 	float* ibuf[2];
-	int block_size = Hydrogen::get_instance()->getAudioOutput()->getBufferSize();
+	int block_size = MAX_BUFFER_SIZE;
 
 	// If the RUB button in the player control is activated and
 	// Hydrogen is told to apply Rubber Band to samples on-the-fly

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1449,18 +1449,11 @@ int audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	return 0;
 }
 
-void audioEngine_setupLadspaFX( unsigned nBufferSize )
+void audioEngine_setupLadspaFX()
 {
-	//___INFOLOG( "buffersize=" + to_string(nBufferSize) );
-
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	Song* pSong = pHydrogen->getSong();
 	if ( ! pSong ) {
-		return;
-	}
-
-	if ( nBufferSize == 0 ) {
-		___ERRORLOG( "nBufferSize=0" );
 		return;
 	}
 
@@ -1515,7 +1508,7 @@ void audioEngine_setSong( Song* pNewSong )
 	}
 
 	// setup LADSPA FX
-	audioEngine_setupLadspaFX( m_pAudioDriver->getBufferSize() );
+	audioEngine_setupLadspaFX();
 
 	// update tick size
 	audioEngine_process_checkBPMChanged( pNewSong );
@@ -2191,7 +2184,7 @@ void audioEngine_startAudioDrivers()
 		audioEngine_renameJackPorts( pSong );
 #endif
 
-		audioEngine_setupLadspaFX( m_pAudioDriver->getBufferSize() );
+		audioEngine_setupLadspaFX();
 	}
 
 
@@ -2918,7 +2911,7 @@ void Hydrogen::startExportSong( const QString& filename)
 		ERRORLOG( "Error starting disk writer driver [DiskWriterDriver::init()]" );
 	}
 
-	audioEngine_setupLadspaFX( m_pAudioDriver->getBufferSize() );
+	audioEngine_setupLadspaFX();
 
 	audioEngine_seek( 0, false );
 
@@ -3453,7 +3446,7 @@ void Hydrogen::restartLadspaFX()
 {
 	if ( m_pAudioDriver ) {
 		AudioEngine::get_instance()->lock( RIGHT_HERE );
-		audioEngine_setupLadspaFX( m_pAudioDriver->getBufferSize() );
+		audioEngine_setupLadspaFX();
 		AudioEngine::get_instance()->unlock();
 	} else {
 		ERRORLOG( "m_pAudioDriver = NULL" );

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -2599,8 +2599,6 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 		}
 	}
 
-	nRealColumn = getRealtimeTickPosition();
-
 	if ( currentPattern && pPreferences->getQuantizeEvents() ) {
 		// quantize it to scale
 		unsigned qcolumn = ( unsigned )::round( column / ( double )scalar ) * scalar;
@@ -2663,12 +2661,12 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 
 	if ( !pPreferences->__playselectedinstrument ) {
 		if ( hearnote && instrRef ) {
-			Note *pNote2 = new Note( instrRef, nRealColumn, velocity, pan_L, pan_R, -1, 0 );
+			Note *pNote2 = new Note( instrRef, 0, velocity, pan_L, pan_R, -1, 0 );
 			midi_noteOn( pNote2 );
 		}
 	} else if ( hearnote  ) {
 		Instrument* pInstr = pSong->getInstrumentList()->get( getSelectedInstrumentNumber() );
-		Note *pNote2 = new Note( pInstr, nRealColumn, velocity, pan_L, pan_R, -1, 0 );
+		Note *pNote2 = new Note( pInstr, 0, velocity, pan_L, pan_R, -1, 0 );
 
 		int divider = msg1 / 12;
 		Note::Octave octave = (Note::Octave)(divider -3);

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -2716,11 +2716,9 @@ unsigned long Hydrogen::getRealtimeTickPosition()
 	// .tv_usec (microseconds) members of the timeval struct.
 	timersub( &currtime, &m_currentTickTime, &deltatime );
 
-	// add a buffers worth for jitter resistance
 	double deltaSec =
 			( double ) deltatime.tv_sec
-			+ ( deltatime.tv_usec / 1000000.0 )
-			+ ( m_pAudioDriver->getBufferSize() / ( double )sampleRate );
+			+ ( deltatime.tv_usec / 1000000.0 );
 
 	retTick = ( unsigned long ) ( ( sampleRate / ( double ) m_pAudioDriver->m_transport.m_fTickSize ) * deltaSec );
 

--- a/src/core/IO/CoreAudioDriver.cpp
+++ b/src/core/IO/CoreAudioDriver.cpp
@@ -45,22 +45,12 @@ static OSStatus renderProc(
 )
 {
 	H2Core::CoreAudioDriver* pDriver = ( H2Core::CoreAudioDriver * )inRefCon;
-	pDriver->mProcessCallback( pDriver->m_nBufferSize, NULL );
-	for ( unsigned i = 0; i < ioData->mNumberBuffers; i++ ) {
-		AudioBuffer &outData = ioData->mBuffers[ i ];
-		Float32* pOutData = ( float* )( outData.mData );
-
-		float *pAudioSource;
-		if ( i == 0 ) {
-			pAudioSource = pDriver->m_pOut_L;
-		} else {
-			pAudioSource = pDriver->m_pOut_R;
-		}
-		for ( unsigned j = 0; j < inNumberFrames; ++j ) {
-			pOutData[ j ] = pAudioSource[ j ];
-		}
-	}
-
+	assert( ioData->mNumberBuffers > 0 && ioData->mNumberBuffers <= 2 );
+	pDriver->m_pOut_L =  static_cast< float *>( ioData->mBuffers[ 0 ].mData );
+	pDriver->m_pOut_R =  static_cast< float *>( ioData->mBuffers[ 1 ].mData );
+	pDriver->mProcessCallback( inNumberFrames, NULL );
+	pDriver->m_pOut_L = nullptr;
+	pDriver->m_pOut_R = nullptr;
 	return noErr;
 }
 
@@ -189,12 +179,6 @@ CoreAudioDriver::~CoreAudioDriver()
 int CoreAudioDriver::init( unsigned bufferSize )
 {
 	OSStatus err = noErr;
-
-	m_pOut_L = new float[ m_nBufferSize ];
-	m_pOut_R = new float[ m_nBufferSize ];
-
-	memset ( m_pOut_L, 0, m_nBufferSize * sizeof( float ) );
-	memset ( m_pOut_R, 0, m_nBufferSize * sizeof( float ) );
 
 	// Get Component
 	AudioComponent compOutput;


### PR DESCRIPTION
Fix #1275 - CoreAudio assumes nFrames equivalent to buffer len
    
Device buffer length is not directly related to render buffer length (as passed to audioEngine_process()), so don't use this to set the number of frames to process. Also, don't use it to update the song timer, for the same reason.
    
Reviewing the lifetime of the pointers `m_pMainBuffer_{L,R}`, the lifetimes of these buffer pointers are actually contained entirely within the lifetime of audioEngine_process(), so these pointers have been removed and replaced with local calls to getOut_{L,R}() when the buffers are actually needed.
    
This then removes the dependency on size of buffers, which solves the problem of dynamically sized buffers which can occur due to mismatched device and AudioUnit sample rates.