### PR TITLE
Don't set position on pattern editor etc. when restoring geometry

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -443,6 +443,7 @@ int main(int argc, char *argv[])
 		delete pPlaylist;
 
 		delete pQueue;
+		preferences->savePreferences();
 		delete pHydrogen;
 		delete preferences;
 		delete pAudioEngine;

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -264,8 +264,6 @@ Preferences::Preferences()
 
 Preferences::~Preferences()
 {
-	savePreferences();
-
 	INFOLOG( "DESTROY" );
 	__instance = nullptr;
 	delete m_pDefaultUIStyle;

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -157,6 +157,13 @@ void HydrogenApp::setWindowProperties( QWidget *pWindow, WindowProperties &prop,
 		newGeometry.setHeight( oldGeometry.height() );
 	}
 
+	// If a window is fixed-size, don't restore it full-screen (macOS sometimes does this, annoyingly)
+	if ( pWindow->minimumSize() == pWindow->maximumSize() ) {
+		if ( pWindow->isFullScreen()) {
+			pWindow->showNormal();
+		}
+	}
+
 	if ( oldGeometry != newGeometry ) {
 		pWindow->setGeometry( newGeometry );
 	}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -230,7 +230,7 @@ void HydrogenApp::setupSinglePanedInterface()
 
 	// MAINFORM
 	WindowProperties mainFormProp = pPref->getMainFormProperties();
-	setWindowProperties( m_pMainForm, mainFormProp );
+	setWindowProperties( m_pMainForm, mainFormProp, SetDefault & ~SetVisible );
 
 	m_pSplitter = new QSplitter( nullptr );
 	m_pSplitter->setOrientation( Qt::Vertical );

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -130,7 +130,17 @@ class HydrogenApp : public QObject, public EventListener, public H2Core::Object
 
 		void cleanupTemporaryFiles();
 
-		void setWindowProperties( QWidget *pWindow, H2Core::WindowProperties &prop, bool bResize = true );
+		enum SetPropertyFlag {
+			SetX = 1 << 0,
+			SetY = 1 << 1,
+			SetWidth = 1 << 2,
+			SetHeight = 1 << 3,
+			SetVisible = 1 << 4,
+			SetAll = SetX + SetY + SetWidth + SetHeight + SetVisible,
+			SetDefault = SetAll
+		};
+
+		void setWindowProperties( QWidget *pWindow, H2Core::WindowProperties &prop, unsigned flags = SetAll );
 		H2Core::WindowProperties getWindowProperties( QWidget *pWindow );
 
 	public slots:

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -582,6 +582,7 @@ int main(int argc, char *argv[])
 
 		pQApp->exec();
 
+		pPref->savePreferences();
 		delete pSplash;
 		delete pMainForm;
 		delete pQApp;

--- a/src/player/main.cpp
+++ b/src/player/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char** argv){
 				delete pSong;
 				delete H2Core::EventQueue::get_instance();
 				delete H2Core::AudioEngine::get_instance();
-                                preferences->savePreferences();
+				preferences->savePreferences();
 				delete preferences;
 				delete H2Core::Logger::get_instance();
 

--- a/src/player/main.cpp
+++ b/src/player/main.cpp
@@ -97,6 +97,7 @@ int main(int argc, char** argv){
 				delete pSong;
 				delete H2Core::EventQueue::get_instance();
 				delete H2Core::AudioEngine::get_instance();
+                                preferences->savePreferences();
 				delete preferences;
 				delete H2Core::Logger::get_instance();
 


### PR DESCRIPTION
This avoids problems switching between tabbed and single-pane
interface modes