### PR TITLE
implement Pattern & Grid OSC commands

### DIFF
--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -62,14 +62,17 @@ void PatternList::add( Pattern* pattern )
 	__patterns.push_back( pattern );
 }
 
-void PatternList::insert( int idx, Pattern* pattern )
+void PatternList::insert( int nIdx, Pattern* pPattern )
 {
 	assertAudioEngineLocked();
 	// do nothing if already in __patterns
-	if ( index( pattern) != -1 ) {
+	if ( index( pPattern ) != -1 ) {
 		return;
 	}
-	__patterns.insert( __patterns.begin() + idx, pattern );
+	if ( nIdx > __patterns.size() ) {
+		__patterns.resize( nIdx );
+	}
+	__patterns.insert( __patterns.begin() + nIdx, pPattern );
 }
 
 Pattern* PatternList::get( int idx )
@@ -105,10 +108,12 @@ int PatternList::index( const Pattern* pattern )
 Pattern* PatternList::del( int idx )
 {
 	assertAudioEngineLocked();
-	assert( idx >= 0 && idx < __patterns.size() );
-	Pattern* pattern = __patterns[idx];
-	__patterns.erase( __patterns.begin() + idx );
-	return pattern;
+	if ( idx >= 0 && idx < __patterns.size() ) {
+		Pattern* pattern = __patterns[idx];
+		__patterns.erase( __patterns.begin() + idx );
+		return pattern;
+	}
+	return nullptr;
 }
 
 Pattern* PatternList::del( Pattern* pattern )

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -176,6 +176,25 @@ int Song::lengthInTicks() const {
     return nSongLength;
 }
 
+bool Song::isPatternActive( int nColumn, int nRow ) const {
+	if ( nRow < 0 || nRow > m_pPatternList->size() ) {
+		return false;
+	}
+	
+	auto pPattern = m_pPatternList->get( nRow );
+	if ( pPattern == nullptr ) {
+		return false;
+	}
+	if ( nColumn < 0 || nColumn >= m_pPatternGroupSequence->size() ) {
+		return false;
+	}
+	auto pColumn = ( *m_pPatternGroupSequence )[ nColumn ];
+	if ( pColumn->index( pPattern ) == -1 ) {
+		return false;
+	}
+
+	return true;
+}
 	
 ///Load a song from file
 std::shared_ptr<Song> Song::load( const QString& sFilename )

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -207,6 +207,9 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		int getPanLawType() const;
 		void setPanLawKNorm( float fKNorm );
 		float getPanLawKNorm() const;
+
+		bool isPatternActive( int nColumn, int nRow ) const;
+	
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of
 		 * every new line

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -27,6 +27,8 @@
 #include <core/Preferences/Preferences.h>
 #include <core/Basics/InstrumentList.h>
 #include <core/Basics/Instrument.h>
+#include <core/Basics/PatternList.h>
+#include <core/Basics/Pattern.h>
 #include "core/OscServer.h"
 #include <core/MidiAction.h>
 #include "core/MidiMap.h"
@@ -746,4 +748,132 @@ bool CoreActionController::locateToFrame( unsigned long nFrame ) {
 #endif
 	return true;
 }
+
+bool CoreActionController::newPattern( const QString& sPatternName ) {
+	auto pPatternList = Hydrogen::get_instance()->getSong()->getPatternList();
+	Pattern* pPattern = new Pattern( sPatternName );
+	
+	return setPattern( pPattern, pPatternList->size() );
+}
+bool CoreActionController::openPattern( const QString& sPath, int nPatternPosition ) {
+	auto pSong = Hydrogen::get_instance()->getSong();
+	auto pPatternList = pSong->getPatternList();
+	Pattern* pNewPattern = Pattern::load_file( sPath, pSong->getInstrumentList() );
+
+	if ( pNewPattern == nullptr ) {
+		ERRORLOG( QString( "Unable to loading the pattern [%1]" ).arg( sPath ) );
+		return false;
+	}
+
+	if ( nPatternPosition == -1 ) {
+		nPatternPosition = pPatternList->size();
+	}
+
+	return setPattern( pNewPattern, nPatternPosition );
+}
+
+bool CoreActionController::setPattern( Pattern* pPattern, int nPatternPosition ) {
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pPatternList = pHydrogen->getSong()->getPatternList();
+
+	// Check whether the name of the new pattern is unique.
+	if ( !pPatternList->check_name( pPattern->get_name() ) ){
+		pPattern->set_name( pPatternList->find_unused_pattern_name( pPattern->get_name() ) );
+	}
+
+	pPatternList->insert( nPatternPosition, pPattern );
+	pHydrogen->setSelectedPatternNumber( nPatternPosition );
+	pHydrogen->getSong()->setIsModified( true );
+	
+	// Update the SongEditor.
+	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG_EDITOR, 0 );
+	}
+	return true;
+}
+
+bool CoreActionController::removePattern( int nPatternNumber ) {
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pPatternList = Hydrogen::get_instance()->getSong()->getPatternList();
+	int nPreviousPatternNumber = pHydrogen->getSelectedPatternNumber();
+	auto pPattern = pPatternList->get( nPatternNumber );
+
+	if ( nPatternNumber == nPreviousPatternNumber ) {
+		pHydrogen->setSelectedPatternNumber( std::max( 0, nPatternNumber - 1 ) );
+	}
+
+	pPatternList->del( pPattern );
+	delete pPattern;
+	pHydrogen->getSong()->setIsModified( true );
+
+	// Update the SongEditor.
+	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG_EDITOR, 0 );
+	}
+	return true;
+}
+
+bool CoreActionController::toggleGridCell( int nColumn, int nRow ){
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+	auto pPatternList = pSong->getPatternList();
+	std::vector<PatternList*>* pColumns = pSong->getPatternGroupVector();
+
+	if ( nRow < 0 || nRow > pPatternList->size() ) {
+		ERRORLOG( QString( "Provided row [%1] is out of bound [0,%2]" )
+				  .arg( nRow ).arg( pPatternList->size() ) );
+		return false;
+	}
+	
+	auto pNewPattern = pPatternList->get( nRow );
+	if ( pNewPattern == nullptr ) {
+		ERRORLOG( QString( "Unable to obtain Pattern in row [%1]." )
+				  .arg( nRow ) );
+
+		return false;
+	}
+
+	pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
+	if ( nColumn >= 0 && nColumn < pColumns->size() ) {
+		PatternList *pColumn = ( *pColumns )[ nColumn ];
+		auto pPattern = pColumn->del( pNewPattern );
+		if ( pPattern == nullptr ) {
+			// No pattern in this row. Let's add it.
+			pColumn->add( pNewPattern );
+		} else {
+			// There was already a pattern present and we removed it.
+			// If there is no pattern left in this column, we remove
+			// it too.
+			if ( pColumn->size() == 0 ) {
+				pColumns->erase( pColumns->begin() + nColumn );
+				delete pColumn;
+			}
+		}
+	} else if ( nColumn >= pColumns->size() ) {
+		// We need to add some new columns..
+		PatternList *pColumn;
+
+		for ( int ii = 0; nColumn - pColumns->size() + 1; ii++ ) {
+			pColumn = new PatternList();
+			pColumns->push_back( pColumn );
+		}
+		pColumn->add( pNewPattern );
+	} else {
+		// nColumn < 0
+		ERRORLOG( QString( "Provided column [%1] is out of bound [0,%2]" )
+				  .arg( nColumn ).arg( pColumns->size() ) );
+		return false;
+	}
+	
+	pSong->setIsModified( true );
+	pHydrogen->getAudioEngine()->unlock();
+
+	// Update the SongEditor.
+	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
+		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG_EDITOR, 0 );
+	}
+
+	return true;
+}
+
 }

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -165,6 +165,9 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 */
 		bool quit();
 
