### PR TITLE
Remember file dialog paths and load multiple patterns

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,7 +19,6 @@
 	* Bugfixes
 		- fix dithering of SongEditor when viewing the playback track
 		  and resizing the application or for very small size (#1379).
-		- fix segfault when entering note in PianoRollEditor (#1386).
 		- fix rewinding to beginning of pattern in pattern mode with no
 		  pattern inserted in SongEditor (#932)
 		- fix display of tags and tempo marker while loading a song

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
 	* General behavior
 		- Remembering paths in all export/import/save/open dialogs.
 		- Introducing keyboard shortcut for the Open Pattern dialog.
+		- Allow for opening more than one Pattern at once.
 	* PreferencesDialog > Appearance tab overhaul
 	  	- Drop previous font options in favor for three different
 		  levels of font (without exposing their point sizes)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 20xx-xx-xx the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2
+	* Remembering paths in all export/import/save/open dialogs.
 	* PreferencesDialog > Appearance tab overhaul
 	  	- Drop previous font options in favor for three different
 		  levels of font (without exposing their point sizes)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 20xx-xx-xx the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2
-	* Remembering paths in all export/import/save/open dialogs.
+	* General behavior
+		- Remembering paths in all export/import/save/open dialogs.
+		- Introducing keyboard shortcut for the Open Pattern dialog.
 	* PreferencesDialog > Appearance tab overhaul
 	  	- Drop previous font options in favor for three different
 		  levels of font (without exposing their point sizes)

--- a/src/core/Preferences.cpp
+++ b/src/core/Preferences.cpp
@@ -93,8 +93,6 @@ Preferences::Preferences()
 	m_nDefaultUILayout = UI_LAYOUT_SINGLE_PANE;
 	m_nUIScalingPolicy = UI_SCALING_SMALLER;
 
-	__lastspatternDirectory = QDir::homePath();
-	__lastsampleDirectory = QDir::homePath(); //audio file browser
 	__playsamplesonclicking = false; // audio file browser
 	__playselectedinstrument = false; // midi keyboard and keyboard play only selected instrument
 
@@ -106,14 +104,27 @@ Preferences::Preferences()
 	__expandPatternItem = true; //SoundLibraryPanel
 	__useTimelineBpm = false;		// use timeline
 	
+	m_sLastExportPatternAsDirectory = QDir::homePath();
+	m_sLastExportSongDirectory = QDir::homePath();
+	m_sLastSaveSongAsDirectory = QDir::homePath();
+	m_sLastOpenSongDirectory = Filesystem::songs_dir();
+	m_sLastOpenPatternDirectory = Filesystem::patterns_dir();
+	m_sLastExportLilypondDirectory = QDir::homePath();
+	m_sLastExportMidiDirectory = QDir::homePath();
+	m_sLastImportDrumkitDirectory = QDir::homePath();
+	m_sLastExportDrumkitDirectory = QDir::homePath();
+	m_sLastOpenLayerDirectory = QDir::homePath();
+	m_sLastOpenPlaybackTrackDirectory = QDir::homePath();
+	m_sLastAddSongToPlaylistDirectory = Filesystem::songs_dir();
+	m_sLastPlaylistDirectory = Filesystem::playlists_dir();
+	m_sLastPlaylistScriptDirectory = Filesystem::scripts_dir();
+	
 	//export dialog
-	m_sExportDirectory = QDir::homePath();
 	m_nExportModeIdx = 0;
 	m_nExportSampleRateIdx = 0;
 	m_nExportSampleDepthIdx = 0;
 
 	//export midi dialog
-	m_sMidiExportDirectory = QDir::homePath();
 	m_nMidiExportMode = 0;
 	/////////////////////////////////////////////////////////////////////////
 	/////////////////// DEFAULT SETTINGS ////////////////////////////////////
@@ -605,18 +616,32 @@ void Preferences::loadPreferences( bool bGlobal )
 				setInstrumentRackProperties( readWindowProperties( guiNode, "instrumentRack_properties", instrumentRackProperties ) );
 				setAudioEngineInfoProperties( readWindowProperties( guiNode, "audioEngineInfo_properties", audioEngineInfoProperties ) );
 
+				// last used file dialog folders
+				m_sLastExportPatternAsDirectory = LocalFileMng::readXmlString( guiNode, "lastExportPatternAsDirectory", QDir::homePath() );
+				m_sLastExportSongDirectory = LocalFileMng::readXmlString( guiNode, "lastExportSongDirectory", QDir::homePath() );
+				m_sLastSaveSongAsDirectory = LocalFileMng::readXmlString( guiNode, "lastSaveSongAsDirectory", QDir::homePath() );
+				m_sLastOpenSongDirectory = LocalFileMng::readXmlString( guiNode, "lastOpenSongDirectory", Filesystem::songs_dir() );
+				m_sLastOpenPatternDirectory = LocalFileMng::readXmlString( guiNode, "lastOpenPatternDirectory", Filesystem::patterns_dir() );
+				m_sLastExportLilypondDirectory = LocalFileMng::readXmlString( guiNode, "lastExportLilypondDirectory", QDir::homePath() );
+				m_sLastExportMidiDirectory = LocalFileMng::readXmlString( guiNode, "lastExportMidiDirectory", QDir::homePath() );
+				m_sLastImportDrumkitDirectory = LocalFileMng::readXmlString( guiNode, "lastImportDrumkitDirectory", QDir::homePath() );
+				m_sLastExportDrumkitDirectory = LocalFileMng::readXmlString( guiNode, "lastExportDrumkitDirectory", QDir::homePath() );
+				m_sLastOpenLayerDirectory = LocalFileMng::readXmlString( guiNode, "lastOpenLayerDirectory", QDir::homePath() );
+				m_sLastOpenPlaybackTrackDirectory = LocalFileMng::readXmlString( guiNode, "lastOpenPlaybackTrackDirectory", QDir::homePath() );
+				m_sLastAddSongToPlaylistDirectory = LocalFileMng::readXmlString( guiNode, "lastAddSongToPlaylistDirectory", Filesystem::songs_dir() );
+				m_sLastPlaylistDirectory = LocalFileMng::readXmlString( guiNode, "lastPlaylistDirectory", Filesystem::playlists_dir() );
+				m_sLastPlaylistScriptDirectory = LocalFileMng::readXmlString( guiNode, "lastPlaylistScriptDirectory", Filesystem::scripts_dir() );
+
 				//export dialog properties
 				m_nExportTemplateIdx = LocalFileMng::readXmlInt( guiNode, "exportDialogTemplate", 0 );
 				m_nExportModeIdx = LocalFileMng::readXmlInt( guiNode, "exportDialogMode", 0 );
 				m_nExportSampleRateIdx = LocalFileMng::readXmlInt( guiNode, "exportDialogSampleRate", 0 );
 				m_nExportSampleDepthIdx = LocalFileMng::readXmlInt( guiNode, "exportDialogSampleDepth", 0 );
-				m_sExportDirectory = LocalFileMng::readXmlString( guiNode, "exportDialogDirectory", QDir::homePath(), true );
 					
 				m_bFollowPlayhead = LocalFileMng::readXmlBool( guiNode, "followPlayhead", true );
 
 				// midi export dialog properties
 				m_nMidiExportMode = LocalFileMng::readXmlInt( guiNode, "midiExportDialogMode", 0 );
-				m_sMidiExportDirectory = LocalFileMng::readXmlString( guiNode, "midiExportDialogDirectory", QDir::homePath(), true );
 				
 				//beatcounter
 				QString bcMode = LocalFileMng::readXmlString( guiNode, "bc", "BC_OFF" );
@@ -1072,19 +1097,32 @@ void Preferences::savePreferences()
 			writeWindowProperties( guiNode, sNode, m_ladspaProperties[nFX] );
 		}
 		
-		
+		// last used file dialog folders
+		LocalFileMng::writeXmlString( guiNode, "lastExportPatternAsDirectory", m_sLastExportPatternAsDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastExportSongDirectory", m_sLastExportSongDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastSaveSongAsDirectory", m_sLastSaveSongAsDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastOpenSongDirectory", m_sLastOpenSongDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastOpenPatternDirectory", m_sLastOpenPatternDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastExportLilypondDirectory", m_sLastExportLilypondDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastExportMidiDirectory", m_sLastExportMidiDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastImportDrumkitDirectory", m_sLastImportDrumkitDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastExportDrumkitDirectory", m_sLastExportDrumkitDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastOpenLayerDirectory", m_sLastOpenLayerDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastOpenPlaybackTrackDirectory", m_sLastOpenPlaybackTrackDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastAddSongToPlaylistDirectory", m_sLastAddSongToPlaylistDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastPlaylistDirectory", m_sLastPlaylistDirectory );
+		LocalFileMng::writeXmlString( guiNode, "lastPlaylistScriptDirectory", m_sLastPlaylistScriptDirectory );
+				
 		//ExportSongDialog
 		LocalFileMng::writeXmlString( guiNode, "exportDialogMode", QString("%1").arg( m_nExportModeIdx ) );
 		LocalFileMng::writeXmlString( guiNode, "exportDialogTemplate", QString("%1").arg( m_nExportTemplateIdx ) );
 		LocalFileMng::writeXmlString( guiNode, "exportDialogSampleRate",  QString("%1").arg( m_nExportSampleRateIdx ) );
 		LocalFileMng::writeXmlString( guiNode, "exportDialogSampleDepth", QString("%1").arg( m_nExportSampleDepthIdx ) );
-		LocalFileMng::writeXmlString( guiNode, "exportDialogDirectory", m_sExportDirectory );
 
 		LocalFileMng::writeXmlBool( guiNode, "followPlayhead", m_bFollowPlayhead );
 
 		//ExportMidiDialog
 		LocalFileMng::writeXmlString( guiNode, "midiExportDialogMode", QString("%1").arg( m_nMidiExportMode ) );
-		LocalFileMng::writeXmlString( guiNode, "midiExportDialogDirectory", m_sMidiExportDirectory );
 
 		//beatcounter
 		QString bcMode;

--- a/src/core/Preferences.h
+++ b/src/core/Preferences.h
@@ -168,8 +168,6 @@ public:
 		UI_SCALING_LARGER
 	};
 
-	QString				__lastspatternDirectory;
-	QString				__lastsampleDirectory; // audio file browser
 	bool				__playsamplesonclicking; // audio file browser
 
 	bool				__playselectedinstrument; // midi keys and keys play instrument or drumset
@@ -639,6 +637,35 @@ public:
 
 	QString			getH2ProcessName();
 
+	QString			getLastExportPatternAsDirectory() const;
+	QString			getLastExportSongDirectory() const;
+	QString			getLastSaveSongAsDirectory() const;
+	QString			getLastOpenSongDirectory() const;
+	QString			getLastOpenPatternDirectory() const;
+	QString			getLastExportLilypondDirectory() const;
+	QString			getLastExportMidiDirectory() const;
+	QString			getLastImportDrumkitDirectory() const;
+	QString			getLastExportDrumkitDirectory() const;
+	QString			getLastOpenLayerDirectory() const;
+	QString			getLastOpenPlaybackTrackDirectory() const;
+	QString			getLastAddSongToPlaylistDirectory() const;
+	QString			getLastPlaylistDirectory() const;
+	QString			getLastPlaylistScriptDirectory() const;
+	void			setLastExportPatternAsDirectory( QString sPath );
+	void			setLastExportSongDirectory( QString sPath );
+	void			setLastSaveSongAsDirectory( QString sPath );
+	void			setLastOpenSongDirectory( QString sPath );
+	void			setLastOpenPatternDirectory( QString sPath );
+	void			setLastExportLilypondDirectory( QString sPath );
+	void			setLastExportMidiDirectory( QString sPath );
+	void			setLastImportDrumkitDirectory( QString sPath );
+	void			setLastExportDrumkitDirectory( QString sPath );
+	void			setLastOpenLayerDirectory( QString sPath );
+	void			setLastOpenPlaybackTrackDirectory( QString sPath );
+	void			setLastAddSongToPlaylistDirectory( QString sPath );
+	void			setLastPlaylistDirectory( QString sPath );
+	void			setLastPlaylistScriptDirectory( QString sPath );
+
 	int				getExportSampleDepthIdx() const;
 	void			setExportSampleDepthIdx( int nExportSampleDepthIdx );
 	
@@ -648,17 +675,11 @@ public:
 	int				getExportModeIdx() const;
 	void			setExportModeIdx(int nExportMode);
 	
-	QString			getExportDirectory() const;
-	void			setExportDirectory( const QString &sExportDirectory );
-	
 	int				getExportTemplateIdx() const;
 	void			setExportTemplateIdx( int nExportTemplateIdx );
 
     int				getMidiExportMode() const;
     void			setMidiExportMode(int nExportMode);
-
-    QString			getMidiExportDirectory() const;
-    void			setMidiExportDirectory( const QString &sExportDirectory );
 
 	/** Returns #m_sPreferencesOverwritePath
 	 * \return #m_sPreferencesOverwritePath */
@@ -790,8 +811,23 @@ private:
 	/** Not read from/written to disk */
 	int						m_nMaxPatternColors;
 
+	// Last directories used in QFileDialogs
+	QString					m_sLastExportPatternAsDirectory;
+	QString					m_sLastExportSongDirectory;
+	QString					m_sLastSaveSongAsDirectory;
+	QString					m_sLastOpenSongDirectory;
+	QString					m_sLastOpenPatternDirectory;
+	QString					m_sLastExportLilypondDirectory;
+	QString					m_sLastExportMidiDirectory;
+	QString					m_sLastImportDrumkitDirectory;
+	QString					m_sLastExportDrumkitDirectory;
+	QString					m_sLastOpenLayerDirectory;
+	QString					m_sLastOpenPlaybackTrackDirectory;
+	QString					m_sLastAddSongToPlaylistDirectory;
+	QString					m_sLastPlaylistDirectory;
+	QString					m_sLastPlaylistScriptDirectory;
+
 	//Export dialog
-	QString					m_sExportDirectory;
 	int						m_nExportModeIdx;
 	int						m_nExportSampleRateIdx;
 	int						m_nExportSampleDepthIdx;
@@ -799,7 +835,6 @@ private:
 	//~ Export dialog
 
     // Export midi dialog
-    QString					m_sMidiExportDirectory;
     int						m_nMidiExportMode;
     //~ Export midi dialog
 	
@@ -828,14 +863,103 @@ private:
 	void readUIStyle( QDomNode parent );
 };
 
