### PR TITLE
Add linker flags for backtrace/execinfo

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -80,6 +80,12 @@ TARGET_LINK_LIBRARIES(hydrogen
 	Qt5::Svg
 )
 
+IF(Backtrace_FOUND)
+	TARGET_LINK_LIBRARIES(hydrogen
+		${Backtrace_LIBRARIES}
+	)
+ENDIF()
+
 # Precompiled headers for Qt and std::vector. These dramatically reduce GUI build times
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.16)
 	target_precompile_headers(hydrogen


### PR DESCRIPTION
This is related to #1429.
Since commit 27ab1d11bee3d6108d0eefb833a68dabab516097, the gui needs to be linked against libexecinfo too (on *BSD).