### PR TITLE
Fix XML encoding, and re-enable Windows test checking

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -122,7 +122,7 @@ for:
           SET CORE_PATH=%cd%\src\core
           echo %CORE_PATH%
           set PATH=%CORE_PATH%;%PATH%
-          src\tests\tests.exe --appveyor || cmd /c "exit /b 0"
+          src\tests\tests.exe --appveyor
           7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen || cmd /c "exit  /b 0"
           if %APPVEYOR_REPO_BRANCH%==appveyor-build-with-artifacts appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
 

--- a/src/core/Helpers/Xml.cpp
+++ b/src/core/Helpers/Xml.cpp
@@ -249,6 +249,7 @@ bool XMLDoc::write( const QString& filepath )
 		return false;
 	}
 	QTextStream out( &file );
+	out.setCodec( "UTF-8" );
 	out << toString().toUtf8();
 	out.flush();
 


### PR DESCRIPTION
The unit tests on Windows seem to have been broken for a while, but the results of the tests have also been ignored for that time.

This PR fixes the issue that shows up in Windows testing (but doesn't show up in the mac / Linux tests), namely that the XML helper would write XML files using the default encoding for the platform. If non-ASCII characters were encoded, this would break *very subtly* on Windows since the default encoding isn't UTF-8, but the generated XML is explicitly UTF-8.

Since the unit tests will now pass on Windows, this PR re-enables checking the result on Windows.