-inline QString Preferences::getMidiExportDirectory() const
-{
-	return m_sMidiExportDirectory;
+inline QString			Preferences::getLastExportPatternAsDirectory() const {
+	return m_sLastExportPatternAsDirectory;
 }
-
-inline void Preferences::setMidiExportDirectory(const QString &ExportDirectory)
+inline QString			Preferences::getLastExportSongDirectory() const {
+	return m_sLastExportSongDirectory;
+}
+inline QString			Preferences::getLastSaveSongAsDirectory() const {
+	return m_sLastSaveSongAsDirectory;
+}
+inline QString			Preferences::getLastOpenSongDirectory() const {
+	return m_sLastOpenSongDirectory;
+}
+inline QString			Preferences::getLastOpenPatternDirectory() const {
+	return m_sLastOpenPatternDirectory;
+}
+inline QString			Preferences::getLastExportLilypondDirectory() const {
+	return m_sLastExportLilypondDirectory;
+}
+inline QString			Preferences::getLastExportMidiDirectory() const {
+	return m_sLastExportMidiDirectory;
+}
+inline QString			Preferences::getLastImportDrumkitDirectory() const {
+	return m_sLastImportDrumkitDirectory;
+}
+inline QString			Preferences::getLastExportDrumkitDirectory() const {
+	return m_sLastExportDrumkitDirectory;
+}
+inline QString			Preferences::getLastOpenLayerDirectory() const {
+	return m_sLastOpenLayerDirectory;
+}
+inline QString			Preferences::getLastOpenPlaybackTrackDirectory() const {
+	return m_sLastOpenPlaybackTrackDirectory;
+}
+inline QString			Preferences::getLastAddSongToPlaylistDirectory() const {
+	return m_sLastAddSongToPlaylistDirectory;
+}
+inline QString			Preferences::getLastPlaylistDirectory() const {
+	return m_sLastPlaylistDirectory;
+}
+inline QString			Preferences::getLastPlaylistScriptDirectory() const {
+	return m_sLastPlaylistScriptDirectory;
+}
+inline void Preferences::setLastExportPatternAsDirectory( QString sPath )
 {
-	m_sMidiExportDirectory = ExportDirectory;
+	m_sLastExportPatternAsDirectory = sPath;
+}
+inline void Preferences::setLastExportSongDirectory( QString sPath )
+{
+	m_sLastExportSongDirectory = sPath;
+}
+inline void Preferences::setLastSaveSongAsDirectory( QString sPath )
+{
+	m_sLastSaveSongAsDirectory = sPath;
+}
+inline void Preferences::setLastOpenSongDirectory( QString sPath )
+{
+	m_sLastOpenSongDirectory = sPath;
+}
+inline void Preferences::setLastOpenPatternDirectory( QString sPath )
+{
+	m_sLastOpenPatternDirectory = sPath;
+}
+inline void Preferences::setLastExportLilypondDirectory( QString sPath )
+{
+	m_sLastExportLilypondDirectory = sPath;
+}
+inline void Preferences::setLastExportMidiDirectory( QString sPath )
+{
+	m_sLastExportMidiDirectory = sPath;
+}
+inline void Preferences::setLastImportDrumkitDirectory( QString sPath )
+{
+	m_sLastImportDrumkitDirectory = sPath;
+}
+inline void Preferences::setLastExportDrumkitDirectory( QString sPath )
+{
+	m_sLastExportDrumkitDirectory = sPath;
+}
+inline void Preferences::setLastOpenLayerDirectory( QString sPath )
+{
+	m_sLastOpenLayerDirectory = sPath;
+}
+inline void Preferences::setLastOpenPlaybackTrackDirectory( QString sPath )
+{
+	m_sLastOpenPlaybackTrackDirectory = sPath;
+}
+inline void Preferences::setLastAddSongToPlaylistDirectory( QString sPath )
+{
+	m_sLastAddSongToPlaylistDirectory = sPath;
+}
+inline void Preferences::setLastPlaylistDirectory( QString sPath )
+{
+	m_sLastPlaylistDirectory = sPath;
+}
+inline void Preferences::setLastPlaylistScriptDirectory( QString sPath )
+{
+	m_sLastPlaylistScriptDirectory = sPath;
 }
 
 inline int Preferences::getMidiExportMode() const
@@ -871,16 +995,6 @@ inline int Preferences::getExportModeIdx() const
 inline void Preferences::setExportModeIdx(int ExportModeIdx)
 {
 	m_nExportModeIdx = ExportModeIdx;
-}
-
-inline QString Preferences::getExportDirectory() const
-{
-	return m_sExportDirectory;
-}
-
-inline void Preferences::setExportDirectory(const QString &ExportDirectory)
-{
-	m_sExportDirectory = ExportDirectory;
 }
 
 inline void Preferences::setExportSampleRateIdx(int ExportSampleRate)

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
@@ -39,7 +39,7 @@
 
 using namespace H2Core;
 
-AudioFileBrowser::AudioFileBrowser ( QWidget* pParent, bool bAllowMultiSelect, bool bShowInstrumentManipulationControls)
+AudioFileBrowser::AudioFileBrowser ( QWidget* pParent, bool bAllowMultiSelect, bool bShowInstrumentManipulationControls, QString sDefaultPath )
 		: QDialog ( pParent )
 		, Object ()
 {
@@ -48,6 +48,11 @@ AudioFileBrowser::AudioFileBrowser ( QWidget* pParent, bool bAllowMultiSelect, b
 	setWindowTitle ( tr ( "Audio File Browser" ) );
 	adjustSize();
 	setFixedSize ( width(), height() );
+
+	if ( sDefaultPath.isEmpty() ) {
+		sDefaultPath = QDir::homePath();
+	}
+	m_sSelectedDirectory = sDefaultPath;
 	
 	m_bAllowMultiSelect = bAllowMultiSelect;
 	m_bShowInstrumentManipulationControls = bShowInstrumentManipulationControls;
@@ -69,9 +74,9 @@ AudioFileBrowser::AudioFileBrowser ( QWidget* pParent, bool bAllowMultiSelect, b
 	m_pTree->resize( 799, 310 );
 	m_pTree->header()->resizeSection( 0, 405 );
 	m_pTree->setAlternatingRowColors( true );
-	m_pTree->setRootIndex( m_pDirModel->index( Preferences::get_instance()->__lastsampleDirectory ) );
+	m_pTree->setRootIndex( m_pDirModel->index( sDefaultPath ) );
 	
-	pathLineEdit->setText( Preferences::get_instance()->__lastsampleDirectory );
+	pathLineEdit->setText( sDefaultPath );
 	m_pSampleFilename = "";
 	m_pSelectedFile << "false" << "false";
 
@@ -337,7 +342,7 @@ void AudioFileBrowser::on_m_pStopBtn_clicked()
 
 void AudioFileBrowser::on_cancelBTN_clicked()
 {
-	Preferences::get_instance()->__lastsampleDirectory = pathLineEdit->text();
+	m_sSelectedDirectory = pathLineEdit->text();
 	m_pSelectedFile << "false" << "false" << "";
 	reject();
 }
@@ -365,7 +370,7 @@ void AudioFileBrowser::on_openBTN_clicked()
 		}
 	}
 
-	Preferences::get_instance()->__lastsampleDirectory = pathLineEdit->text();
+	m_sSelectedDirectory = pathLineEdit->text();
 	accept();
 }
 
@@ -389,7 +394,9 @@ QStringList AudioFileBrowser::getSelectedFiles()
 	return m_pSelectedFile;
 }
 
