### PR TITLE
Don't fail win build if test produces no outputs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -123,7 +123,7 @@ for:
           echo %CORE_PATH%
           set PATH=%CORE_PATH%;%PATH%
           src\tests\tests.exe --appveyor || cmd /c "exit /b 0"
-          7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen
+          7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen || cmd /c "exit  /b 0"
           if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
 
           mkdir %APPVEYOR_BUILD_FOLDER%\windows\extralibs


### PR DESCRIPTION
Currently the result of the Windows unit test is ignored; however, if there's no output produced by the test in the temporary output directory, attempting to zip up the result will fail the build.

Normally there should be at least some output from the logger, but that seems to fail to open. As the unit tests pass anyway, there's no need to fail the build when the `7z` process fails. So, disabling that (to re-enable other PRs to be merged) while I continue to investigate the logger issue.