### PR TITLE
Relax bit-precise float requirement on audio tests

### DIFF
--- a/src/tests/assertions/AudioFile.cpp
+++ b/src/tests/assertions/AudioFile.cpp
@@ -73,7 +73,10 @@ void H2Test::checkAudioFilesEqual(const QString &expected, const QString &actual
 		if ( read2 != toRead ) throw CppUnit::Exception( CppUnit::Message( "Short read or read error" ), sourceLine );
 
 		for ( sf_count_t i = 0; i < toRead; ++i ) {
-			if ( buf1[i] != buf2[i] ) {
+			// Bit-precise floating point on all platforms is unneeded, and arbitrarily small differences can
+			// create rounding differences. Allow results to differ by 1 either way to account for this.
+			int delta = (int)buf1[i] - (int)buf2[i];
+			if ( delta < -1 || delta > 1 ) {
 				auto diffLocation = offset + i + 1;
 				CppUnit::Message msg(
 					std::string("Files differ at sample ") + std::to_string(diffLocation),


### PR DESCRIPTION
Currently audio tests fail on 32-bit Windows machines because the tests rely on bit-precise float arithmetic. There's no practical reason to require that level of accurary, particularly since it precludes some optimisations such as the use of SSE instructions.

Arbitrarily small differences in float arithmetic will cause differences in the rounded 16-bit output, so direct bit comparison of the rounded `short`s from `libsndfile` stands a chance of failing.

This change allows for a +/-1 difference between the test and reference sample values to account for this.

A slightly stronger comparison methodology would be to assume that they're randomly distributed, therefore the ratio of errors to accurate samples is proportional to the additional precision that's lost through rounding, and apply an acceptable error threshold.