+		// -----------------------------------------------------------
+		// Further OSC commands
+
 		/**
 		 * (De)activates the usage of the Timeline.
 		 *
@@ -265,6 +268,47 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * @return bool true on success
 		 */
 		bool locateToFrame( unsigned long nFrame );
+
+	    /** Creates an empty pattern and adds it to the pattern list.
+		 *
+		 * @param sPath Name for the created pattern.
+		 *
+		 * @return bool true on success
+		 */
+    	bool newPattern( const QString& sPatternName );
+	    /** Opens a pattern from disk and adds it to the pattern list.
+		 *
+		 * @param sPath Absolute path to an existing .h2pattern file.
+		 * @param nPatternNumber Row the pattern will be added to. If
+		 * set to -1, the pattern will be appended at the end of the
+		 * pattern list.
+		 *
+		 * @return bool true on success
+		 */
+    	bool openPattern( const QString& sPath, int nPatternNumber = -1 );
+        /** Opens a pattern to the current pattern list.
+		 *
+		 * @param pPattern pattern to be added.
+		 * @param nPatternNumber Row the pattern will be added to.
+		 *
+		 * @return bool true on success
+		 */
+		bool setPattern( Pattern* pPattern, int nPatternNumber );
+	    /** Removes a pattern from the pattern list.
+		 *
+		 * @param nPatternNumber Specifies the position/row of the pattern.
+		 *
+		 * @return bool true on success
+		 */
+    	bool removePattern( int nPatternNumber );
+	    /** Fills or clears a specific grid cell in the SongEditor.
+		 *
+		 * @param nColumn column of the pattern.
+		 * @param nRow row of the pattern.
+		 *
+		 * @return bool true on success
+		 */
+    	bool toggleGridCell( int nColumn, int nRow );
 		
 		// -----------------------------------------------------------
 		// Helper functions

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -151,7 +151,9 @@ enum EventType {
 	/** Toggles the button indicating the usage loop mode.*/
 	EVENT_LOOP_MODE_ACTIVATION,
 	/** Switches between select mode (0) and draw mode (1) in the *SongEditor.*/
-	EVENT_ACTION_MODE_CHANGE
+	EVENT_ACTION_MODE_CHANGE,
+	/** Triggers an udpate of the entire SongEditor*/
+	EVENT_UPDATE_SONG_EDITOR
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -659,6 +659,8 @@ void OscServer::QUIT_Handler(lo_arg **argv, int argc) {
 	pController->quit();
 }
 
+// -------------------------------------------------------------------
+
 void OscServer::TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 
 	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
@@ -727,6 +729,31 @@ void OscServer::LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 void OscServer::RELOCATE_Handler(lo_arg **argv, int argc) {
 
 	H2Core::Hydrogen::get_instance()->getCoreActionController()->locateToColumn( static_cast<int>(std::round( argv[0]->f ) ) );
+}
+
+void OscServer::NEW_PATTERN_Handler(lo_arg **argv, int argc) {
+	
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	pController->newPattern( QString::fromUtf8( &argv[0]->s ) );
+}
+
+void OscServer::OPEN_PATTERN_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	pController->openPattern( QString::fromUtf8( &argv[0]->s ) );
+}
+
+void OscServer::REMOVE_PATTERN_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	pController->removePattern( static_cast<int>(std::round( argv[0]->f )) );
+}
+
+void OscServer::SONG_EDITOR_TOGGLE_GRID_CELL_Handler(lo_arg **argv, int argc) {
+
+	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	pController->toggleGridCell( static_cast<int>(std::round( argv[0]->f )),
+								 static_cast<int>(std::round( argv[1]->f )) );
 }
 
 // -------------------------------------------------------------------