-
+QString AudioFileBrowser::getSelectedDirectory() {
+	return m_sSelectedDirectory;
+}
 
 void AudioFileBrowser::on_m_pPathHometoolButton_clicked()
 {

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
@@ -45,11 +45,11 @@ class AudioFileBrowser :  public QDialog, public Ui_AudioFileBrowser_UI,  public
 	Q_OBJECT
 	public:
 		
-		AudioFileBrowser( QWidget* pParent, bool bAllowMultiSelect, bool bShowInstrumentManipulationControls);
-		~AudioFileBrowser();
+	AudioFileBrowser( QWidget* pParent, bool bAllowMultiSelect, bool bShowInstrumentManipulationControls, QString sDefaultPath = "" );
+	~AudioFileBrowser();
 	
-		QStringList getSelectedFiles();
-		QString		setDir( QString dir );
+	QStringList getSelectedFiles();
+	QString getSelectedDirectory();
 
 	private slots:
 		void on_cancelBTN_clicked();
@@ -79,6 +79,7 @@ class AudioFileBrowser :  public QDialog, public Ui_AudioFileBrowser_UI,  public
 		
 		QString				m_pSampleFilename;
 		QStringList			m_pSelectedFile;
+		QString				m_sSelectedDirectory;
 
 		bool				m_SingleClick;
 		QFileSystemModel *	m_pDirModel;

--- a/src/gui/src/ExportMidiDialog.cpp
+++ b/src/gui/src/ExportMidiDialog.cpp
@@ -78,8 +78,7 @@ void ExportMidiDialog::saveSettingsToPreferences()
 	}
 	
 	sLastFilename = info.fileName();
