### PR TITLE
Fix #1381 -- LADSPA filters broken for variable-sized buffers (eg. PulseAudio)

### DIFF
--- a/src/core/Basics/DrumkitComponent.cpp
+++ b/src/core/Basics/DrumkitComponent.cpp
@@ -85,12 +85,6 @@ void DrumkitComponent::reset_outs( uint32_t nFrames )
 	memset( __out_R, 0, nFrames * sizeof( float ) );
 }
 
-void DrumkitComponent::set_outs( int nBufferPos, float valL, float valR )
-{
-	__out_L[nBufferPos] += valL;
-	__out_R[nBufferPos] += valR;
-}
-
 float DrumkitComponent::get_out_L( int nBufferPos )
 {
 	return __out_L[nBufferPos];

--- a/src/core/Basics/DrumkitComponent.h
+++ b/src/core/Basics/DrumkitComponent.h
@@ -171,7 +171,12 @@ inline float DrumkitComponent::get_peak_r() const
 	return __peak_r;
 }
 
-};
+inline void DrumkitComponent::set_outs( int nBufferPos, float valL, float valR )
+{
+	__out_L[nBufferPos] += valL;
+	__out_R[nBufferPos] += valR;
+}
 
+};
 
 #endif

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -309,6 +309,12 @@ class Note : public H2Core::Object
 		 * \return String presentation of current object.*/
 		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
 
+		/** Convert a logarithmic pitch-space value in semitones to a frequency-domain value */
+		static inline double pitchToFrequency( double fPitch ) {
+			// Equivalent to, but quicker to compute than, pow( 2.0, ( fPitch/12 ) )
+			return pow( 1.0594630943593, fPitch );
+		}
+
 	private:
 		Instrument*		__instrument;   ///< the instrument to be played by this note
 		int				__instrument_id;        ///< the id of the instrument played by this note

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -233,6 +233,8 @@ class Note : public H2Core::Object
 		float get_lpfb_l() const;
 		/** #__lpfb_r accessor */
 		float get_lpfb_r() const;
+		/** Filter output is sustaining note */
+		bool filter_sustain() const;
 		/** #__key accessor */
 		Key get_key();
 		/** #__octave accessor */
@@ -520,6 +522,13 @@ inline float Note::get_lpfb_l() const
 inline float Note::get_lpfb_r() const
 {
 	return __lpfb_r;
+}
+
+inline bool Note::filter_sustain() const
+{
+	const double fLimit = 0.001;
+	return ( fabs( __lpfb_l ) > fLimit || fabs( __lpfb_r ) > fLimit ||
+			 fabs( __bpfb_l ) > fLimit || fabs( __bpfb_r ) > fLimit );
 }
 
 inline Note::Key Note::get_key()

--- a/src/core/Basics/Sample.cpp
+++ b/src/core/Basics/Sample.cpp
@@ -29,6 +29,7 @@
 #include <core/Preferences.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Basics/Sample.h>
+#include <core/Basics/Note.h>
 
 #if defined(H2CORE_HAVE_RUBBERBAND) || _DOXYGEN_
 #include <rubberband/RubberBandStretcher.h>
@@ -624,14 +625,14 @@ bool Sample::exec_rubberband_cli( const Rubberband& rb )
 
 		QStringList arguments;
 		QString rCs = QString( " %1" ).arg( rb.c_settings );
-		float pitch = pow( 1.0594630943593, ( double )rb.pitch );
-		QString rPs = QString( " %1" ).arg( pitch );
+		float fFrequency = Note::pitchToFrequency( ( double )rb.pitch );
+		QString rFs = QString( " %1" ).arg( fFrequency );
 		QString rubberResultPath = QDir::tempPath() + "/tmp_rb_result_file.wav";
 
 		arguments << "-D" << QString( " %1" ).arg( durationtime ) 	//stretch or squash to make output file X seconds long
 		          << "--threads"					//assume multi-CPU even if only one CPU is identified
 		          << "-P"						//aim for minimal time distortion
-		          << "-f" << rPs					//pitch
+		          << "-f" << rFs					//frequency
 		          << "-c" << rCs					//"crispness" levels
 		          << outfilePath 					//infile
 		          << rubberResultPath;					//outfile