@@ -1006,6 +1033,10 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/SONG_MODE_ACTIVATION", "f", SONG_MODE_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/LOOP_MODE_ACTIVATION", "f", LOOP_MODE_ACTIVATION_Handler);
 	m_pServerThread->add_method("/Hydrogen/RELOCATE", "f", RELOCATE_Handler);
+	m_pServerThread->add_method("/Hydrogen/NEW_PATTERN", "s", NEW_PATTERN_Handler);
+	m_pServerThread->add_method("/Hydrogen/OPEN_PATTERN", "s", OPEN_PATTERN_Handler);
+	m_pServerThread->add_method("/Hydrogen/REMOVE_PATTERN", "f", REMOVE_PATTERN_Handler);
+	m_pServerThread->add_method("/Hydrogen/SONG_EDITOR_TOGGLE_GRID_CELL", "ff", SONG_EDITOR_TOGGLE_GRID_CELL_Handler);
 
 	m_bInitialized = true;
 	

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -595,19 +595,17 @@ class OscServer : public H2Core::Object<OscServer>
 		 * a .h2song file. If another file already exists with the
 		 * same name, it will be overwritten.
 		 *
-		 * \param argv Unused pointer to a vector of arguments passed
-		 * by the OSC message.
+		 * \param argv The "s" field does contain the absolute path.
 		 * \param argc Number of arguments passed by the OSC message.
 		 */
 		static void NEW_SONG_Handler(lo_arg **argv, int argc);
 		/**
 		 * Triggers CoreActionController::openSong().
 		 *
-		 * The handler expects the user to provide an absolute path to
+		 * The handler expects the user to provide an absolute path for
 		 * a .h2song file.
 		 *
-		 * \param argv Unused pointer to a vector of arguments passed
-		 * by the OSC message.
+		 * \param argv The "s" field does contain the absolute path.
 		 * \param argc Number of arguments passed by the OSC message.
 		 */
 		static void OPEN_SONG_Handler(lo_arg **argv, int argc);
@@ -626,8 +624,7 @@ class OscServer : public H2Core::Object<OscServer>
 		 * a .h2song file. If another file already exists with the
 		 * same name, it will be overwritten.
 		 *
-		 * \param argv Unused pointer to a vector of arguments passed
-		 * by the OSC message.
+		 * \param argv The "s" field does contain the absolute path.
 		 * \param argc Number of arguments passed by the OSC
 		 * message.*/
 		static void SAVE_SONG_AS_Handler(lo_arg **argv, int argc);
