### PR TITLE
Rework timeline handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@
 		  overwrites all internal tempo settings.
 		- The BPM widget switches to read-only mode and displays the
 		  current playback speed when the Timeline is activated.
+		- Activation of the Timeline is now stored in each individual
+		  .h2song file.
 	* Interface
 		- Improved scalability (most PNG images were replaced by SVGs,
 		  hardcoded PNG labels are now directly drawn by Qt, and spin boxes,

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -779,7 +779,7 @@ float AudioEngine::getBpmAtColumn( int nColumn ) {
 			fBpm = fJackMasterBpm;
 			DEBUGLOG( QString( "Tempo update by the JACK server [%1]").arg( fJackMasterBpm ) );
 		}
-	} else if ( Preferences::get_instance()->getUseTimelineBpm() &&
+	} else if ( pHydrogen->getSong()->getIsTimelineActivated() &&
 				pHydrogen->getMode() == Song::Mode::Song ) {
 
 		float fTimelineBpm = pHydrogen->getTimeline()->getTempoAtColumn( nColumn );

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1326,6 +1326,8 @@ void AudioEngine::setSong( std::shared_ptr<Song> pNewSong )
 	setNextBpm( pNewSong->getBpm() );
 	processCheckBPMChanged();
 
+	Hydrogen::get_instance()->setTimeline( pNewSong->getTimeline() );
+
 	this->unlock();
 
 	m_pEventQueue->push_event( EVENT_STATE, static_cast<int>(State::Ready) );

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1473,7 +1473,7 @@ std::shared_ptr<Song> SongReader::readSong( const QString& sFileName )
 		WARNINGLOG( "ladspa node not found" );
 	}
 
-	Timeline* pTimeline = Hydrogen::get_instance()->getTimeline();
+	auto pTimeline = Hydrogen::get_instance()->getTimeline();
 	pTimeline->deleteAllTempoMarkers();
 	QDomNode bpmTimeLine = songNode.firstChildElement( "BPMTimeLine" );
 	if ( !bpmTimeLine.isNull() ) {

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -47,6 +47,28 @@ class Song;
 class DrumkitComponent;
 class PatternList;
 class AutomationPath;
+class Timeline;
+
+/**
+\ingroup H2CORE
+\brief	Read XML file of a song
+*/
+/** \ingroup docCore*/
+class SongReader : public H2Core::Object<SongReader>
+{
+		H2_OBJECT(SongReader)
+	public:
+		SongReader();
+		~SongReader();
+		const QString getPath( const QString& filename ) const;
+		std::shared_ptr<Song> readSong( const QString& filename );
+
+	private:
+		QString m_sSongVersion;
+
+		/// Dato un XmlNode restituisce un oggetto Pattern
+		Pattern* getPattern( QDomNode pattern, InstrumentList* instrList );
+};
 
 /**
 \ingroup H2CORE
@@ -209,6 +231,8 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		float getPanLawKNorm() const;
 
 		bool isPatternActive( int nColumn, int nRow ) const;
+
+	std::shared_ptr<Timeline> getTimeline() const;
 	
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of
@@ -219,7 +243,9 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		 *
 		 * \return String presentation of current object.*/
 		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
-
+	
+	friend std::shared_ptr<Song> SongReader::readSong( const QString& filename );
+	
 	private:
 							
 		bool m_bIsMuted;
@@ -298,7 +324,17 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		// k such that L^k+R^k = 1. Used in constant k-Norm pan law
 		float m_fPanLawKNorm;
 
+	void setTimeline( std::shared_ptr<Timeline> pTimeline );
+	std::shared_ptr<Timeline> m_pTimeline;
+
 };
+
+inline std::shared_ptr<Timeline> Song::getTimeline() const {
+	return m_pTimeline;
+}
+inline void Song::setTimeline( std::shared_ptr<Timeline> pTimeline ) {
+	m_pTimeline = pTimeline;
+}
 
 inline bool Song::getIsMuted() const
 {
@@ -570,27 +606,6 @@ inline int Song::getPanLawType() const {
 inline float Song::getPanLawKNorm() const {
 	return m_fPanLawKNorm;
 }
-
-/**
-\ingroup H2CORE
-\brief	Read XML file of a song
-*/
-/** \ingroup docCore*/
-class SongReader : public H2Core::Object<SongReader>
-{
-		H2_OBJECT(SongReader)
-	public:
-		SongReader();
-		~SongReader();
-		const QString getPath( const QString& filename ) const;
-		std::shared_ptr<Song> readSong( const QString& filename );
-
-	private:
-		QString m_sSongVersion;
-
-		/// Dato un XmlNode restituisce un oggetto Pattern
-		Pattern* getPattern( QDomNode pattern, InstrumentList* instrList );
-};
 
 };
 

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -90,6 +90,9 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		static std::shared_ptr<Song> getEmptySong();
 		static std::shared_ptr<Song> getDefaultSong();
 
+	bool getIsTimelineActivated() const;
+	void setIsTimelineActivated( bool bIsTimelineActivated );
+
 		bool getIsMuted() const;
 		void setIsMuted( bool bIsMuted );
 
@@ -247,6 +250,10 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 	friend std::shared_ptr<Song> SongReader::readSong( const QString& filename );
 	
 	private:
+
+	/** Whether the Timeline button was pressed in the GUI or it was
+		activated via an OSC command. */
+	bool m_bIsTimelineActivated;
 							
 		bool m_bIsMuted;
 		///< Resolution of the song (number of ticks per quarter)
@@ -329,6 +336,12 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 
 };
 
