### PR TITLE
fix #1386: segfault in PianoRollEditor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@
 	* Bugfixes
 		- fix dithering of SongEditor when viewing the playback track
 		  and resizing the application or for very small size (#1379).
+		- fix segfault when entering note in PianoRollEditor (#1386).
 
 2021-09-04 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.1

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -126,8 +126,6 @@ class PianoRollEditor: public PatternEditor, protected WidgetWithScalableFont<7,
 		void onPreferencesChanged( bool bAppearanceOnly );
 
 	private:
-		H2Core::AudioEngine* m_pAudioEngine;
-
 		bool m_bNeedsUpdate;
 		bool m_bNeedsBackgroundUpdate;
 


### PR DESCRIPTION
- do not override definition of m_pAudioEngine in PianoRollEditor with respect to the parent one in PatternEditor

fixes #1386 

As this was introduced with the refactoring of the audio engine a year ago it seems not so much folks do use the PianoRollEditor :laughing: 