### PR TITLE
Record window geometry using Qt's saveGeometry() (fix #1369)

### DIFF
--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -1253,6 +1253,9 @@ WindowProperties Preferences::readWindowProperties( QDomNode parent, const QStri
 		prop.y = LocalFileMng::readXmlInt( windowPropNode, "y", prop.y );
 		prop.width = LocalFileMng::readXmlInt( windowPropNode, "width", prop.width );
 		prop.height = LocalFileMng::readXmlInt( windowPropNode, "height", prop.height );
+		prop.m_geometry = QByteArray::fromBase64( LocalFileMng::readXmlString( windowPropNode, "geometry",
+																			   prop.m_geometry.toBase64() )
+												  .toUtf8() );
 	}
 
 	return prop;
@@ -1275,6 +1278,8 @@ void Preferences::writeWindowProperties( QDomNode parent, const QString& windowN
 	LocalFileMng::writeXmlString( windowPropNode, "y", QString("%1").arg( prop.y ) );
 	LocalFileMng::writeXmlString( windowPropNode, "width", QString("%1").arg( prop.width ) );
 	LocalFileMng::writeXmlString( windowPropNode, "height", QString("%1").arg( prop.height ) );
+	LocalFileMng::writeXmlString( windowPropNode, "geometry", QString( prop.m_geometry.toBase64() ) );
+
 	parent.appendChild( windowPropNode );
 }
 

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -769,7 +769,7 @@ void Preferences::savePreferences()
 	} else {
 		sPreferencesFilename = sPreferencesOverwritePath;
 	}
-	
+
 	INFOLOG( QString( "Saving preferences file %1" ).arg( sPreferencesFilename ) );
 
 	QDomDocument doc;

--- a/src/core/Preferences.h
+++ b/src/core/Preferences.h
@@ -54,14 +54,16 @@ public:
 	int width;
 	int height;
 	bool visible;
+	QByteArray m_geometry;
 
 	WindowProperties();
 	~WindowProperties();
 
-	void set(int _x, int _y, int _width, int _height, bool _visible) {
+	void set(int _x, int _y, int _width, int _height, bool _visible, QByteArray geometry = QByteArray() ) {
 		x = _x; y = _y;
 		width = _width; height = _height;
 		visible = _visible;
+		m_geometry = geometry;
 	}
 
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -105,13 +105,7 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 	// restore audio engine form properties
 	m_pAudioEngineInfoForm = new AudioEngineInfoForm( nullptr );
 	WindowProperties audioEngineInfoProp = pPref->getAudioEngineInfoProperties();
-	m_pAudioEngineInfoForm->move( audioEngineInfoProp.x, audioEngineInfoProp.y );
-	if ( audioEngineInfoProp.visible ) {
-		m_pAudioEngineInfoForm->show();
-	}
-	else {
-		m_pAudioEngineInfoForm->hide();
-	}
+	setWindowProperties( m_pAudioEngineInfoForm, audioEngineInfoProp, /*bResize=*/false );
 	
 	m_pFilesystemInfoForm = new FilesystemInfoForm( nullptr );
 
@@ -127,6 +121,37 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm, Song *pFirstSong )
 	addEventListener( this );
 }
 
+void HydrogenApp::setWindowProperties( QWidget *pWindow, WindowProperties &prop, bool bResize ) {
+	if ( prop.visible) {
+		pWindow->show();
+	} else {
+		pWindow->hide();
+	}
+	if ( prop.m_geometry.size() == 0 ) {
+		// No geometry saved in preferences. Most likely an old preferences file. Set the size and shape
+		if ( bResize ) {
+			pWindow->resize( prop.width, prop.height );
+		}
+		pWindow->move( prop.x, prop.y );
+		prop.m_geometry = pWindow->saveGeometry();
+	}
+
+	// restore geometry will also ensure things are visible if screen geometry has changed.
+	pWindow->restoreGeometry( prop.m_geometry );
+}
+
+
+WindowProperties HydrogenApp::getWindowProperties( QWidget *pWindow ) {
+	WindowProperties prop;
+	prop.x = pWindow->x();
+	prop.y = pWindow->y();
+	prop.height = pWindow->height();
+	prop.width = pWindow->width();
+	prop.visible = pWindow->isVisible();
+	prop.m_geometry = pWindow->saveGeometry();
+
+	return prop;
+}
 
 
 HydrogenApp::~HydrogenApp()
@@ -183,8 +208,7 @@ void HydrogenApp::setupSinglePanedInterface()
 
 	// MAINFORM
 	WindowProperties mainFormProp = pPref->getMainFormProperties();
