### PR TITLE
windows: fix libhydrogen-core dll path

### DIFF
--- a/windows/Build-WinNative.ps1
+++ b/windows/Build-WinNative.ps1
@@ -93,7 +93,7 @@ if($build)
     $arguments= "-m","pip","install","-r","..\windows\ci\requirements.txt"
     & $python_exe $arguments
 
-    $arguments="..\windows\ci\copy_thirdparty_dlls.py","--no-overwrite", "-V", "debug" ,"-L","$msys\bin","-d","windows\extralibs", "src/gui/hydrogen.exe", "src/core/libhydrogen-core-1.1.0.dll"
+    $arguments="..\windows\ci\copy_thirdparty_dlls.py","--no-overwrite", "-V", "debug" ,"-L","$msys\bin","-d","windows\extralibs", "src/gui/hydrogen.exe", "src/core/libhydrogen-core-*.dll"
     & $python_exe $arguments
     
     cd ../windows


### PR DESCRIPTION
the path to the shared library was hard-coded to a specific version of Hydrogen. Now, the script uses a regular expression in order to work with arbitrary versions. (Under the assumption that just a single shared lib is build in the build folder. But this should hold).