### PR TITLE
Fix crash on quitting after inserting a pattern.

### DIFF
--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -229,7 +229,7 @@ public:
 		H2Core::Hydrogen::get_instance()->getCoreActionController()->removePattern( m_nPatternPosition );
 	}
 	virtual void redo() {
-		H2Core::Hydrogen::get_instance()->getCoreActionController()->setPattern( m_pNewPattern,
+		H2Core::Hydrogen::get_instance()->getCoreActionController()->setPattern( new H2Core::Pattern( m_pNewPattern ),
 																				 m_nPatternPosition );
 	}
 private:


### PR DESCRIPTION
The redo method for inserting a pattern failed to take a new copy
of the pattern when inserting into the song, leading to double
delete of the pattern on finalisation.