### PR TITLE
Tweak the default selection of audio and MIDI drivers

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,8 @@
 		  pattern inserted in SongEditor (#932)
 		- fix display of tags and tempo marker while loading a song
 		  (introduced in 1.1.0) (#1393)
+		- default MIDI driver is now picked with the system's capabilities
+		  in mind
 
 2021-09-04 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.1

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -143,7 +143,19 @@ Preferences::Preferences()
 	m_sOSSDevice = QString("/dev/dsp");
 
 	//___ MIDI Driver properties
+#if defined(H2CORE_HAVE_ALSA)
 	m_sMidiDriver = QString("ALSA");
+#elif defined(H2CORE_HAVE_PORTMIDI)
+	m_sMidiDriver = QString("PortMidi");
+#elif defined(H2CORE_HAVE_COREMIDI)
+	m_sMidiDriver = QString("CoreMIDI");
+#elif defined(H2CORE_HAVE_JACK)
+	m_sMidiDriver = QString("JACK-MIDI");
+#else
+	// Set ALSA as fallback if none of the above options are available
+	// (although MIDI won't work in this case).
+	m_sMidiDriver = QString( "ALSA" );
+#endif
 	m_sMidiPortName = QString("None");
 	m_sMidiOutputPortName = QString("None");
 	m_nMidiChannelFilter = -1;


### PR DESCRIPTION
-  reintroduce changes of #1268 . For some reason (probably during the separation of the AudioEngine from the Hydrogen class) these changes were lost.
- previously ALSA was set as the default MIDI driver without checking whether the system is capable of supporting it (known at compile time). Now, the first one among ALSA, PortMidi, CoreMIDI and JACK-MIDI supported by the system is picked.

This supersedes #191 which tried to cope with the default MIDI selection by looping over all available drivers. But since the MIDI drivers do not feature a way of stating whether their creation was successful, this approach is flawed.