### PR TITLE
CLI audio driver selection + tweaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 		- Remembering paths in all export/import/save/open dialogs.
 		- Introducing keyboard shortcut for the Open Pattern dialog.
 		- Allow for opening more than one Pattern at once.
+		- All available audio drivers can now be chosen via CLI.
 	* Interface
 		- Improved scalability (most PNG images were replaced by SVGs,
 		  hardcoded PNG labels are now directly drawn by Qt, and spin boxes,

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -204,6 +204,13 @@ Synth* AudioEngine::getSynth() const
 
 void AudioEngine::lock( const char* file, unsigned int line, const char* function )
 {
+	#ifdef H2CORE_HAVE_DEBUG
+	if ( __logger->should_log( Logger::Locks ) ) {
+		__logger->log( Logger::Locks, _class_name(), __FUNCTION__,
+					   QString( "by %1 : %2 : %3" ).arg( function ).arg( line ).arg( file ) );
+	}
+	#endif
+
 	m_EngineMutex.lock();
 	__locker.file = file;
 	__locker.line = line;
@@ -213,6 +220,12 @@ void AudioEngine::lock( const char* file, unsigned int line, const char* functio
 
 bool AudioEngine::tryLock( const char* file, unsigned int line, const char* function )
 {
+	#ifdef H2CORE_HAVE_DEBUG
+	if ( __logger->should_log( Logger::Locks ) ) {
+		__logger->log( Logger::Locks, _class_name(), __FUNCTION__,
+					   QString( "by %1 : %2 : %3" ).arg( function ).arg( line ).arg( file ) );
+	}
+	#endif
 	bool res = m_EngineMutex.try_lock();
 	if ( !res ) {
 		// Lock not obtained
@@ -222,11 +235,22 @@ bool AudioEngine::tryLock( const char* file, unsigned int line, const char* func
 	__locker.line = line;
 	__locker.function = function;
 	m_LockingThread = std::this_thread::get_id();
+	#ifdef H2CORE_HAVE_DEBUG
+	if ( __logger->should_log( Logger::Locks ) ) {
+		__logger->log( Logger::Locks, _class_name(), __FUNCTION__, QString( "locked" ) );
+	}
+	#endif
 	return true;
 }
 
 bool AudioEngine::tryLockFor( std::chrono::microseconds duration, const char* file, unsigned int line, const char* function )
 {
+	#ifdef H2CORE_HAVE_DEBUG
+	if ( __logger->should_log( Logger::Locks ) ) {
+		__logger->log( Logger::Locks, _class_name(), __FUNCTION__,
+					   QString( "by %1 : %2 : %3" ).arg( function ).arg( line ).arg( file ) );
+	}
+	#endif
 	bool res = m_EngineMutex.try_lock_for( duration );
 	if ( !res ) {
 		// Lock not obtained
@@ -239,6 +263,12 @@ bool AudioEngine::tryLockFor( std::chrono::microseconds duration, const char* fi
 	__locker.line = line;
 	__locker.function = function;
 	m_LockingThread = std::this_thread::get_id();
+	
+	#ifdef H2CORE_HAVE_DEBUG
+	if ( __logger->should_log( Logger::Locks ) ) {
+		__logger->log( Logger::Locks, _class_name(), __FUNCTION__, QString( "locked" ) );
+	}
+	#endif
 	return true;
 }
 
@@ -247,6 +277,11 @@ void AudioEngine::unlock()
 	// Leave "__locker" dirty.
 	m_LockingThread = std::thread::id();
 	m_EngineMutex.unlock();
+	#ifdef H2CORE_HAVE_DEBUG
+	if ( __logger->should_log( Logger::Locks ) ) {
+		__logger->log( Logger::Locks, _class_name(), __FUNCTION__, QString( "" ) );
+	}
+	#endif
 }
 
 void AudioEngine::startPlayback()

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -633,19 +633,11 @@ private:
 	 */
 	std::thread::id 	m_LockingThread;
 
-	/**
-	 * This struct is most probably intended to be used for
-	 * logging the locking of the AudioEngine. But neither it nor
-	 * the Logger::AELockTracing state is ever used.
-	 */
 	struct _locker_struct {
 		const char* file;
 		unsigned int line;
 		const char* function;
-	} __locker; ///< This struct is most probably intended to be
-		    ///< used for logging the locking of the
-		    ///< AudioEngine. But neither it nor the
-		    ///< Logger::AELockTracing state is ever used.
+	} __locker;
 	
 	/** Time in seconds since the beginning of the Song.
 	 *

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -709,13 +709,10 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2m_bPlaybackTrackEnabled: %3\n" ).arg( sPrefix ).arg( s ).arg( m_bPlaybackTrackEnabled ) )
 			.append( QString( "%1%2m_fPlaybackTrackVolume: %3\n" ).arg( sPrefix ).arg( s ).arg( m_fPlaybackTrackVolume ) )
 			.append( QString( "%1" ).arg( m_pVelocityAutomationPath->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( "%1%2m_sLicense: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sLicense ) );
-		if ( m_actionMode == ActionMode::selectMode ) {
-			sOutput.append( QString( "%1%2m_actionMode: 0\n" ).arg( sPrefix ).arg( s ) );
-		} else if ( m_actionMode == ActionMode::drawMode ) {
-			sOutput.append( QString( "%1%2m_actionMode: 1\n" ).arg( sPrefix ).arg( s ) );
-		}
-		sOutput.append( QString( "%1%2m_nPanLawType: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nPanLawType ) )
+			.append( QString( "%1%2m_sLicense: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sLicense ) )
+			.append( QString( "%1%2m_actionMode: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( static_cast<int>(m_actionMode) ) )
+			.append( QString( "%1%2m_nPanLawType: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nPanLawType ) )
 			.append( QString( "%1%2m_fPanLawKNorm: %3\n" ).arg( sPrefix ).arg( s ).arg( m_fPanLawKNorm ) );
 	} else {
 		
@@ -757,13 +754,9 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", m_bPlaybackTrackEnabled: %1" ).arg( m_bPlaybackTrackEnabled ) )
 			.append( QString( ", m_fPlaybackTrackVolume: %1" ).arg( m_fPlaybackTrackVolume ) )
 			.append( QString( ", m_pVelocityAutomationPath: %1" ).arg( m_pVelocityAutomationPath->toQString( sPrefix ) ) )
-			.append( QString( ", m_sLicense: %1" ).arg( m_sLicense ) );
-		if ( m_actionMode == ActionMode::selectMode ) {
-			sOutput.append( QString( ", m_actionMode: 0" ) );
-		} else if ( m_actionMode == ActionMode::drawMode ) {
-			sOutput.append( QString( ", m_actionMode: 1" ) );
-		}
-		sOutput.append( QString( ", m_nPanLawType: %1" ).arg( m_nPanLawType ) )
+			.append( QString( ", m_sLicense: %1" ).arg( m_sLicense ) )
+			.append( QString( ", m_actionMode: %1" ).arg( static_cast<int>(m_actionMode) ) )
+			.append( QString( ", m_nPanLawType: %1" ).arg( m_nPanLawType ) )
 			.append( QString( ", m_fPanLawKNorm: %1" ).arg( m_fPanLawKNorm ) );
 	}
 	
@@ -821,18 +814,8 @@ std::shared_ptr<Song> SongReader::readSong( const QString& sFileName )
 	bool bPlaybackTrackEnabled = LocalFileMng::readXmlBool( songNode, "playbackTrackEnabled", false );
 	float fPlaybackTrackVolume = LocalFileMng::readXmlFloat( songNode, "playbackTrackVolume", 0.0 );
 
-	Song::ActionMode actionMode;
- 	int nActionMode = LocalFileMng::readXmlInt( songNode, "action_mode", 0 );
-	if ( nActionMode == 0 ){
-		actionMode = Song::ActionMode::selectMode;
-	} else if ( nActionMode == 1 ) {
-		actionMode = Song::ActionMode::drawMode;
-	} else {
-		WARNINGLOG( QString( "Unknown action_mode value [%1]. Using Song::ActionMode::selectMode instead." )
-					.arg( nActionMode ) );
-		actionMode = Song::ActionMode::selectMode;
-	}
-
+	Song::ActionMode actionMode = static_cast<Song::ActionMode>( LocalFileMng::readXmlInt( songNode, "action_mode",
+																						   static_cast<int>( Song::ActionMode::selectMode ) ) );
 	float fHumanizeTimeValue = LocalFileMng::readXmlFloat( songNode, "humanize_time", 0.0 );
 	float fHumanizeVelocityValue = LocalFileMng::readXmlFloat( songNode, "humanize_velocity", 0.0 );
 	float fSwingFactor = LocalFileMng::readXmlFloat( songNode, "swing_factor", 0.0 );

--- a/src/core/IO/CoreMidiDriver.cpp
+++ b/src/core/IO/CoreMidiDriver.cpp
@@ -102,7 +102,7 @@ CoreMidiDriver::CoreMidiDriver()
 		: MidiInput() ,MidiOutput(), Object<CoreMidiDriver>()
 		, m_bRunning( false )
 {
-	INFOLOG( "INIT" );
+	
 	OSStatus err = noErr;
 
 	QString sMidiPortName = Preferences::get_instance()->m_sMidiPortName;

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -41,7 +41,7 @@ MidiInput::MidiInput()
 		, __noteOffTick( 0 )
 		, __noteOnTick( 0 )
 {
-	//INFOLOG( "INIT" );
+	//
 
 }
 

--- a/src/core/IO/MidiOutput.cpp
+++ b/src/core/IO/MidiOutput.cpp
@@ -27,7 +27,7 @@ namespace H2Core
 
 MidiOutput::MidiOutput()
 {
-	//INFOLOG( "INIT" );
+	//
 }
 
 

--- a/src/core/IO/NullDriver.cpp
+++ b/src/core/IO/NullDriver.cpp
@@ -31,7 +31,7 @@ NullDriver::NullDriver( audioProcessCallback processCallback )
 		: AudioOutput()
 {
 	UNUSED( processCallback );
-//	INFOLOG( "INIT" );
+//	
 }
 
 

--- a/src/core/IO/PulseAudioDriver.cpp
+++ b/src/core/IO/PulseAudioDriver.cpp
@@ -70,10 +70,12 @@ int PulseAudioDriver::init( unsigned nBufferSize )
 int PulseAudioDriver::connect()
 {
 	if (m_connected) {
+		ERRORLOG( "already connected" );
 		return 1;
 	}
 
 	if (pipe(m_pipe)) {
+		ERRORLOG( "unable to open pipe." );
 		return 1;
 	}
 
@@ -84,6 +86,7 @@ int PulseAudioDriver::connect()
 	{
 		close(m_pipe[0]);
 		close(m_pipe[1]);
+		ERRORLOG( "unable to start thread." );
 		return 1;
 	}
 
@@ -98,6 +101,7 @@ int PulseAudioDriver::connect()
 		pthread_join(m_thread, nullptr);
 		close(m_pipe[0]);
 		close(m_pipe[1]);
+		ERRORLOG( QString( "unable to run driver. Main loop returned %1" ).arg( m_ready ) );
 		return 1;
 	}
 

--- a/src/core/IO/PulseAudioDriver.h
+++ b/src/core/IO/PulseAudioDriver.h
@@ -58,6 +58,8 @@ private:
 	pthread_t				m_thread;
 	pthread_mutex_t			m_mutex;
 	pthread_cond_t			m_cond;
+	/** File descriptors used to write data to (m_pipe[1]) and read
+		data from (m_pipe[0]) the pipe.*/
 	int						m_pipe[2];
 	audioProcessCallback	m_callback;
 	pa_mainloop*			m_main_loop;

--- a/src/core/LocalFileMgr.cpp
+++ b/src/core/LocalFileMgr.cpp
@@ -412,15 +412,8 @@ int SongWriter::writeSong( std::shared_ptr<Song> pSong, const QString& filename 
 	LocalFileMng::writeXmlString( songNode, "playbackTrackFilename", QString("%1").arg( pSong->getPlaybackTrackFilename() ) );
 	LocalFileMng::writeXmlBool( songNode, "playbackTrackEnabled", pSong->getPlaybackTrackEnabled() );
 	LocalFileMng::writeXmlString( songNode, "playbackTrackVolume", QString("%1").arg( pSong->getPlaybackTrackVolume() ) );
-
-	int nActionMode = 0;
-	if ( pSong->getActionMode() == Song::ActionMode::selectMode ) {
-		nActionMode = 0;
-	} else if ( pSong->getActionMode() == Song::ActionMode::drawMode ) {
-		nActionMode = 1;
-	}
 	LocalFileMng::writeXmlString( songNode, "action_mode",
-								  QString::number( nActionMode ) );
+								  QString::number( static_cast<int>( pSong->getActionMode() ) ) );
 	
 	if ( pSong->getMode() == Song::SONG_MODE ) {
 		LocalFileMng::writeXmlString( songNode, "mode", QString( "song" ) );

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -35,7 +35,7 @@ namespace H2Core {
 
 unsigned Logger::__bit_msk = 0;
 Logger* Logger::__instance=nullptr;
-const char* Logger::__levels[] = { "None", "Error", "Warning", "Info", "Debug", "Constructors" };
+const char* Logger::__levels[] = { "None", "Error", "Warning", "Info", "Debug", "Constructors", "Locks" };
 
 pthread_t loggerThread;
 
@@ -127,11 +127,11 @@ void Logger::log( unsigned level, const QString& class_name, const char* func_na
 		return;
 	}
 
-	const char* prefix[] = { "", "(E) ", "(W) ", "(I) ", "(D) ", "(C) " };
+	const char* prefix[] = { "", "(E) ", "(W) ", "(I) ", "(D) ", "(C)", "(L) " };
 #ifdef WIN32
-	const char* color[] = { "", "", "", "", "", "" };
+	const char* color[] = { "", "", "", "", "", "", "" };
 #else
-	const char* color[] = { "", "\033[31m", "\033[36m", "\033[32m", "\033[35m", "\033[35m" };
+	const char* color[] = { "", "\033[31m", "\033[36m", "\033[32m", "\033[35m", "\033[35;1m", "\033[35;1m" };
 #endif // WIN32
 
 	int i;
@@ -150,6 +150,10 @@ void Logger::log( unsigned level, const QString& class_name, const char* func_na
 		break;
 	case Constructors:
 		i = 5;
+		break;
+	case Locks:
+		i = 6;
+		break;
 	default:
 		i = 0;
 		break;
@@ -182,6 +186,8 @@ unsigned Logger::parse_log_level( const char* level ) {
 		log_level = Logger::Error | Logger::Warning | Logger::Info | Logger::Debug;
 	} else if ( 0 == strncasecmp( level, __levels[5], strlen( __levels[5] ) ) ) {
 		log_level = Logger::Error | Logger::Warning | Logger::Info | Logger::Debug | Logger::Constructors;
+	} else if ( 0 == strncasecmp( level, __levels[6], strlen( __levels[6] ) ) ) {
+		log_level = Logger::Error | Logger::Warning | Logger::Info | Logger::Debug | Logger::Locks;
 	} else {
 #ifdef HAVE_SSCANF
 		int val = sscanf( level,"%x",&log_level );

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -49,10 +49,7 @@ class Logger {
 			Info            = 0x04,
 			Debug           = 0x08,
 			Constructors    = 0x10,
-			/** Intended to be used log the locking of the
-			    AudioEngine. But this feature isn't
-			    implemented yet. */
-			AELockTracing   = 0x20
+			Locks   = 0x20
 		};
 
 		/** message queue type */

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -72,7 +72,7 @@ Sampler::Sampler()
 		, m_pPreviewInstrument( nullptr )
 		, m_interpolateMode( Interpolation::InterpolateMode::Linear )
 {
-	INFOLOG( "INIT" );
+	
 	
 	m_pMainOut_L = new float[ MAX_BUFFER_SIZE ];
 	m_pMainOut_R = new float[ MAX_BUFFER_SIZE ];

--- a/src/core/Smf/Smf.cpp
+++ b/src/core/Smf/Smf.cpp
@@ -37,7 +37,7 @@ SMFHeader::SMFHeader( int nFormat, int nTracks, int nTPQN )
 		, m_nTracks( nTracks )
 		, m_nTPQN( nTPQN )
 {
-	INFOLOG( "INIT" );
+	
 }
 
 
@@ -70,7 +70,7 @@ std::vector<char> SMFHeader::getBuffer()
 SMFTrack::SMFTrack()
 		: Object()
 {
-	INFOLOG( "INIT" );
+	
 }
 
 
@@ -138,7 +138,7 @@ void SMFTrack::addEvent( SMFEvent *pEvent )
 
 SMF::SMF(int nFormat, int nTPQN )
 {
-	INFOLOG( "INIT" );
+	
 
 	m_pHeader = new SMFHeader( nFormat, 0, nTPQN );
 }
@@ -199,7 +199,7 @@ constexpr unsigned int NOTE_LENGTH = 12;
 
 SMFWriter::SMFWriter()
 {
-	INFOLOG( "INIT" );
+	
 }
 
 

--- a/src/core/Synth/Synth.cpp
+++ b/src/core/Synth/Synth.cpp
@@ -34,7 +34,7 @@ namespace H2Core
 Synth::Synth()
 		: Object()
 {
-	INFOLOG( "INIT" );
+	
 
 	m_pOut_L = new float[ MAX_BUFFER_SIZE ];
 	m_pOut_R = new float[ MAX_BUFFER_SIZE ];

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
@@ -44,7 +44,7 @@ AudioFileBrowser::AudioFileBrowser ( QWidget* pParent, bool bAllowMultiSelect, b
 		, Object ()
 {
 	setupUi ( this );
-	INFOLOG ( "INIT" );
+	
 	setWindowTitle ( tr ( "Audio File Browser" ) );
 	adjustSize();
 	setFixedSize ( width(), height() );

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
@@ -34,7 +34,7 @@ SampleWaveDisplay::SampleWaveDisplay(QWidget* pParent)
 {
 //	setAttribute(Qt::WA_OpaquePaintEvent);
 
-	//INFOLOG( "INIT" );
+	//
 	int w = 445;
 	int h = 85;
 	resize( w, h );

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -71,7 +71,7 @@ Director::Director ( QWidget* pParent )
 
 	HydrogenApp::get_instance()->addEventListener( this );
 	setupUi ( this );
-	//INFOLOG ( "INIT" );
+	//
 	setWindowTitle ( tr ( "Director" ) );
 
 	m_nCounter = 1;	// to compute the right beat

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -47,7 +47,7 @@ InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent )
 {
 	UNUSED( pParent );
 
-	INFOLOG( "INIT" );
+	
 
 	m_pInstance = this;
 	m_pInstrumentEditor = new InstrumentEditor( nullptr );

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -50,7 +50,7 @@ LayerPreview::LayerPreview( QWidget* pParent )
 {
 	setAttribute(Qt::WA_OpaquePaintEvent);
 
-	//INFOLOG( "INIT" );
+	//
 
 	setMouseTracking( true );
 

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -34,7 +34,7 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
  : QWidget( pParent )
  , Object()
 {
-	INFOLOG( "INIT" );
+	
 
 	auto pPref = H2Core::Preferences::get_instance();
 	

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -44,7 +44,7 @@ LadspaFXProperties::LadspaFXProperties(QWidget* parent, uint nLadspaFX)
  : QWidget( parent )
  , Object()
 {
-//	INFOLOG( "INIT" );
+//	
 
 	m_nLadspaFX = nLadspaFX;
 

--- a/src/gui/src/LadspaFXSelector.cpp
+++ b/src/gui/src/LadspaFXSelector.cpp
@@ -35,7 +35,7 @@ LadspaFXSelector::LadspaFXSelector(int nLadspaFX)
  : QDialog( nullptr )
  , m_pCurrentItem( nullptr )
 {
-	//INFOLOG( "INIT" );
+	//
 
 	setupUi( this );
 

--- a/src/gui/src/Mixer/Mixer.h
+++ b/src/gui/src/Mixer/Mixer.h
@@ -74,7 +74,7 @@ class Mixer :  public QWidget, public EventListener,  public H2Core::Object<Mixe
 		void showFXPanelClicked();
 		void showPeaksBtnClicked();
 		void openMixerSettingsDialog();
-		void ladspaActiveBtnClicked( LadspaFXMixerLine* ref );
+		void ladspaBypassBtnClicked( LadspaFXMixerLine* ref );
 		void ladspaEditBtnClicked( LadspaFXMixerLine *ref );
 		void ladspaVolumeChanged( LadspaFXMixerLine* ref);
 		void closeEvent(QCloseEvent *event) override;

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -55,7 +55,7 @@ using namespace H2Core;
 MixerLine::MixerLine(QWidget* parent, int nInstr)
  : PixmapWidget( parent )
 {
-//	INFOLOG( "INIT" );
+//	
 
 	m_nWidth = MIXERLINE_WIDTH;
 	m_nHeight = MIXERLINE_HEIGHT;
@@ -385,7 +385,7 @@ void MixerLine::setSelected( bool bIsSelected )
 ComponentMixerLine::ComponentMixerLine(QWidget* parent, int CompoID)
  : PixmapWidget( parent )
 {
-//	INFOLOG( "INIT" );
+//	
 
 	m_nComponentID = CompoID;
 

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -884,9 +884,10 @@ LadspaFXMixerLine::LadspaFXMixerLine(QWidget* parent)
 	setPixmap( "/mixerPanel/fxline_background.png" );
 
 	// active button
-	m_pActiveBtn = new Button( this, QSize( 34, 14 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getBypassButton(), true, QSize(), tr( "FX bypass") );
-	m_pActiveBtn->move( 52, 25 );
-	connect( m_pActiveBtn, SIGNAL( pressed() ), this, SLOT( activeBtnClicked() ) );
+	m_pBypassBtn = new Button( this, QSize( 34, 14 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getBypassButton(), true, QSize(), tr( "FX bypass") );
+	m_pBypassBtn->move( 52, 25 );
+	connect( m_pBypassBtn, SIGNAL( pressed() ), this, SLOT( bypassBtnClicked() ) );
+	
 
 	// edit button
 	m_pEditBtn = new Button( this, QSize( 34, 14 ), Button::Type::Push, "", HydrogenApp::get_instance()->getCommonStrings()->getEditButton(), false, QSize(), tr( "Edit FX parameters") );
@@ -923,24 +924,25 @@ void LadspaFXMixerLine::setName(QString name)
 }
 
 
-void LadspaFXMixerLine::activeBtnClicked() {
-	emit activeBtnClicked( this );
+void LadspaFXMixerLine::bypassBtnClicked() {
+	emit bypassBtnClicked( this );
 }
 void LadspaFXMixerLine::editBtnClicked() {
 	emit editBtnClicked( this );
 }
 
-bool LadspaFXMixerLine::isFxActive()
+bool LadspaFXMixerLine::isFxBypassed()
 {
-	return ( ( m_pActiveBtn->isChecked() && ! m_pActiveBtn->isDown() ) || ( ! m_pActiveBtn->isChecked() && m_pActiveBtn->isDown() ) );
+	return ( ( m_pBypassBtn->isChecked() && ! m_pBypassBtn->isDown() ) ||
+			 ( ! m_pBypassBtn->isChecked() && m_pBypassBtn->isDown() ) );
 }
 
-void LadspaFXMixerLine::setFxActive( bool active )
+void LadspaFXMixerLine::setFxBypassed( bool bBypassed )
 {
-	if ( ! m_pActiveBtn->isDown() ) {
-		m_pActiveBtn->setChecked( active );
+	if ( ! m_pBypassBtn->isDown() ) {
+		m_pBypassBtn->setChecked( bBypassed );
 	}
-	m_pRotary->setIsActive( active );
+	m_pRotary->setIsActive( ! bBypassed );
 }
 
 void LadspaFXMixerLine::rotaryChanged( WidgetWithInput *ref)

--- a/src/gui/src/Mixer/MixerLine.h
+++ b/src/gui/src/Mixer/MixerLine.h
@@ -294,8 +294,8 @@ public:
 	explicit LadspaFXMixerLine(QWidget* parent);
 	~LadspaFXMixerLine();
 
-	bool	isFxActive();
-	void	setFxActive( bool active );
+	bool	isFxBypassed();
+	void	setFxBypassed( bool active );
 		
 	void	setPeaks( float fPeak_L, float fPeak_R );
 	void	getPeaks( float *fPeak_L, float *fPeak_R );
@@ -305,18 +305,18 @@ public:
 	void	setVolume( float value );
 
 public slots:
-	void activeBtnClicked();
+	void bypassBtnClicked();
 	void editBtnClicked();
 	void rotaryChanged( WidgetWithInput* ref);
 
 signals:
-	void activeBtnClicked( LadspaFXMixerLine *ref );
+	void bypassBtnClicked( LadspaFXMixerLine *ref );
 	void editBtnClicked( LadspaFXMixerLine *ref );
 	void volumeChanged( LadspaFXMixerLine *ref);
 
 private:
 	float			m_fMaxPeak;
-	Button *	m_pActiveBtn;
+	Button *	m_pBypassBtn;
 	Button *		m_pEditBtn;
 	Rotary *		m_pRotary;
 	LCDDisplay *	m_pNameLCD;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -44,7 +44,7 @@ PianoRollEditor::PianoRollEditor( QWidget *pParent, PatternEditorPanel *panel,
 	: PatternEditor( pParent, panel )
 	, m_pScrollView( pScrollView )
 {
-	INFOLOG( "INIT" );
+	
 		
 	m_nGridHeight = 10;
 	m_nOctaves = 7;

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -60,7 +60,7 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 {
 
 	setupUi ( this );
-	INFOLOG ( "INIT" );
+	
 
 	auto pPref = H2Core::Preferences::get_instance();
 	

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.cpp
@@ -36,7 +36,7 @@ DetailWaveDisplay::DetailWaveDisplay(QWidget* pParent )
 {
 //	setAttribute(Qt::WA_OpaquePaintEvent);
 
-	//INFOLOG( "INIT" );
+	//
 	int w = 180;
 	int h = 265;
 	resize( w, h );

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
@@ -35,7 +35,7 @@ MainSampleWaveDisplay::MainSampleWaveDisplay(QWidget* pParent)
  {
 //	setAttribute(Qt::WA_OpaquePaintEvent);
 
-	//INFOLOG( "INIT" );
+	//
 	int w = 624;
 	int h = 265;
 	resize( w, h );

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -54,7 +54,7 @@ SampleEditor::SampleEditor ( QWidget* pParent, int nSelectedComponent, int nSele
 		, Object ()
 {
 	setupUi ( this );
-	INFOLOG ( "INIT" );
+	
 
 	m_pTimer = new QTimer(this);
 	connect(m_pTimer, SIGNAL(timeout()), this, SLOT(updateMainsamplePositionRuler()));

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -48,7 +48,7 @@ TargetWaveDisplay::TargetWaveDisplay(QWidget* pParent)
 {
 //	setAttribute(Qt::WA_OpaquePaintEvent);
 
-	//INFOLOG( "INIT" );
+	//
 	int w = UI_WIDTH;
 	int h = UI_HEIGHT;
 	resize( w, h );

--- a/src/gui/src/SongEditor/PlaybackTrackWaveDisplay.cpp
+++ b/src/gui/src/SongEditor/PlaybackTrackWaveDisplay.cpp
@@ -41,7 +41,7 @@ using namespace H2Core;
 PlaybackTrackWaveDisplay::PlaybackTrackWaveDisplay(QWidget* pParent)
  : WaveDisplay( pParent )
 {
-	INFOLOG( "INIT" );
+	
 	
 	setAcceptDrops(true);
 }

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -317,8 +317,6 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	defaultPalette.setColor( QPalette::Window, QColor( 58, 62, 72 ) );
 	this->setPalette( defaultPalette );
 
-	Hydrogen::get_instance()->getSong()->setActionMode( H2Core::Song::ActionMode::selectMode );
-
 	show();
 
 	updateAll();

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -39,7 +39,7 @@ SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int beat )
 	, m_stimelineposition ( beat )
 {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "BPM" ) );
 
 	lineEditBeat->setText(QString("%1").arg( m_stimelineposition + 1) );

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -40,7 +40,7 @@ SongEditorPanelTagWidget::SongEditorPanelTagWidget( QWidget* pParent, int beat )
 	, m_stimelineposition ( beat )
 {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "Tag" ) );
 	createTheTagTableWidget();
 

--- a/src/gui/src/SoundLibrary/SoundLibraryDatastructures.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryDatastructures.cpp
@@ -47,7 +47,7 @@ SoundLibraryDatabase* SoundLibraryDatabase::__instance = nullptr;
 
 SoundLibraryDatabase::SoundLibraryDatabase()
 {
-	INFOLOG( "INIT" );
+	
 	patternVector = new soundLibraryInfoVector();
 	updatePatterns();
 }

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -55,7 +55,7 @@ SoundLibraryExportDialog::SoundLibraryExportDialog( QWidget* pParent,  const QSt
 	, m_preselectedKitLookup( lookup )
 {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "Export Sound Library" ) );
 	m_sSysDrumkitSuffix = " (system)";
 	updateDrumkitList();

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
@@ -50,7 +50,7 @@ SoundLibraryImportDialog::SoundLibraryImportDialog( QWidget* pParent, bool bOnli
  : QDialog( pParent )
 {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "Sound Library import" ) );
 
 	QStringList headers;

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
@@ -31,7 +31,7 @@ using namespace H2Core;
 SoundLibraryOpenDialog::SoundLibraryOpenDialog( QWidget* pParent )
 	: QDialog( pParent )
 {
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "Open Sound Library" ) );
 	setFixedSize( 280, 380 );
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -76,7 +76,7 @@ SoundLibraryPanel::SoundLibraryPanel( QWidget *pParent, bool bInItsOwnDialog )
  , m_bInItsOwnDialog( bInItsOwnDialog )
 {
 	
-	//INFOLOG( "INIT" );
+	//
 	__drumkit_menu = new QMenu( this );
 	__drumkit_menu->addAction( tr( "Load" ), this, SLOT( on_drumkitLoadAction() ) );
 	__drumkit_menu->addAction( tr( "Export" ), this, SLOT( on_drumkitExportAction() ) );

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
@@ -39,7 +39,7 @@ SoundLibraryPropertiesDialog::SoundLibraryPropertiesDialog( QWidget* pParent, Dr
  , m_pPreDrumkitInfo( pPreDrumkit )
 {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "SoundLibrary Properties" ) );
 	adjustSize();
 	setMinimumSize( width(), height() );

--- a/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.cpp
@@ -32,7 +32,7 @@ SoundLibraryRepositoryDialog::SoundLibraryRepositoryDialog( QWidget* pParent )
  : QDialog( pParent )
  {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "Edit repository settings" ) );
 	adjustSize();
 	setMinimumSize( width(), height() );

--- a/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibrarySaveDialog.cpp
@@ -31,7 +31,7 @@ SoundLibrarySaveDialog::SoundLibrarySaveDialog( QWidget* pParent )
  : QDialog( pParent )
 {
 	setupUi( this );
-	INFOLOG( "INIT" );
+	
 	setWindowTitle( tr( "Save Sound Library" ) );
 	adjustSize();
 	setFixedSize( width(), height() );

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -322,7 +322,7 @@ void WidgetWithInput::setMin( float fMin )
 	if ( fMin == m_fMin ) {
 		return;
 	}
-	if ( m_bUseIntSteps && std::fmod( fMin, 1.0 ) != 0.0 ) {
+	if ( m_bUseIntSteps && std::fmod( fMin, 1.0 ) != 0.0 && ! std::isinf( fMin ) ) {
 		___WARNINGLOG( QString( "As widget is set to use integer values only the supply minimal value [%1] will be rounded to [%2] " )
 					.arg( fMin )
 					.arg( std::round( fMin ) ) );
@@ -350,7 +350,7 @@ void WidgetWithInput::setMax( float fMax )
 	if ( fMax == m_fMax ) {
 		return;
 	}
-	if ( m_bUseIntSteps && std::fmod( fMax, 1.0 ) != 0.0 ) {
+	if ( m_bUseIntSteps && std::fmod( fMax, 1.0 ) != 0.0 && ! std::isinf( fMax ) ) {
 		___WARNINGLOG( QString( "As widget is set to use integer values only the supply maximal value [%1] will be rounded to [%2] " )
 					.arg( fMax )
 					.arg( std::round( fMax ) ) );
@@ -380,7 +380,7 @@ void WidgetWithInput::setDefaultValue( float fDefaultValue )
 		return;
 	}
 
-	if ( m_bUseIntSteps && std::fmod( fDefaultValue, 1.0 ) != 0.0 ) {
+	if ( m_bUseIntSteps && std::fmod( fDefaultValue, 1.0 ) != 0.0 && ! std::isinf( fDefaultValue ) ) {
 		___WARNINGLOG( QString( "As widget is set to use integer values only the supply default value [%1] will be rounded to [%2] " )
 					.arg( fDefaultValue )
 					.arg( std::round( fDefaultValue ) ) );

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -182,8 +182,32 @@ int main(int argc, char *argv[])
 		QString( "\nHydrogen comes with ABSOLUTELY NO WARRANTY\nThis is free software, and you are welcome to redistribute it under certain conditions. See the file COPYING for details.\n" );
 		
 		parser.setApplicationDescription( aboutText );
+
+		QStringList availableAudioDrivers;
+#ifdef H2CORE_HAVE_JACK
+		availableAudioDrivers << "jack";
+#endif
+#ifdef H2CORE_HAVE_ALSA
+		availableAudioDrivers << "alsa";
+#endif
+#ifdef H2CORE_HAVE_OSS
+		availableAudioDrivers << "oss";
+#endif
+#ifdef H2CORE_HAVE_PULSEAUDIO
+		availableAudioDrivers << "pulseaudio";
+#endif
+#ifdef H2CORE_HAVE_PORTAUDIO
+		availableAudioDrivers << "portaudio";
+#endif
+#ifdef H2CORE_HAVE_COREAUDIO
+		availableAudioDrivers << "coreaudio";
+#endif
+		availableAudioDrivers << "auto";
 		
-		QCommandLineOption audioDriverOption( QStringList() << "d" << "driver", "Use the selected audio driver (jack, alsa, oss)", "Audiodriver");
+		QCommandLineOption audioDriverOption( QStringList() << "d" << "driver",
+											  QString( "Use the selected audio driver (%1)" )
+											  .arg( availableAudioDrivers.join( ", " ) ),
+											  "Audiodriver");
 		QCommandLineOption installDrumkitOption( QStringList() << "i" << "install", "Install a drumkit (*.h2drumkit)" , "File");
 		QCommandLineOption noSplashScreenOption( QStringList() << "n" << "nosplash", "Hide splash screen" );
 		QCommandLineOption playlistFileNameOption( QStringList() << "p" << "playlist", "Load a playlist (*.h2playlist) at startup", "File" );
@@ -321,18 +345,26 @@ int main(int argc, char *argv[])
 			exit(0);
 		}
 		
-		if (sSelectedDriver == "auto") {
+		if ( sSelectedDriver == "auto" ) {
+			pPref->m_sAudioDriver = "Auto";
+		} else if ( sSelectedDriver == "jack" ) {
+			pPref->m_sAudioDriver = "JACK";
+		} else if ( sSelectedDriver == "oss" ) {
+			pPref->m_sAudioDriver = "OSS";
+		} else if ( sSelectedDriver == "alsa" ) {
+			pPref->m_sAudioDriver = "ALSA";
+		} else if ( sSelectedDriver == "pulseaudio" ) {
+			pPref->m_sAudioDriver = "PulseAudio";
+		} else if ( sSelectedDriver == "coreaudio" ) {
+			pPref->m_sAudioDriver = "CoreAudio";
+		} else if ( sSelectedDriver == "portaudio" ) {
+			pPref->m_sAudioDriver = "PortAudio";
+		} else if ( ! sSelectedDriver.isEmpty() ) {
+			___WARNINGLOG( QString( "Unknown driver [%1]. The 'auto' driver will be used instead" )
+						.arg( sSelectedDriver ) );
 			pPref->m_sAudioDriver = "Auto";
 		}
-		else if (sSelectedDriver == "jack") {
-			pPref->m_sAudioDriver = "JACK";
-		}
-		else if ( sSelectedDriver == "oss" ) {
-			pPref->m_sAudioDriver = "OSS";
-		}
-		else if ( sSelectedDriver == "alsa" ) {
-			pPref->m_sAudioDriver = "ALSA";
-		}
+				
 
 		// Bootstrap is complete, start GUI
 		delete pBootStrApp;
@@ -525,6 +557,10 @@ int main(int argc, char *argv[])
 			}
 			delete pDrumkitInfo;
 		}
+
+		// Write the changes in the Preferences to disk to make them
+		// accessible in the PreferencesDialog.
+		pPref->savePreferences();
 
 		pQApp->setMainForm( pMainForm );
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
 		QCommandLineOption systemDataPathOption( QStringList() << "P" << "data", "Use an alternate system data path", "Path" );
 		QCommandLineOption songFileOption( QStringList() << "s" << "song", "Load a song (*.h2song) at startup", "File" );
 		QCommandLineOption kitOption( QStringList() << "k" << "kit", "Load a drumkit at startup", "DrumkitName" );
-		QCommandLineOption verboseOption( QStringList() << "V" << "verbose", "Level, if present, may be None, Error, Warning, Info, Debug, Constructors or 0xHHHH", "Level" );
+		QCommandLineOption verboseOption( QStringList() << "V" << "verbose", "Level, if present, may be None, Error, Warning, Info, Debug, Constructors, Locks, or 0xHHHH", "Level" );
 		QCommandLineOption shotListOption( QStringList() << "t" << "shotlist", "Shot list of widgets to grab", "ShotList" );
 		QCommandLineOption uiLayoutOption( QStringList() << "layout", "UI layout ('tabbed' or 'single')", "Layout" );
 		


### PR DESCRIPTION
- If the peak value supplied to the Fader is `Inf` (e.g. when using LADSPA plugins), a WARNING was shown in the log (well, a lot of them actually).
- show all available audio drivers in the CLI help message (and only them)
- store the changes in Preferences done by the CLI options. Otherwise opening the PreferencesDialog would overwrite them (and a different audio driver will be shown).
- introduce Locks log level: it will print out INFO, WARNING, ERROR, as well as all locking and unlocking of the AudioEngine including the function and line which issued the locking.
-  Mixer: fix Ladspa bypass button: It was out of sync. When checked, the effect was active. In addition to fixing this I renamed all isFxActive and similar functions to isFxBypassed to make handling them more straight forward.
-  SongEditor: use ActionMode from last session: instead of overwriting the stored Song::ActionMode value with selectMode, the one from the .h2song file will be used