-	QString sSelectedDirname = dir.absolutePath();
-	m_pPreferences->setMidiExportDirectory( sSelectedDirname );
+	Preferences::get_instance()->setLastExportMidiDirectory( dir.absolutePath() );
 }
 
 QString ExportMidiDialog::createDefaultFilename()
@@ -108,7 +107,7 @@ void ExportMidiDialog::restoreSettingsFromPreferences()
 		sLastFilename = createDefaultFilename();
 	}
 
-	QString sDirPath = m_pPreferences->getMidiExportDirectory();
+	QString sDirPath = m_pPreferences->getLastExportMidiDirectory();
 	QDir qd = QDir( sDirPath );
 	
 	// joining filepath with dirname
@@ -122,12 +121,16 @@ void ExportMidiDialog::restoreSettingsFromPreferences()
 
 void ExportMidiDialog::on_browseBtn_clicked()
 {
+	QString sPath = Preferences::get_instance()->getLastExportMidiDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::usr_data_path();
+	}
+	
 	QFileDialog fd( this );
-	QString sPrevDir = m_pPreferences->getMidiExportDirectory();
 
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( tr("Midi file (*%1)").arg( m_sExtension ) );
-	fd.setDirectory( sPrevDir );
+	fd.setDirectory( sPath );
 	fd.setWindowTitle( tr( "Export MIDI file" ) );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
 

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -177,8 +177,7 @@ void ExportSongDialog::saveSettingsToPreferences()
 	
 	// saving filename for this session	
 	sLastFilename = info.fileName();