@@ -650,7 +647,7 @@ class OscServer : public H2Core::Object<OscServer>
 		/**
 		 * Triggers CoreActionController::activateTimeline().
 		 *
-		 * \param argv The "i" field does contain the value supplied
+		 * \param argv The "f" field does contain the value supplied
 		 * by the user. If it is 0, the Timeline will be
 		 * deactivated. Else, it will be activated instead.
 		 * \param argc Unused number of arguments passed by the OSC
@@ -659,7 +656,7 @@ class OscServer : public H2Core::Object<OscServer>
 		/**
 		 * Triggers CoreActionController::addTempoMarker().
 		 *
-		 * \param argv The first field "i" does contain the bar at
+		 * \param argv The first field "f" does contain the bar at
 		 * which to place the new Timeline::TempoMarker while the
 		 * second one "f" specifies its tempo in bpm.
 		 * \param argc Unused number of arguments passed by the OSC
@@ -668,7 +665,7 @@ class OscServer : public H2Core::Object<OscServer>
 		/**
 		 * Triggers CoreActionController::deleteTempoMarker().
 		 *
-		 * \param argv The first field "i" does contain the bar at
+		 * \param argv The first field "f" does contain the bar at
 		 * which to delete a Timeline::TempoMarker.
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
@@ -676,7 +673,7 @@ class OscServer : public H2Core::Object<OscServer>
 		/**
 		 * Triggers CoreActionController::activatedJackTransport().
 		 *
-		 * \param argv The "i" field does contain the value supplied
+		 * \param argv The "f" field does contain the value supplied
 		 * by the user. If it is 0, the Jack transport will be
 		 * deactivated. Else, it will be activated instead.
 		 * \param argc Unused number of arguments passed by the OSC
@@ -685,7 +682,7 @@ class OscServer : public H2Core::Object<OscServer>
 		/**
 		 * Triggers CoreActionController::activateJackTimebaseMaster().
 		 *
-		 * \param argv The "i" field does contain the value supplied
+		 * \param argv The "f" field does contain the value supplied
 		 * by the user. If it is 0, the Jack timebase master will be
 		 * deactivated. Else, it will be activated instead.
 		 * \param argc Unused number of arguments passed by the OSC
@@ -694,7 +691,7 @@ class OscServer : public H2Core::Object<OscServer>
 		/**
 		 * Triggers CoreActionController::activateSongMode().
 		 *
-		 * \param argv The "i" field does contain the value supplied
+		 * \param argv The "f" field does contain the value supplied
 		 * by the user. If it is 0, Pattern mode of the playback will
 		 * be activated. Else, Song mode will be activated instead.
 		 * \param argc Unused number of arguments passed by the OSC
@@ -703,19 +700,63 @@ class OscServer : public H2Core::Object<OscServer>
 	/**
 		 * Triggers CoreActionController::activateLoopMode().
 		 *
-		 * \param argv The "i" field does contain the value supplied
+		 * \param argv The "f" field does contain the value supplied
 		 * by the user. If it is 0, loop mode will
 		 * be deactivated. Else, it will be activated instead.
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc);
 		/**
-		 * \param argv The "i" field does contain the desired
+		 * \param argv The "f" field does contain the desired
 		 * position / number of the pattern group (starting with
 		 * 0).
 		 * \param argc Unused number of arguments passed by the OSC
 		 * message.*/
 		static void RELOCATE_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::newSong().
+		 *
+		 * The handler expects the user to provide an absolute path for
+		 * a .h2pattern file. If another file already exists with the
+		 * same name, it will be overwritten.
+		 *
+		 * \param argv The "s" field does contain the name for the new
+		 * pattern.
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void NEW_PATTERN_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::openPattern().
+		 *
+		 * The handler expects the user to provide an absolute path to
+		 * a .h2pattern file.
+		 *
+		 * \param argv The "s" field does contain the absolute path.
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void OPEN_PATTERN_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::removePattern().
+		 *
+		 * The handler expects the user to provide the pattern number
+		 * (row the pattern resides in within the SongEditor).
+		 *
+		 * \param argv The "f" field does contain the pattern number
+		 * (caution: it starts at 0).
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void REMOVE_PATTERN_Handler(lo_arg **argv, int argc);
+		/**
+		 * Triggers CoreActionController::songEditorToggleGridCell().
+		 *
+		 * The handler expects the user to provide the pattern number
+		 * (row the pattern resides in within the SongEditor).
+		 *
+		 * \param argv The first two "f" fields do contain the column
+		 * and row number of the particular grid cell.
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void SONG_EDITOR_TOGGLE_GRID_CELL_Handler(lo_arg **argv, int argc);
 		/** 
 		 * Catches any incoming messages and display them. 
 		 *

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -322,6 +322,8 @@ CommonStrings::CommonStrings(){
 	  capabilities of  Hydrogen. Indicating  that there is  not Action
 	  which could be associated to a MIDI event.*/
 	m_sMidiSenseUnavailable = tr( "This element is not MIDI operable." );
