### PR TITLE
use dynamic_cast to tell audio drivers apart

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -633,23 +633,13 @@ void Hydrogen::startExportSong( const QString& filename)
 
 	DiskWriterDriver* pDiskWriterDriver = static_cast<DiskWriterDriver*>(pAudioEngine->getAudioDriver());
 	pDiskWriterDriver->setFileName( filename );
-	
-	if ( pDiskWriterDriver->connect() != 0 ) {
-		ERRORLOG( "Error starting disk writer driver [DiskWriterDriver::connect()]" );
-	}
-	
+	pDiskWriterDriver->write();
 }
 
 void Hydrogen::stopExportSong()
 {
 	AudioEngine* pAudioEngine = m_pAudioEngine;
-	
-	if ( dynamic_cast<DiskWriterDriver*>(pAudioEngine->getAudioDriver()) == nullptr ) {
-		return;
-	}
-
 	pAudioEngine->getSampler()->stopPlayingNotes();
-	pAudioEngine->getAudioDriver()->disconnect();
 	pAudioEngine->reset();
 }
 
@@ -665,7 +655,7 @@ void Hydrogen::stopExportSession()
 	
 	pAudioEngine->startAudioDrivers();
 	if ( pAudioEngine->getAudioDriver() == nullptr ) {
-		ERRORLOG( "pAudioEngine->getAudioDriver() = nullptr" );
+		ERRORLOG( "Unable to restart previous audio driver after exporting song." );
 	}
 	m_bExportSessionIsActive = false;
 }

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -644,7 +644,7 @@ void Hydrogen::stopExportSong()
 {
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
-	if ( pAudioEngine->getAudioDriver()->class_name() != DiskWriterDriver::_class_name() ) {
+	if ( dynamic_cast<DiskWriterDriver*>(pAudioEngine->getAudioDriver()) == nullptr ) {
 		return;
 	}
 
@@ -1298,7 +1298,7 @@ bool Hydrogen::haveJackAudioDriver() const {
 #ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	if ( pAudioEngine->getAudioDriver() != nullptr ) {
-		if ( JackAudioDriver::_class_name() == pAudioEngine->getAudioDriver()->class_name() ){
+		if ( dynamic_cast<JackAudioDriver*>(pAudioEngine->getAudioDriver()) != nullptr ) {
 			return true;
 		}
 	}
@@ -1312,7 +1312,7 @@ bool Hydrogen::haveJackTransport() const {
 #ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	if ( pAudioEngine->getAudioDriver() != nullptr ) {
-		if ( JackAudioDriver::_class_name() == pAudioEngine->getAudioDriver()->class_name() &&
+		if ( dynamic_cast<JackAudioDriver*>(pAudioEngine->getAudioDriver()) != nullptr &&
 			 Preferences::get_instance()->m_bJackTransportMode ==
 			 Preferences::USE_JACK_TRANSPORT ){
 			return true;
@@ -1327,13 +1327,13 @@ bool Hydrogen::haveJackTransport() const {
 float Hydrogen::getMasterBpm() const {
 #ifdef H2CORE_HAVE_JACK
   if ( m_pAudioEngine->getAudioDriver() != nullptr ) {
-    if ( JackAudioDriver::_class_name() == m_pAudioEngine->getAudioDriver()->class_name() ) {
-      return static_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver())->getMasterBpm();
-    } else {
-      return std::nan("No JACK driver");
-    }
+	  if ( dynamic_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver()) != nullptr ) {
+		  return static_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver())->getMasterBpm();
+	  } else {
+		  return std::nan("No JACK driver");
+	  }
   } else {
-    return std::nan("No audio driver");
+	  return std::nan("No audio driver");
   }
 #else
   return std::nan("No JACK support");

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -263,30 +263,27 @@ int DiskWriterDriver::init( unsigned nBufferSize )
 	INFOLOG( QString( "Init, buffer size: %1" ).arg( nBufferSize ) );
 
 	m_nBufferSize = nBufferSize;
+	
+	m_pOut_L = new float[ m_nBufferSize ];
+	m_pOut_R = new float[ m_nBufferSize ];
 
 	return 0;
 }
 
-
-///
-/// Connect
-/// return 0: Ok
-///
 int DiskWriterDriver::connect()
 {
+	return 0;
+}
+
+void DiskWriterDriver::write()
+{
 	INFOLOG( "" );
-	
-	m_pOut_L = new float[ m_nBufferSize ];
-	m_pOut_R = new float[ m_nBufferSize ];
 	
 	pthread_attr_t attr;
 	pthread_attr_init( &attr );
 
 	pthread_create( &diskWriterDriverThread, &attr, diskWriterDriver_thread, this );
-	
-	return 0;
 }
-
 
 /// disconnect
 void DiskWriterDriver::disconnect()

--- a/src/core/IO/DiskWriterDriver.h
+++ b/src/core/IO/DiskWriterDriver.h
@@ -59,7 +59,7 @@ class DiskWriterDriver : public Object<DiskWriterDriver>, public AudioOutput
 		virtual int connect() override;
 		virtual void disconnect() override;
 
-		void write( float* buffer_L, float* buffer_R, unsigned int bufferSize );
+		void write();
 
 		virtual unsigned getBufferSize() override {
 			return m_nBufferSize;

--- a/src/core/IO/OssDriver.cpp
+++ b/src/core/IO/OssDriver.cpp
@@ -68,7 +68,7 @@ void* ossDriver_processCaller( void* param )
 
 
 OssDriver::OssDriver( audioProcessCallback processCallback )
-		: AudioOutput( __class_name )
+		: AudioOutput()
 {
 	audioBuffer = NULL;
 	ossDriver_running = false;

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -35,7 +35,6 @@
 #include <core/LocalFileMng.h>
 #include <core/Timeline.h>
 #include <core/Helpers/Xml.h>
-#include <core/IO/DiskWriterDriver.h>
 using namespace H2Core;
 
 #include "UndoActions.h"


### PR DESCRIPTION
The previous comparison based on the class name was flawed (see comments in https://github.com/hydrogen-music/hydrogen/commit/ebc9a68ab3cfaa6ec1f84a97bab351d83a218665)