### PR TITLE
Fix #1354 -- save audio preferences after driver restart

### DIFF
--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -727,15 +727,13 @@ void PreferencesDialog::on_okBtn_clicked()
 		pPref->setPreferredLanguage( sPreferredLanguage );
 	}
 
-	pPref->savePreferences();
-
-
 	if (m_bNeedDriverRestart) {
 		int res = QMessageBox::information( this, "Hydrogen", tr( "Driver restart required.\n Restart driver?"), tr("&Ok"), tr("&Cancel"), nullptr, 1 );
 		if ( res == 0 ) {
 			QApplication::setOverrideCursor( Qt::WaitCursor );
 			Hydrogen::get_instance()->restartDrivers();
 			QApplication::restoreOverrideCursor();
+			pPref->savePreferences();
 		}
 	}
 	accept();
@@ -1050,8 +1048,8 @@ void PreferencesDialog::on_restartDriverBtn_clicked()
 {
 	updateDriverPreferences();
 	Preferences *pPref = Preferences::get_instance();
-	pPref->savePreferences();
 	Hydrogen::get_instance()->restartDrivers();
+	pPref->savePreferences();
 	m_bNeedDriverRestart = false;
 }
 


### PR DESCRIPTION
Save the preferences *after* a driver restart rather than before.

This makes it less likely that we'll get stuck in a state where we have bad driver settings in the preferences.