-	QString sSelectedDirname = dir.absolutePath();
-	m_pPreferences->setExportDirectory( sSelectedDirname );
+	Preferences::get_instance()->setLastExportSongDirectory( dir.absolutePath() );
 	
 	// saving other options
 	m_pPreferences->setExportModeIdx( exportTypeCombo->currentIndex() );
@@ -196,7 +195,7 @@ void ExportSongDialog::restoreSettingsFromPreferences()
 		sLastFilename = createDefaultFilename();
 	}
 
-	QString sDirPath = m_pPreferences->getExportDirectory();
+	QString sDirPath = m_pPreferences->getLastExportSongDirectory();
 	QDir qd = QDir( sDirPath );
 	
 	// joining filepath with dirname
@@ -225,17 +224,25 @@ void ExportSongDialog::restoreSettingsFromPreferences()
 
 void ExportSongDialog::on_browseBtn_clicked()
 {
-	QString sPrevDir = m_pPreferences->getExportDirectory();
+	QString sPath = Preferences::get_instance()->getLastExportSongDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = QDir::homePath();
+	}
 
 	QFileDialog fd(this);
 	fd.setFileMode(QFileDialog::AnyFile);
 
-	if( templateCombo->currentIndex() <= 4 ) fd.setNameFilter("Microsoft WAV (*.wav *.WAV)");
-	if( templateCombo->currentIndex() > 4 && templateCombo->currentIndex() < 8  ) fd.setNameFilter( "Apple AIFF (*.aiff *.AIFF)");
-	if( templateCombo->currentIndex() == 8) fd.setNameFilter( "Lossless  Flac (*.flac *.FLAC)");
-	if( templateCombo->currentIndex() == 9) fd.setNameFilter( "Compressed Ogg (*.ogg *.OGG)");
+	if( templateCombo->currentIndex() <= 4 ) {
+		fd.setNameFilter("Microsoft WAV (*.wav *.WAV)");
+	} else if ( templateCombo->currentIndex() > 4 && templateCombo->currentIndex() < 8  ) {
+		fd.setNameFilter( "Apple AIFF (*.aiff *.AIFF)");
+	} else if ( templateCombo->currentIndex() == 8 ) {
+		fd.setNameFilter( "Lossless  Flac (*.flac *.FLAC)");
+	} else if ( templateCombo->currentIndex() == 9 ) {
+		fd.setNameFilter( "Compressed Ogg (*.ogg *.OGG)");
+	}
 
-	fd.setDirectory( sPrevDir );
+	fd.setDirectory( sPath );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
 	fd.setWindowTitle( tr( "Export song" ) );
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -953,12 +953,19 @@ void InstrumentEditor::loadLayer()
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 
-	AudioFileBrowser *pFileBrowser = new AudioFileBrowser( nullptr, true, true);
+	QString sPath = Preferences::get_instance()->getLastOpenLayerDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = QDir::homePath();
+	}
+
+
+	AudioFileBrowser *pFileBrowser = new AudioFileBrowser( nullptr, true, true, sPath );
 	QStringList filename;
 	filename << "false" << "false" << "";
 
 	if (pFileBrowser->exec() == QDialog::Accepted) {
 		filename = pFileBrowser->getSelectedFiles();
+		Preferences::get_instance()->setLastOpenLayerDirectory( pFileBrowser->getSelectedDirectory() );
 	}
 
 	delete pFileBrowser;

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -590,11 +590,17 @@ void MainForm::action_file_save_as()
 			pHydrogen->sequencer_stop();
 	}
 
+	QString sPath = Preferences::get_instance()->getLastSaveSongAsDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::songs_dir();
+	}
+
 	//std::auto_ptr<QFileDialog> fd( new QFileDialog );
 	QFileDialog fd(this);
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::songs_filter_name );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
+	fd.setDirectory( sPath );
 
 	if ( bUnderSessionManagement ) {	
 		fd.setWindowTitle( tr( "Export song from Session" ) );
@@ -610,11 +616,12 @@ void MainForm::action_file_save_as()
 
 	if ( lastFilename.isEmpty() ) {
 		defaultFilename = pHydrogen->getSong()->getName();
-		defaultFilename += Filesystem::songs_ext;
 	}
 	else {
-		defaultFilename = lastFilename;
+		QFileInfo fileInfo( lastFilename );
+		defaultFilename = fileInfo.baseName();
 	}
+	defaultFilename += Filesystem::songs_ext;
 
 	fd.selectFile( defaultFilename );
 
@@ -624,6 +631,8 @@ void MainForm::action_file_save_as()
 	}
 
 	if ( !filename.isEmpty() ) {
+		Preferences::get_instance()->setLastSaveSongAsDirectory( fd.directory().absolutePath( ) );
+
 		QString sNewFilename = filename;
 		if ( sNewFilename.endsWith( Filesystem::songs_ext ) == false ) {
 			filename += Filesystem::songs_ext;
@@ -774,12 +783,15 @@ void MainForm::action_file_export_pattern_as()
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	Pattern *pPattern = pSong->getPatternList()->get( pHydrogen->getSelectedPatternNumber() );
 
-	QDir dir = Preferences::get_instance()->__lastspatternDirectory;
+	QString sPath = Preferences::get_instance()->getLastExportPatternAsDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::patterns_dir();
+	}
 
 	QString title = tr( "Save Pattern as ..." );
 	QFileDialog fd(this);
 	fd.setWindowTitle( title );
-	fd.setDirectory( dir );
+	fd.setDirectory( sPath );
 	fd.selectFile( pPattern->get_name() );
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::patterns_filter_name );
@@ -792,7 +804,7 @@ void MainForm::action_file_export_pattern_as()
 	}
 
 	QFileInfo fileInfo = fd.selectedFiles().first();
