### PR TITLE
Cache macOS build deps in Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,43 +63,133 @@ for:
 
     test_script: |-
       TMPDIR=/tmp src/tests/tests --appveyor
+
   - 
+    cache: /Users/appveyor/cache_dir
     matrix:
       only:
         - job_group: 'Mac OS X'
 
     before_build: |-
+
+      ###############################################################
+      # Set up macOS dependencies
+      # We use the Appveyor build cache to store the installed
+      # prerequisites, since installing and custom-building the
+      # needed macOS components in each build takes far longer than
+      # the Hydrogen build itself.
+      #
+      # However, the Homebrew installation is much larger than the
+      # size of cache that Appveyor allows (1GB per project, shared
+      # between all configurations), so we archive only objects that
+      # are new or modified relative to the pre-existing 'clean' VM
+      # state, using `treestate.py` to compare.
+      #
+      # For most build jobs, we just unpack the cached Homebrew on top
+      # of the existing Homebrew installation.
+      #
+      # If the cache is cleaned or out of date, we first record the
+      # state of the Homebrew installation, then update it and install
+      # prerequisites, and build a new archive of the current Homebrew
+      # installation.
+      #
+      # Currently the necessary changes, compressed with xz, occupy
+      # about 170Mb of cache space.
+      #
+
       export MACOSX_DEPLOYMENT_TARGET=10.12
       sudo ln -s /usr/local /opt/local;
 
-      brew update
-      # Build libsndfile and bdb from source to enable building for 10.12
-      brew install --build-from-source ./macos/HomebrewFormulae/berkeley-db.rb
-      brew install --build-from-source ./macos/HomebrewFormulae/libogg.rb
-      brew install --build-from-source ./macos/HomebrewFormulae/libvorbis.rb
-      brew install --build-from-source ./macos/HomebrewFormulae/libsndfile.rb
+      cache_tag=usr_local_1 # this can be modified to rebuild deps
 