+inline bool Song::getIsTimelineActivated() const {
+	return m_bIsTimelineActivated;
+}
+inline void Song::setIsTimelineActivated( bool bIsTimelineActivated ) {
+	m_bIsTimelineActivated = bIsTimelineActivated;
+}
 inline std::shared_ptr<Timeline> Song::getTimeline() const {
 	return m_pTimeline;
 }

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -567,8 +567,8 @@ bool CoreActionController::isSongPathValid( const QString& sSongPath ) {
 
 bool CoreActionController::activateTimeline( bool bActivate ) {
 	auto pHydrogen = Hydrogen::get_instance();
-	
-	pHydrogen->setUseTimelineBpm( bActivate );
+
+	pHydrogen->setIsTimelineActivated( bActivate );
 	
 	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		WARNINGLOG( QString( "Timeline usage was [%1] in the Preferences. But these changes won't have an effect as long as there is still an external JACK timebase master." )

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -54,9 +54,15 @@ CoreActionController::~CoreActionController() {
 	//nothing
 }
 
-void CoreActionController::setMasterVolume( float masterVolumeValue )
+bool CoreActionController::setMasterVolume( float masterVolumeValue )
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	pHydrogen->getSong()->setVolume( masterVolumeValue );
 	
 #ifdef H2CORE_HAVE_OSC
@@ -70,11 +76,18 @@ void CoreActionController::setMasterVolume( float masterVolumeValue )
 	int ccParamValue = pMidiMap->findCCValueByActionType( QString("MASTER_VOLUME_ABSOLUTE"));
 	
 	handleOutgoingControlChange( ccParamValue, (masterVolumeValue / 1.5) * 127 );
+
+	return true;
 }
 
-void CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip )
+bool CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
 
 	if ( bSelectStrip ) {
 		pHydrogen->setSelectedInstrumentNumber( nStrip );
@@ -100,9 +113,11 @@ void CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool 
 	
 	handleOutgoingControlChange( ccParamValue, (fVolumeValue / 1.5) * 127 );
 	pHydrogen->setIsModified( true );
+
+	return true;
 }
 
-void CoreActionController::setMetronomeIsActive( bool isActive )
+bool CoreActionController::setMetronomeIsActive( bool isActive )
 {
 	Preferences::get_instance()->m_bUseMetronome = isActive;
 	
@@ -118,11 +133,19 @@ void CoreActionController::setMetronomeIsActive( bool isActive )
 	int ccParamValue = pMidiMap->findCCValueByActionType( QString("TOGGLE_METRONOME"));
 	
 	handleOutgoingControlChange( ccParamValue, (int) isActive * 127 );
+
+	return true;
 }
 
-void CoreActionController::setMasterIsMuted( bool isMuted )
+bool CoreActionController::setMasterIsMuted( bool isMuted )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	pHydrogen->getSong()->setIsMuted( isMuted );
 	
 #ifdef H2CORE_HAVE_OSC
@@ -137,11 +160,19 @@ void CoreActionController::setMasterIsMuted( bool isMuted )
 	int ccParamValue = pMidiMap->findCCValueByActionType( QString("MUTE_TOGGLE") );
 
 	handleOutgoingControlChange( ccParamValue, (int) isMuted * 127 );
+
+	return true;
 }
 
-void CoreActionController::toggleStripIsMuted(int nStrip)
+bool CoreActionController::toggleStripIsMuted(int nStrip)
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
@@ -153,11 +184,19 @@ void CoreActionController::toggleStripIsMuted(int nStrip)
 			setStripIsMuted( nStrip , !pInstr->is_muted() );
 		}
 	}
+
+	return true;
 }
 
-void CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
+bool CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 
@@ -178,11 +217,19 @@ void CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
 	
 	handleOutgoingControlChange( ccParamValue, ((int) isMuted) * 127 );
 	pHydrogen->setIsModified( true );
+
+	return true;
 }
 
-void CoreActionController::toggleStripIsSoloed( int nStrip )
+bool CoreActionController::toggleStripIsSoloed( int nStrip )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
@@ -194,11 +241,19 @@ void CoreActionController::toggleStripIsSoloed( int nStrip )
 			setStripIsSoloed( nStrip , !pInstr->is_soloed() );
 		}
 	}
+
+	return true;
 }
 
-void CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
+bool CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
@@ -219,13 +274,21 @@ void CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
 	
 	handleOutgoingControlChange( ccParamValue, ((int) isSoloed) * 127 );
 	pHydrogen->setIsModified( true );
+
+	return true;
 }
 
 
 
-void CoreActionController::setStripPan( int nStrip, float fValue, bool bSelectStrip )
+bool CoreActionController::setStripPan( int nStrip, float fValue, bool bSelectStrip )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	if ( bSelectStrip ) {
 		pHydrogen->setSelectedInstrumentNumber( nStrip );
 	}