@@ -806,13 +807,7 @@ QString Sample::toQString( const QString& sPrefix, bool bShort ) const {
 #ifdef H2CORE_HAVE_RUBBERBAND
 static double compute_pitch_scale( const Sample::Rubberband& rb )
 {
-	double pitchshift = rb.pitch;
-	double frequencyshift = 1.0;
-	if ( pitchshift != 0.0 ) {
-		frequencyshift *= pow( 2.0, pitchshift / 12 );
-	}
-	//float pitch = pow( 1.0594630943593, ( double )rb.pitch );
-	return frequencyshift;
+	return Note::pitchToFrequency( rb.pitch );
 }
 
 static RubberBand::RubberBandStretcher::Options compute_rubberband_options( const Sample::Rubberband& rb )

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -367,7 +367,7 @@ void MidiInput::handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke )
 		pInstr =  pInstrList->get(nInstrument);
 	}
 
-	float fStep = pow( 1.0594630943593, (nNote) );
+	float fStep = Note::pitchToFrequency( nNote );
 	if ( !Preferences::get_instance()->__playselectedinstrument ) {
 		fStep = 1;
 	}

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -1223,7 +1223,6 @@ bool Sampler::renderNoteResample(
 	float fNotePitch = pNote->get_total_pitch() + fLayerPitch;
 
 	float fStep = Note::pitchToFrequency( fNotePitch );
-//	_ERRORLOG( QString("pitch: %1, step: %2" ).arg(fNotePitch).arg( fStep) );
 	fStep *= ( float )pSample->get_sample_rate() / pAudioOutput->getSampleRate(); // Adjust for audio driver sample rate
 
 	// verifico il numero di frame disponibili ancora da eseguire
@@ -1284,45 +1283,45 @@ bool Sampler::renderNoteResample(
 		if ( ( nSamplePos + 1 ) >= nSampleFrames ) {
 			//we reach the last audioframe.
 			//set this last frame to zero do nothing wrong.
-						fVal_L = 0.0;
-						fVal_R = 0.0;
+			fVal_L = 0.0;
+			fVal_R = 0.0;
 		} else {
 			// some interpolation methods need 4 frames data.
-				float last_l;
-				float last_r;
-				if ( ( nSamplePos + 2 ) >= nSampleFrames ) {
-					last_l = 0.0;
-					last_r = 0.0;
-				} else {
-					last_l =  pSample_data_L[nSamplePos + 2];
-					last_r =  pSample_data_R[nSamplePos + 2];
-				}
+			float last_l;
+			float last_r;
+			if ( ( nSamplePos + 2 ) >= nSampleFrames ) {
+				last_l = 0.0;
+				last_r = 0.0;
+			} else {
+				last_l =  pSample_data_L[nSamplePos + 2];
+				last_r =  pSample_data_R[nSamplePos + 2];
+			}
 
-				switch( m_interpolateMode ){
+			switch( m_interpolateMode ){
 
-						case Interpolation::InterpolateMode::Linear:
-								fVal_L = pSample_data_L[nSamplePos] * (1 - fDiff ) + pSample_data_L[nSamplePos + 1] * fDiff;
-								fVal_R = pSample_data_R[nSamplePos] * (1 - fDiff ) + pSample_data_R[nSamplePos + 1] * fDiff;
-								//fVal_L = linear_Interpolate( pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], fDiff);
-								//fVal_R = linear_Interpolate( pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], fDiff);
-								break;
-						case Interpolation::InterpolateMode::Cosine:
-								fVal_L = Interpolation::cosine_Interpolate( pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], fDiff);
-								fVal_R = Interpolation::cosine_Interpolate( pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], fDiff);
-								break;
-						case Interpolation::InterpolateMode::Third:
-								fVal_L = Interpolation::third_Interpolate( pSample_data_L[ nSamplePos -1], pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], last_l, fDiff);
-								fVal_R = Interpolation::third_Interpolate( pSample_data_R[ nSamplePos -1], pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], last_r, fDiff);
-								break;
-						case Interpolation::InterpolateMode::Cubic:
-								fVal_L = Interpolation::cubic_Interpolate( pSample_data_L[ nSamplePos -1], pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], last_l, fDiff);
-								fVal_R = Interpolation::cubic_Interpolate( pSample_data_R[ nSamplePos -1], pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], last_r, fDiff);
-								break;
-						case Interpolation::InterpolateMode::Hermite:
-								fVal_L = Interpolation::hermite_Interpolate( pSample_data_L[ nSamplePos -1], pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], last_l, fDiff);
-								fVal_R = Interpolation::hermite_Interpolate( pSample_data_R[ nSamplePos -1], pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], last_r, fDiff);
-								break;
-				}
+			case Interpolation::InterpolateMode::Linear:
+				fVal_L = pSample_data_L[nSamplePos] * (1 - fDiff ) + pSample_data_L[nSamplePos + 1] * fDiff;
+				fVal_R = pSample_data_R[nSamplePos] * (1 - fDiff ) + pSample_data_R[nSamplePos + 1] * fDiff;
+				//fVal_L = linear_Interpolate( pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], fDiff);
+				//fVal_R = linear_Interpolate( pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], fDiff);
+				break;
+			case Interpolation::InterpolateMode::Cosine:
+				fVal_L = Interpolation::cosine_Interpolate( pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], fDiff);
+				fVal_R = Interpolation::cosine_Interpolate( pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], fDiff);
+				break;
+			case Interpolation::InterpolateMode::Third:
+				fVal_L = Interpolation::third_Interpolate( pSample_data_L[ nSamplePos -1], pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], last_l, fDiff);
+				fVal_R = Interpolation::third_Interpolate( pSample_data_R[ nSamplePos -1], pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], last_r, fDiff);
+				break;
+			case Interpolation::InterpolateMode::Cubic:
+				fVal_L = Interpolation::cubic_Interpolate( pSample_data_L[ nSamplePos -1], pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], last_l, fDiff);
+				fVal_R = Interpolation::cubic_Interpolate( pSample_data_R[ nSamplePos -1], pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], last_r, fDiff);
+				break;
+			case Interpolation::InterpolateMode::Hermite:
+				fVal_L = Interpolation::hermite_Interpolate( pSample_data_L[ nSamplePos -1], pSample_data_L[nSamplePos], pSample_data_L[nSamplePos + 1], last_l, fDiff);
+				fVal_R = Interpolation::hermite_Interpolate( pSample_data_R[ nSamplePos -1], pSample_data_R[nSamplePos], pSample_data_R[nSamplePos + 1], last_r, fDiff);
+				break;
+			}
 		}
 
 		// ADSR envelope