-	m_pMainForm->resize( mainFormProp.width, mainFormProp.height );
-	m_pMainForm->move( mainFormProp.x, mainFormProp.y );
+	setWindowProperties( m_pMainForm, mainFormProp );
 
 	m_pSplitter = new QSplitter( nullptr );
 	m_pSplitter->setOrientation( Qt::Vertical );
@@ -201,7 +225,7 @@ void HydrogenApp::setupSinglePanedInterface()
 	}
 
 	WindowProperties songEditorProp = pPref->getSongEditorProperties();
-	m_pSongEditorPanel->resize( songEditorProp.width, songEditorProp.height );
+	setWindowProperties( m_pSongEditorPanel, songEditorProp );
 
 	if( uiLayout == Preferences::UI_LAYOUT_TABBED) {
 		m_pTab->addTab( m_pSongEditorPanel, tr("Song Editor") );
@@ -229,7 +253,7 @@ void HydrogenApp::setupSinglePanedInterface()
 	// PATTERN EDITOR
 	m_pPatternEditorPanel = new PatternEditorPanel( nullptr );
 	WindowProperties patternEditorProp = pPref->getPatternEditorProperties();
-	m_pPatternEditorPanel->resize( patternEditorProp.width, patternEditorProp.height );
+	setWindowProperties( m_pPatternEditorPanel, patternEditorProp );
 
 	pEditorHBox->addWidget( m_pPatternEditorPanel );
 	pEditorHBox->addWidget( m_pInstrumentRack );
@@ -264,9 +288,7 @@ void HydrogenApp::setupSinglePanedInterface()
 	// MIXER
 	m_pMixer = new Mixer(nullptr);
 	WindowProperties mixerProp = pPref->getMixerProperties();
-
-	m_pMixer->resize( mixerProp.width, mixerProp.height );
-	m_pMixer->move( mixerProp.x, mixerProp.y );
+	setWindowProperties( m_pMixer, mixerProp );
 
 	if( uiLayout == Preferences::UI_LAYOUT_TABBED){
 		m_pTab->addTab(m_pMixer,tr("Mixer"));
@@ -288,7 +310,7 @@ void HydrogenApp::setupSinglePanedInterface()
 		m_pLadspaFXProperties[nFX] = new LadspaFXProperties( nullptr, nFX );
 		m_pLadspaFXProperties[nFX]->hide();
 		WindowProperties prop = pPref->getLadspaProperties(nFX);
-		m_pLadspaFXProperties[nFX]->move( prop.x, prop.y );
+		setWindowProperties( m_pLadspaFXProperties[ nFX ], prop, /*bResize=*/ false );
 		if ( prop.visible ) {
 			m_pLadspaFXProperties[nFX]->show();
 		}
@@ -740,7 +762,7 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 		int uiLayout = pPref->getDefaultUILayout();
 
 		WindowProperties audioEngineInfoProp = pPref->getAudioEngineInfoProperties();
-		m_pAudioEngineInfoForm->move( audioEngineInfoProp.x, audioEngineInfoProp.y );
+		setWindowProperties( m_pAudioEngineInfoForm, audioEngineInfoProp );
 		if ( audioEngineInfoProp.visible ) {
 			m_pAudioEngineInfoForm->show();
 		}
@@ -750,27 +772,24 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 
 		// MAINFORM
 		WindowProperties mainFormProp = pPref->getMainFormProperties();
-		m_pMainForm->resize( mainFormProp.width, mainFormProp.height );
-		m_pMainForm->move( mainFormProp.x, mainFormProp.y );
+		setWindowProperties( m_pMainForm, mainFormProp );
 
 		m_pSplitter->setOrientation( Qt::Vertical );
 		m_pSplitter->setOpaqueResize( true );
 
 		// SONG EDITOR
 		WindowProperties songEditorProp = pPref->getSongEditorProperties();
-		m_pSongEditorPanel->resize( songEditorProp.width, songEditorProp.height );
+		setWindowProperties( m_pSongEditorPanel, songEditorProp );
 
 		// PATTERN EDITOR
 		WindowProperties patternEditorProp = pPref->getPatternEditorProperties();
-		m_pPatternEditorPanel->resize( patternEditorProp.width, patternEditorProp.height );
+		setWindowProperties( m_pPatternEditorPanel, patternEditorProp );
 		
 		WindowProperties instrumentRackProp = pPref->getInstrumentRackProperties();
 		m_pInstrumentRack->setHidden( !instrumentRackProp.visible );
 
 		WindowProperties mixerProp = pPref->getMixerProperties();
-
-		m_pMixer->resize( mixerProp.width, mixerProp.height );
-		m_pMixer->move( mixerProp.x, mixerProp.y );
+		setWindowProperties( m_pMixer, mixerProp );
 
 		m_pMixer->updateMixer();
 
@@ -786,7 +805,7 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 		for (uint nFX = 0; nFX < MAX_FX; nFX++) {
 			m_pLadspaFXProperties[nFX]->hide();
 			WindowProperties prop = pPref->getLadspaProperties(nFX);
-			m_pLadspaFXProperties[nFX]->move( prop.x, prop.y );
+			setWindowProperties( m_pLadspaFXProperties[ nFX ], prop, /*bResize=*/false );
 			if ( prop.visible ) {
 				m_pLadspaFXProperties[nFX]->show();
 			}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -288,6 +288,9 @@ void HydrogenApp::setupSinglePanedInterface()
 	// MIXER
 	m_pMixer = new Mixer(nullptr);
 	WindowProperties mixerProp = pPref->getMixerProperties();
+	if ( uiLayout != Preferences::UI_LAYOUT_SINGLE_PANE ) {
+		mixerProp.visible = false;
+	}
 	setWindowProperties( m_pMixer, mixerProp );
 
 	if( uiLayout == Preferences::UI_LAYOUT_TABBED){
@@ -296,12 +299,6 @@ void HydrogenApp::setupSinglePanedInterface()
 
 	m_pMixer->updateMixer();
 
-	if ( mixerProp.visible && uiLayout == Preferences::UI_LAYOUT_SINGLE_PANE ) {
-		m_pMixer->show();
-	}
-	else {
-		m_pMixer->hide();
-	}
 
 
 #ifdef H2CORE_HAVE_LADSPA
@@ -311,12 +308,6 @@ void HydrogenApp::setupSinglePanedInterface()
 		m_pLadspaFXProperties[nFX]->hide();
 		WindowProperties prop = pPref->getLadspaProperties(nFX);
 		setWindowProperties( m_pLadspaFXProperties[ nFX ], prop, /*bResize=*/ false );
-		if ( prop.visible ) {
-			m_pLadspaFXProperties[nFX]->show();
-		}
-		else {
-			m_pLadspaFXProperties[nFX]->hide();
-		}
 	}
 #endif
 
@@ -763,12 +754,6 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 
 		WindowProperties audioEngineInfoProp = pPref->getAudioEngineInfoProperties();
 		setWindowProperties( m_pAudioEngineInfoForm, audioEngineInfoProp );
-		if ( audioEngineInfoProp.visible ) {
-			m_pAudioEngineInfoForm->show();
-		}
-		else {
-			m_pAudioEngineInfoForm->hide();
-		}
 
 		// MAINFORM
 		WindowProperties mainFormProp = pPref->getMainFormProperties();
@@ -789,16 +774,12 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 		m_pInstrumentRack->setHidden( !instrumentRackProp.visible );
 
 		WindowProperties mixerProp = pPref->getMixerProperties();
+		if ( uiLayout != Preferences::UI_LAYOUT_SINGLE_PANE ) {
+			mixerProp.visible = false;
+		}
 		setWindowProperties( m_pMixer, mixerProp );
 
 		m_pMixer->updateMixer();
-
-		if ( mixerProp.visible && uiLayout == Preferences::UI_LAYOUT_SINGLE_PANE ) {
-			m_pMixer->show();
-		}
-		else {
-			m_pMixer->hide();
-		}
 		
 #ifdef H2CORE_HAVE_LADSPA
 		// LADSPA FX
@@ -806,12 +787,6 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 			m_pLadspaFXProperties[nFX]->hide();
 			WindowProperties prop = pPref->getLadspaProperties(nFX);
 			setWindowProperties( m_pLadspaFXProperties[ nFX ], prop, /*bResize=*/false );
-			if ( prop.visible ) {
-				m_pLadspaFXProperties[nFX]->show();
-			}
-			else {
-				m_pLadspaFXProperties[nFX]->hide();
-			}
 		}
 #endif
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -130,6 +130,9 @@ class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 
 		void cleanupTemporaryFiles();
 
+		void setWindowProperties( QWidget *pWindow, H2Core::WindowProperties &prop, bool bResize = true );
+		H2Core::WindowProperties getWindowProperties( QWidget *pWindow );
+
 	public slots:
 		/**
 		 * Function called every #QUEUE_TIMER_PERIOD

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1398,67 +1398,21 @@ void MainForm::savePreferences() {
 	Preferences *pPreferences = Preferences::get_instance();
 
 	// mainform
-	WindowProperties mainFormProp;
-	mainFormProp.x = x();
-	mainFormProp.y = y();
-	mainFormProp.height = height();
-	mainFormProp.width = width();
-	pPreferences->setMainFormProperties( mainFormProp );
-
+	pPreferences->setMainFormProperties( h2app->getWindowProperties( this ) );
 	// Save mixer properties
-	WindowProperties mixerProp;
-	mixerProp.x = h2app->getMixer()->x();
-	mixerProp.y = h2app->getMixer()->y();
-	mixerProp.width = h2app->getMixer()->width();
-	mixerProp.height = h2app->getMixer()->height();
-	mixerProp.visible = h2app->getMixer()->isVisible();
-	pPreferences->setMixerProperties( mixerProp );
-
+	pPreferences->setMixerProperties( h2app->getWindowProperties( h2app->getMixer() ) );
 	// save pattern editor properties
-	WindowProperties patternEditorProp;
-	patternEditorProp.x = h2app->getPatternEditorPanel()->x();
-	patternEditorProp.y = h2app->getPatternEditorPanel()->y();
-	patternEditorProp.width = h2app->getPatternEditorPanel()->width();
-	patternEditorProp.height = h2app->getPatternEditorPanel()->height();
-	patternEditorProp.visible = h2app->getPatternEditorPanel()->isVisible();
-	pPreferences->setPatternEditorProperties( patternEditorProp );
-
+	pPreferences->setPatternEditorProperties( h2app->getWindowProperties( h2app->getPatternEditorPanel() ) );
 	// save song editor properties
-	WindowProperties songEditorProp;
-	songEditorProp.x = h2app->getSongEditorPanel()->x();
-	songEditorProp.y = h2app->getSongEditorPanel()->y();
-	songEditorProp.width = h2app->getSongEditorPanel()->width();
-	songEditorProp.height = h2app->getSongEditorPanel()->height();
-
-	QSize size = h2app->getSongEditorPanel()->frameSize();
-	songEditorProp.visible = h2app->getSongEditorPanel()->isVisible();
-	pPreferences->setSongEditorProperties( songEditorProp );
-
-
-	WindowProperties instrumentRackProp;
-	instrumentRackProp.x = h2app->getInstrumentRack()->x();
-	instrumentRackProp.y = h2app->getInstrumentRack()->y();
-	instrumentRackProp.width = h2app->getInstrumentRack()->width();
-	instrumentRackProp.height = h2app->getInstrumentRack()->height();
-	instrumentRackProp.visible = h2app->getInstrumentRack()->isVisible();
-	pPreferences->setInstrumentRackProperties( instrumentRackProp );
-
+	pPreferences->setSongEditorProperties( h2app->getWindowProperties( h2app->getSongEditorPanel() ) );
+	pPreferences->setInstrumentRackProperties( h2app->getWindowProperties( h2app->getInstrumentRack() ) );
 	// save audio engine info properties
-	WindowProperties audioEngineInfoProp;
-	audioEngineInfoProp.x = h2app->getAudioEngineInfoForm()->x();
-	audioEngineInfoProp.y = h2app->getAudioEngineInfoForm()->y();
-	audioEngineInfoProp.visible = h2app->getAudioEngineInfoForm()->isVisible();
-	pPreferences->setAudioEngineInfoProperties( audioEngineInfoProp );
-
+	pPreferences->setAudioEngineInfoProperties( h2app->getWindowProperties( h2app->getAudioEngineInfoForm() ) );
 
 #ifdef H2CORE_HAVE_LADSPA
 	// save LADSPA FX window properties
 	for (uint nFX = 0; nFX < MAX_FX; nFX++) {
-		WindowProperties prop;
-		prop.x = h2app->getLadspaFXProperties(nFX)->x();
-		prop.y = h2app->getLadspaFXProperties(nFX)->y();
-		prop.visible= h2app->getLadspaFXProperties(nFX)->isVisible();
-		pPreferences->setLadspaProperties(nFX, prop);
+		pPreferences->setLadspaProperties( nFX, h2app->getWindowProperties( h2app->getLadspaFXProperties( nFX ) ) );
 	}
 #endif
 }


### PR DESCRIPTION
Save geometry from `saveGeometry()` as a base64 string in preferences.

For backwards compatability with existing preferences, we still store
x/y/width/height, and restore using these if no saved geometry spec is
present in the preferences.

This enables a fix for #1369 (windows moved off-screen when screen geometry changes) since window placement is now controlled by Qt's `restoreGeometry()` which contains the necessary logic for ensuring windows (especially title bars) are kept within some visible space.