@@ -250,11 +313,19 @@ void CoreActionController::setStripPan( int nStrip, float fValue, bool bSelectSt
 
 	handleOutgoingControlChange( ccParamValue, fValue * 127 );
 	pHydrogen->setIsModified( true );
+
+	return true;
 }
 
-void CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelectStrip )
+bool CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelectStrip )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	if ( bSelectStrip ) {
 		pHydrogen->setSelectedInstrumentNumber( nStrip );
 	}
@@ -278,22 +349,31 @@ void CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelec
 	int ccParamValue = pMidiMap->findCCValueByActionParam1( QString("PAN_ABSOLUTE"), QString("%1").arg( nStrip ) );
 	handleOutgoingControlChange( ccParamValue, pInstr->getPanWithRangeFrom0To1() * 127 );
 	pHydrogen->setIsModified( true );
+
+	return true;
 }
 
-void CoreActionController::handleOutgoingControlChange(int param, int value)
+bool CoreActionController::handleOutgoingControlChange(int param, int value)
 {
 	Preferences *pPref = Preferences::get_instance();
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	MidiOutput *pMidiDriver = pHydrogen->getMidiOutput();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
 	
 	if(	pMidiDriver 
 		&& pPref->m_bEnableMidiFeedback 
 		&& param >= 0 ){
 		pMidiDriver->handleOutgoingControlChange( param, value, m_nDefaultMidiFeedbackChannel );
 	}
+
+	return true;
 }
 
-void CoreActionController::initExternalControlInterfaces()
+bool CoreActionController::initExternalControlInterfaces()
 {
 	/*
 	 * Push the current state of Hydrogen to the attached control interfaces (e.g. OSC clients)
@@ -301,6 +381,12 @@ void CoreActionController::initExternalControlInterfaces()
 	
 	//MASTER_VOLUME_ABSOLUTE
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	setMasterVolume( pSong->getVolume() );
 	
@@ -330,6 +416,8 @@ void CoreActionController::initExternalControlInterfaces()
 	
 	//MUTE_TOGGLE
 	setMasterIsMuted( Hydrogen::get_instance()->getSong()->getIsMuted() );
+
+	return true;
 }
 
 bool CoreActionController::newSong( const QString& sSongPath ) {
@@ -444,6 +532,11 @@ bool CoreActionController::saveSong() {
 	
 	auto pHydrogen = Hydrogen::get_instance();
 
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+
 	// Get the current Song which is about to be saved.
 	auto pSong = pHydrogen->getSong();
 	
@@ -474,6 +567,11 @@ bool CoreActionController::saveSong() {
 bool CoreActionController::saveSongAs( const QString& sSongPath ) {
 	
 	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
 	
 	// Get the current Song which is about to be saved.
 	auto pSong = pHydrogen->getSong();
@@ -568,6 +666,11 @@ bool CoreActionController::isSongPathValid( const QString& sSongPath ) {
 bool CoreActionController::activateTimeline( bool bActivate ) {
 	auto pHydrogen = Hydrogen::get_instance();
 
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+
 	pHydrogen->setIsTimelineActivated( bActivate );
 	
 	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
@@ -582,10 +685,17 @@ bool CoreActionController::activateTimeline( bool bActivate ) {
 }
 
 bool CoreActionController::addTempoMarker( int nPosition, float fBpm ) {
-	auto pTimeline = Hydrogen::get_instance()->getTimeline();
+	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
+	auto pTimeline = pHydrogen->getTimeline();
 	pTimeline->deleteTempoMarker( nPosition );
 	pTimeline->addTempoMarker( nPosition, fBpm );
-	Hydrogen::get_instance()->setIsModified( true );
+	pHydrogen->setIsModified( true );
 
 	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
 
@@ -593,8 +703,15 @@ bool CoreActionController::addTempoMarker( int nPosition, float fBpm ) {
 }
 
 bool CoreActionController::deleteTempoMarker( int nPosition ) {
-	Hydrogen::get_instance()->getTimeline()->deleteTempoMarker( nPosition );
-	Hydrogen::get_instance()->setIsModified( true );
+	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
+	pHydrogen->getTimeline()->deleteTempoMarker( nPosition );
+	pHydrogen->setIsModified( true );
 	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
 
 	return true;
@@ -657,6 +774,12 @@ bool CoreActionController::activateJackTimebaseMaster( bool bActivate ) {
 bool CoreActionController::activateSongMode( bool bActivate ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	pHydrogen->sequencer_stop();
 	if ( bActivate && pHydrogen->getMode() != Song::Mode::Song ) {
 		locateToColumn( 0 );
@@ -670,7 +793,14 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 
 bool CoreActionController::activateLoopMode( bool bActivate, bool bTriggerEvent ) {
 
-	auto pSong = Hydrogen::get_instance()->getSong();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	pSong->setIsLoopEnabled( bActivate );
 	
 	if ( bTriggerEvent ) {
@@ -689,6 +819,12 @@ bool CoreActionController::locateToColumn( int nPatternGroup ) {
 	}
 	
 	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 	
 	EventQueue::get_instance()->push_event( EVENT_METRONOME, 1 );
@@ -720,6 +856,11 @@ bool CoreActionController::locateToFrame( unsigned long nFrame, bool bWithJackBr
 	const auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 	auto pDriver = pHydrogen->getAudioOutput();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
 
 	pAudioEngine->lock( RIGHT_HERE );
 	
@@ -757,7 +898,14 @@ bool CoreActionController::newPattern( const QString& sPatternName ) {
 	return setPattern( pPattern, pPatternList->size() );
 }
 bool CoreActionController::openPattern( const QString& sPath, int nPatternPosition ) {
-	auto pSong = Hydrogen::get_instance()->getSong();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	auto pPatternList = pSong->getPatternList();
 	Pattern* pNewPattern = Pattern::load_file( sPath, pSong->getInstrumentList() );
 
@@ -775,6 +923,12 @@ bool CoreActionController::openPattern( const QString& sPath, int nPatternPositi
 
 bool CoreActionController::setPattern( Pattern* pPattern, int nPatternPosition ) {
 	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	auto pPatternList = pHydrogen->getSong()->getPatternList();
 
 	// Check whether the name of the new pattern is unique.
@@ -795,6 +949,12 @@ bool CoreActionController::setPattern( Pattern* pPattern, int nPatternPosition )
 
 bool CoreActionController::removePattern( int nPatternNumber ) {
 	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	auto pPatternList = Hydrogen::get_instance()->getSong()->getPatternList();
 	int nPreviousPatternNumber = pHydrogen->getSelectedPatternNumber();
 	auto pPattern = pPatternList->get( nPatternNumber );
@@ -816,6 +976,12 @@ bool CoreActionController::removePattern( int nPatternNumber ) {
 
 bool CoreActionController::toggleGridCell( int nColumn, int nRow ){
 	auto pHydrogen = Hydrogen::get_instance();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
 	auto pSong = pHydrogen->getSong();
 	auto pPatternList = pSong->getPatternList();
 	std::vector<PatternList*>* pColumns = pSong->getPatternGroupVector();

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -37,39 +37,39 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		CoreActionController();
 		~CoreActionController();
 	
-		void setMasterVolume( float masterVolumeValue );
+		bool setMasterVolume( float masterVolumeValue );
 		/**
 		 * \param nStrip Instrument which to set the volume for.
 		 * \param fVolumeValue New volume.
 		 * \param bSelectStrip Whether the corresponding instrument
 		 * should be selected.
 		 */
-		void setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip );
+		bool setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip );
 		/**
 		 * \param nStrip Instrument which to set the pan for.
 		 * \param fValue New pan.
 		 * \param bSelectStrip Whether the corresponding instrument
 		 * should be selected.
 		 */