@@ -1373,6 +1372,7 @@ bool Sampler::renderNoteResample(
 		m_pMainOut_R[nBufferPos] += fVal_R;
 
 	}
+
 	pSelectedLayerInfo->SamplePosition += nAvail_bytes * fStep;
 	pNote->get_instrument()->set_peak_l( fInstrPeak_L );
 	pNote->get_instrument()->set_peak_r( fInstrPeak_R );

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -1225,7 +1225,7 @@ bool Sampler::renderNoteResample(
 	}
 	float fNotePitch = pNote->get_total_pitch() + fLayerPitch;
 
-	float fStep = pow( 1.0594630943593, ( double )fNotePitch );
+	float fStep = Note::pitchToFrequency( fNotePitch );
 //	_ERRORLOG( QString("pitch: %1, step: %2" ).arg(fNotePitch).arg( fStep) );
 	fStep *= ( float )pSample->get_sample_rate() / pAudioOutput->getSampleRate(); // Adjust for audio driver sample rate
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -623,7 +623,7 @@ void DrumPatternEditor::mouseDragUpdateEvent( QMouseEvent *ev )
 		float fNotePitch = m_pDraggedNote->get_octave() * 12 + m_pDraggedNote->get_key();
 		float fStep = 0;
 		if(nLen > -1){
-			fStep = pow( 1.0594630943593, ( double )fNotePitch );
+			fStep = Note::pitchToFrequency( ( double )fNotePitch );
 		}else
 		{
 			fStep = 1.0;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -188,7 +188,7 @@ void PatternEditor::drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote
 		// Draw tail
 		if ( pNote->get_length() != -1 ) {
 			float fNotePitch = pNote->get_octave() * 12 + pNote->get_key();
-			float fStep = pow( 1.0594630943593, ( double )fNotePitch );
+			float fStep = Note::pitchToFrequency( ( double )fNotePitch );
 			width = m_fGridWidth * pNote->get_length() / fStep;
 			width = width - 1;	// lascio un piccolo spazio tra una nota ed un altra
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -697,7 +697,7 @@ void PianoRollEditor::mouseDragUpdateEvent( QMouseEvent *ev )
 		float fNotePitch = m_pDraggedNote->get_notekey_pitch();
 		float fStep = 0;
 		if(nLen > -1){
-			fStep = pow( 1.0594630943593, ( double )fNotePitch );
+			fStep = Note::pitchToFrequency( ( double )fNotePitch );
 		} else {
 			fStep = 1.0;
 		}


### PR DESCRIPTION
The LADSPA interface was subtly broken, in that it always read a buffer's worth further into the sample than the main audio would read. This missed the start of samples, and also created awful distortion on PulseAudio (or PortAudio with new driver) due to reading a variable number of samples ahead on each buffer fill.

This fixes this problem, as well as reduces CPU overhead for LADSPA filters, by doing sample interpolation *once* into a separate buffer that feeds the main output *and* the LADSPA plugins, avoiding repeating the costly interpolation and ADSR calculations. 
