### PR TITLE
update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,12 +8,9 @@ BUILDING AND INSTALLING HYDROGEN
 Content:
 
 1. [System Requirements](#system-requirements)
-2. [Download](#download)
-3. [Binary Packages](#binary-packages)
-4. [Prerequisites to Build from Source](#prerequisites-to-build-from-source)
-5. [Build and Install from Source](#build-and-install-from-source)
-6. [Creating a Binary Package](#creating-a-binary-package)
-7. [Generate the Documentation](#generate-the-documentation)
+2. [Binary Packages](#binary-packages)
+3. [Build and Install from Source](#build-and-install-from-source)
+4. [Generate the Documentation](#generate-the-documentation)
 
 
 ## System Requirements
@@ -24,13 +21,57 @@ Hydrogen is supported on the following operating systems:
   * Mac OS X
   * Windows 10 (maybe 7)
 
-## Download
+## Binary Packages
+
+### Mac OS X and Windows
 
 Hydrogen can be downloaded as a binary package, source distribution,
 or you can check out the current development version.
-These can be accessed on the Hydrogen home page:
 
-> [http://www.hydrogen-music.org/](http://www.hydrogen-music.org/)
+Binary packages can be accessed on the project's Github page:
+
+- [https://github.com/hydrogen-music/hydrogen/releases](https://github.com/hydrogen-music/hydrogen/releases)
+
+If you are interested in older versions or installers, you can check
+out the Hydrogen home page:
+
+- [http://www.hydrogen-music.org/](http://www.hydrogen-music.org/)
+
+To get the latest version with the latest features on **Mac OS X**,
+you can install Hydrogen using **Mac Ports**.
+
+- [Installing on Mac OS X with MacPorts](https://github.com/hydrogen-music/hydrogen/wiki/Building-Hydrogen-from-source-(MAC-OSX)#method-1-building-everything-with-macports
+)
+
+### Linux
+
+Please check your package management system for the package called
+_hydrogen_. In **Debian (GNU/Linux)**-based distributions this can be
+done with `apt`
+
+``` bash
+$ sudo apt-get install hydrogen
+```
+
+## Build and Install from Source
+
+### Mac OS X
+
+If you intend to build Hydrogen from source on Mac OS X, please read
+the relevant wiki pages for more information:
+
+- [Building Hydrogen from source on Mac OS X](https://github.com/hydrogen-music/hydrogen/wiki/Building-Hydrogen-from-Source-(macOS))
+  
+### Windows
+
+For building Hydrogen on Windows, please check out the following wiki
+page:
+
+- [Packaging Hydrogen for Windows](https://github.com/hydrogen-music/hydrogen/wiki/Packaging-for-Windows)
+
+### Linux
+
+#### Prerequisites
 
 The source code for the current development version can be checked out
 via git:
@@ -39,41 +80,10 @@ via git:
 $ git clone git://github.com/hydrogen-music/hydrogen.git
 ```
 
-
-## Binary Packages
-
-In **Debian (GNU/Linux)** and **Ubuntu (GNU/Linux)** Hydrogen can be installed
-with `apt`
-
-``` bash
-$ sudo apt-get install hydrogen
-```
-
-However, if you wish to have a more current version of Hydrogen, the
-Hydrogen devs typically maintain a .deb package for Debian stable,
-testing, and some Ubuntu distributions.  Note that `apt` takes care of
-any library dependencies that you have.
-
-For **other GNU/Linux** :
-
-Please check your package management system for the package called
-_hydrogen_.
-
-For **Mac OS X** the [Hydrogen home page](http://hydrogen-music.org/)
-has a binary package available.  Extract the ZIP archive and it will
-create a hydrogen.app folder.
-
-To get the latest version with the latest features, install it with **Mac Ports**.
-
-- [Installing on Mac OS X with MacPorts](https://github.com/hydrogen-music/hydrogen/wiki/Building-Hydrogen-from-source-(MAC-OSX)#method-1-building-everything-with-macports
-)
-
-## Prerequisites to Build from Source
-
 In order to build Hydrogen from source, you will need the following
 libraries and development header files installed on your system:
 
-#### Required
+##### Required
 
 - Qt 5 Library
 - Qt 5 SDK (moc, uic, etc.)
@@ -84,7 +94,7 @@ libraries and development header files installed on your system:
 - OS X: Xcode
 - At least one of the following audio and midi driver
 
-#### Audio and Midi Drivers
+##### Audio and Midi Drivers
 
 - JACK Audio Connection Kit (>=0.103.0)
 - ALSA (Advanced Linux Sound Architecture)
@@ -94,7 +104,7 @@ libraries and development header files installed on your system:
 - CoreAudio (OS X)
 - CoreMidi (OS X)
 
-#### Optional Support
+##### Optional Support
 
 - liblo for OSC (Open Sound Control)
 - LASH (Linux Audio Session Handler)
@@ -109,7 +119,7 @@ package beside `librubberband2`. Rubberband works properly even if
 this option is disabled. If available, Hydrogen locates the installed
 `rubberband-cli` binary.
 
-#### Packages Required on Debian-based Systems
+##### Packages Required on Debian-based Systems
 
 In order to build Hydrogen on Debian-based Systems, you can use the
 following command to install all basic and some optional requirements.
@@ -129,30 +139,7 @@ pick](https://github.com/jackaudio/jackaudio.github.com/wiki/Q_difference_jack1_
 depends on whether JACK2 or JACK1 is installed on your system. If none
 is present, either package will work.
 
-#### Packages Required on OS X
-
-To compile Hydrogen on OS X, be sure the install the following
-commands using [MacPorts](https://www.macports.org/) first.
-
-``` bash
-sudo port install cmake libsndfile jack cppunit libarchive qwt-qt5 \
-     qt5-qtxmlpatterns liblo liblrdf rubberband
-```
-
-In case you already installed some of these packages using `brew` you
-might have to remove them first for `cmake` to find the proper
-version.
-
-## Build and Install from Source
-
-If you intend to build Hydrogen from source on Windows or with
-Homebrew or Fink on Mac OS X, please read the relevant wiki pages for
-more information:
-
-- [Building Hydrogen from source on Mac OS X](https://github.com/hydrogen-music/hydrogen/wiki/Building-Hydrogen-from-Source-(macOS))
-- [Packaging Hydrogen for Windows](https://github.com/hydrogen-music/hydrogen/wiki/Packaging-for-Windows)
-
-### Building and Installing Hydrogen
+#### Building and Installing Hydrogen
 
 After you have installed all the prerequisites, building and
 installing will look like this:
@@ -165,7 +152,7 @@ $ cmake ..
 $ make && sudo make install
 ```
 
-### Running Hydrogen
+#### Running Hydrogen
 
 After installation, Hydrogen's binaries can be found in `CMAKE_INSTALL_PREFIX/bin`.
 If this path is not in your `PATH` environment variable, consider adding it to it.
@@ -193,7 +180,7 @@ installed with your distribution's package manager.
 
 see [issue#677](https://github.com/hydrogen-music/hydrogen/issues/677)
 
-### Build Script
+#### Build Script
 
 Alternatively you could use our custom build script
 [./build.sh](https://github.com/hydrogen-music/hydrogen/blob/master/build.sh). This
@@ -221,7 +208,7 @@ compilation, which takes a little longer than the one with the usual
 components will be recompiled. This can marginally speed up development.
 
 
-### Additional Build Features and Uninstall
+#### Additional Build Features and Uninstall
 
 All the following `cmake` commands should be executed in a build
 directory :
@@ -264,45 +251,6 @@ fails to build, some environment variables could help it.
 
 ``` bash
 $ QTDIR=/opt/lib/qt4 OSS_PATH="/usr/lib/oss/lib" OSS_INCLUDE="/usr/lib/oss/include" cmake ..
-```
-
-## Creating a Binary Package
-
-If you are a package maintainer and wish for your packaging scripts to
-be included in the Hydrogen source tree, we would be happy to work
-with you.  Please contact the developer mailing list (see the
-[Hydrogen home page](http://hydrogen-music.org/)).  The instructions
-below are for the package systems that have been contributed so far.
-
-### Creating a **.deb** Package
-
-In order to create a .deb package for **Debian-based systems** (like
-Debian, Devuan, Ubuntu, or Mint), you first need the `debhelper`
-package:
-
-``` bash
-$ sudo apt-get install debhelper
-```
-
-To build the Hydrogen package, run the following commands.
-
-``` bash
-$ git clone git://github.com/hydrogen-music/hydrogen.git
-$ cd hydrogen
-$ cd linux
-$ dpkg-buildpackage -rfakeroot -b -uc -us
-
-```
-
-This will place the .deb package and description files in the parent
-directory.  If you wish to change the version number for the archive,
-edit *linux/debian/changelog* to set the version. To install the newly
-created deb package, run the following (substitute the deb package
-name with the version your build created):
-
-``` bash
-$ cd ..
-$ sudo dpkg -i hydrogen_X.Y.Z_amd64.deb
 ```
 
 ## Generate the Documentation


### PR DESCRIPTION
- removing obsolete and redundant information
- put Windows, Mac OS X, and Linux on equal levels instead of interweaving them in the sections
- packaging stuff was moved to the wiki