-		void setStripPan( int nStrip, float fValue, bool bSelectStrip );
+		bool setStripPan( int nStrip, float fValue, bool bSelectStrip );
 		/**
 		 * \param nStrip Instrument which to set the pan for.
 		 * \param fValue New pan. range in [-1;1] => symmetric respect to 0
 		 * \param bSelectStrip Whether the corresponding instrument
 		 * should be selected.
 		 */
-		void setStripPanSym( int nStrip, float fValue, bool bSelectStrip );
-		void setMetronomeIsActive( bool isActive );
-		void setMasterIsMuted( bool isMuted );
+		bool setStripPanSym( int nStrip, float fValue, bool bSelectStrip );
+		bool setMetronomeIsActive( bool isActive );
+		bool setMasterIsMuted( bool isMuted );
 		
-		void setStripIsMuted( int nStrip, bool isMuted );
-		void toggleStripIsMuted( int nStrip );
+		bool setStripIsMuted( int nStrip, bool isMuted );
+		bool toggleStripIsMuted( int nStrip );
 		
-		void setStripIsSoloed( int nStrip, bool isSoloed );
-		void toggleStripIsSoloed( int nStrip );
+		bool setStripIsSoloed( int nStrip, bool isSoloed );
+		bool toggleStripIsSoloed( int nStrip );
 		
-		void initExternalControlInterfaces();
-		void handleOutgoingControlChange( int param, int value);
+		bool initExternalControlInterfaces();
+		bool handleOutgoingControlChange( int param, int value);
 	
 		// -----------------------------------------------------------
 		// Actions required for session management.

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -298,6 +298,11 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 	} else {		
 		Preferences::get_instance()->setLastSongFilename( pSong->getFilename() );
 	}
+	
+	EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION,
+											( pSong->getMode() == Song::Mode::Song) ? 1 : 0 );
+	EventQueue::get_instance()->push_event( EVENT_TIMELINE_ACTIVATION,
+											static_cast<int>( pSong->getIsTimelineActivated() ) );
 }
 
 /* Mean: remove current song from memory */
