### PR TITLE
Fix CLI driver selection

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -230,6 +230,7 @@ int main(int argc, char *argv[])
 			exit(0);
 		}
 
+		sSelectedDriver = sSelectedDriver.toLower();
 		if (sSelectedDriver == "auto") {
 			preferences->m_sAudioDriver = "Auto";
 		}
@@ -242,11 +243,14 @@ int main(int argc, char *argv[])
 		else if ( sSelectedDriver == "alsa" ) {
 			preferences->m_sAudioDriver = "ALSA";
 		}
-		else if (sSelectedDriver == "CoreAudio") {
+		else if (sSelectedDriver == "coreaudio") {
 			preferences->m_sAudioDriver = "CoreAudio";
 		}
-		else if (sSelectedDriver == "PulseAudio") {
+		else if (sSelectedDriver == "pulseaudio") {
 			preferences->m_sAudioDriver = "PulseAudio";
+		}
+		else {
+			___ERRORLOG( QString( "Unknown driver '%1'" ).arg( sSelectedDriver ) );
 		}
 
 #ifdef H2CORE_HAVE_LASH

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -370,7 +370,7 @@ int main(int argc, char *argv[])
 			H2Core::Drumkit::install( sDrumkitName );
 			exit(0);
 		}
-		
+		sSelectedDriver = sSelectedDriver.toLower();
 		if (sSelectedDriver == "auto") {
 			pPref->m_sAudioDriver = "Auto";
 		}
@@ -382,6 +382,18 @@ int main(int argc, char *argv[])
 		}
 		else if ( sSelectedDriver == "alsa" ) {
 			pPref->m_sAudioDriver = "ALSA";
+		}
+		else if ( sSelectedDriver == "portaudio" ) {
+			pPref->m_sAudioDriver = "PortAudio";
+		}
+		else if ( sSelectedDriver == "pulseaudio" ) {
+			pPref->m_sAudioDriver = "PulseAudio";
+		}
+		else if ( sSelectedDriver == "coreaudio" ) {
+			pPref->m_sAudioDriver = "CoreAudio";
+		}
+		else {
+			___ERRORLOG( QString( "Unknown driver '%1'" ).arg( sSelectedDriver ) );
 		}
 
 		// Bootstrap is complete, start GUI


### PR DESCRIPTION
  * Make driver id on command line case-insensitive
  * Add PulseAudio, CoreAudio, PortAudio to the GUI app's command line

Really there should be a driver registry or similar to handle this sort of thing