### PR TITLE
Calculate latency for CoreAudio

### DIFF
--- a/src/core/IO/CoreAudioDriver.h
+++ b/src/core/IO/CoreAudioDriver.h
@@ -87,6 +87,8 @@ public:
 
 	static QStringList getDevices();
 
+	virtual int getLatency();
+
 private:
 	AudioDeviceID defaultOutputDevice(void);
 	void retrieveBufferSize(void);


### PR DESCRIPTION
Not that it gets used for anything other than display in the Audio Engine Info dialog box.

CoreAudio's interface is clunky. I really ought to wrap these accessors in something nicer.