### PR TITLE
Fix #1138, crash in Instrument Editor.

### DIFF
--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -189,7 +189,7 @@ void SampleEditor::getAllFrameInfos()
 	
 	assert( pInstrument );
 
-	InstrumentComponent *pCompo = pInstrument->get_component(0);
+	InstrumentComponent *pCompo = pInstrument->get_component( m_nSelectedComponent );
 	assert( pCompo );
 
 	InstrumentLayer *pLayer = pCompo->get_layer( m_nSelectedLayer );
@@ -395,7 +395,7 @@ void SampleEditor::createNewLayer()
 		
 		H2Core::InstrumentLayer *pLayer = nullptr;
 		if( pInstrument ) {
-			pLayer = pInstrument->get_component(0)->get_layer( m_nSelectedLayer );
+			pLayer = pInstrument->get_component( m_nSelectedComponent )->get_layer( m_nSelectedLayer );
 
 			// insert new sample from newInstrument
 			pLayer->set_sample( pEditSample );
@@ -576,7 +576,7 @@ void SampleEditor::on_PlayOrigPushButton_clicked()
 	 *instrument. Otherwise pInstr would be deleted if consumed by preview_instrument.
 	*/
 	Instrument *pTmpInstrument = Instrument::load_instrument( pInstr->get_drumkit_name(), pInstr->get_name() );
-	auto pNewSample = Sample::load( pInstr->get_component(0)->get_layer( selectedlayer )->get_sample()->get_filepath() );
+	auto pNewSample = Sample::load( pInstr->get_component( m_nSelectedComponent )->get_layer( selectedlayer )->get_sample()->get_filepath() );
 
 	if ( pNewSample != nullptr ){
 		int length = ( ( pNewSample->get_frames() / pNewSample->get_sample_rate() + 1) * 100 );


### PR DESCRIPTION
Instrument editor assumes that a component with ID 0 exists in an instrument, including when trying to open the sample editor. This is not always the case. In fact, the right thing to do in these cases isn't to open the *default* component, but the *currently selected* component of the Instrument Editor.