### PR TITLE
fix repology reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hydrogen drum machine
 
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true)](https://ci.appveyor.com/api/projects/status/32r7s2skrgm9ubva?svg=true)
-[![Packaging status](https://repology.org/badge/tiny-repos/hydrogen.svg)](https://repology.org/project/hydrogen/versions)
+[![Packaging status](https://repology.org/badge/tiny-repos/hydrogen-drum-machine.svg)](https://repology.org/project/hydrogen-drum-machine/versions)
 
 Hydrogen is an advanced drum machine for GNU/Linux, Mac and Windows.
 Its main goal is to bring professional yet simple and intuitive pattern-based drum programming.


### PR DESCRIPTION
seems like the projects name was changed from "hydrogen" to "hydrogen-drum-machine