+
+	m_sPatternLoadError = tr( "Unable to load pattern" );
 }
 
 CommonStrings::~CommonStrings(){

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -126,6 +126,8 @@ public:
 	const QString& getMidiSenseWindowTitle() const { return m_sMidiSenseWindowTitle; }
 	const QString& getMidiSenseInput() const { return m_sMidiSenseInput; }
 	const QString& getMidiSenseUnavailable() const { return m_sMidiSenseUnavailable; }
+	
+	const QString& getPatternLoadError() const { return m_sPatternLoadError; }
 
 private:
 	QString m_sSmallSoloButton;
@@ -210,6 +212,8 @@ private:
 	QString m_sMidiSenseWindowTitle;
 	QString m_sMidiSenseInput;
 	QString m_sMidiSenseUnavailable;
+
+	QString m_sPatternLoadError;
 	
 };
 #endif

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -56,6 +56,7 @@ class EventListener
 		virtual void loopModeActivationEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void updatePreferencesEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void actionModeChangeEvent( int nValue ){ UNUSED( nValue ); }
+    	virtual void updateSongEditorEvent( int nValue ){ UNUSED( nValue ); }
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -625,6 +625,10 @@ void HydrogenApp::onEventQueueTimer()
 			case EVENT_ACTION_MODE_CHANGE:
 				pListener->actionModeChangeEvent( event.value );
 				break;
+
+			case EVENT_UPDATE_SONG_EDITOR:
+				pListener->updateSongEditorEvent( event.value );
+				break;
 				
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -156,73 +156,20 @@ QPoint SongEditor::columnRowToXy( QPoint p )
 }
 
 
-bool SongEditor::togglePatternActive( int nColumn, int nRow )
-{
-	HydrogenApp* h2app = HydrogenApp::get_instance();
-	std::shared_ptr<Song> pSong = m_pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-
-	if ( nRow >= pPatternList->size() || nRow < 0 || nColumn < 0 ) {
-		return true;
-	}
-
-	H2Core::Pattern *pPattern = pPatternList->get( nRow );
-	assert( pPattern != nullptr );
-
-	std::vector<PatternList*> *pColumns = pSong->getPatternGroupVector();
-	if ( nColumn < pColumns->size() ) {
-		PatternList *pColumn = ( *pColumns )[ nColumn ];
-		unsigned nColumnIndex = pColumn->index( pPattern );
-
-		if ( nColumnIndex != -1 ) {
-			// Delete pattern
-			h2app->m_pUndoStack->push( new SE_deletePatternAction( nColumn, nRow ) );
-			return false;
-
-		} else {
-			h2app->m_pUndoStack->push( new SE_addPatternAction( nColumn, nRow ) );
-			return true;
-		}
-	}
-	else {
-		SE_addPatternAction *action = new SE_addPatternAction( nColumn, nRow ) ;
-		h2app->m_pUndoStack->push( action );
-		return true;
-	}
+void SongEditor::togglePatternActive( int nColumn, int nRow ) {
+	SE_togglePatternAction *action = new SE_togglePatternAction( nColumn, nRow );
+	HydrogenApp::get_instance()->m_pUndoStack->push( action );
 }
 
-void SongEditor::setPatternActive( int nColumn, int nRow, bool value )
+void SongEditor::setPatternActive( int nColumn, int nRow, bool bActivate )
 {
 	HydrogenApp* h2app = HydrogenApp::get_instance();
 	std::shared_ptr<Song> pSong = m_pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
+	bool bPatternIsActive = pSong->isPatternActive( nColumn, nRow );
 
-	if ( nRow >= pPatternList->size() || nRow < 0 || nColumn < 0 ) {
-		return;
+	if ( bPatternIsActive && ! bActivate || ! bPatternIsActive && bActivate ) {
+		h2app->m_pUndoStack->push( new SE_togglePatternAction( nColumn, nRow ) );
 	}
-
-	H2Core::Pattern *pPattern = pPatternList->get( nRow );
-	assert( pPattern != nullptr );
-
-	std::vector<PatternList*> *pColumns = pSong->getPatternGroupVector();
-	if ( nColumn < pColumns->size() ) {
-		PatternList *pColumn = ( *pColumns )[ nColumn ];
-		unsigned nColumnIndex = pColumn->index( pPattern );
-
-		if ( nColumnIndex != -1 && value == false ) {
-			// Delete existing pattern
-			h2app->m_pUndoStack->push( new SE_deletePatternAction( nColumn, nRow ) );
-
-		} else if ( nColumnIndex == -1 && value == true ) {
-			// Add pattern to  column
-			h2app->m_pUndoStack->push( new SE_addPatternAction( nColumn, nRow ) );
-		}
-	} else if ( value == true ) {
-		// Add a new pattern
-		SE_addPatternAction *action = new SE_addPatternAction( nColumn, nRow ) ;
-		h2app->m_pUndoStack->push( action );
-	}
-
 }
 
 
@@ -400,8 +347,7 @@ void SongEditor::keyPressEvent( QKeyEvent * ev )
 			deleteSelection();
 		} else {
 			// No selection, delete at the current cursor position
-			QUndoStack *pUndo = HydrogenApp::get_instance()->m_pUndoStack;
-			pUndo->push( new SE_deletePatternAction( m_nCursorColumn, m_nCursorRow ) );
+			togglePatternActive( m_nCursorColumn, m_nCursorRow );
 		}
 
 	} else if ( ev->matches( QKeySequence::MoveToNextChar ) || ( bSelectionKey = ev->matches( QKeySequence::SelectNextChar ) ) ) {
@@ -586,7 +532,7 @@ void SongEditor::mousePressEvent( QMouseEvent *ev )
 		if ( ev->button() == Qt::LeftButton ) {
 			// Start of a drawing gesture. Pick up whether we are painting Active or Inactive cells.
 			QPoint p = xyToColumnRow( ev->pos() );
-			m_bDrawingActiveCell = togglePatternActive( p.x(), p.y() );
+			m_bDrawingActiveCell = Hydrogen::get_instance()->getSong()->isPatternActive( p.x(), p.y() );
 			m_pSongEditorPanel->updatePlaybackTrackIfNecessary();
 
 		} else if ( ev->button() == Qt::RightButton ) {
@@ -624,71 +570,6 @@ void SongEditor::updateModifiers( QInputEvent *ev )
 	}
 
 }