-      brew install qt5; export CMAKE_PREFIX_PATH="$(brew --prefix qt5)";
-      brew install libarchive; export PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig";
-      brew install libsndfile jack pulseaudio cppunit
+      cdir=$HOME/cache_dir
+      cache_tar=$cdir/$cache_tag.tar
+      cache=$cache_tar.xz
+
+      CPUS=$(sysctl -n hw.ncpu)
+
+      if [ -d $cdir ] && [ -f $cache ]; then
+        echo "=== Unpacking cached Homebrew $cache ==="
+        (
+          cd /
+          tar xf $cache
+        )
+        echo "done"
+      else
+        echo "=== Building dependencies ==="
+        echo "Couldn't find cache $cache"
+        ls -alrt "$cdir"
+
+        echo "Recording /usr/local state"
+        python3 ./treestate.py scan /usr/local usrlocal.json
+
+        brew update
+        # Build our own versions of these for macOS 10.12 target systems.
+        brew install --build-from-source ./macos/HomebrewFormulae/berkeley-db.rb
+        brew install --build-from-source ./macos/HomebrewFormulae/libogg.rb
+        brew install --build-from-source ./macos/HomebrewFormulae/libvorbis.rb
+        brew install --build-from-source ./macos/HomebrewFormulae/libsndfile.rb
+
+        brew install qt5 libarchive jack pulseaudio cppunit ruby
+
+        # The build environment is now ready for use. We can complete
+        # the rest of the process of creating the Homebrew archive
+        # during the rest of the build, using idle CPU time. To minimise
+        # the amount of space needed for the archive, we compress with
+        # xz, which adds only about a minute to the non-cached build.
+        (
+          echo "=== Creating cache tarball $cache ==="
+          echo "Check /usr/local for updates"
+          python3 ./treestate.py updates usrlocal.json /usr/local       \
+              | fgrep -v .git                                           \
+                      > updated_list
+          echo Need to record $( wc -l updated_list ) updates
+
+          mkdir -p $cdir
+          rm -f $cdir/*
+          nice tar cf $cache_tar -T updated_list
+          echo nice xz -9 -T$CPUS $cache_tar
+          nice xz -9 -T$CPUS $cache_tar
+          du -h $cdir
+        ) 2>&1 | sed 's/^/CACHE: /' &
+
+      fi
+
+      export CMAKE_PREFIX_PATH="$(brew --prefix qt5)";
+      export PKG_CONFIG_PATH="$(brew --prefix libarchive)/lib/pkgconfig";
 
     build_script: |-
-      #fix use of register keyword in jack: https://github.com/jackaudio/jack1/issues/84
+      # fix use of register keyword in jack: https://github.com/jackaudio/jack1/issues/84
       sed -i '' 's/, int register,/, int,/g' /opt/local/include/jack/types.h
 
       git submodule init && git submodule update
-      CPUS=$(sysctl -n hw.ncpu)
-      echo "Building with $CPUS cpus"
-      mkdir build && cd build && cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 .. && make -j $CPUS
 
-      PATH="$(brew --prefix qt5)/bin:$PATH"
-      ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg
+      # Do the build
+      (
+          mkdir build &&                                                        \
+              cd build &&                                                       \
+              cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 .. &&       \
+              make -j $CPUS
+      )
 
-      #deploy dmg only on branch $ARTIFACT_BRANCH
-      if [ "$APPVEYOR_REPO_BRANCH" = "$ARTIFACT_BRANCH" ]; then appveyor PushArtifact Hydrogen*.dmg -DeploymentName Installer; fi
+      # Build installation DMG
+      (
+        PATH="$(brew --prefix qt5)/bin:$PATH"
+        ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg
+
+        # deploy dmg only on branch $ARTIFACT_BRANCH
+        if [ "$APPVEYOR_REPO_BRANCH" = "$ARTIFACT_BRANCH" ]; then
+            appveyor PushArtifact Hydrogen*.dmg -DeploymentName Installer;
+        fi
+      ) | sed 's/^/DMG: /' &
 
     test_script: |-
-      TMPDIR=/tmp src/tests/tests --appveyor || true
+      cd build
+      TMPDIR=/tmp src/tests/tests --appveyor || exit 1
+
+      echo "Waiting for installer creation and cache archiving"
+      wait
+      echo "Done"
 
   -
     matrix:

--- a/treestate.py
+++ b/treestate.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Record the current state of a tree in the filesystem
+
+import os
+import sys
+import json
+
+DIR = 1
+LINK = 2
+FILE = 3
+
+# Scan filesystem
+def scanTreeState(path):
+    if os.path.islink(path):
+        yield [LINK, path ]
+    elif os.path.isdir(path):
+        yield [DIR, path]
+        for leaf in os.listdir(path):
+            p = os.path.join(path, leaf)
+            for item in scanTreeState(p):
+                yield item
+    else:
+        yield [FILE, path, os.path.getmtime(path)]
+
+# Write the tree in JSON format
+def writeTree(filename, tree):
+    with open(filename, 'w') as f:
+        json.dump(list(tree), f, indent=1)
+
+def readTree(filename):
+    with open(filename, "r") as f:
+        if f == None:
+            print(f"*** couldn't open {filename} ***")
+        return json.load(f)
+
+# Find updates in tree between states A and B
+def findUpdates(a, b):
+    a_map = {}
+
+    # Build mapping of filename -> modified time in A
+    for o in a:
+        if o[0] == FILE:
+            a_map[ o[1] ] = o[2]
+        else:
+            a_map[ o[1] ] = True
+
+    # Find updated or new items in B
+    for o in b:
+        if o[1] in a_map:
+            if o[0] == FILE and o[2] != a_map[ o[1] ]:
+                print(o[1])
+
+        elif o[0] == FILE or o[0] == LINK:
+            print(o[1])
+
+
+def help():
+    print("Syntax:")
+    print(f"  {sys.argv[0]} scan path stateFile")
+    print(f"      Record the state of <path> in <stateFile>")
+    print(f"  {sys.argv[0]} updates stateFile path")
+    print(f"      Print the paths of objects in <path> which have updated since <stateFile>")
+    exit()
+
+
+# Process arguments
+if len(sys.argv) < 2:
+    help()
+
+if sys.argv[1] == 'scan':
+    if len(sys.argv) != 4:
+        help()
+
+    path = sys.argv[2]
+    stateFile = sys.argv[3]
+
+    tree = scanTreeState(path)
+    writeTree(stateFile, tree)
+
+elif sys.argv[1] == 'updates':
+    if len(sys.argv) != 4:
+        help()
+
+    a = sys.argv[2]
+    b = sys.argv[3]
+
+    findUpdates(readTree(a), scanTreeState(b))
+
+else:
+    print(f"Unknown command: {sys.argv[1]}")
+    help()
+


### PR DESCRIPTION
Use the Appveyor build cache to store the state of Homebrew build dependencies.

Only updated objects from homebrew are cached since the install is too large for the 1Gb cache allowance.

With this change, most macOS builds should take ~5 minutes rather than the ~20 minutes that they've been taking recently.
