### PR TITLE
small fix: Sample.is_empty() was always returning false

### DIFF
--- a/src/core/Basics/Sample.h
+++ b/src/core/Basics/Sample.h
@@ -363,7 +363,7 @@ inline void Sample::unload()
 
 inline bool Sample::is_empty() const
 {
-	return ( __data_l==__data_r==0 );
+	return ( __data_l == 0 && __data_r == 0 );
 }
 
 inline const QString Sample::get_filepath() const


### PR DESCRIPTION
Another catch from python bindings

```python
from h2core import Sample
sample = Sample.load_static('/path/to/sample.flac')
sample.unload()
assert sample.is_empty()
sample.load()
assert not sample.is_empty()
```
