### PR TITLE
Reduce PortAudio latency (mostly for Windows' sake)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@
 		  pattern inserted in SongEditor (#932)
 		- fix display of tempo marker while loading a song
 		  (introduced in 1.1.0) (#1393)
+	* Explicitly set latency target for PortAudio (Windows) audio driver
 
 2021-09-04 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.1

--- a/src/core/IO/AudioOutput.h
+++ b/src/core/IO/AudioOutput.h
@@ -49,6 +49,15 @@ public:
 	virtual void disconnect() = 0;
 	virtual unsigned getBufferSize() = 0;
 	virtual unsigned getSampleRate() = 0;
+
+	/** Approximate audio latency.
+	 * A reasonable approximation is the buffer time on most audio systems.
+	 * For systems with variable buffer sizes, this isn't very useful though
+	 */
+	virtual float getLatency()
+	{
+		return getBufferSize() * 1.0 / getSampleRate();
+	}
 	virtual float* getOut_L() = 0;
 	virtual float* getOut_R() = 0;
 

--- a/src/core/IO/AudioOutput.h
+++ b/src/core/IO/AudioOutput.h
@@ -50,13 +50,13 @@ public:
 	virtual unsigned getBufferSize() = 0;
 	virtual unsigned getSampleRate() = 0;
 
-	/** Approximate audio latency.
+	/** Approximate audio latency (in frames)
 	 * A reasonable approximation is the buffer time on most audio systems.
 	 * For systems with variable buffer sizes, this isn't very useful though
 	 */
-	virtual float getLatency()
+	virtual int getLatency()
 	{
-		return getBufferSize() * 1.0 / getSampleRate();
+		return getBufferSize();
 	}
 	virtual float* getOut_L() = 0;
 	virtual float* getOut_R() = 0;

--- a/src/core/IO/PortAudioDriver.h
+++ b/src/core/IO/PortAudioDriver.h
@@ -53,7 +53,7 @@ public:
 	virtual int connect();
 	virtual void disconnect();
 	virtual unsigned getBufferSize();
-	virtual float getLatency();
+	virtual int getLatency();
 	virtual unsigned getSampleRate();
 	virtual float* getOut_L();
 	virtual float* getOut_R();

--- a/src/core/IO/PortAudioDriver.h
+++ b/src/core/IO/PortAudioDriver.h
@@ -45,7 +45,6 @@ public:
 	audioProcessCallback m_processCallback;
 	float* m_pOut_L;
 	float* m_pOut_R;
-	unsigned m_nBufferSize;
 
 	PortAudioDriver( audioProcessCallback processCallback );
 	virtual ~PortAudioDriver();
@@ -54,6 +53,7 @@ public:
 	virtual int connect();
 	virtual void disconnect();
 	virtual unsigned getBufferSize();
+	virtual float getLatency();
 	virtual unsigned getSampleRate();
 	virtual float* getOut_L();
 	virtual float* getOut_R();

--- a/src/core/IO/PortaudioDriver.cpp
+++ b/src/core/IO/PortaudioDriver.cpp
@@ -190,6 +190,7 @@ int PortAudioDriver::connect()
 				// latency. This should probably be an option.
 				outputParameters.suggestedLatency =
 					Pa_GetDeviceInfo( nDevice )->defaultHighInputLatency;
+				outputParameters.suggestedLatency = pPreferences->m_nLatencyTarget * 1.0 / getSampleRate();
 
 				err = Pa_OpenStream( &m_pStream,
 									 nullptr, /* No input stream */
@@ -284,10 +285,10 @@ unsigned PortAudioDriver::getSampleRate()
 	return m_nSampleRate;
 }
 
-float PortAudioDriver::getLatency()
+int PortAudioDriver::getLatency()
 {
 	const PaStreamInfo *pStreamInfo = Pa_GetStreamInfo( m_pStream );
-	return pStreamInfo->outputLatency;
+	return (int)( pStreamInfo->outputLatency * getSampleRate() );
 }
 
 float* PortAudioDriver::getOut_L()

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -157,6 +157,7 @@ Preferences::Preferences()
 	// PortAudio properties
 	m_sPortAudioDevice = QString();
 	m_sPortAudioHostAPI = QString();
+	m_nLatencyTarget = 0;
 
 	// CoreAudio
 	m_sCoreAudioDevice = QString();
@@ -442,6 +443,7 @@ void Preferences::loadPreferences( bool bGlobal )
 				} else {
 					m_sPortAudioDevice = LocalFileMng::readXmlString( portAudioDriverNode, "portAudioDevice", m_sPortAudioDevice );
 					m_sPortAudioHostAPI = LocalFileMng::readXmlString( portAudioDriverNode, "portAudioHostAPI", m_sPortAudioHostAPI );
+					m_nLatencyTarget = LocalFileMng::readXmlInt( portAudioDriverNode, "latencyTarget", m_nLatencyTarget );
 				}
 
 				//// COREAUDIO DRIVER ////
@@ -894,6 +896,7 @@ void Preferences::savePreferences()
 		{
 			LocalFileMng::writeXmlString( portAudioDriverNode, "portAudioDevice", m_sPortAudioDevice );
 			LocalFileMng::writeXmlString( portAudioDriverNode, "portAudioHostAPI", m_sPortAudioHostAPI );
+			LocalFileMng::writeXmlString( portAudioDriverNode, "latencyTarget", QString("%1").arg( m_nLatencyTarget ) );
 		}
 		audioEngineNode.appendChild( portAudioDriverNode );
 

--- a/src/core/Preferences.h
+++ b/src/core/Preferences.h
@@ -334,6 +334,7 @@ public:
 	// PortAudio properties
 	QString				m_sPortAudioDevice;
 	QString				m_sPortAudioHostAPI;
+	int					m_nLatencyTarget;
 
 	// CoreAudio properties
 	QString				m_sCoreAudioDevice;

--- a/src/gui/src/AudioEngineInfoForm.cpp
+++ b/src/gui/src/AudioEngineInfoForm.cpp
@@ -144,7 +144,7 @@ void AudioEngineInfoForm::updateInfo()
 		bufferSizeLbl->setText(QString(tmp));
 
 		// Audio latency estimate
-		latencyLbl->setText( QString( "%1s" ).arg( driver->getLatency() ) );
+		latencyLbl->setText( QString( "%1 frames" ).arg( driver->getLatency() ) );
 
 		// Audio driver sampleRate
 		sprintf(tmp, "%d", driver->getSampleRate());

--- a/src/gui/src/AudioEngineInfoForm.cpp
+++ b/src/gui/src/AudioEngineInfoForm.cpp
@@ -143,6 +143,9 @@ void AudioEngineInfoForm::updateInfo()
 		sprintf(tmp, "%d", driver->getBufferSize());
 		bufferSizeLbl->setText(QString(tmp));
 
+		// Audio latency estimate
+		latencyLbl->setText( QString( "%1s" ).arg( driver->getLatency() ) );
+
 		// Audio driver sampleRate
 		sprintf(tmp, "%d", driver->getSampleRate());
 		sampleRateLbl->setText(QString(tmp));
@@ -154,6 +157,7 @@ void AudioEngineInfoForm::updateInfo()
 	else {
 		driverLbl->setText( "NULL driver" );
 		bufferSizeLbl->setText( "N/A" );
+		latencyLbl->setText( "N/A" );
 		sampleRateLbl->setText( "N/A" );
 		nFramesLbl->setText( "N/A" );
 	}

--- a/src/gui/src/AudioEngineInfoForm_UI.ui
+++ b/src/gui/src/AudioEngineInfoForm_UI.ui
@@ -331,42 +331,7 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <item row="2" column="1">
-         <widget class="QLabel" name="sampleRateLbl">
-          <property name="text">
-           <string>###</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="textLabel1_3_3">
-          <property name="text">
-           <string>Realtime frames</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="textLabel1_2">
-          <property name="text">
-           <string>Buffer size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="bufferSizeLbl">
-          <property name="text">
-           <string>###</string>
-          </property>
-         </widget>
-        </item>
         <item row="4" column="1">
-         <widget class="QLabel" name="nRealtimeFramesLbl">
-          <property name="text">
-           <string>###</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
          <widget class="QLabel" name="nFramesLbl">
           <property name="minimumSize">
            <size>
@@ -379,10 +344,24 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="1">
+         <widget class="QLabel" name="sampleRateLbl">
+          <property name="text">
+           <string>###</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
          <widget class="QLabel" name="textLabel1_4">
           <property name="text">
            <string>Sample rate</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="textLabel1_3_3">
+          <property name="text">
+           <string>Realtime frames</string>
           </property>
          </widget>
         </item>
@@ -393,6 +372,13 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="textLabel1_2">
+          <property name="text">
+           <string>Buffer size</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="1">
          <widget class="QLabel" name="driverLbl">
           <property name="text">
@@ -400,10 +386,38 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="1" column="1">
+         <widget class="QLabel" name="bufferSizeLbl">
+          <property name="text">
+           <string>###</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
          <widget class="QLabel" name="textLabel1_3_2">
           <property name="text">
            <string>Frames</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="nRealtimeFramesLbl">
+          <property name="text">
+           <string>###</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Latency (estimated)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="latencyLbl">
+          <property name="text">
+           <string>###</string>
           </property>
          </widget>
         </item>

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -808,7 +808,7 @@ void PreferencesDialog::updateDriverInfo()
 		}
 		m_pAudioDeviceTxt->setEnabled( true );
 		m_pAudioDeviceTxt->lineEdit()->setText( "" );
-		bufferSizeSpinBox->setEnabled( true );
+		bufferSizeSpinBox->setEnabled( false );
 		sampleRateComboBox->setEnabled( true );
 		trackOutputComboBox->setEnabled( false );
 		connectDefaultsCheckBox->setEnabled( false );
@@ -968,7 +968,7 @@ void PreferencesDialog::updateDriverInfo()
 		}
 		m_pAudioDeviceTxt->setEnabled( true );
 		m_pAudioDeviceTxt->lineEdit()->setText( pPref->m_sCoreAudioDevice );