-
-
-void SongEditor::addPattern( int nColumn , int nRow )
-{
-	std::shared_ptr<Song> pSong = m_pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-	H2Core::Pattern *pPattern = pPatternList->get( nRow );
-	std::vector<PatternList*> *pColumns = pSong->getPatternGroupVector();
-
-	m_pAudioEngine->lock( RIGHT_HERE );
-	if ( nColumn < (int)pColumns->size() ) {
-		PatternList *pColumn = ( *pColumns )[ nColumn ];
-		// ADD PATTERN
-		pColumn->add( pPattern );
-
-	} else {
-		//we need to add some new columns..
-		PatternList *pColumn = new PatternList();
-		int nSpaces = nColumn - pColumns->size();
-
-		pColumns->push_back( pColumn );
-
-		for ( int i = 0; i < nSpaces; i++ ) {
-			pColumn = new PatternList();
-			pColumns->push_back( pColumn );
-		}
-		pColumn->add( pPattern );
-	}
-	pSong->setIsModified( true );
-	m_pAudioEngine->unlock();
-	m_bSequenceChanged = true;
-	update();
-}
-
-
-void SongEditor::deletePattern( int nColumn , int nRow )
-{
-	std::shared_ptr<Song> pSong = m_pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-	H2Core::Pattern *pPattern = pPatternList->get( nRow );
-	std::vector<PatternList*> *pColumns = pSong->getPatternGroupVector();
-
-	m_pAudioEngine->lock( RIGHT_HERE );
-
-	PatternList *pColumn = ( *pColumns )[ nColumn ];
-
-	pColumn->del( pPattern );
-
-	// elimino le colonne vuote
-	for ( int i = pColumns->size() - 1; i >= 0; i-- ) {
-		PatternList *pColumn = ( *pColumns )[ i ];
-		if ( pColumn->size() == 0 ) {
-			pColumns->erase( pColumns->begin() + i );
-			delete pColumn;
-		}
-		else {
-			break;
-		}
-	}
-	pSong->setIsModified( true );
-	m_pAudioEngine->unlock();
-	m_bSequenceChanged = true;
-	update();
-}
-
 
 void SongEditor::mouseMoveEvent(QMouseEvent *ev)
 {
@@ -794,14 +675,14 @@ void SongEditor::mouseReleaseEvent( QMouseEvent *ev )
 //! Modify pattern cells by first deleting some, then adding some.
 //! deleteCells and addCells *may* safely overlap
 void SongEditor::modifyPatternCellsAction( std::vector<QPoint> & addCells, std::vector<QPoint> & deleteCells, std::vector<QPoint> & selectCells ) {
-
+	
 	for ( QPoint cell : deleteCells ) {
-		deletePattern( cell.x(), cell.y() );
+		setPatternActive( cell.x(), cell.y(), false );
 	}
 
 	m_selection.clearSelection();
 	for ( QPoint cell : addCells ) {
-		addPattern( cell.x(), cell.y() );
+		setPatternActive( cell.x(), cell.y(), true );
 		m_selection.addToSelection( cell );
 	}
 	// Select additional cells (probably merged cells on redo)
@@ -1449,6 +1330,9 @@ void SongEditorPatternList::createBackground()
 	//assemble the data..
 	for ( int i = 0; i < nPatterns; i++ ) {
 		H2Core::Pattern *pPattern = pSong->getPatternList()->get(i);
+		if ( pPattern == nullptr ) {
+			continue;
+		}
 
 		if ( pCurrentPatternList->index( pPattern ) != -1 ) {
 			PatternArray[i].bActive = true;
@@ -1585,30 +1469,6 @@ void SongEditorPatternList::patternPopup_load()
 	HydrogenApp *hydrogenApp = HydrogenApp::get_instance();
 	hydrogenApp->m_pUndoStack->push( action );
 }
-
-void SongEditorPatternList::loadPatternAction( QString afilename, int position)
-{
-	std::shared_ptr<Song> pSong =m_pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-
-	Pattern* pNewPattern = Pattern::load_file( afilename, pSong->getInstrumentList() );
-	if ( pNewPattern == nullptr ) {
-		_ERRORLOG( "Error loading the pattern" );
-		return;
-	}
-
-	if( !pPatternList->check_name( pNewPattern->get_name() ) ) {
-		pNewPattern->set_name( pPatternList->find_unused_pattern_name( pNewPattern->get_name() ) );
-	}
-
-	pPatternList->insert( position, pNewPattern );
-
-	m_pHydrogen->setSelectedPatternNumber( position );
-	pSong->setIsModified( true );
-	createBackground();
-	HydrogenApp::get_instance()->getSongEditorPanel()->updateAll();
-}
-
 
 void SongEditorPatternList::patternPopup_export()
 {
@@ -1832,35 +1692,11 @@ void SongEditorPatternList::patternPopup_duplicate()
 			return;
 		}
 		SE_duplicatePatternAction *action = new SE_duplicatePatternAction( filePath, nSelectedPattern + 1 );
-		HydrogenApp *hydrogenApp = HydrogenApp::get_instance();
-		hydrogenApp->m_pUndoStack->push( action );
+		HydrogenApp::get_instance()->m_pUndoStack->push( action );
 	}
 
 	delete dialog;
 	delete pNewPattern;
-
-	HydrogenApp::get_instance()->getSongEditorPanel()->updateAll();
-}
-
-
-void SongEditorPatternList::patternPopup_duplicateAction( QString patternFilename, int patternposition )
-{
-	Hydrogen *engine = Hydrogen::get_instance();
-	std::shared_ptr<Song> pSong = engine->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-
-	Pattern* pattern = Pattern::load_file( patternFilename, pSong->getInstrumentList() );
-	if ( pattern == nullptr ) {
-		_ERRORLOG( "Error loading the pattern" );
-		return;
-	}
-
-	pPatternList->insert( patternposition, pattern );
-	engine->setSelectedPatternNumber( patternposition );
-	pSong->setIsModified( true );
-	createBackground();
-	HydrogenApp::get_instance()->getSongEditorPanel()->updateAll();
-	EventQueue::get_instance()->push_event( EVENT_SELECTED_PATTERN_CHANGED, -1 );
 }
 
 void SongEditorPatternList::patternPopup_fill()

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -88,10 +88,6 @@ class SongEditor :  public QWidget,  public H2Core::Object<SongEditor>, public S
 		int getCursorRow() const;
 		int getCursorColumn() const;
 
-		//! Add or delete pattern in the sequence grid.
-		void addPattern( int nColumn, int nRow);
-		void deletePattern( int nColumn, int nRow );
-
 		//! Modify many pattern cells at once, for use in a single efficient undo/redo action
 		void modifyPatternCellsAction( std::vector<QPoint> & addCells, std::vector<QPoint> & deleteCells,
 									   std::vector<QPoint> & selectCells );
@@ -196,8 +192,8 @@ class SongEditor :  public QWidget,  public H2Core::Object<SongEditor>, public S
 		virtual void leaveEvent( QEvent *ev ) override;
 		//! @}
 
-		bool togglePatternActive( int nColumn, int nRow );
-		void setPatternActive( int nColumn, int nRow, bool value );
+    	void togglePatternActive( int nColumn, int nRow );
+		void setPatternActive( int nColumn, int nRow, bool bActivate );
 
 		void drawSequence();
   
@@ -261,9 +257,7 @@ class SongEditorPatternList :  public QWidget, protected WidgetWithScalableFont<
 		void restoreDeletedPatternsFromList( QString patternFilename, QString sequenceFileName, int patternPosition );
 		void acceptPatternPropertiesDialogSettings( QString newPatternName, QString newPatternInfo, QString newPatternCategory, int patternNr );
 		void revertPatternPropertiesDialogSettings(QString oldPatternName, QString oldPatternInfo, QString oldPatternCategory, int patternNr);
-		void loadPatternAction( QString filename, int position);
 		void fillRangeWithPattern(FillRange* r, int nPattern);
-		void patternPopup_duplicateAction( QString patternFilename, int patternposition );
 		int getGridHeight() { return m_nGridHeight; }
 
 	public slots:

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -513,36 +513,6 @@ void SongEditorPanel::newPatBtnClicked()
 	delete pDialog;
 }
 
