### PR TITLE
remove misplaced deletion of tags and markers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,8 @@
 		- fix segfault when entering note in PianoRollEditor (#1386).
 		- fix rewinding to beginning of pattern in pattern mode with no
 		  pattern inserted in SongEditor (#932)
+		- fix display of tags and tempo marker while loading a song
+		  (introduced in 1.1.0) (#1393)
 
 2021-09-04 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.1

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -413,10 +413,6 @@ bool CoreActionController::openSong( std::shared_ptr<Song> pSong ) {
 bool CoreActionController::setSong( std::shared_ptr<Song> pSong ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
-	
-	// Remove all BPM markers and tags on the Timeline.
-	pHydrogen->getTimeline()->deleteAllTempoMarkers();
-	pHydrogen->getTimeline()->deleteAllTags();
 
 	// Update the Song.
 	pHydrogen->setSong( pSong );


### PR DESCRIPTION
The tempo markers and tags are written to the timeline the moment the Song is read from file (and not when it is set using the CoreActionController). I got that mixed up and both of them were not properly displayed in the GUI.

Fixes #1393