-		bufferSizeSpinBox->setEnabled(true);
+		bufferSizeSpinBox->setEnabled( false );
 		sampleRateComboBox->setEnabled(true);
 		trackOutputComboBox->hide();
 		trackOutputLbl->hide();

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -158,6 +158,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	portaudioHostAPIComboBox->setValue( pPref->m_sPortAudioHostAPI );
 	m_pAudioDeviceTxt->setHostAPI( pPref->m_sPortAudioHostAPI );
 
+	latencyTargetSpinBox->setValue( pPref->m_nLatencyTarget );
+
 
 	// Language selection menu
 	for ( QString sLang : Translations::availableTranslations( "hydrogen" ) ) {
@@ -523,6 +525,7 @@ void PreferencesDialog::updateDriverPreferences() {
 		pPref->m_sAudioDriver = "PortAudio";
 		pPref->m_sPortAudioDevice = m_pAudioDeviceTxt->lineEdit()->text();
 		pPref->m_sPortAudioHostAPI = portaudioHostAPIComboBox->currentText();
+		pPref->m_nLatencyTarget = latencyTargetSpinBox->value();
 	}
 	else if (driverComboBox->currentText() == "CoreAudio" ) {
 		pPref->m_sAudioDriver = "CoreAudio";
@@ -815,6 +818,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->setEnabled( false );
 		portaudioHostAPIComboBox->hide();
 		portaudioHostAPILabel->hide();
+		latencyTargetLabel->hide();
+		latencyTargetSpinBox->hide();
 		if ( std::strcmp( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name(),
 						  "JackAudioDriver" ) == 0 ) {
 			trackOutputComboBox->setEnabled( true );
@@ -868,6 +873,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->hide();
 		portaudioHostAPIComboBox->hide();
 		portaudioHostAPILabel->hide();
+		latencyTargetLabel->hide();
+		latencyTargetSpinBox->hide();
 	}
 	else if ( driverComboBox->currentText() == "JACK" ) {	// JACK
 		info.append( "<b>" )
@@ -897,6 +904,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->show();
 		portaudioHostAPIComboBox->hide();
 		portaudioHostAPILabel->hide();
+		latencyTargetLabel->hide();
+		latencyTargetSpinBox->hide();
 	}
 	else if ( driverComboBox->currentText() == "ALSA" ) {	// ALSA
 		info.append( "<b>" ).append( tr( "ALSA Driver" ) )
@@ -920,6 +929,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->hide();
 		portaudioHostAPIComboBox->hide();
 		portaudioHostAPILabel->hide();
+		latencyTargetLabel->hide();
+		latencyTargetSpinBox->hide();
 	}
 	else if ( driverComboBox->currentText() == "PortAudio" ) {
 		info.append( "<b>" ).append( tr( "PortAudio Driver" ) )
@@ -943,6 +954,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->hide();
 		portaudioHostAPIComboBox->show();
 		portaudioHostAPILabel->show();
+		latencyTargetLabel->show();
+		latencyTargetSpinBox->show();
 	}
 	else if ( driverComboBox->currentText() == "CoreAudio" ) {
 		info.append( "<b>" ).append( tr( "CoreAudio Driver" ) )
@@ -966,6 +979,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->hide();
 		portaudioHostAPIComboBox->hide();
 		portaudioHostAPILabel->hide();
+		latencyTargetLabel->hide();
+		latencyTargetSpinBox->hide();
 	}
 	else if ( driverComboBox->currentText() == "PulseAudio" ) {
 		info.append( "<b>" ).append( tr( "PulseAudio Driver" ) )
@@ -989,6 +1004,8 @@ void PreferencesDialog::updateDriverInfo()
 		jackBBTSyncLbl->hide();
 		portaudioHostAPIComboBox->hide();
 		portaudioHostAPILabel->hide();
+		latencyTargetLabel->hide();
+		latencyTargetSpinBox->hide();
 	}
 	else {
 		QString selectedDriver = driverComboBox->currentText();
@@ -1031,6 +1048,11 @@ void PreferencesDialog::on_selectApplicationFontBtn_clicked()
 
 
 
+void PreferencesDialog::on_latencyTargetSpinBox_valueChanged( int i )
+{
+	UNUSED( i );
+	m_bNeedDriverRestart = true;
+}
 
 void PreferencesDialog::on_bufferSizeSpinBox_valueChanged( int i )
 {

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -820,6 +820,7 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->hide();
 		latencyTargetLabel->hide();
 		latencyTargetSpinBox->hide();
+		latencyValueLabel->hide();
 		if ( std::strcmp( H2Core::Hydrogen::get_instance()->getAudioOutput()->class_name(),
 						  "JackAudioDriver" ) == 0 ) {
 			trackOutputComboBox->setEnabled( true );
@@ -875,6 +876,7 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->hide();
 		latencyTargetLabel->hide();
 		latencyTargetSpinBox->hide();
+		latencyValueLabel->hide();
 	}
 	else if ( driverComboBox->currentText() == "JACK" ) {	// JACK
 		info.append( "<b>" )
@@ -906,6 +908,7 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->hide();
 		latencyTargetLabel->hide();
 		latencyTargetSpinBox->hide();
+		latencyValueLabel->hide();
 	}
 	else if ( driverComboBox->currentText() == "ALSA" ) {	// ALSA
 		info.append( "<b>" ).append( tr( "ALSA Driver" ) )
@@ -931,6 +934,7 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->hide();
 		latencyTargetLabel->hide();
 		latencyTargetSpinBox->hide();
+		latencyValueLabel->hide();
 	}
 	else if ( driverComboBox->currentText() == "PortAudio" ) {
 		info.append( "<b>" ).append( tr( "PortAudio Driver" ) )
@@ -956,6 +960,9 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->show();
 		latencyTargetLabel->show();
 		latencyTargetSpinBox->show();
+		latencyValueLabel->show();
+		latencyValueLabel->setText( QString("Current: %1 frames").arg( H2Core::Hydrogen::get_instance()->getAudioOutput()->getLatency() ) );
+
 	}
 	else if ( driverComboBox->currentText() == "CoreAudio" ) {
 		info.append( "<b>" ).append( tr( "CoreAudio Driver" ) )
@@ -981,6 +988,7 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->hide();
 		latencyTargetLabel->hide();
 		latencyTargetSpinBox->hide();
+		latencyValueLabel->hide();
 	}
 	else if ( driverComboBox->currentText() == "PulseAudio" ) {
 		info.append( "<b>" ).append( tr( "PulseAudio Driver" ) )
@@ -1006,6 +1014,7 @@ void PreferencesDialog::updateDriverInfo()
 		portaudioHostAPILabel->hide();
 		latencyTargetLabel->hide();
 		latencyTargetSpinBox->hide();
+		latencyValueLabel->hide();
 	}
 	else {
 		QString selectedDriver = driverComboBox->currentText();
@@ -1077,6 +1086,7 @@ void PreferencesDialog::on_restartDriverBtn_clicked()
 	Hydrogen::get_instance()->restartDrivers();
 	pPref->savePreferences();
 	m_bNeedDriverRestart = false;
+	updateDriverInfo();
 }
 
 

--- a/src/gui/src/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog.cpp
@@ -932,7 +932,7 @@ void PreferencesDialog::updateDriverInfo()
 		}
 		m_pAudioDeviceTxt->setEnabled( true );
 		m_pAudioDeviceTxt->lineEdit()->setText( pPref->m_sPortAudioDevice );
-		bufferSizeSpinBox->setEnabled(true);
+		bufferSizeSpinBox->setEnabled(false);
 		sampleRateComboBox->setEnabled(true);
 		trackOutputComboBox->hide();
 		trackOutputLbl->hide();

--- a/src/gui/src/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog.h
@@ -80,6 +80,7 @@ class PreferencesDialog : public QDialog, private Ui_PreferencesDialog_UI, publi
 		void on_restartDriverBtn_clicked();
 		void on_driverComboBox_activated( int index );
 		void on_portaudioHostAPIComboBox_activated( int index );
+		void on_latencyTargetSpinBox_valueChanged( int i );
 		void on_bufferSizeSpinBox_valueChanged( int i );
 		void on_resampleComboBox_currentIndexChanged ( int index );
 		void on_sampleRateComboBox_editTextChanged( const QString& text );

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -248,6 +248,19 @@
          </item>
          <item>
           <layout class="QGridLayout" columnstretch="1,2">
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Audio System</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="driverComboBox"/>
+           </item>
+           <item row="4" column="1">
+            <widget class="HostAPIComboBox" name="portaudioHostAPIComboBox"/>
+           </item>
            <item row="9" column="1">
             <widget class="QComboBox" name="trackOutputComboBox">
              <property name="currentIndex">
@@ -261,72 +274,6 @@
              <item>
               <property name="text">
                <string>Pre-Fader</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="10" column="1">
-            <widget class="QComboBox" name="jackBBTSyncComboBox">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
-             </property>
-             <item>
-              <property name="text">
-               <string>constant measure</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>matching bars</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="10" column="0">
-            <widget class="QLabel" name="jackBBTSyncLbl">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
-             </property>
-             <property name="text">
-              <string>BBT sync method</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="1">
-            <widget class="QComboBox" name="sampleRateComboBox">
-             <property name="currentIndex">
-              <number>0</number>
-             </property>
-             <item>
-              <property name="text">
-               <string>44100</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>48000</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>88200</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>96000</string>
               </property>
              </item>
             </widget>
@@ -357,33 +304,6 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
-            <widget class="QLabel" name="buffer_sizeLbl">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Buffer size</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0">
-            <widget class="QLabel" name="latencyTargetLabel">
-             <property name="text">
-              <string>Latency target</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Audio System</string>
-             </property>
-            </widget>
-           </item>
            <item row="4" column="0">
             <widget class="QLabel" name="portaudioHostAPILabel">
              <property name="text">
@@ -391,11 +311,21 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="driverComboBox"/>
-           </item>
-           <item row="4" column="1">
-            <widget class="HostAPIComboBox" name="portaudioHostAPIComboBox"/>
+           <item row="10" column="0">
+            <widget class="QLabel" name="jackBBTSyncLbl">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+             </property>
+             <property name="text">
+              <string>BBT sync method</string>
+             </property>
+            </widget>
            </item>
            <item row="6" column="1">
             <widget class="QSpinBox" name="bufferSizeSpinBox">
@@ -419,6 +349,83 @@
              </property>
             </widget>
            </item>
+           <item row="10" column="1">
+            <widget class="QComboBox" name="jackBBTSyncComboBox">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+             </property>
+             <item>
+              <property name="text">
+               <string>constant measure</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>matching bars</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="audioDeviceLbl">
+             <property name="text">
+              <string>Device</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="latencyTargetLabel">
+             <property name="text">
+              <string>Latency target</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="QComboBox" name="sampleRateComboBox">
+             <property name="currentIndex">
+              <number>0</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>44100</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>48000</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>88200</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>96000</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QLabel" name="buffer_sizeLbl">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Buffer size</string>
+             </property>
+            </widget>
+           </item>
            <item row="8" column="0">
             <widget class="QLabel" name="sampleRateLbl">
              <property name="minimumSize">
@@ -432,22 +439,26 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="audioDeviceLbl">
-             <property name="text">
-              <string>Device</string>
-             </property>
-            </widget>
-           </item>
            <item row="7" column="1">
-            <widget class="QSpinBox" name="latencyTargetSpinBox">
-             <property name="maximum">
-              <number>48000</number>
-             </property>
-             <property name="value">
-              <number>100</number>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="horizontalLayout_11">
+             <item>
+              <widget class="QSpinBox" name="latencyTargetSpinBox">
+               <property name="maximum">
+                <number>48000</number>
+               </property>
+               <property name="value">
+                <number>100</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="latencyValueLabel">
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -444,9 +444,6 @@
              <property name="maximum">
               <number>48000</number>
              </property>
-             <property name="stepType">
-              <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
-             </property>
              <property name="value">
               <number>100</number>
              </property>

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>663</width>
-    <height>616</height>
+    <height>633</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -248,7 +248,47 @@
          </item>
          <item>
           <layout class="QGridLayout" columnstretch="1,2">
-           <item row="9" column="0">
+           <item row="9" column="1">
+            <widget class="QComboBox" name="trackOutputComboBox">
+             <property name="currentIndex">
+              <number>0</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>Post-Fader</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Pre-Fader</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="10" column="1">
+            <widget class="QComboBox" name="jackBBTSyncComboBox">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+             </property>
+             <item>
+              <property name="text">
+               <string>constant measure</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>matching bars</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="10" column="0">
             <widget class="QLabel" name="jackBBTSyncLbl">
              <property name="minimumSize">
               <size>
@@ -264,29 +304,7 @@
              </property>
             </widget>
            </item>
-           <item row="6" column="1">
-            <widget class="QSpinBox" name="bufferSizeSpinBox">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="minimum">
-              <number>100</number>
-             </property>
-             <property name="maximum">
-              <number>5000</number>
-             </property>
-             <property name="singleStep">
-              <number>100</number>
-             </property>
-             <property name="value">
-              <number>1024</number>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="1">
+           <item row="8" column="1">
             <widget class="QComboBox" name="sampleRateComboBox">
              <property name="currentIndex">
               <number>0</number>
@@ -313,21 +331,20 @@
              </item>
             </widget>
            </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="audioDeviceLbl">
-             <property name="text">
-              <string>Device</string>
+           <item row="5" column="1">
+            <widget class="DeviceComboBox" name="m_pAudioDeviceTxt">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="editable">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Audio System</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="0">
+           <item row="9" column="0">
             <widget class="QLabel" name="trackOutputLbl">
              <property name="minimumSize">
               <size>
@@ -339,9 +356,6 @@
               <string>Track output</string>
              </property>
             </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QComboBox" name="driverComboBox"/>
            </item>
            <item row="6" column="0">
             <widget class="QLabel" name="buffer_sizeLbl">
@@ -356,43 +370,56 @@
              </property>
             </widget>
            </item>
-           <item row="9" column="1">
-            <widget class="QComboBox" name="jackBBTSyncComboBox">
+           <item row="7" column="0">
+            <widget class="QLabel" name="latencyTargetLabel">
+             <property name="text">
+              <string>Latency target</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>Audio System</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="portaudioHostAPILabel">
+             <property name="text">
+              <string>Host API</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QComboBox" name="driverComboBox"/>
+           </item>
+           <item row="4" column="1">
+            <widget class="HostAPIComboBox" name="portaudioHostAPIComboBox"/>
+           </item>
+           <item row="6" column="1">
+            <widget class="QSpinBox" name="bufferSizeSpinBox">
              <property name="minimumSize">
               <size>
                <width>0</width>
                <height>22</height>
               </size>
              </property>
-             <property name="toolTip">
-              <string>Specifies the variable, which has to remain constant in order to guarantee a working synchronization and relocation in the presence of another Jack timebase master.</string>
+             <property name="minimum">
+              <number>100</number>
              </property>
-             <item>
-              <property name="text">
-               <string>constant measure</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>matching bars</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="DeviceComboBox" name="m_pAudioDeviceTxt">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+             <property name="maximum">
+              <number>5000</number>
              </property>
-             <property name="editable">
-              <bool>true</bool>
+             <property name="singleStep">
+              <number>100</number>
+             </property>
+             <property name="value">
+              <number>1024</number>
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
+           <item row="8" column="0">
             <widget class="QLabel" name="sampleRateLbl">
              <property name="minimumSize">
               <size>
@@ -405,32 +432,25 @@
              </property>
             </widget>
            </item>
-           <item row="8" column="1">
-            <widget class="QComboBox" name="trackOutputComboBox">
-             <property name="currentIndex">
-              <number>0</number>
-             </property>
-             <item>
-              <property name="text">
-               <string>Post-Fader</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Pre-Fader</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="portaudioHostAPILabel">
+           <item row="5" column="0">
+            <widget class="QLabel" name="audioDeviceLbl">
              <property name="text">
-              <string>Host API</string>
+              <string>Device</string>
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
-            <widget class="HostAPIComboBox" name="portaudioHostAPIComboBox"/>
+           <item row="7" column="1">
+            <widget class="QSpinBox" name="latencyTargetSpinBox">
+             <property name="maximum">
+              <number>1000</number>
+             </property>
+             <property name="stepType">
+              <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>
+             </property>
+             <property name="value">
+              <number>100</number>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>

--- a/src/gui/src/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog_UI.ui
@@ -442,7 +442,7 @@
            <item row="7" column="1">
             <widget class="QSpinBox" name="latencyTargetSpinBox">
              <property name="maximum">
-              <number>1000</number>
+              <number>48000</number>
              </property>
              <property name="stepType">
               <enum>QAbstractSpinBox::AdaptiveDecimalStepType</enum>

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -114,6 +114,18 @@ void setPalette( QApplication *pQApp )
 	// A text color that contrasts with Highlight.
 	defaultPalette.setColor( QPalette::HighlightedText, QColor( 255, 255, 255 ) );
 
+
+	// Desaturate disabled widgets by blending with the alternate colour
+	for ( QPalette::ColorRole role : { QPalette::Window, QPalette::Base, QPalette::AlternateBase, QPalette::Dark,
+									  QPalette::Light, QPalette::Midlight, QPalette::Mid, QPalette::Shadow,
+									  QPalette::Text } ) {
+		QColor normalColor = defaultPalette.color( QPalette::Normal, role );
+		QColor disabledColor = QColor( ( normalColor.red() + 138 ) / 2,
+									   ( normalColor.green() + 144 ) / 2,
+									   ( normalColor.blue() + 162 ) / 2);
+		defaultPalette.setColor( QPalette::Disabled, role, disabledColor );
+	}
+
 	pQApp->setPalette( defaultPalette );
 	pQApp->setStyleSheet("QToolTip {padding: 1px; border: 1px solid rgb(199, 202, 204); background-color: rgb(227, 243, 252); color: rgb(64, 64, 66);}");
 }


### PR DESCRIPTION
Reduce PortAudio latency by using variable-length buffers, and by allowing a target latency to be specified (rather than just accepting the default conservative latency from the driver)

This also changes the colours used for disabled widgets, because I spent 10 minutes wondering why it looked like the 'buffer' textentry wasn't being disabled 😆 

Might be good to amend this to feed back the 'actual' latency value to the target latency text box, but there's the possibility that this might lead to unstable iteration of the preferences value.