-
-void SongEditorPanel::insertPattern( int idx, Pattern* pPattern )
-{
-	Hydrogen	*pHydrogen = Hydrogen::get_instance();
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-
-	pPatternList->insert( idx, pPattern );
-	pHydrogen->setSelectedPatternNumber( idx );
-	pSong->setIsModified( true );
-	updateAll();
-}
-
-void SongEditorPanel::deletePattern( int idx )
-{
-	Hydrogen	*pHydrogen = Hydrogen::get_instance();
-	std::shared_ptr<Song> pSong = 	pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-	H2Core::Pattern *pPattern = pPatternList->get( idx );
-	
-	if( idx == 	pHydrogen->getSelectedPatternNumber() ) {
-		pHydrogen->setSelectedPatternNumber( idx -1 );
-	}
-	
-	pPatternList->del( pPattern );
-	delete pPattern;
-	pSong->setIsModified( true );
-	updateAll();
-}
-
 ///
 /// Move up a pattern in the patternList
 ///
@@ -949,4 +919,8 @@ void SongEditorPanel::timelineActivationEvent( int nEvent ){
 	}
 	
 	m_pPositionRuler->createBackground();
+}
+
+void SongEditorPanel::updateSongEditorEvent( int ) {
+	updateAll();
 }

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -69,12 +69,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		// Implements EventListener interface
 		virtual void selectedPatternChangedEvent() override;
 		void restoreGroupVector( QString filename );
