### PR TITLE
fix #1379: dithering of SongEditor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@
 	* InstrumentEditor UX improvements:
 		- rework start/end/loop frame slider selection and motion.
 		- rework velocity/pan envelope editing
+	* Bugfixes
+		- fix dithering of SongEditor when viewing the playback track
+		  and resizing the application or for very small size (#1379).
 
 2021-09-04 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.1

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2105,6 +2105,8 @@ void SongEditorPatternList::onPreferencesChanged( bool bAppearanceOnly ) {
 SongEditorPositionRuler::SongEditorPositionRuler( QWidget *parent )
  : QWidget( parent )
  , m_bRightBtnPressed( false )
+ , m_nPlayheadWidth( 11 )
+ , m_nPlayheadHeight( 8 )
 {
 	m_pHydrogen = Hydrogen::get_instance();
 	m_pAudioEngine = m_pHydrogen->getAudioEngine();
@@ -2119,6 +2121,13 @@ SongEditorPositionRuler::SongEditorPositionRuler( QWidget *parent )
 	m_nMaxPatternSequence = pPref->getMaxBars();
 
 	m_nInitialWidth = m_nMaxPatternSequence * 16;
+
+	// Offset position of the shaft of the arrow head indicating the
+	// playback position.
+	m_nXShaft = std::floor( static_cast<float>( m_nPlayheadWidth ) / 2 );
+	if ( m_nPlayheadWidth % 2 != 0 ) {
+		m_nXShaft++;
+	}
 
 	resize( m_nInitialWidth, m_nHeight );
 	setFixedHeight( m_nHeight );
@@ -2375,10 +2384,12 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	painter.drawPixmap( ev->rect(), *m_pBackgroundPixmap, srcRect );
 
 	if (fPos != -1) {
-		uint x = (int)( m_nMargin + fPos * m_nGridWidth - 11 / 2 );
-		painter.drawPixmap( QRect( x, height() / 2, 11, 8), m_tickPositionPixmap, QRect(0, 0, 11, 8) );
+		uint x = (int)( m_nMargin + fPos * m_nGridWidth - m_nPlayheadWidth / 2 );
+		painter.drawPixmap( QRect( x, height() / 2, m_nPlayheadWidth, m_nPlayheadHeight ),
+							m_tickPositionPixmap,
+							QRect( 0, 0, m_nPlayheadWidth, m_nPlayheadHeight ) );
 		painter.setPen( QColor(35, 39, 51) );
-		painter.drawLine( x + 5 , 8, x +5 , 24 );
+		painter.drawLine( x + m_nXShaft, m_nPlayheadHeight, x + m_nXShaft, 24 );
 	}
 
 	if ( pIPos <= pOPos ) {

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -342,6 +342,8 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 		void editTagAction( QString text, int position, QString textToReplace );
 		void deleteTagAction( QString text, int position );
 
+	int getPlayheadWidth() const;
+
 	public slots:
 		void updatePosition();
 		void showTagWidget( int nColumn );
@@ -358,6 +360,14 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 		static const uint	m_nHeight = 50;
 		const int m_nMargin = 10;
 
+	/** Width of the playhead pixmap in pixel.*/
+	int m_nPlayheadWidth;
+	/** Height of the playhead pixmap in pixel.*/
+	int m_nPlayheadHeight;
+	/** Horizontal offset of the line used to represent the base of
+		the playhead.*/
+	int m_nXShaft;
+
 		QPixmap *			m_pBackgroundPixmap;
 		QPixmap				m_tickPositionPixmap;
 		bool				m_bRightBtnPressed;
@@ -373,5 +383,8 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 
 };
 
+inline int SongEditorPositionRuler::getPlayheadWidth() const {
+	return m_nPlayheadWidth;
+}
 
 #endif

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -337,7 +337,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	m_pPositionRuler->setFocusPolicy( Qt::ClickFocus );
 	m_pPositionRuler->setFocusProxy( m_pSongEditor );
-	
+
 	m_pPlaybackTrackScrollView = new WidgetScrollArea( m_pWidgetStack );
 	m_pPlaybackTrackScrollView->setFrameShape( QFrame::NoFrame );
 	m_pPlaybackTrackScrollView->setVerticalScrollBarPolicy( Qt::ScrollBarAlwaysOff );
@@ -441,18 +441,33 @@ void SongEditorPanel::updatePlayHeadPosition()
 			return;
 		}
 
+		int nWidth;
+		if ( m_pViewPlaybackToggleBtn->isPressed() ) {
+			nWidth = m_pPlaybackTrackScrollView->viewport()->width();
+		} else {
+			nWidth = m_pPositionRulerScrollView->viewport()->width();
+		}
+
 		QPoint pos = m_pPositionRuler->pos();
 		int x = -pos.x();
-		int w = m_pPositionRulerScrollView->viewport()->width();
 
 		int nPlayHeadPosition = Hydrogen::get_instance()->getPatternPos() * m_pSongEditor->getGridWidth();
 
 		int value = m_pEditorScrollView->horizontalScrollBar()->value();
-		if ( nPlayHeadPosition > ( x + w - 50 ) ) {
-			hScrollTo( value + 100 );
+
+		// Distance the grid will be moved left or right.
+		int nIncrement = 100;
+		if ( nIncrement > std::round( static_cast<float>(nWidth) / 3 ) ) {
+			nIncrement = std::round( static_cast<float>(nWidth) / 3 );
+		} else if ( nIncrement < 2 * m_pPositionRuler->getPlayheadWidth() ) {
+			nIncrement = 2 * m_pPositionRuler->getPlayheadWidth();
+		}
+		
+		if ( nPlayHeadPosition > ( x + nWidth - std::floor( static_cast<float>( nIncrement ) / 2 ) ) ) {
+			hScrollTo( value + nIncrement );
 		}
 		else if ( nPlayHeadPosition < x ) {
-			hScrollTo( value - 100 );
+			hScrollTo( value - nIncrement );
 		}
 	}
 }
@@ -760,7 +775,6 @@ void SongEditorPanel::updateTimelineUsage() {
 
 void SongEditorPanel::timeLineBtnPressed( Button* pBtn )
 {
-	
 	auto pHydrogen = Hydrogen::get_instance();
 	
 	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {


### PR DESCRIPTION
- correct viewport width will be used for calculating the playhead position depending on whether the timeline or the playback track is selected
- SongEditorPositionRuler does now encapsulate all playhead dimensions in member variables and offers a getter for its width. Using this the incremental scrolling of the SongEditor while playing is now scaling more properly for small main window sizes.
- additional dithering introduced when shrinking the width of the main window a lot (beyond any usability) is fixed too.