### PR TITLE
Fix compiler warnings & smaller code issues

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -78,8 +78,8 @@ inline float getGaussian( float z )
 	// gaussian distribution -- dimss
 	float x1, x2, w;
 	do {
-		x1 = 2.0 * ( ( ( float ) rand() ) / RAND_MAX ) - 1.0;
-		x2 = 2.0 * ( ( ( float ) rand() ) / RAND_MAX ) - 1.0;
+		x1 = 2.0 * ( ( ( float ) rand() ) / static_cast<float>(RAND_MAX) ) - 1.0;
+		x2 = 2.0 * ( ( ( float ) rand() ) / static_cast<float>(RAND_MAX) ) - 1.0;
 		w = x1 * x1 + x2 * x2;
 	} while ( w >= 1.0 );
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1545,7 +1545,7 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2lastMidiEvent: %3\n" ).arg( sPrefix ).arg( s ).arg( lastMidiEvent ) )
 			.append( QString( "%1%2lastMidiEventParameter: %3\n" ).arg( sPrefix ).arg( s ).arg( lastMidiEventParameter ) )
 			.append( QString( "%1%2m_nInstrumentLookupTable: [ %3 ... %4 ]\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS ] ) );
+					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS -1 ] ) );
 	} else {
 		
 		sOutput = QString( "%1[Hydrogen]" ).arg( sPrefix )
@@ -1593,7 +1593,7 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", lastMidiEvent: %1" ).arg( lastMidiEvent ) )
 			.append( QString( ", lastMidiEventParameter: %1" ).arg( lastMidiEventParameter ) )
 			.append( QString( ", m_nInstrumentLookupTable: [ %1 ... %2 ]" )
-					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS ] ) );
+					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS -1 ] ) );
 	}
 		
 	return sOutput;

--- a/src/core/IO/AlsaAudioDriver.h
+++ b/src/core/IO/AlsaAudioDriver.h
@@ -50,13 +50,13 @@ public:
 	AlsaAudioDriver( audioProcessCallback processCallback );
 	~AlsaAudioDriver();
 
-	virtual int init( unsigned nBufferSize );
-	virtual int connect();
-	virtual void disconnect();
-	virtual unsigned getBufferSize();
-	virtual unsigned getSampleRate();
-	virtual float* getOut_L();
-	virtual float* getOut_R();
+	virtual int init( unsigned nBufferSize ) override;
+	virtual int connect() override;
+	virtual void disconnect() override;
+	virtual unsigned getBufferSize() override;
+	virtual unsigned getSampleRate() override;
+	virtual float* getOut_L() override;
+	virtual float* getOut_R() override;
 	static QStringList getDevices();
 private:
 

--- a/src/core/IO/AlsaMidiDriver.h
+++ b/src/core/IO/AlsaMidiDriver.h
@@ -47,18 +47,18 @@ public:
 	AlsaMidiDriver();
 	virtual ~AlsaMidiDriver();
 
-	virtual void open();
-	virtual void close();
-	virtual std::vector<QString> getInputPortList();
-	virtual std::vector<QString> getOutputPortList();
+	virtual void open() override;
+	virtual void close() override;
+	virtual std::vector<QString> getInputPortList() override;
+	virtual std::vector<QString> getOutputPortList() override;
 
 	void midi_action( snd_seq_t *seq_handle );
 	void getPortInfo( const QString& sPortName, int& nClient, int& nPort );
-	virtual void handleQueueNote(Note* pNote);
+	virtual void handleQueueNote(Note* pNote) override;
 	
-	virtual void handleQueueNoteOff( int channel, int key, int velocity );
-	virtual void handleQueueAllNoteOff();
-	virtual void handleOutgoingControlChange( int param, int value, int channel );
+	virtual void handleQueueNoteOff( int channel, int key, int velocity ) override;
+	virtual void handleQueueAllNoteOff() override;
+	virtual void handleOutgoingControlChange( int param, int value, int channel ) override;
 
 private:
 };

--- a/src/core/IO/CoreAudioDriver.h
+++ b/src/core/IO/CoreAudioDriver.h
@@ -66,20 +66,20 @@ public:
 	CoreAudioDriver( audioProcessCallback processCallback );
 	virtual ~CoreAudioDriver();
 
-	int init( unsigned bufferSize );
+	virtual int init( unsigned bufferSize ) override;
 
-	unsigned getSampleRate();
-	unsigned getBufferSize();
+	virtual unsigned getSampleRate() override;
+	virtual unsigned getBufferSize() override;
 
-	int connect();
-	void disconnect();
+	virtual int connect() override;
+	virtual void disconnect() override;
 
-	float* getOut_L();
-	float* getOut_R();
+	virtual float* getOut_L() override;
+	virtual float* getOut_R() override;
 
 	static QStringList getDevices();
 
-	virtual int getLatency();
+	virtual int getLatency() override;
 
 private:
 	AudioDeviceID defaultOutputDevice(void);

--- a/src/core/IO/CoreMidiDriver.h
+++ b/src/core/IO/CoreMidiDriver.h
@@ -48,15 +48,15 @@ public:
 
 	bool m_bRunning;
 
