### PR TITLE
AppVeyor: install and include OpenSSL

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,10 @@ environment:
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
       appveyor_build_worker_image: Visual Studio 2019
       LIBJACK: libjack64.dll
+      OPENSSL_DIR: OpenSSL-Win64
+      LIBSSL: libssl-1_1-x64.dll
+      LIBCRYPTO: libcrypto-1_1-x64.dll
+
       CHOCO_ARCH:
       PROGRAM_FILES: "Program Files"
 
@@ -30,6 +34,10 @@ environment:
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
       appveyor_build_worker_image: Visual Studio 2019
       LIBJACK: libjack.dll
+      OPENSSL_DIR: OpenSSL-Win32
+      LIBSSL: libssl-1_1.dll
+      LIBCRYPTO: libcrypto-1_1.dll
+
       CHOCO_ARCH:  --x86
       PROGRAM_FILES: "Program Files (x86)"
 
@@ -213,6 +221,13 @@ for:
           dir "c:\%PROGRAM_FILES%\JACK2"
           dir "c:\%PROGRAM_FILES%\JACK2\lib"
 
+          REM *** Results are ignored since a dependency was not properly installed in 32 bit Windows. But the .dll files required are installed regardless, so we don't care.***
+
+          choco install %CHOCO_ARCH% -y openssl --version=1.1.1.1300 || cmd /c "exit /b 0"
+
+          echo "C:\%OPENSSL_DIR%"
+          dir "C:\%OPENSSL_DIR%"
+
           REM *** Install dependencies ***
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libarchive
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libsndfile
@@ -265,6 +280,8 @@ for:
           REM copy_third_party_libs.py thinks it's a system lib and
           REM won't copy it.
           copy c:\Windows\%LIBJACK% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
+          copy c:\%OPENSSL_DIR%\%LIBSSL% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
+          copy c:\%OPENSSL_DIR%\%LIBCRYPTO% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
 
           REM *** Build installer ***
           cpack -G NSIS -v


### PR DESCRIPTION
Qt5 does not include OpenSSL libraries it was build against. See https://forum.qt.io/topic/95700/qsslsocket-tls-initialization-failed/18

As a result we have to make sure a compatible libssl.dll and libcrypto.dll is included in PATH when the software is loaded. It seems not to be detected by our Python dependency script. So, I added it manually like the JACK library.

Important: when upgrading/downgrading the Qt version a different version of OpenSSL might be required. One has to manually check the version it was build against https://wiki.qt.io/Qt_5.15_Tools_and_Versions#windows_10_x86_64_7.

But this can also be abstracted by a unit test as soon as the GUI can also be covered (I think we have to build a dedicated library as in #1329 first).