@@ -1495,8 +1500,8 @@ void Hydrogen::setIsModified( bool bIsModified ) {
 void Hydrogen::setMode( Song::Mode mode ) {
 	if ( getSong() != nullptr ) {
 		getSong()->setMode( mode );
+		EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION, ( mode == Song::Mode::Song) ? 1 : 0 );
 	}
-	EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION, ( mode == Song::Mode::Song) ? 1 : 0 );
 }
 
 void Hydrogen::setIsTimelineActivated( bool bEnabled ) {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1367,7 +1367,7 @@ bool Hydrogen::isUnderSessionManagement() const {
 }
 
 bool Hydrogen::isTimelineEnabled() const {
-	if ( Preferences::get_instance()->getUseTimelineBpm() &&
+	if ( getSong()->getIsTimelineActivated() &&
 		 getMode() == Song::Mode::Song &&
 		 getJackTimebaseState() != JackAudioDriver::Timebase::Slave ) {
 		return true;
@@ -1380,7 +1380,7 @@ Hydrogen::Tempo Hydrogen::getTempoSource() const {
 	if ( getMode() == Song::Mode::Song ) {
 		if ( getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 			return Tempo::Jack;
-		} else if ( Preferences::get_instance()->getUseTimelineBpm() ) {
+		} else if ( getSong()->getIsTimelineActivated() ) {
 			return Tempo::Timeline;
 		}
 	}
@@ -1499,11 +1499,12 @@ void Hydrogen::setMode( Song::Mode mode ) {
 	EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION, ( mode == Song::Mode::Song) ? 1 : 0 );
 }
 
-void Hydrogen::setUseTimelineBpm( bool bEnabled ) {
+void Hydrogen::setIsTimelineActivated( bool bEnabled ) {
 	auto pPref = Preferences::get_instance();
 
-	if ( bEnabled != pPref->getUseTimelineBpm() ) {
+	if ( bEnabled != getSong()->getIsTimelineActivated() ) {
 		pPref->setUseTimelineBpm( bEnabled );
+		getSong()->setIsTimelineActivated( bEnabled );
 
 		EventQueue::get_instance()->push_event( EVENT_TIMELINE_ACTIVATION, static_cast<int>( bEnabled ) );
 	}

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -68,7 +68,6 @@
 #include <core/Preferences/Preferences.h>
 #include <core/Sampler/Sampler.h>
 #include "MidiMap.h"
-#include <core/Timeline.h>
 
 #ifdef H2CORE_HAVE_OSC
 #include <core/NsmClient.h>
@@ -116,7 +115,7 @@ Hydrogen::Hydrogen() : m_nSelectedInstrumentNumber( 0 )
 
 	__song = nullptr;
 
-	m_pTimeline = new Timeline();
+	m_pTimeline = std::make_shared<Timeline>();
 	m_pCoreActionController = new CoreActionController();
 
 	initBeatcounter();
@@ -162,7 +161,6 @@ Hydrogen::~Hydrogen()
 	__kill_instruments();
 
 	delete m_pCoreActionController;
-	delete m_pTimeline;
 	delete m_pAudioEngine;
 
 	__instance = nullptr;

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -187,9 +187,11 @@ public:
 	code except for song reading/setting.*/
 	void setMode( Song::Mode mode );
 
-	/** Wrapper around Preferences::setUseTimelinebpm() which also
+	/** Wrapper around both Song::setIsTimelineActivated (recent) and
+	Preferences::setUseTimelinebpm() (former place to store the
+	variable but kept to maintain backward compatibility) which also
 	triggers EVENT_TIMELINE_ACTIVATION.*/
-	void setUseTimelineBpm( bool bEnabled );
+	void setIsTimelineActivated( bool bEnabled );
 
 	void			removeSong();
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -373,6 +373,7 @@ void			previewSample( Sample *pSample );
 
 	void			__panic();
 	std::shared_ptr<Timeline>	getTimeline() const;
+	void			setTimeline( std::shared_ptr<Timeline> );
 	
 	//export management
 	bool			getIsExportSessionActive() const;
@@ -601,6 +602,10 @@ private:
 inline std::shared_ptr<Timeline> Hydrogen::getTimeline() const
 {
 	return m_pTimeline;
+}
+inline void Hydrogen::setTimeline( std::shared_ptr<Timeline> pTimeline )
+{
+	m_pTimeline = pTimeline;
 }
 
 inline CoreActionController* Hydrogen::getCoreActionController() const

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -99,16 +99,6 @@ public:
 
 	/**
 	 * Destructor taking care of most of the clean up.
-	 *
-	 * -# Shuts down the NsmClient using NsmClient::shutdown() and
-              deletes it.
-	 * -# Deletes the OscServer object.
-	 * -# Stops the AudioEngine if playing via audioEngine_stop().
-	 * -# Calls removeSong(), audioEngine_stopAudioDrivers(),
-              audioEngine_destroy(), __kill_instruments()
-         * -# Deletes the #m_pCoreActionController and #m_pTimeline
-              object
-	 * -# Sets #__instance to NULL.
 	 */
 	~Hydrogen();
 
@@ -382,7 +372,7 @@ void			previewSample( Sample *pSample );
 	void			onJackMaster();
 
 	void			__panic();
-	Timeline*		getTimeline() const;
+	std::shared_ptr<Timeline>	getTimeline() const;
 	
 	//export management
 	bool			getIsExportSessionActive() const;
@@ -551,7 +541,7 @@ private:
 	/**
 	 * Local instance of the Timeline object.
 	 */
-	Timeline*		m_pTimeline;
+	std::shared_ptr<Timeline>	m_pTimeline;
 	/**
 	 * Local instance of the CoreActionController object.
 	 */ 
@@ -608,7 +598,7 @@ private:
 /*
  * inline methods
  */
-inline Timeline* Hydrogen::getTimeline() const
+inline std::shared_ptr<Timeline> Hydrogen::getTimeline() const
 {
 	return m_pTimeline;
 }

--- a/src/core/LocalFileMgr.cpp
+++ b/src/core/LocalFileMgr.cpp
@@ -196,6 +196,23 @@ bool LocalFileMng::readXmlBool( QDomNode node , const QString& nodeName, bool de
 	}
 }
 
+bool LocalFileMng::readXmlBool( QDomNode node , const QString& nodeName, bool defaultValue, bool* pFound, bool bShouldExists, bool tinyXmlCompatMode)
+{
+	QString text = processNode( node, nodeName, bShouldExists, bShouldExists );
+	if ( text.isEmpty() ) {
+		_WARNINGLOG( QString( "\tusing default value : '%1' for node '%2'" ).arg( defaultValue ? "true" : "false" ).arg( nodeName ) );
+		*pFound = false;
+		return defaultValue;
+	} else {
+		*pFound = true;
+		if ( text == "true") {
+			return true;
+		} else {
+			return false;
+		}
+	}
+}
+
 
 void LocalFileMng::writeXmlString( QDomNode parent, const QString& name, const QString& text )
 {
@@ -414,6 +431,7 @@ int SongWriter::writeSong( std::shared_ptr<Song> pSong, const QString& filename 
 	LocalFileMng::writeXmlString( songNode, "playbackTrackVolume", QString("%1").arg( pSong->getPlaybackTrackVolume() ) );
 	LocalFileMng::writeXmlString( songNode, "action_mode",
 								  QString::number( static_cast<int>( pSong->getActionMode() ) ) );
+	LocalFileMng::writeXmlBool( songNode, "isTimelineActivated", pSong->getIsTimelineActivated() );
 	
 	if ( pSong->getMode() == Song::Mode::Song ) {
 		LocalFileMng::writeXmlString( songNode, "mode", QString( "song" ) );

--- a/src/core/LocalFileMgr.cpp
+++ b/src/core/LocalFileMgr.cpp
@@ -739,7 +739,7 @@ int SongWriter::writeSong( std::shared_ptr<Song> pSong, const QString& filename 
 
 
 	//bpm time line
-	Timeline * pTimeline = Hydrogen::get_instance()->getTimeline();
+	auto pTimeline = Hydrogen::get_instance()->getTimeline();
 
 	QDomNode bpmTimeLine = doc.createElement( "BPMTimeLine" );
 

--- a/src/core/LocalFileMng.h
+++ b/src/core/LocalFileMng.h
@@ -65,6 +65,12 @@ public:
 	static float	readXmlFloat( QDomNode, const QString& nodeName, float defaultValue, bool *pFound,
 								 bool bCanBeEmpty = false, bool bShouldExists = true, bool tinyXmlCompatMode = false );	
 	static int		readXmlInt( QDomNode , const QString& nodeName, int defaultValue, bool bCanBeEmpty = false, bool bShouldExists = true , bool tinyXmlCompatMode = false);
+	static bool		readXmlBool( QDomNode,
+								 const QString& nodeName,
+								 bool defaultValue,
+								 bool *pFound,
+								 bool bShouldExists = true,
+								 bool tinyXmlCompatMode = false );
 	static bool		readXmlBool( QDomNode , const QString& nodeName, bool defaultValue, bool bShouldExists = true , bool tinyXmlCompatMode = false );
 	static void		convertFromTinyXMLString( QByteArray* str );
 	static bool		checkTinyXMLCompatMode( const QString& filename );

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -80,7 +80,6 @@ Director::Director ( QWidget* pParent )
 	m_nFlashingArea = width() * 5/100;
 
 	m_fBpm = Hydrogen::get_instance()->getSong()->getBpm();
-	m_pTimeline = Hydrogen::get_instance()->getTimeline();
 	m_pTimer = new QTimer( this );
 	connect( m_pTimer, SIGNAL( timeout() ), this, SLOT( updateMetronomBackground() ) );
 }
@@ -106,11 +105,13 @@ void Director::closeEvent( QCloseEvent* ev )
 void Director::metronomeEvent( int nValue )
 {
 
+	auto pHydrogen = Hydrogen::get_instance();
+
 	//load a new song
 	if( nValue == 3 ){
 
 		//update songname
-		QStringList list = Hydrogen::get_instance()->getSong()->getFilename().split("/");
+		QStringList list = pHydrogen->getSong()->getFilename().split("/");
 
 		if ( !list.isEmpty() ){
 			m_sSongName = list.last().replace( Filesystem::songs_ext, "" );
@@ -126,9 +127,9 @@ void Director::metronomeEvent( int nValue )
 	}
 
 	//bpm
-	m_fBpm = Hydrogen::get_instance()->getSong()->getBpm();
+	m_fBpm = pHydrogen->getSong()->getBpm();
 	//bar
-	m_nBar = Hydrogen::get_instance()->getAudioEngine()->getColumn() + 1;
+	m_nBar = pHydrogen->getAudioEngine()->getColumn() + 1;
 
 	if ( m_nBar <= 0 ){
 		m_nBar = 1;
@@ -161,12 +162,14 @@ void Director::metronomeEvent( int nValue )
 	}
 
 	// get tags
-	if ( m_pTimeline->hasColumnTag( m_nBar ) ) {
-		m_sTAG = m_pTimeline->getTagAtColumn( m_nBar );
+	auto pTimeline = pHydrogen->getTimeline();
+
+	if ( pTimeline->hasColumnTag( m_nBar ) ) {
+		m_sTAG = pTimeline->getTagAtColumn( m_nBar );
 	} else {
 		m_sTAG = "";
 	}
-	m_sTAG2 = m_pTimeline->getTagAtColumn( m_nBar - 1 );
+	m_sTAG2 = pTimeline->getTagAtColumn( m_nBar - 1 );
 	update();
 }
 

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -29,7 +29,6 @@
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
 #include <core/Hydrogen.h>
-#include <core/Timeline.h>
 #include "EventListener.h"
 
 
@@ -57,7 +56,6 @@ private slots:
 
 private:
 	QTimer				*m_pTimer;
-	H2Core::Timeline	*m_pTimeline;
 	QColor				m_Color;
 	QPalette			m_BlinkerPalette;
 	int					m_nCounter;

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -118,8 +118,9 @@ ExportSongDialog::ExportSongDialog(QWidget* parent)
 	}
 
 	// use of timeline
-	toggleTimeLineBPMCheckBox->setChecked(m_pPreferences->getUseTimelineBpm());
-	m_bOldTimeLineBPMMode = m_pPreferences->getUseTimelineBpm();
+	auto pSong = H2Core::Hydrogen::get_instance()->getSong();
+	toggleTimeLineBPMCheckBox->setChecked( pSong->getIsTimelineActivated());
+	m_bOldTimeLineBPMMode = pSong->getIsTimelineActivated();
 	connect(toggleTimeLineBPMCheckBox, SIGNAL(toggled(bool)), this, SLOT(toggleTimeLineBPMMode( bool )));
 
 	// use of interpolation mode
@@ -477,7 +478,7 @@ void ExportSongDialog::closeExport() {
 		m_pHydrogen->getAudioEngine()->unlock();
 	}
 	m_pPreferences->setRubberBandBatchMode( m_bOldRubberbandBatchMode );
-	m_pPreferences->setUseTimelineBpm( m_bOldTimeLineBPMMode );
+	m_pHydrogen->setIsTimelineActivated( m_bOldTimeLineBPMMode );
 	
 	m_pHydrogen->getAudioEngine()->getSampler()->setInterpolateMode( m_OldInterpolationMode );
 	accept();
@@ -677,7 +678,7 @@ void ExportSongDialog::toggleRubberbandBatchMode(bool toggled)
 
 void ExportSongDialog::toggleTimeLineBPMMode(bool toggled)
 {
-	m_pPreferences->setUseTimelineBpm(toggled);
+	m_pHydrogen->setIsTimelineActivated( toggled );
 }
 
 void ExportSongDialog::resampleComboBoIndexChanged(int index )

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -706,6 +706,7 @@ void PlayerControl::songModeActivationEvent( int nValue )
 	}
 
 	updateBPMSpinbox();
+	updateBeatCounter();
 }
 
 void PlayerControl::bpmChanged( double fNewBpmValue ) {

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -190,7 +190,6 @@ private:
 	QTimer *m_pMidiActivityTimer;
 	std::chrono::milliseconds m_midiActivityTimeout;
 
-	bool m_bLastUseTimelineBpm;
 	bool m_bLastBCOnOffBtnState;
 	
 	/** Store the tool tip of the beat counter since it gets

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2196,7 +2196,7 @@ void SongEditorPositionRuler::createBackground()
 	Preferences *pPref = Preferences::get_instance();
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
-	Timeline * pTimeline = pHydrogen->getTimeline();
+	auto pTimeline = pHydrogen->getTimeline();
 	auto tagVector = pTimeline->getAllTags();
 	
 	QColor textColor( pPref->getColorTheme()->m_songEditor_textColor );
@@ -2686,7 +2686,7 @@ void SongEditorPositionRuler::updatePosition()
 
 void SongEditorPositionRuler::editTagAction( QString text, int position, QString textToReplace)
 {
-	Timeline* pTimeline = m_pHydrogen->getTimeline();
+	auto pTimeline = m_pHydrogen->getTimeline();
 
 	const QString sTag = pTimeline->getTagAtColumn( position );
 	pTimeline->deleteTag( position );
@@ -2697,7 +2697,7 @@ void SongEditorPositionRuler::editTagAction( QString text, int position, QString
 
 void SongEditorPositionRuler::deleteTagAction( QString text, int position )
 {
-	Timeline* pTimeline = m_pHydrogen->getTimeline();
+	auto pTimeline = m_pHydrogen->getTimeline();
 
 	const QString sTag = pTimeline->getTagAtColumn( position );
 	pTimeline->deleteTag( position );

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -78,7 +78,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	m_pTimelineBtn->move( 94, 4 );
 	m_pTimelineBtn->setObjectName( "TimelineBtn" );
 	connect( m_pTimelineBtn, SIGNAL( pressed() ), this, SLOT( timelineBtnPressed() ) );
-	m_bLastUseTimelineBpm = pPref->getUseTimelineBpm();
+	m_bLastIsTimelineActivated = pSong->getIsTimelineActivated();
 	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		m_pTimelineBtn->setToolTip( pCommonStrings->getTimelineDisabledTimebaseSlave() );
 		m_pTimelineBtn->setIsActive( false );
@@ -86,7 +86,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 		m_pTimelineBtn->setToolTip( pCommonStrings->getTimelineDisabledPatternMode() );
 		m_pTimelineBtn->setIsActive( false );
 	} else {
-		m_pTimelineBtn->setChecked( m_bLastUseTimelineBpm );
+		m_pTimelineBtn->setChecked( m_bLastIsTimelineActivated );
 	}
 
 	// clear sequence button
@@ -921,7 +921,7 @@ void SongEditorPanel::setTimelineActive( bool bActive ){
 		m_pTimelineBtn->setChecked( bActive );
 	}
 	
-	Hydrogen::get_instance()->setUseTimelineBpm( bActive );
+	Hydrogen::get_instance()->setIsTimelineActivated( bActive );
 
 	QString sMessage = QString( "%1 = %2" )
 		.arg( pCommonStrings->getTimelineBigButton() )
@@ -939,9 +939,9 @@ void SongEditorPanel::setTimelineEnabled( bool bEnabled ) {
 	
 	if ( bEnabled ) {
 		m_pTimelineBtn->setIsActive( true );
-		setTimelineActive( m_bLastUseTimelineBpm );
+		setTimelineActive( m_bLastIsTimelineActivated );
 	} else {
-		m_bLastUseTimelineBpm = Preferences::get_instance()->getUseTimelineBpm();
+		m_bLastIsTimelineActivated = Hydrogen::get_instance()->getSong()->getIsTimelineActivated();
 		if ( m_pTimelineBtn->isChecked() ) {
 			setTimelineActive( false );
 		}

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -934,16 +934,15 @@ bool SongEditorPanel::getTimelineEnabled() const {
 }
 
 void SongEditorPanel::setTimelineEnabled( bool bEnabled ) {
-	DEBUGLOG( bEnabled );
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	
 	if ( bEnabled ) {
 		m_pTimelineBtn->setIsActive( true );
-		setTimelineActive( m_bLastIsTimelineActivated );
+		// setTimelineActive( m_bLastIsTimelineActivated );
 	} else {
 		m_bLastIsTimelineActivated = Hydrogen::get_instance()->getSong()->getIsTimelineActivated();
 		if ( m_pTimelineBtn->isChecked() ) {
-			setTimelineActive( false );
+			// setTimelineActive( false );
 		}
 		m_pTimelineBtn->setIsActive( false );
 	}

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -185,7 +185,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		virtual void resizeEvent( QResizeEvent *ev ) override;
 		void resyncExternalScrollBar();
 
-	bool m_bLastUseTimelineBpm;
+	bool m_bLastIsTimelineActivated;
 };
 
 #endif

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -126,7 +126,7 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 void SongEditorPanelBpmWidget::on_deleteBtn_clicked()
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	Timeline* pTimeline = pHydrogen->getTimeline();
+	auto pTimeline = pHydrogen->getTimeline();
 
 	float fBpm = pTimeline->getTempoAtColumn( m_nColumn );
 

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -62,7 +62,7 @@ void SongEditorPanelTagWidget::a_itemIsChanged(QTableWidgetItem *item)
 void SongEditorPanelTagWidget::createTheTagTableWidget()
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	Timeline* pTimeline = pHydrogen->getTimeline();
+	auto pTimeline = pHydrogen->getTimeline();
 	int nMaxColumns = Preferences::get_instance()->getMaxBars();
 	
 	for( int i = 0; i < nMaxColumns; i++ )
@@ -123,7 +123,7 @@ void SongEditorPanelTagWidget::on_CancelBtn_clicked()
 void SongEditorPanelTagWidget::on_okBtn_clicked()
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	Timeline* pTimeline = pHydrogen->getTimeline();
+	auto pTimeline = pHydrogen->getTimeline();
 	auto tagVector = pTimeline->getAllTags();
 	int nMaxColumns = Preferences::get_instance()->getMaxBars();
 


### PR DESCRIPTION
Previously, there was a single `Timeline` instance in the `Hydrogen` class. Everytime a `Song` was read (not set!!) all tags and tempo markers were removed from the Timeline and the ones stored in .h2song added. It is an edge case but when loading two Songs and setting the first one the Timeline will be in a dirty state.

Now, every song holds the Timeline read from the corresponding .h2song file as a shared pointer and the currently loaded song will set `Hydrogen::m_pTimeline`. This way the Timeline should always correspond to the associated Song.

This also fixes a bug introduced during the recent changes of the BPM handling. When loading a different song, the default BPM used for the special tempo marker was not updated and potentially dirty. This leads to fails in the unit tests of the Windows images.

Additional changes 
- store Timeline in shared pointer
- store Timeline activation in Song. Previously, whether or not the Timeline was activated was stored in the Preferences file. This feels quite odd because
  1. all Timeline information are stored in the .h2song files
  2. some song feature tempo changes and some do not.
- ensure both Timeline and Mode changes are propagated to the GUI when loading a new song
- do not overwrite the state of the Timeline activation when entering pattern mode. The Timeline will still be disabled
- ensure the BeatCounter is in sync when switching between pattern and song mode