-	virtual void open();
-	virtual void close();
-	virtual std::vector<QString> getInputPortList();
-	virtual std::vector<QString> getOutputPortList();
+	virtual void open() override;
+	virtual void close() override;
+	virtual std::vector<QString> getInputPortList() override;
+	virtual std::vector<QString> getOutputPortList() override;
 
-	virtual void handleQueueNote(Note* pNote);
-	virtual void handleQueueNoteOff( int channel, int key, int velocity );
-	virtual void handleQueueAllNoteOff();
-	virtual void handleOutgoingControlChange( int param, int value, int channel );
+	virtual void handleQueueNote(Note* pNote) override;
+	virtual void handleQueueNoteOff( int channel, int key, int velocity ) override;
+	virtual void handleQueueAllNoteOff() override;
+	virtual void handleOutgoingControlChange( int param, int value, int channel ) override;
 
 	MIDIClientRef  h2MIDIClient;
 	ItemCount cmSources;

--- a/src/core/IO/DiskWriterDriver.h
+++ b/src/core/IO/DiskWriterDriver.h
@@ -54,23 +54,23 @@ class DiskWriterDriver : public Object<DiskWriterDriver>, public AudioOutput
 		DiskWriterDriver( audioProcessCallback processCallback, unsigned nSamplerate, int nSampleDepth );
 		~DiskWriterDriver();
 
-		int init( unsigned nBufferSize );
+		virtual int init( unsigned nBufferSize ) override;
 
-		int connect();
-		void disconnect();
+		virtual int connect() override;
+		virtual void disconnect() override;
 
 		void write( float* buffer_L, float* buffer_R, unsigned int bufferSize );
 