-		//~ Implements EventListener interface	
-		///< an empty new pattern will be added to pattern list at idx
-		void insertPattern( int idx, H2Core::Pattern* pPattern );
-		///< pattern at idx within pattern list will be destroyed
-		void deletePattern( int idx );
-
+		//~ Implements EventListener interface
 		/** Disables and deactivates the Timeline when an external
 		 * JACK timebase master is detected and enables it when it's
 		 * gone or Hydrogen itself becomes the timebase master.
@@ -87,6 +82,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		 * \param nValue 0 - select mode and 1 - draw mode.
 		 */
 		void actionModeChangeEvent( int nValue ) override;
+		void updateSongEditorEvent( int nValue ) override;
 
 	public slots:
 		void setModeActionBtn( bool mode );

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -812,26 +812,12 @@ void SoundLibraryPanel::on_songLoadAction()
 
 
 
-void SoundLibraryPanel::on_patternLoadAction()
-{
-	LocalFileMng mng;
+void SoundLibraryPanel::on_patternLoadAction() {
 
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	PatternList *pPatternList = pSong->getPatternList();
-	QString patternName = __sound_library_tree->currentItem()->text( 0 );
-	QString drumkitName = __sound_library_tree->currentItem()->toolTip ( 0 );
-	
-	// FIXME : file path should come from the selected item
-	Pattern* pErr = Pattern::load_file( Filesystem::pattern_path( drumkitName, patternName ), pSong->getInstrumentList() );
-
-	if ( pErr == nullptr ) {
-		ERRORLOG( "Error loading the pattern" );
-		return;
-	}
-	pPatternList->add ( pErr );
-	pSong->setIsModified( true );
-	HydrogenApp::get_instance()->getSongEditorPanel()->updateAll();
+	QString sPatternName = __sound_library_tree->currentItem()->text( 0 );
+	QString sDrumkitName = __sound_library_tree->currentItem()->toolTip ( 0 );
+	Hydrogen::get_instance()->getCoreActionController()->openPattern( Filesystem::pattern_path( sDrumkitName,
+																								sPatternName ) );
 }
 
 


### PR DESCRIPTION
- logic for creating a new/loading an existing/removing a pattern has been moves to H2Core
- logic for toggling a grid cell in the song editor has been moved to H2Core
- all the above actions have been exposed via the OSC API

New OSC API commands are
- `oscsend localhost 9000 /Hydrogen/NEW_PATTERN s "patternName"`
- `oscsend localhost 9000 /Hydrogen/OPEN_PATTERN s "/absolute/path/to/pattern.h2pattern"`
- `oscsend localhost 9000 /Hydrogen/REMOVE_PATTERN f 0`
- `oscsend localhost 9000 /Hydrogen/SONG_EDITOR_TOGGLE_GRID_CELL ff 2 3`


implements #1395 