-	Preferences::get_instance()->__lastspatternDirectory =  fileInfo.path();
+	Preferences::get_instance()->setLastExportPatternAsDirectory( fileInfo.path() );
 	QString filePath = fileInfo.absoluteFilePath();
 
 	QString originalName = pPattern->get_name();
@@ -826,11 +838,14 @@ void MainForm::action_file_open() {
 		return;
 	}
 
-	static QString sLastUsedDir = Filesystem::songs_dir();
+	QString sPath = Preferences::get_instance()->getLastOpenSongDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = Filesystem::songs_dir();
+	}
 
 	QFileDialog fd(this);
 	fd.setFileMode( QFileDialog::ExistingFile );
-	fd.setDirectory( sLastUsedDir );
+	fd.setDirectory( sPath );
 	fd.setNameFilter( Filesystem::songs_filter_name );
 
 	if ( H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ) {
@@ -841,8 +856,8 @@ void MainForm::action_file_open() {
 
 	QString sFilename;
 	if ( fd.exec() == QDialog::Accepted ) {
+		Preferences::get_instance()->setLastOpenSongDirectory( fd.directory().absolutePath() );
 		sFilename = fd.selectedFiles().first();
-		sLastUsedDir = fd.directory().absolutePath();
 	}
 
 	if ( !sFilename.isEmpty() ) {
@@ -863,9 +878,14 @@ void MainForm::action_file_openPattern()
 	auto pInstrument = pSong->getInstrumentList()->get ( 0 );
 	assert ( pInstrument );
 
+	QString sPath = Preferences::get_instance()->getLastOpenPatternDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = Filesystem::patterns_dir();
+	}
+
 	QFileDialog fd(this);
 	fd.setFileMode ( QFileDialog::ExistingFile );
-	fd.setDirectory ( Filesystem::patterns_dir() );
+	fd.setDirectory ( sPath );
 	fd.setNameFilter( Filesystem::patterns_filter_name );
 
 	fd.setWindowTitle ( tr ( "Open Pattern" ) );
@@ -874,6 +894,7 @@ void MainForm::action_file_openPattern()
 	QString filename;
 	if ( fd.exec() == QDialog::Accepted )
 	{
+		Preferences::get_instance()->setLastOpenPatternDirectory( fd.directory().absolutePath() );
 		filename = fd.selectedFiles().first();
 	}
 	QString patternname = filename;
@@ -1878,17 +1899,23 @@ void MainForm::action_file_export_lilypond()
 		tr( "\nThe LilyPond export is an experimental feature.\n"
 		"It should work like a charm provided that you use the "
 		"GMRockKit, and that you do not use triplet.\n" ),
-		QMessageBox::Ok ); 
+		QMessageBox::Ok );
+
+	QString sPath = Preferences::get_instance()->getLastExportLilypondDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::usr_data_path();
+	}
 
 	QFileDialog fd( this );
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( tr( "LilyPond file (*.ly)" ) );
-	fd.setDirectory( QDir::homePath() );
+	fd.setDirectory( sPath );
 	fd.setWindowTitle( tr( "Export LilyPond file" ) );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
 
 	QString sFilename;
 	if ( fd.exec() == QDialog::Accepted ) {
+		Preferences::get_instance()->setLastExportLilypondDirectory( fd.directory().absolutePath() );
 		sFilename = fd.selectedFiles().first();
 	}
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -884,37 +884,32 @@ void MainForm::action_file_openPattern()
 	}
 
 	QFileDialog fd(this);
-	fd.setFileMode ( QFileDialog::ExistingFile );
+	fd.setFileMode ( QFileDialog::ExistingFiles );
 	fd.setDirectory ( sPath );
 	fd.setNameFilter( Filesystem::patterns_filter_name );
 
 	fd.setWindowTitle ( tr ( "Open Pattern" ) );
 
