### PR TITLE
fix PreferencesDialog OK button handling

### DIFF
--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -764,9 +764,13 @@ void PreferencesDialog::on_okBtn_clicked()
 			QApplication::setOverrideCursor( Qt::WaitCursor );
 			Hydrogen::get_instance()->restartDrivers();
 			QApplication::restoreOverrideCursor();
-			pPref->savePreferences();
+		} else {
+			// Don't save the Preferences and don't close the PreferencesDialog
+			return;
 		}
 	}
+	
+	pPref->savePreferences();
 	accept();
 }
 


### PR DESCRIPTION
Preferences are stored regardless of whether the audio driver needs a restart.

If the Cancel button gets hit on the driver restart dialog (after hitting the OK button), the Preferences are not stored and the PreferencesDialog closed. So, whenever closed via the OK button, everything is stored.

Fixes #1375