### PR TITLE
SongEditorPosRuler: locate to beginning of current pattern

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,8 @@
 		  widget can receive keyboard input
 		- MIDI-learnable widgets now show their corresponding MIDI action
 		  and it's binding in the tooltip
+		- It's now possible to jump to the beginning of the currently
+		  playing pattern by clicking its position on the ruler.
 	* PreferencesDialog > Appearance tab overhaul
 	  	- Drop previous font options in favor for three different
 		  levels of font (without exposing their point sizes)

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2321,12 +2321,8 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 		}
 
 		int nPatternPos = m_pHydrogen->getAudioEngine()->getColumn();
-		if ( nPatternPos != column ) {
-			WARNINGLOG( "relocate via mouse click" );
-			
-			m_pHydrogen->getCoreActionController()->locateToColumn( column );
-			update();
-		}
+		m_pHydrogen->getCoreActionController()->locateToColumn( column );
+		update();
 		
 	} else if (ev->button() == Qt::MiddleButton && ev->y() >= 26) {
 		showTagWidget( ev->x() / m_nGridWidth );


### PR DESCRIPTION
It is now possible to jump to the beginning of the current pattern by clicking its position in the position ruler. Previously one had to click on a different pattern first in order to relocate to the beginning.

Fixes #1099