-
-	QString filename;
-	if ( fd.exec() == QDialog::Accepted )
-	{
+	if ( fd.exec() == QDialog::Accepted ) {
 		Preferences::get_instance()->setLastOpenPatternDirectory( fd.directory().absolutePath() );
-		filename = fd.selectedFiles().first();
-	}
-	QString patternname = filename;
 
-	Pattern* err = Pattern::load_file( patternname, pSong->getInstrumentList() );
-	if ( err == nullptr )
-	{
-		_ERRORLOG( "Error loading the pattern" );
-		_ERRORLOG( patternname );
-	}
-	else
-	{
-		H2Core::Pattern *pNewPattern = err;
+		for ( auto& ssFilename : fd.selectedFiles() ) {
 
-		if(!pPatternList->check_name( pNewPattern->get_name() ) ){
-			pNewPattern->set_name( pPatternList->find_unused_pattern_name( pNewPattern->get_name() ) );
+			Pattern* err = Pattern::load_file( ssFilename, pSong->getInstrumentList() );
+			if ( err == nullptr ) {
+					_ERRORLOG( "Error loading the pattern" );
+					_ERRORLOG( ssFilename );
+			} else {
+					H2Core::Pattern *pNewPattern = err;
+
+					if ( !pPatternList->check_name( pNewPattern->get_name() ) ){
+						pNewPattern->set_name( pPatternList->find_unused_pattern_name( pNewPattern->get_name() ) );
+					}
+					SE_insertPatternAction* pAction =
+						new SE_insertPatternAction( selectedPatternPosition + 1, pNewPattern );
+					HydrogenApp::get_instance()->m_pUndoStack->push( pAction );
+			}
 		}
-		SE_insertPatternAction* pAction =
-				new SE_insertPatternAction( selectedPatternPosition + 1, pNewPattern );
-		HydrogenApp::get_instance()->m_pUndoStack->push( pAction );
 	}
 }
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -275,7 +275,7 @@ void MainForm::createMenuBar()
 	
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction ( tr ( "Open &Pattern" ), this, SLOT ( action_file_openPattern() ), QKeySequence ( "" ) );
+	m_pFileMenu->addAction ( tr ( "Open &Pattern" ), this, SLOT ( action_file_openPattern() ), QKeySequence ( "Ctrl+Shift+P" ) );
 	m_pFileMenu->addAction( tr( "E&xport Pattern As..." ), this, SLOT( action_file_export_pattern_as() ), QKeySequence( "Ctrl+P" ) );
 
 	m_pFileMenu->addSeparator();				// -----

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -290,15 +290,22 @@ void PlaylistDialog::closeEvent( QCloseEvent* ev )
 
 void PlaylistDialog::addSong()
 {
+	QString sPath = Preferences::get_instance()->getLastAddSongToPlaylistDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = Filesystem::songs_dir();
+	}
+
 	QFileDialog fd(this);
 	fd.setWindowTitle( tr( "Add Song to PlayList" ) );
 	fd.setFileMode( QFileDialog::ExistingFiles );
 	fd.setNameFilter( Filesystem::songs_filter_name );
-	fd.setDirectory( Filesystem::songs_dir() );
+	fd.setDirectory( sPath );
 
 	if ( fd.exec() != QDialog::Accepted ) {
 		return;
 	}
+	
+	Preferences::get_instance()->setLastAddSongToPlaylistDirectory( fd.directory().absolutePath() );
 
 	foreach( QString filePath, fd.selectedFiles() ) {
 		updatePlayListNode( filePath );
@@ -403,10 +410,15 @@ void PlaylistDialog::updatePlayListNode ( QString file )
 
 void PlaylistDialog::loadList()
 {
+	QString sPath = Preferences::get_instance()->getLastPlaylistDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = Filesystem::playlists_dir();
+	}
+
 	QFileDialog fd(this);
 	fd.setWindowTitle( tr( "Load Playlist" ) );
 	fd.setFileMode( QFileDialog::ExistingFile );
-	fd.setDirectory( Filesystem::playlists_dir() );
+	fd.setDirectory( sPath );
 	fd.setNameFilter( Filesystem::playlists_filter_name );
 
 	if ( fd.exec() != QDialog::Accepted ) {
@@ -414,6 +426,7 @@ void PlaylistDialog::loadList()
 	}
 
 	QString filename = fd.selectedFiles().first();
+	Preferences::get_instance()->setLastPlaylistDirectory( fd.directory().absolutePath() );
 
 	bool relativePaths = Preferences::get_instance()->isPlaylistUsingRelativeFilenames();
 	Playlist* pPlaylist = Playlist::load( filename, relativePaths);
@@ -455,15 +468,19 @@ void PlaylistDialog::loadList()
 
 void PlaylistDialog::newScript()
 {
-
 	Preferences *pPref = Preferences::get_instance();
+
+	QString sPath = Preferences::get_instance()->getLastPlaylistScriptDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::scripts_dir();
+	}
 
 	QFileDialog fd(this);
 	fd.setFileMode ( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::scripts_filter_name );
 	fd.setAcceptMode ( QFileDialog::AcceptSave );
 	fd.setWindowTitle ( tr ( "New Script" ) );
-	fd.setDirectory( Filesystem::scripts_dir() );
+	fd.setDirectory( sPath );
 
 	QString defaultFilename;
 
@@ -485,6 +502,8 @@ void PlaylistDialog::newScript()
 	if (!chngPerm.open(QIODevice::WriteOnly | QIODevice::Text)) {
 		return;
 	}
+
+	Preferences::get_instance()->setLastPlaylistScriptDirectory( fd.directory().absolutePath() );
 
 	QTextStream out(&chngPerm);
 	out <<  "#!/bin/sh\n\n#have phun";
@@ -522,12 +541,17 @@ void PlaylistDialog::newScript()
 
 void PlaylistDialog::saveListAs()
 {
+	QString sPath = Preferences::get_instance()->getLastPlaylistDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::playlists_dir();
+	}
+	
 	QFileDialog fd(this);
 	fd.setWindowTitle( tr( "Save Playlist" ) );
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::playlists_filter_name );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
-	fd.setDirectory( Filesystem::playlists_dir() );
+	fd.setDirectory( sPath );
 	fd.selectFile( Filesystem::untitled_playlist_file_name() );
 	fd.setDefaultSuffix( Filesystem::playlist_ext );
 
@@ -544,6 +568,7 @@ void PlaylistDialog::saveListAs()
 	}
 
 	pPlaylist->setIsModified( false );
+	Preferences::get_instance()->setLastPlaylistDirectory( fd.directory().absolutePath() );
 
 	setWindowTitle( tr( "Playlist Browser" ) + QString(" - %1").arg( filename ) );
 }
@@ -572,11 +597,14 @@ void PlaylistDialog::loadScript()
 		return;
 	}
 
-	static QString lastUsedDir = Filesystem::scripts_dir();
+	QString sPath = Preferences::get_instance()->getLastPlaylistScriptDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = Filesystem::scripts_dir();
+	}
 
 	QFileDialog fd(this);
 	fd.setFileMode ( QFileDialog::ExistingFile );
-	fd.setDirectory ( lastUsedDir );
+	fd.setDirectory ( sPath );
 	fd.setNameFilter ( tr ( "Hydrogen Playlist (*.sh)" ) );
 	fd.setWindowTitle ( tr ( "Add Script to selected Song" ) );
 