-		unsigned getBufferSize() {
+		virtual unsigned getBufferSize() override {
 			return m_nBufferSize;
 		}
 
-		unsigned getSampleRate();
+		virtual unsigned getSampleRate() override;
 		
-		float* getOut_L() {
+		virtual float* getOut_L() override {
 			return m_pOut_L;
 		}
-		float* getOut_R() {
+		virtual float* getOut_R() override {
 			return m_pOut_R;
 		}
 		

--- a/src/core/IO/FakeDriver.h
+++ b/src/core/IO/FakeDriver.h
@@ -40,16 +40,16 @@ public:
 	FakeDriver( audioProcessCallback processCallback );
 	~FakeDriver();
 
-	int init( unsigned nBufferSize );
-	int connect();
-	void disconnect();
-	unsigned getBufferSize() {
+	virtual int init( unsigned nBufferSize ) override;
+	virtual int connect() override;
+	virtual void disconnect() override;
+	virtual unsigned getBufferSize() override {
 		return m_nBufferSize;
 	}
-	unsigned getSampleRate();
+	virtual unsigned getSampleRate() override;
 
-	float* getOut_L();
-	float* getOut_R();
+	virtual float* getOut_L() override;
+	virtual float* getOut_R() override;
 
 	void processCallback();
 

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -190,7 +190,7 @@ public:
 	 *       JackPortIsInput flag found or no connection to them could
 	 *       be established.
 	 */
-	int connect();
+	virtual int connect() override;
 	/**
 	 * Disconnects the JACK client of the Hydrogen from the JACK
 	 * server.
@@ -200,7 +200,7 @@ public:
 	 * jack_client_close (jack/jack.h), and sets the #m_pClient
 	 * pointer to nullptr.
 	 */
-	void disconnect();
+	virtual void disconnect() override;
 	/**
 	 * Deactivates the JACK client of Hydrogen and disconnects all
 	 * ports belonging to it.
@@ -211,9 +211,9 @@ public:
 	 */
 	void deactivate();
 	/** \return Global variable #jackServerBufferSize. */
-	unsigned getBufferSize();
+	virtual unsigned getBufferSize() override;
 	/** \return Global variable #jackServerSampleRate. */
-	unsigned getSampleRate();
+	virtual unsigned getSampleRate() override;
 
 	/** Resets the buffers contained in #m_pTrackOutputPortsL and
 	 * #m_pTrackOutputPortsR.
@@ -261,7 +261,7 @@ public:
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
-	float* getOut_L();
+	virtual float* getOut_L() override;
 	/**
 	 * Get content in the right stereo output port.
 	 *
@@ -272,7 +272,7 @@ public:
 	 * \return Pointer to buffer content of type
 	 * _jack_default_audio_sample_t*_ (jack/types.h)
 	 */
-	float* getOut_R();
+	virtual float* getOut_R() override;
 	/**
 	 * Get content of left output port of a specific track.
 	 *
@@ -395,7 +395,7 @@ public:
 	 * output ports for the JACK client using
 	 * _jack_port_register()_ (jack/jack.h).
 	 */
-	int init( unsigned bufferSize );
+	virtual int init( unsigned bufferSize ) override;
 
 	/**
 	 * Tells the JACK server to start transport.

--- a/src/core/IO/JackMidiDriver.h
+++ b/src/core/IO/JackMidiDriver.h
@@ -54,19 +54,19 @@ public:
 	JackMidiDriver();
 	virtual ~JackMidiDriver();
 
-	virtual void open();
-	virtual void close();
-	virtual std::vector<QString> getInputPortList();	
-	virtual std::vector<QString> getOutputPortList();
+	virtual void open() override;
+	virtual void close() override;
+	virtual std::vector<QString> getInputPortList() override;
+	virtual std::vector<QString> getOutputPortList() override;
 
 	void getPortInfo( const QString& sPortName, int& nClient, int& nPort );
 	void JackMidiWrite(jack_nframes_t nframes);
 	void JackMidiRead(jack_nframes_t nframes);
 	
-	virtual void handleQueueNote(Note* pNote);
-	virtual void handleQueueNoteOff( int channel, int key, int velocity );
-	virtual void handleQueueAllNoteOff();
-	virtual void handleOutgoingControlChange( int param, int value, int channel );
+	virtual void handleQueueNote(Note* pNote) override;
+	virtual void handleQueueNoteOff( int channel, int key, int velocity ) override;
+	virtual void handleQueueAllNoteOff() override;
+	virtual void handleOutgoingControlChange( int param, int value, int channel ) override;
 
 private:
 	void JackMidiOutEvent(uint8_t *buf, uint8_t len);

--- a/src/core/IO/NullDriver.h
+++ b/src/core/IO/NullDriver.h
@@ -41,14 +41,14 @@ public:
 	NullDriver( audioProcessCallback processCallback );
 	~NullDriver();
 
-	int init( unsigned nBufferSize );
-	int connect();
-	void disconnect();
-	unsigned getBufferSize();
-	unsigned getSampleRate();
+	int init( unsigned nBufferSize ) override; 
+	int connect() override;
+	void disconnect() override;
+	unsigned getBufferSize() override;
+	unsigned getSampleRate() override;
 
-	float* getOut_L();
-	float* getOut_R();
+	float* getOut_L() override;
+	float* getOut_R() override;
 
 };
 

--- a/src/core/IO/PortAudioDriver.cpp
+++ b/src/core/IO/PortAudioDriver.cpp
@@ -177,7 +177,7 @@ int PortAudioDriver::connect()
 			memset( &outputParameters, '\0', sizeof( outputParameters ) );
 			outputParameters.channelCount = 2;
 			outputParameters.device = nDevice;
-			outputParameters.hostApiSpecificStreamInfo = NULL;
+			outputParameters.hostApiSpecificStreamInfo = nullptr;
 			outputParameters.sampleFormat = paFloat32;
 
 			// Use the same latency setting as Pa_OpenDefaultStream() -- defaulting to the high suggested

--- a/src/core/IO/PortAudioDriver.h
+++ b/src/core/IO/PortAudioDriver.h
@@ -48,14 +48,14 @@ public:
 	PortAudioDriver( audioProcessCallback processCallback );
 	virtual ~PortAudioDriver();
 
-	virtual int init( unsigned nBufferSize );
-	virtual int connect();
-	virtual void disconnect();
-	virtual unsigned getBufferSize();
-	virtual int getLatency();
-	virtual unsigned getSampleRate();
-	virtual float* getOut_L();
-	virtual float* getOut_R();
+	virtual int init( unsigned nBufferSize ) override;
+	virtual int connect() override;
+	virtual void disconnect() override;
+	virtual unsigned getBufferSize() override;
+	virtual int getLatency() override;
+	virtual unsigned getSampleRate() override;
+	virtual float* getOut_L() override;
+	virtual float* getOut_R() override;
 
 	static QStringList getDevices();
 	static QStringList getDevices( QString HostAPI );

--- a/src/core/IO/PortMidiDriver.h
+++ b/src/core/IO/PortMidiDriver.h
@@ -44,15 +44,15 @@ public:
 	PortMidiDriver();
 	virtual ~PortMidiDriver();
 
-	virtual void open();
-	virtual void close();
-	virtual std::vector<QString> getInputPortList();	
-	virtual std::vector<QString> getOutputPortList();
+	virtual void open() override;
+	virtual void close() override;
+	virtual std::vector<QString> getInputPortList() override;
+	virtual std::vector<QString> getOutputPortList() override;
 
-	virtual void handleQueueNote(Note* pNote);
-	virtual void handleQueueNoteOff( int channel, int key, int velocity );
-	virtual void handleQueueAllNoteOff();
-	virtual void handleOutgoingControlChange( int param, int value, int channel );
+	virtual void handleQueueNote(Note* pNote) override;
+	virtual void handleQueueNoteOff( int channel, int key, int velocity ) override;
+	virtual void handleQueueAllNoteOff() override;
+	virtual void handleOutgoingControlChange( int param, int value, int channel ) override;
 
 private:
 

--- a/src/core/IO/PulseAudioDriver.h
+++ b/src/core/IO/PulseAudioDriver.h
@@ -46,13 +46,13 @@ public:
 	PulseAudioDriver(audioProcessCallback processCallback);
 	~PulseAudioDriver();
 
-	virtual int init( unsigned nBufferSize );
-	virtual int connect();
-	virtual void disconnect();
-	virtual unsigned getBufferSize();
-	virtual unsigned getSampleRate();
-	virtual float* getOut_L();
-	virtual float* getOut_R();
+	virtual int init( unsigned nBufferSize ) override;
+	virtual int connect() override;
+	virtual void disconnect() override;
+	virtual unsigned getBufferSize() override;
+	virtual unsigned getSampleRate() override;
+	virtual float* getOut_L() override;
+	virtual float* getOut_R() override;
 
 private:
 	pthread_t				m_thread;

--- a/src/core/Smf/SMF.h
+++ b/src/core/Smf/SMF.h
@@ -45,7 +45,7 @@ public:
 	~SMFHeader();
 	
 	void addTrack();
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 	
 private:
 	int m_nFormat;		///< SMF format
@@ -66,7 +66,7 @@ public:
 
 	void addEvent( SMFEvent *pEvent );
 
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 private:
 	std::vector<SMFEvent*> m_eventList;
@@ -83,7 +83,7 @@ public:
 	~SMF();
 
 	void addTrack( SMFTrack *pTrack );
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 private:
 	std::vector<SMFTrack*> m_trackList;
@@ -109,7 +109,7 @@ protected:
 	void sortEvents( EventList* pEventList );
 	SMFTrack* createTrack0( std::shared_ptr<Song> pSong );
 	
-	virtual SMF* createSMF( std::shared_ptr<Song> pSong )=0;
+	virtual SMF* createSMF( std::shared_ptr<Song> pSong ) = 0;
 	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf )=0;
 	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr ) = 0;
 	virtual void  packEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) = 0;
@@ -129,7 +129,7 @@ public:
     SMF1Writer();
 	virtual ~SMF1Writer();
 protected:
-	virtual SMF* createSMF( std::shared_ptr<Song> pSong );
+	virtual SMF* createSMF( std::shared_ptr<Song> pSong ) override;
 };
 
 
@@ -141,9 +141,9 @@ public:
     SMF1WriterSingle();
 	virtual ~SMF1WriterSingle();
 protected:
-	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf );
-	virtual void  packEvents( std::shared_ptr<Song> pSong, SMF* pSmf );
-	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr );
+	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) override;
+	virtual void packEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) override;
+	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr ) override;
 private:
 	EventList m_eventList;
 };
@@ -157,9 +157,9 @@ public:
     SMF1WriterMulti();
 	virtual ~SMF1WriterMulti();
 protected:
-	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf );
-	virtual void  packEvents( std::shared_ptr<Song> pSong, SMF* pSmf );
-	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr );
+	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) override;
+	virtual void  packEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) override;
+	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr ) override;
 private:
 	// contains events for each instrument in separate vector
 	std::vector<EventList*> m_eventLists;
@@ -176,10 +176,10 @@ public:
     SMF0Writer();
 	virtual ~SMF0Writer();
 protected:
-	virtual SMF* createSMF( std::shared_ptr<Song> pSong );
-	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf );
-	virtual void  packEvents( std::shared_ptr<Song> pSong, SMF* pSmf );
-	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr );
+	virtual SMF* createSMF( std::shared_ptr<Song> pSong ) override;
+	virtual void prepareEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) override;
+	virtual void  packEvents( std::shared_ptr<Song> pSong, SMF* pSmf ) override;
+	virtual EventList* getEvents( std::shared_ptr<Song> pSong, std::shared_ptr<Instrument> pInstr ) override;
 private:
 	SMFTrack* m_pTrack;
 	EventList m_eventList;

--- a/src/core/Smf/SMFEvent.h
+++ b/src/core/Smf/SMFEvent.h
@@ -104,7 +104,7 @@ class SMFTrackNameMetaEvent : public SMFEvent, public H2Core::Object<SMFTrackNam
 	H2_OBJECT(SMFTrackNameMetaEvent)
 public:
 	SMFTrackNameMetaEvent( const QString& sTrackName, unsigned nDeltaTime );
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 private:
 	QString m_sTrackName;
@@ -119,7 +119,7 @@ class SMFSetTempoMetaEvent : public SMFEvent, public H2Core::Object<SMFSetTempoM
 	H2_OBJECT(SMFSetTempoMetaEvent)
 public:
 	SMFSetTempoMetaEvent( float fBPM, unsigned nDeltaTime );
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 private:
 	unsigned m_fBPM;
@@ -134,7 +134,7 @@ class SMFCopyRightNoticeMetaEvent : public SMFEvent, public H2Core::Object<SMFCo
 	H2_OBJECT(SMFCopyRightNoticeMetaEvent)
 public:
 	SMFCopyRightNoticeMetaEvent( const QString& sAuthor, unsigned nDeltaTime );
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 private:
 	QString m_sAuthor;
@@ -149,7 +149,7 @@ class SMFTimeSignatureMetaEvent : public SMFEvent, public H2Core::Object<SMFTime
 	H2_OBJECT(SMFTimeSignatureMetaEvent)
 public:
 	SMFTimeSignatureMetaEvent( unsigned nBeats, unsigned nNote , unsigned nMTPMC , unsigned nTSNP24 , unsigned nTicks );
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 	// MTPMC = MIDI ticks per metronome click
 	// TSNP24 = Thirty Second Notes Per 24 MIDI Ticks.
 private:
@@ -165,7 +165,7 @@ class SMFNoteOnEvent : public SMFEvent, public H2Core::Object<SMFNoteOnEvent>
 public:
 	SMFNoteOnEvent( unsigned nTicks, int nChannel, int nPitch, int nVelocity );
 
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 protected:
 	unsigned m_nChannel;
@@ -182,7 +182,7 @@ class SMFNoteOffEvent : public SMFEvent, public H2Core::Object<SMFNoteOffEvent>
 public:
 	SMFNoteOffEvent(  unsigned nTicks, int nChannel, int nPitch, int nVelocity );
 
-	virtual std::vector<char> getBuffer();
+	virtual std::vector<char> getBuffer() override;
 
 protected:
 	unsigned m_nChannel;

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
@@ -64,8 +64,8 @@ class AudioFileBrowser :  public QDialog, public Ui_AudioFileBrowser_UI,  public
 		void on_playSamplescheckBox_clicked();
 		void on_hiddenCB_clicked();
 
-		virtual void keyPressEvent (QKeyEvent *ev);
-		virtual void keyReleaseEvent (QKeyEvent *ev);
+		virtual void keyPressEvent (QKeyEvent *ev) override;
+		virtual void keyReleaseEvent (QKeyEvent *ev) override;
 
 
 	private:

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
@@ -41,7 +41,7 @@ class SampleWaveDisplay :  public QWidget,  public H2Core::Object<SampleWaveDisp
 
 		void updateDisplay( QString filename );
 
-		void paintEvent(QPaintEvent *ev);
+		virtual void paintEvent(QPaintEvent *ev) override;
 
 	private:
 		QPixmap m_Background;

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -46,10 +46,10 @@ public:
 	Director(const Director&) = delete;
 	Director& operator=( const Director& rhs ) = delete;
 
-	virtual void metronomeEvent( int nValue );
-	virtual void paintEvent( QPaintEvent*);
-	void keyPressEvent( QKeyEvent* ev );
-	void closeEvent( QCloseEvent* ev );
+	virtual void metronomeEvent( int nValue ) override;
+	virtual void paintEvent( QPaintEvent*) override;
+	virtual void keyPressEvent( QKeyEvent* ev ) override;
+	virtual void closeEvent( QCloseEvent* ev ) override;
 
 private slots:
 	void updateMetronomBackground();

--- a/src/gui/src/FilesystemInfoForm.h
+++ b/src/gui/src/FilesystemInfoForm.h
@@ -50,7 +50,7 @@ private slots:
 	void	on_openUsrButton_clicked();
 	void	on_openSysButton_clicked();
 	
-	void	showEvent ( QShowEvent* );
+	virtual void showEvent ( QShowEvent* ) override;
 };
 
 #endif // FILESYSTEMINFOFORM_H

--- a/src/gui/src/InstrumentEditor/WaveDisplay.h
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.h
@@ -47,9 +47,9 @@ class WaveDisplay :  public QWidget, protected WidgetWithScalableFont<8, 10, 12>
 
 		virtual void	updateDisplay( std::shared_ptr<H2Core::InstrumentLayer> pLayer );
 
-		void			paintEvent( QPaintEvent *ev );
-		void			resizeEvent( QResizeEvent * event );
-		void			mouseDoubleClickEvent(QMouseEvent *ev);
+		virtual void	paintEvent( QPaintEvent *ev ) override;
+		virtual void	resizeEvent( QResizeEvent * event ) override;
+		virtual void	mouseDoubleClickEvent(QMouseEvent *ev) override;
 		
 		void			setSampleNameAlignment(Qt::AlignmentFlag flag);
 

--- a/src/gui/src/LadspaFXProperties.h
+++ b/src/gui/src/LadspaFXProperties.h
@@ -46,8 +46,8 @@ class LadspaFXProperties :  public QWidget,  public H2Core::Object<LadspaFXPrope
 
 		void updateControls();
 
-		void showEvent ( QShowEvent *ev );
-		void closeEvent( QCloseEvent *ev );
+		virtual void showEvent ( QShowEvent *ev ) override;
+		virtual void closeEvent( QCloseEvent *ev ) override;
 
 	public slots:
 		void faderChanged( WidgetWithInput* ref );

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -101,7 +101,7 @@ public slots:
 		Button *m_pSoloBtn;
 		Button *m_pSampleWarning;
 
-		virtual void mousePressEvent(QMouseEvent *ev);
+		virtual void mousePressEvent(QMouseEvent *ev) override;
 		H2Core::Pattern* getCurrentPattern();
 };
 
@@ -115,12 +115,12 @@ class PatternEditorInstrumentList :  public QWidget,  public H2Core::Object<Patt
 		PatternEditorInstrumentList( QWidget *parent, PatternEditorPanel *pPatternEditorPanel );
 		~PatternEditorInstrumentList();
 
-		virtual void mousePressEvent(QMouseEvent *event);
-		virtual void mouseMoveEvent(QMouseEvent *event);
+		virtual void mousePressEvent(QMouseEvent *event) override;
+		virtual void mouseMoveEvent(QMouseEvent *event) override;
 
 
-		virtual void dragEnterEvent(QDragEnterEvent *event);
-		virtual void dropEvent(QDropEvent *event);
+		virtual void dragEnterEvent(QDragEnterEvent *event) override;
+		virtual void dropEvent(QDropEvent *event) override;
 
 
 	public slots:

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.h
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.h
@@ -56,8 +56,10 @@ public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
 	private slots:
-		void keyPressEvent( QKeyEvent* ev );
-		void closeEvent( QCloseEvent* ev );
+		virtual void keyPressEvent( QKeyEvent* ev ) override;
+		virtual void closeEvent( QCloseEvent* ev ) override;
+		virtual bool eventFilter ( QObject *o, QEvent *e ) override;
+	
 		void addSong();
 		void addCurrentSong();
 		void removeFromList();
@@ -78,7 +80,6 @@ public slots:
 		void o_downBClicked();
 		void on_m_pPlaylistTree_itemDoubleClicked ();
 		void updateActiveSongNumber();
-		bool eventFilter ( QObject *o, QEvent *e );
 
 
 	private:

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.h
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.h
@@ -45,7 +45,7 @@ class DetailWaveDisplay :  public QWidget,  public H2Core::Object<DetailWaveDisp
 
 		void updateDisplay( QString filename );
 
-		void paintEvent(QPaintEvent *ev);
+		virtual void paintEvent(QPaintEvent *ev) override;
 		void setDetailSamplePosition( unsigned posi, float zoomfactor, QString type);
 
 	private:

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
@@ -225,7 +225,7 @@ void MainSampleWaveDisplay::mouseUpdateDone() {
 
 void MainSampleWaveDisplay::mouseMoveEvent(QMouseEvent *ev)
 {
-	if (ev->buttons() && Qt::LeftButton) {
+	if (ev->buttons() & Qt::LeftButton) {
 		testPosition( ev );
 	} else {
 		chooseSlider( ev );

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
@@ -52,7 +52,7 @@ class MainSampleWaveDisplay :  public QWidget,  public H2Core::Object<MainSample
 		void updateDisplayPointer();
 
 		void paintLocatorEvent( int pos, bool last_event);
-		void paintEvent(QPaintEvent *ev);
+		virtual void paintEvent(QPaintEvent *ev) override;
 		
 		void testPositionFromSampleeditor();
 		
@@ -68,9 +68,9 @@ class MainSampleWaveDisplay :  public QWidget,  public H2Core::Object<MainSample
 
 
 	private:
-		virtual void mouseMoveEvent(QMouseEvent *ev);
-		virtual void mousePressEvent(QMouseEvent *ev);
-		virtual void mouseReleaseEvent(QMouseEvent *ev);
+		virtual void mouseMoveEvent(QMouseEvent *ev) override;
+		virtual void mousePressEvent(QMouseEvent *ev) override;
+		virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 		void testPosition( QMouseEvent *ev );
 		void chooseSlider( QMouseEvent *ev );
 		void mouseUpdateDone();

--- a/src/gui/src/SampleEditor/SampleEditor.h
+++ b/src/gui/src/SampleEditor/SampleEditor.h
@@ -91,10 +91,10 @@ class SampleEditor :  public QDialog, public Ui_SampleEditor_UI,  public H2Core:
 		void setSamplelengthFrames();
 		void createPositionsRulerPath();
 		void testpTimer();
-		void closeEvent(QCloseEvent *event);
 		void checkRatioSettings();
 
-		virtual void mouseReleaseEvent(QMouseEvent *ev);
+		virtual void closeEvent(QCloseEvent *event) override;
+		virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 	
 		MainSampleWaveDisplay *m_pMainSampleWaveDisplay;
 		TargetWaveDisplay *m_pTargetSampleView;

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -84,28 +84,34 @@ TargetWaveDisplay::~TargetWaveDisplay()
 static void paintEnvelope(Sample::VelocityEnvelope &envelope, QPainter &painter,
 	int selected, const QColor & lineColor, const QColor & handleColor, const QColor & selectedColor)
 {
-	if (envelope.empty())
+	if (envelope.empty()) {
 		return;
+	}
+	
 	for ( int i = 0; i < static_cast<int>(envelope.size()) -1; i++){
 		painter.setPen( QPen(lineColor, 1 , Qt::SolidLine) );
 		painter.drawLine( envelope[i].frame, envelope[i].value, envelope[i + 1].frame, envelope[i +1].value );
-		if ( i == selected )
+		if ( i == selected ) {
 			painter.setBrush( selectedColor );
-		else
+		} else {
 			painter.setBrush( handleColor );
+		}
 		painter.drawEllipse ( envelope[i].frame - 6/2, envelope[i].value  - 6/2, 6, 6 );
 	}
+	
 	// draw first and last points as squares
-	if ( 0 == selected )
+	if ( 0 == selected ) {
 		painter.setBrush( selectedColor );
-	else
+	} else {
 		painter.setBrush( handleColor );
+	}
 	painter.drawRect ( envelope[0].frame - 12/2, envelope[0].value  - 6/2, 12, 6 );
 
-	if ( envelope.size() - 1 == selected )
+	if ( envelope.size() - 1 == selected ) {
 		painter.setBrush( selectedColor );
-	else
+	} else {
 		painter.setBrush( handleColor );
+	}
 	painter.drawRect ( envelope[envelope.size() -1].frame - 12/2, envelope[envelope.size() -1].value  - 6/2, 12, 6 );
 }
 
@@ -270,9 +276,9 @@ void TargetWaveDisplay::updateMouseSelection(QMouseEvent *ev)
 		}
 		m_nSelectedEnvelopePoint = selection;
 	}
-	if (m_nSelectedEnvelopePoint == -1)
+	if (m_nSelectedEnvelopePoint == -1) {
 		m_sInfo = "";
-	else {
+	} else {
 		float info = (UI_HEIGHT - envelope[m_nSelectedEnvelopePoint].value) / (float)UI_HEIGHT;
 		m_sInfo.setNum( info, 'g', 2 );
 	}

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.h
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.h
@@ -56,7 +56,7 @@ class TargetWaveDisplay :  public QWidget,  public H2Core::Object<TargetWaveDisp
 		void updateDisplay( std::shared_ptr<H2Core::InstrumentLayer> pLayer );
 		void updateDisplayPointer();
 		void paintLocatorEventTargetDisplay( int pos, bool last_event);
-		void paintEvent(QPaintEvent *ev);
+		virtual void paintEvent(QPaintEvent *ev) override;
 		H2Core::Sample::PanEnvelope* get_pan() { return &m_PanEnvelope; }
 		H2Core::Sample::VelocityEnvelope* get_velocity() { return &m_VelocityEnvelope; }
 
@@ -80,9 +80,9 @@ class TargetWaveDisplay :  public QWidget,  public H2Core::Object<TargetWaveDisp
 
 		int m_nSnapRadius;
 
-		virtual void mouseMoveEvent(QMouseEvent *ev);
-		virtual void mousePressEvent(QMouseEvent *ev);
-		virtual void mouseReleaseEvent(QMouseEvent *ev);
+		virtual void mouseMoveEvent(QMouseEvent *ev) override;
+		virtual void mousePressEvent(QMouseEvent *ev) override;
+		virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 
 		virtual void updateMouseSelection(QMouseEvent *ev);
 		virtual void updateEnvelope();

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -384,6 +384,7 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 		virtual void mousePressEvent( QMouseEvent *ev ) override;
 		virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 		virtual void paintEvent( QPaintEvent *ev ) override;
+
 	// virtual void enterEvent( QEvent* ev ) override;
 	virtual void leaveEvent( QEvent* ev ) override;
 	virtual bool event( QEvent* ev ) override;

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -90,9 +90,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		void actionModeChangeEvent( int nValue ) override;
 		void updateSongEditorEvent( int nValue ) override;
 
-	void jackTimebaseStateChangedEvent( int );
-
-
+		virtual void jackTimebaseStateChangedEvent( int ) override;
 		virtual void songModeActivationEvent( int nValue ) override;
 
 	public slots:

--- a/src/gui/src/SoundLibrary/SoundLibraryTree.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryTree.h
@@ -47,8 +47,8 @@ class SoundLibraryTree : public QTreeWidget, private H2Core::Object<SoundLibrary
 
 	protected:
 
-		virtual void mousePressEvent(QMouseEvent *event);
-		virtual void mouseMoveEvent(QMouseEvent *event);
+		virtual void mousePressEvent(QMouseEvent *event) override;
+		virtual void mouseMoveEvent(QMouseEvent *event) override;
 
 
 };

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -148,8 +148,8 @@ private:
 
 	bool m_bIsActive;
 
-	void mousePressEvent(QMouseEvent *ev);
-	void paintEvent( QPaintEvent* ev);
+	virtual void mousePressEvent(QMouseEvent *ev) override;
+	virtual void paintEvent( QPaintEvent* ev) override;
 
 };
 inline bool Button::getIsActive() const {

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -52,7 +52,7 @@ public:
 	};
 	
 	explicit ClickableLabel( QWidget *pParent, QSize size = QSize( 0, 0 ), QString sText = "", Color color = Color::Bright );
-	void mousePressEvent( QMouseEvent * e );
+	virtual void mousePressEvent( QMouseEvent * e ) override;
 
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );

--- a/src/gui/src/Widgets/ColorSelectionButton.h
+++ b/src/gui/src/Widgets/ColorSelectionButton.h
@@ -55,10 +55,10 @@ signals:
 private:
 	bool m_bMouseOver;
 
-	void mousePressEvent(QMouseEvent *ev);
-	void enterEvent(QEvent *ev);
-	void leaveEvent(QEvent *ev);
-	void paintEvent( QPaintEvent* ev);
+	virtual void mousePressEvent(QMouseEvent *ev) override;
+	virtual void enterEvent(QEvent *ev) override;
+	virtual void leaveEvent(QEvent *ev) override;
+	virtual void paintEvent( QPaintEvent* ev) override;
 
 	QColor m_sColor;
 };

--- a/src/gui/src/Widgets/CpuLoadWidget.h
+++ b/src/gui/src/Widgets/CpuLoadWidget.h
@@ -66,7 +66,7 @@ private:
 	
 	virtual void paintEvent( QPaintEvent *ev ) override;
 
-	void XRunEvent();
+	virtual void XRunEvent() override;
 
 };
 

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -231,7 +231,7 @@ void Fader::paintEvent( QPaintEvent *ev)
 			fFaderTopLeftY_L = 2;
 			fFaderTopLeftX_R = 12;
 			fFaderTopLeftY_R = 2;
-			fFaderWidth = 6,8;
+			fFaderWidth = 6.8;
 			fFaderHeight = 186;
 			fPeak_L = ( m_fPeakValue_L - m_fMinPeak ) / ( m_fMaxPeak - m_fMinPeak ) * fFaderHeight;
 			fPeak_R = ( m_fPeakValue_R - m_fMinPeak ) / ( m_fMaxPeak - m_fMinPeak ) * fFaderHeight;

--- a/src/gui/src/Widgets/Fader.h
+++ b/src/gui/src/Widgets/Fader.h
@@ -78,8 +78,8 @@ private:
 	float m_fMinPeak;
 	float m_fMaxPeak;
 	
-	virtual void mouseMoveEvent(QMouseEvent *ev);
-	virtual void mousePressEvent(QMouseEvent *ev);
-	virtual void paintEvent(QPaintEvent *ev);
+	virtual void mouseMoveEvent(QMouseEvent *ev) override;
+	virtual void mousePressEvent(QMouseEvent *ev) override;
+	virtual void paintEvent(QPaintEvent *ev) override;
 };
 #endif

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -50,9 +50,9 @@ private:
 
 	bool m_bEntered;
 		
-	virtual void paintEvent( QPaintEvent *ev );
-	virtual void enterEvent( QEvent *ev );
-	virtual void leaveEvent( QEvent *ev );
+	virtual void paintEvent( QPaintEvent *ev ) override;
+	virtual void enterEvent( QEvent *ev ) override;
+	virtual void leaveEvent( QEvent *ev ) override;
 };
 
 

--- a/src/gui/src/Widgets/LCDDisplay.h
+++ b/src/gui/src/Widgets/LCDDisplay.h
@@ -60,7 +60,7 @@ private:
 
 	std::vector<int> m_fontPointSizes;
 	
-	virtual void paintEvent( QPaintEvent *ev );
+	virtual void paintEvent( QPaintEvent *ev ) override;
 };
 
 #endif

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -73,7 +73,7 @@ public:
 	~LCDSpinBox();
 
 	void setKind( Kind kind );
-	QValidator::State validate( QString &text, int &pos ) const;
+	virtual QValidator::State validate( QString &text, int &pos ) const override;
 	
 	bool getIsActive() const;
 	void setIsActive( bool bIsActive );

--- a/src/gui/src/Widgets/LED.h
+++ b/src/gui/src/Widgets/LED.h
@@ -58,7 +58,7 @@ protected:
 	QSvgRenderer* m_background;
 	
 	bool m_bActivated;
-	void paintEvent( QPaintEvent* ev);
+	virtual void paintEvent( QPaintEvent* ev);
 
 };
 
@@ -88,7 +88,7 @@ private:
 	QTimer* m_pTimer;
 	std::chrono::milliseconds m_activityTimeout;
 	
-	void paintEvent( QPaintEvent* ev);
+	virtual void paintEvent( QPaintEvent* ev) override; 
 };
 
 #endif

--- a/src/gui/src/Widgets/LED.h
+++ b/src/gui/src/Widgets/LED.h
@@ -58,7 +58,7 @@ protected:
 	QSvgRenderer* m_background;
 	
 	bool m_bActivated;
-	virtual void paintEvent( QPaintEvent* ev);
+	virtual void paintEvent( QPaintEvent* ev) override;
 
 };
 
@@ -78,7 +78,7 @@ public:
 	virtual ~MetronomeLED();
 
 public slots:
-	void metronomeEvent( int nValue );
+	virtual void metronomeEvent( int nValue ) override;
 						   
 private slots:
 	void turnOff();

--- a/src/gui/src/Widgets/PixmapWidget.h
+++ b/src/gui/src/Widgets/PixmapWidget.h
@@ -45,7 +45,7 @@ class PixmapWidget :   public H2Core::Object<PixmapWidget>, public QWidget
 		QPixmap m_pixmap;
 		bool __expand_horiz;
 
-		virtual void paintEvent( QPaintEvent* ev);
+		virtual void paintEvent( QPaintEvent* ev) override;
 };
 
 #endif

--- a/src/gui/src/Widgets/Rotary.h
+++ b/src/gui/src/Widgets/Rotary.h
@@ -71,6 +71,6 @@ private:
 	QSvgRenderer* m_background;
 	QSvgRenderer* m_knob;
 
-	virtual void paintEvent(QPaintEvent *ev);
+	virtual void paintEvent(QPaintEvent *ev) override;
 };
 #endif


### PR DESCRIPTION
This pull request contains some fixes for issues which came by using clang/clang-tidy:
- off-by-one error in Hydrogen.cpp: 
   `m_nInstrumentLookupTable[ MAX_INSTRUMENTS ]` -> `m_nInstrumentLookupTable[ MAX_INSTRUMENTS - 1]`

- "," instead of "." used as (or at least was intended to be used as) a floating point number delimiter in Fader.cpp 
  `fFaderWidth = 6,8;` -> `fFaderWidth = 6.8;` 

- "&&" erroneously used for bitmask comparison
 `(ev->buttons() && Qt::LeftButton)` -> `(ev->buttons() & Qt::LeftButton)`