@@ -588,6 +616,7 @@ void PlaylistDialog::loadScript()
 			QMessageBox::information ( this, "Hydrogen", tr ( "Script name or path to the script contains whitespaces.\nIMPORTANT\nThe path to the script and the scriptname must without whitespaces.") );
 			return;
 		}
+		Preferences::get_instance()->setLastPlaylistScriptDirectory( fd.directory().absolutePath() );
 
 		pPlaylistItem->setText ( 1, filename );
 		updatePlayListVector();

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1533,10 +1533,15 @@ void SongEditorPatternList::patternPopup_load()
 	std::shared_ptr<Song> song = engine->getSong();
 	Pattern *pattern = song->getPatternList()->get( nSelectedPattern );
 
+	QString sPath = Preferences::get_instance()->getLastOpenPatternDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = Filesystem::patterns_dir();
+	}
+
 	QFileDialog fd(this);
 	fd.setFileMode( QFileDialog::ExistingFile );
 	fd.setNameFilter( Filesystem::patterns_filter_name );
-	fd.setDirectory( Filesystem::patterns_dir() );
+	fd.setDirectory( sPath );
 	fd.setWindowTitle( tr( "Open Pattern" ) );
 
 	if (fd.exec() != QDialog::Accepted) {
@@ -1555,6 +1560,7 @@ void SongEditorPatternList::patternPopup_load()
 		QMessageBox::warning( this, "Hydrogen", tr("Could not export sequence.") );
 		return;
 	}
+	Preferences::get_instance()->setLastOpenPatternDirectory( fd.directory().absolutePath() );
 
 	SE_loadPatternAction *action = new SE_loadPatternAction( patternPath, prevPatternPath, sequencePath, nSelectedPattern, false );
 	HydrogenApp *hydrogenApp = HydrogenApp::get_instance();

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -862,13 +862,19 @@ void SongEditorPanel::editPlaybackTrackBtnPressed( Button* pBtn )
 	if ( Hydrogen::get_instance()->getAudioEngine()->getState() == H2Core::AudioEngine::State::Playing ) {
 		Hydrogen::get_instance()->sequencer_stop();
 	}
+
+	QString sPath = Preferences::get_instance()->getLastOpenPlaybackTrackDirectory();
+	if ( ! Filesystem::dir_readable( sPath, false ) ){
+		sPath = QDir::homePath();
+	}
 	
 	//use AudioFileBrowser, but don't allow multi-select. Also, hide all no necessary controls.
-	AudioFileBrowser *pFileBrowser = new AudioFileBrowser( nullptr, false, false);
+	AudioFileBrowser *pFileBrowser = new AudioFileBrowser( nullptr, false, false, sPath );
 	
 	QStringList filenameList;
 	
 	if ( pFileBrowser->exec() == QDialog::Accepted ) {
+		Preferences::get_instance()->setLastOpenPlaybackTrackDirectory( pFileBrowser->getSelectedDirectory() );
 		filenameList = pFileBrowser->getSelectedFiles();
 	}
 

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -61,7 +61,7 @@ SoundLibraryExportDialog::SoundLibraryExportDialog( QWidget* pParent,  const QSt
 	updateDrumkitList();
 	adjustSize();
 	setFixedSize( width(), height() );
-	drumkitPathTxt->setText( QDir::homePath() );
+	drumkitPathTxt->setText( Preferences::get_instance()->getLastExportDrumkitDirectory() );
 }
 
 
@@ -280,15 +280,17 @@ void SoundLibraryExportDialog::on_drumkitPathTxt_textChanged( QString str )
 
 void SoundLibraryExportDialog::on_browseBtn_clicked()
 {
-	static QString lastUsedDir = QDir::homePath();
-	QString filename = QFileDialog::getExistingDirectory (this, tr("Directory"), lastUsedDir);
-	if ( filename.isEmpty() ) {
-		drumkitPathTxt->setText( QDir::homePath() );
+	QString sPath = Preferences::get_instance()->getLastExportDrumkitDirectory();
+	if ( ! Filesystem::dir_writable( sPath, false ) ){
+		sPath = QDir::homePath();
 	}
-	else
-	{
+
+	QString filename = QFileDialog::getExistingDirectory( this, tr("Directory"), sPath );
+	if ( filename.isEmpty() ) {
+		drumkitPathTxt->setText( sPath );
+	} else {
 		drumkitPathTxt->setText( filename );
-		lastUsedDir = filename;
+		Preferences::get_instance()->setLastExportDrumkitDirectory( filename );
 	}
 }
 

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
@@ -691,12 +691,15 @@ void SoundLibraryImportDialog::on_DownloadBtn_clicked()
 
 void SoundLibraryImportDialog::on_BrowseBtn_clicked()
 {
-	static QString lastUsedDir = QDir::homePath();
+	QString sPath = H2Core::Preferences::get_instance()->getLastImportDrumkitDirectory();
+	if ( ! H2Core::Filesystem::dir_readable( sPath, false ) ){
+		sPath = QDir::homePath();
+	}
 
 	QFileDialog fd(this);
 	fd.setFileMode(QFileDialog::ExistingFile);
 	fd.setNameFilter( "Hydrogen drumkit (*.h2drumkit)" );
-	fd.setDirectory( lastUsedDir );
+	fd.setDirectory( sPath );
 
 	fd.setWindowTitle( tr( "Import drumkit" ) );
 
@@ -707,7 +710,7 @@ void SoundLibraryImportDialog::on_BrowseBtn_clicked()
 
 	if (filename != "") {
 		SoundLibraryPathTxt->setText( filename );
-		lastUsedDir = fd.directory().absolutePath();
+		H2Core::Preferences::get_instance()->setLastImportDrumkitDirectory( fd.directory().absolutePath() );
 		InstallBtn->setEnabled ( true );
 	}
 }


### PR DESCRIPTION
-  remembering all paths in QFileDialogs. They will be stored in the hydrogen.conf file and persist between sessions.
- introduce shortcut for Open Pattern Dialog (Ctrl + Shift + P)
-  allow for opening more than one pattern at once via Open Pattern in the MainForm

addresses #1078 