### PR TITLE
Rework autosave

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,10 @@
 		  current playback speed when the Timeline is activated.
 		- Activation of the Timeline is now stored in each individual
 		  .h2song file.
+		- Autosave files will be hidden. The interval they are stored with
+		  as well whether there is an autosave at all can be set via the
+		  Preferences. Hydrogen will inform the user whether there are
+		  unsaved changes to recover taken from the autosave file.
 	* Interface
 		- Improved scalability (most PNG images were replaced by SVGs,
 		  hardcoded PNG labels are now directly drawn by Qt, and spin boxes,

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -459,8 +459,7 @@ bool CoreActionController::newSong( const QString& sSongPath ) {
 	return true;
 }
 
-bool CoreActionController::openSong( const QString& sSongPath ) {
-	
+bool CoreActionController::openSong( const QString& sSongPath, const QString& sRecoverSongPath ) {
 	auto pHydrogen = Hydrogen::get_instance();
  
 	if ( pHydrogen->getAudioEngine()->getState() == AudioEngine::State::Playing ) {
@@ -474,9 +473,17 @@ bool CoreActionController::openSong( const QString& sSongPath ) {
 		// isSongPathValid takes care of the error log message.
 		return false;
 	}
-	
-	// Create an empty Song.
-	auto pSong = Song::load( sSongPath );
+
+	std::shared_ptr<Song> pSong;
+	if ( ! sRecoverSongPath.isEmpty() ) {
+		// Use an autosave file to load the song but 
+		pSong = Song::load( sRecoverSongPath );
+		if ( pSong != nullptr ) {
+			pSong->setFilename( sSongPath );
+		}
+	} else {
+		pSong = Song::load( sSongPath );
+	}
 
 	if ( pSong == nullptr ) {
 		ERRORLOG( QString( "Unable to open song [%1]." )

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -417,6 +417,8 @@ bool CoreActionController::initExternalControlInterfaces()
 	//MUTE_TOGGLE
 	setMasterIsMuted( Hydrogen::get_instance()->getSong()->getIsMuted() );
 
+	pHydrogen->setIsModified( false );
+	
 	return true;
 }
 

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -99,28 +99,22 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * This will be done immediately and without saving
 		 * the current #H2Core::Song. All unsaved changes will be lost!
 		 *
-		 * The intended use of this function for session
-		 * management. Therefore, the function will *not* store the
-		 * provided @a songPath in Preferences::m_lastSongFilename and
-		 * Hydrogen won't resume with the corresponding song on
-		 * restarting.
-		 *
 		 * \param songPath Absolute path to the .h2song file to be
 		 *    opened.
+		 * \param sRecoverSongPath If set to a value other than "",
+		 *    the corresponding path will be used to load the song and
+		 *    the latter is assigned @a songPath as Song::m_sFilename
+		 *    afterwards. Using this mechanism the GUI can use an
+		 *    autosave backup file to load a song without the core
+		 *    having to do some string magic to retrieve the original name.
 		 * \return true on success
 		 */
-		bool openSong( const QString& songPath );
+	bool openSong( const QString& songPath, const QString& sRecoverSongPath = "" );
 		/**
 		 * Opens the #H2Core::Song specified in @a songPath.
 		 *
 		 * This will be done immediately and without saving
 		 * the current #H2Core::Song. All unsaved changes will be lost!
-		 *
-		 * The intended use of this function for session
-		 * management. Therefore, the function will *not* store the
-		 * provided @a pSong in Preferences::m_lastSongFilename and
-		 * Hydrogen won't resume with the corresponding song on
-		 * restarting.
 		 *
 		 * \param pSong New Song.
 		 * \return true on success
@@ -330,9 +324,6 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 *
 		 * This will be done immediately and without saving the
 		 * current #H2Core::Song. All unsaved changes will be lost!
-		 *
-		 * The intended use of this function for session
-		 * management.
 		 *
 		 * \param pSong Pointer to the #H2Core::Song to set.
 		 * \return true on success

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -274,7 +274,7 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 		EventQueue::get_instance()->push_event( EVENT_PATTERN_CHANGED, -1 );
 		EventQueue::get_instance()->push_event( EVENT_SELECTED_INSTRUMENT_CHANGED, -1 );
 	}
-	
+
 	// In order to allow functions like audioEngine_setupLadspaFX() to
 	// load the settings of the new song, like whether the LADSPA FX
 	// are activated, __song has to be set prior to the call of
@@ -807,11 +807,11 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool conditional )
 	pAudioEngine->unlock();
 #endif
 
-	setIsModified( true );
-
 	pAudioEngine->setState( oldAudioEngineState );
 	
 	m_pCoreActionController->initExternalControlInterfaces();
+
+	setIsModified( true );
 	
 	// Create a symbolic link in the session folder when under session
 	// management.

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1483,7 +1483,9 @@ void Hydrogen::recalculateRubberband( float fBpm ) {
 
 void Hydrogen::setIsModified( bool bIsModified ) {
 	if ( getSong() != nullptr ) {
-		getSong()->setIsModified( bIsModified );
+		if ( getSong()->getIsModified() != bIsModified ) {
+			getSong()->setIsModified( bIsModified );
+		}
 	}
 }
 

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -898,8 +898,9 @@ void HydrogenApp::changePreferences( H2Core::Preferences::Changes changes ) {
 	m_pPreferencesUpdateTimer->start( m_nPreferencesUpdateTimeout );
 	// Ensure the provided changes will be propagated too.
 
-	if ( ! ( m_bufferedChanges | changes ) ) {
+	if ( ! ( m_bufferedChanges & changes ) ) {
 		m_bufferedChanges = static_cast<H2Core::Preferences::Changes>(m_bufferedChanges | changes);
+
 	}
 }
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -88,8 +88,8 @@ class HydrogenApp :  public QObject, public EventListener,  public H2Core::Objec
 		 * \param sFilename Absolute path used to load the next Song.
 		 * \return bool true on success
 		 */
-		bool openSong( const QString sFilename );
-		bool openSong( std::shared_ptr<H2Core::Song> pSong );
+		static bool openSong( QString sFilename );
+		static bool openSong( std::shared_ptr<H2Core::Song> pSong );
 
 		void showPreferencesDialog();
 		void updateMixerCheckbox();

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -167,7 +167,8 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 
 	// Filter
 	m_pFilterBypassBtn = new Button( m_pInstrumentProp, QSize( 36, 15 ), Button::Type::Toggle,
-									 "", pCommonStrings->getBypassButton(), true );
+									 "", pCommonStrings->getBypassButton(), true,
+									 QSize( 0, 0 ), "", false, true );
 	connect( m_pFilterBypassBtn, SIGNAL( pressed() ),
 			 this, SLOT( filterActiveBtnClicked() ) );
 	m_pFilterBypassBtn->move( 67, 169 );

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2315,6 +2315,13 @@ void MainForm::action_banks_properties()
 	delete pDrumkitInfo;
 }
 
+void MainForm::updateSongEvent( int nValue ) {
+	if ( nValue == 0 ) {
+		// A new song was set.
+		updateRecentUsedSongList();
+	}
+}
+
 void MainForm::startPlaybackAtCursor( QObject* pObject ) {
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -186,9 +186,12 @@ MainForm::~MainForm()
 {
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	// remove the autosave file
-	QFile file( getAutoSaveFilename() );
-	file.remove();
+	// Remove the autosave file in case all modifications already have
+	// been written to disk.
+	if ( ! pHydrogen->getSong()->getIsModified() ) {
+		QFile file( getAutoSaveFilename() );
+		file.remove();
+	}
 
 	//if a playlist is used, we save the last playlist-path to hydrogen.conf
 	Preferences::get_instance()->setLastPlaylistFilename( Playlist::get_instance()->getFilename() );

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -264,6 +264,7 @@ public slots:
 
 		QUndoView *	m_pUndoView;///debug only
 
+	void startAutosaveTimer();
 		QTimer		m_AutosaveTimer;
 
 		/** Create the menubar */

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -54,11 +54,10 @@ class MainForm :  public QMainWindow, protected WidgetWithScalableFont<8, 10, 12
 	MainForm( QApplication * pQApplication, QString sSongFilename );
 		~MainForm();
 
-		void updateRecentUsedSongList();
-
 		virtual void errorEvent( int nErrorCode ) override;
 		virtual void jacksessionEvent( int nValue) override;
 		virtual void playlistLoadSongEvent(int nIndex) override;
+		virtual void updateSongEvent( int nValue ) override;
 
 		/** Handles the loading and saving of the H2Core::Preferences
 		 * from the core part of H2Core::Hydrogen.
@@ -235,6 +234,8 @@ public slots:
 		bool handleUnsavedChanges();
 
 	private:
+		void updateRecentUsedSongList();
+
 		HydrogenApp*	h2app;
 
 		static int sigusr1Fd[2];

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -51,7 +51,7 @@ class MainForm :  public QMainWindow, protected WidgetWithScalableFont<8, 10, 12
 	public:
 		QApplication* m_pQApp;
 
-		MainForm( QApplication * pQApplication );
+	MainForm( QApplication * pQApplication, QString sSongFilename );
 		~MainForm();
 
 		void updateRecentUsedSongList();

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -309,6 +309,11 @@ public slots:
 		QMenu* m_pOptionsMenu;
 		QMenu* m_pDebugMenu;
 		QMenu* m_pInfoMenu;
+
+	/** Since the filename of the current song does change whenever
+		the users uses "Save As" multiple autosave files would be
+		written unless we take care of them.*/
+	QString m_sPreviousAutoSaveFilename;
 };
 
 #endif

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -310,6 +310,8 @@ public slots:
 		QMenu* m_pDebugMenu;
 		QMenu* m_pInfoMenu;
 
+	void openSongWithDialog( const QString& sWindowTitle, const QString& sPath, bool bIsDemo );
+
 	/** Since the filename of the current song does change whenever
 		the users uses "Save As" multiple autosave files would be
 		written unless we take care of them.*/

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -57,6 +57,7 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 {
 
 	auto pPref = H2Core::Preferences::get_instance();
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	
 	int h = pPref->getPatternEditorGridHeight();
 	setFixedSize(181, h);
@@ -71,7 +72,11 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 
 	/*: Text displayed on the button for muting an instrument. Its
 	  size is designed for a single character.*/
-	m_pMuteBtn = new Button( this, QSize( 18, height() - 1 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSmallMuteButton(), true, QSize(), tr("Mute instrument") );
+	m_pMuteBtn = new Button( this, QSize( 18, height() - 1 ),
+							 Button::Type::Toggle, "",
+							 pCommonStrings->getSmallMuteButton(),
+							 true, QSize(), tr("Mute instrument"),
+							 false, true );
 	m_pMuteBtn->move( 145, 0 );
 	m_pMuteBtn->setChecked(false);
 	m_pMuteBtn->setObjectName( "MuteButton" );
@@ -79,7 +84,11 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 
 	/*: Text displayed on the button for soloing an instrument. Its
 	  size is designed for a single character.*/
-	m_pSoloBtn = new Button( this, QSize( 18, height() - 1 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSmallSoloButton(), false, QSize(), tr("Solo") );
+	m_pSoloBtn = new Button( this, QSize( 18, height() - 1 ),
+							 Button::Type::Toggle, "",
+							 pCommonStrings->getSmallSoloButton(),
+							 false, QSize(), tr("Solo"),
+							 false, true );
 	m_pSoloBtn->move( 163, 0 );
 	m_pSoloBtn->setChecked(false);
 	m_pSoloBtn->setObjectName( "SoloButton" );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -172,7 +172,9 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	m_pEditorTop1_hbox_2->addWidget( m_pRec );
 
 	// Hear notes btn
-	m_pHearNotesBtn = new Button( m_pRec, QSize( 21, 18 ), Button::Type::Toggle, "speaker.svg", "", false, QSize( 15, 13 ), tr( "Hear new notes" ) );
+	m_pHearNotesBtn = new Button( m_pRec, QSize( 21, 18 ), Button::Type::Toggle,
+								  "speaker.svg", "", false, QSize( 15, 13 ),
+								  tr( "Hear new notes" ), false, true );
 	m_pHearNotesBtn->move( 42, 1 );
 	connect( m_pHearNotesBtn, SIGNAL( pressed() ), this, SLOT( hearNotesBtnClick() ) );
 	m_pHearNotesBtn->setChecked( pPref->getHearNewNotes() );
@@ -183,7 +185,11 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 
 	// quantize
-	m_pQuantizeEventsBtn = new Button( m_pRec, QSize( 21, 18 ), Button::Type::Toggle, "quantization.svg", "", false, QSize( 15, 14 ), tr( "Quantize keyboard/midi events to grid" ) );
+	m_pQuantizeEventsBtn = new Button( m_pRec, QSize( 21, 18 ),
+									   Button::Type::Toggle, "quantization.svg",
+									   "", false, QSize( 15, 14 ),
+									   tr( "Quantize keyboard/midi events to grid" ),
+									   false, true );
 	m_pQuantizeEventsBtn->move( 111, 1 );
 	m_pQuantizeEventsBtn->setChecked( pPref->getQuantizeEvents() );
 	m_pQuantizeEventsBtn->setObjectName( "QuantizeEventsBtn" );

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -143,8 +143,10 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pFfwdBtn->setAction( pAction );
 
 	// Loop song button button
-	m_pSongLoopBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Toggle,
-								 "loop.svg", "", false, QSize( 17, 13 ), tr("Loop song") );
+	m_pSongLoopBtn = new Button( pControlsPanel, QSize( 25, 19 ),
+								 Button::Type::Toggle, "loop.svg", "", false,
+								 QSize( 17, 13 ), tr("Loop song"),
+								 false, true );
 	m_pSongLoopBtn->move( 308, 15);
 	connect( m_pSongLoopBtn, SIGNAL( pressed() ), this, SLOT( songLoopBtnClicked() ) );
 
@@ -152,9 +154,11 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pPatternModeLED = new LED( pControlsPanel, QSize( 11, 9 ) );
 	m_pPatternModeLED->move( 179, 4 );
 	m_pPatternModeLED->setActivated( true );
-	m_pPatternModeBtn = new Button( pControlsPanel, QSize( 59, 11 ), Button::Type::Toggle,
-									"", pCommonStrings->getPatternModeButton(), false, QSize(),
-									tr("Pattern Mode") );
+	m_pPatternModeBtn = new Button( pControlsPanel, QSize( 59, 11 ),
+									Button::Type::Toggle, "",
+									pCommonStrings->getPatternModeButton(),
+									false, QSize(), tr("Pattern Mode"),
+									false, true );
 	m_pPatternModeBtn->move( 190, 3 );
 	m_pPatternModeBtn->setChecked(true);
 	connect(m_pPatternModeBtn, SIGNAL( pressed() ), this, SLOT( patternModeBtnClicked() ));
@@ -162,9 +166,11 @@ PlayerControl::PlayerControl(QWidget *parent)
 	// Song mode button
 	m_pSongModeLED = new LED( pControlsPanel, QSize( 11, 9 ) );
 	m_pSongModeLED->move( 252, 4 );
-	m_pSongModeBtn = new Button( pControlsPanel, QSize( 59, 11 ), Button::Type::Toggle,
-								 "", pCommonStrings->getSongModeButton(), false, QSize(),
-								 tr("Song Mode") );
+	m_pSongModeBtn = new Button( pControlsPanel, QSize( 59, 11 ),
+								 Button::Type::Toggle, "",
+								 pCommonStrings->getSongModeButton(),
+								 false, QSize(), tr("Song Mode"),
+								 false, true );
 	m_pSongModeBtn->move( 263, 3 );
 	m_pSongModeBtn->setChecked(false);
 	connect(m_pSongModeBtn, SIGNAL( pressed() ), this, SLOT( songModeBtnClicked() ));
@@ -180,9 +186,11 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_sBCOnOffBtnToolTip = tr("Toggle the BeatCounter Panel");
 	m_sBCOnOffBtnTimelineToolTip = tr( "Please deactivate the Timeline first in order to use the BeatCounter" );
 	m_sBCOnOffBtnJackTimebaseToolTip = tr( "In the presence of an external JACK Timebase master the BeatCounter can not be used" );
-	m_pBCOnOffBtn = new Button( pControlsBBTBConoffPanel, QSize( 13, 42 ), Button::Type::Toggle,
-								"", pCommonStrings->getBeatCounterButton(), false, QSize(),
-								m_sBCOnOffBtnToolTip );
+	m_pBCOnOffBtn = new Button( pControlsBBTBConoffPanel, QSize( 13, 42 ),
+								Button::Type::Toggle, "",
+								pCommonStrings->getBeatCounterButton(), false,
+								QSize(), m_sBCOnOffBtnToolTip,
+								false, true );
 	m_pBCOnOffBtn->move(0, 0);
 	if ( pPref->m_bbc == Preferences::BC_ON ) {
 		m_bLastBCOnOffBtnState = true;
@@ -234,29 +242,36 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pBCDisplayB->move( 45, 25 );
 	m_pBCDisplayB->setText( "04" );
 
-	m_pBCTUpBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push,
-							  "plus.svg", "", false, QSize( 8, 8 ) );
+	m_pBCTUpBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
+							  Button::Type::Push, "plus.svg", "", false,
+							  QSize( 8, 8 ), "", false, true );
 	m_pBCTUpBtn->move( 2, 3 );
 	connect( m_pBCTUpBtn, SIGNAL( pressed() ), this, SLOT( bctUpButtonClicked() ) );
 
-	m_pBCTDownBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push,
-								"minus.svg", "", false, QSize( 8, 8 ) );
+	m_pBCTDownBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
+								Button::Type::Push, "minus.svg", "", false,
+								QSize( 8, 8 ), "", false, true );
 	m_pBCTDownBtn->move( 2, 14 );
 	connect( m_pBCTDownBtn, SIGNAL( pressed() ), this, SLOT( bctDownButtonClicked() ) );
 
-	m_pBCBUpBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push,
-							  "plus.svg", "", false, QSize( 8, 8 ) );
+	m_pBCBUpBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
+							  Button::Type::Push, "plus.svg", "", false,
+							  QSize( 8, 8 ), "", false, true );
 	m_pBCBUpBtn->move( 64, 3 );
 	connect( m_pBCBUpBtn, SIGNAL( pressed() ), this, SLOT( bcbUpButtonClicked() ) );
 
-	m_pBCBDownBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push,
-								"minus.svg", "", false, QSize( 8, 8 ) );
+	m_pBCBDownBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
+								Button::Type::Push, "minus.svg", "", false,
+								QSize( 8, 8 ), "", false, true );
 	m_pBCBDownBtn->move( 64, 14 );
 	connect( m_pBCBDownBtn, SIGNAL( pressed() ), this, SLOT( bcbDownButtonClicked() ) );
 
-	m_pBCSetPlayBtn = new Button( m_pControlsBCPanel, QSize( 19, 15 ), Button::Type::Push,
-								  "", pCommonStrings->getBeatCounterSetPlayButtonOff(), false,
-								  QSize(), tr("Set BPM / Set BPM and play") );
+	m_pBCSetPlayBtn = new Button( m_pControlsBCPanel, QSize( 19, 15 ),
+								  Button::Type::Push, "",
+								  pCommonStrings->getBeatCounterSetPlayButtonOff(),
+								  false, QSize(),
+								  tr("Set BPM / Set BPM and play"),
+								  false, true );
 	m_pBCSetPlayBtn->move( 64, 25 );
 	connect(m_pBCSetPlayBtn, SIGNAL( pressed() ), this, SLOT( bcSetPlayBtnClicked() ));
 //~ beatcounter
@@ -289,9 +304,12 @@ PlayerControl::PlayerControl(QWidget *parent)
 								   H2Core::Hydrogen::Tempo::Song );
 	updateBPMSpinboxToolTip();
 
-	m_pRubberBPMChange = new Button( pBPMPanel, QSize( 13, 42 ), Button::Type::Toggle,
-									 "", pCommonStrings->getRubberbandButton(), false, QSize(),
-									 tr("Recalculate Rubberband modified samples if bpm will change") );
+	m_pRubberBPMChange = new Button( pBPMPanel, QSize( 13, 42 ),
+									 Button::Type::Toggle, "",
+									 pCommonStrings->getRubberbandButton(),
+									 false, QSize(),
+									 tr("Recalculate Rubberband modified samples if bpm will change"),
+									 false, true );
 
 	m_pRubberBPMChange->move( 131, 0 );
 	m_pRubberBPMChange->setChecked( pPref->getRubberBandBatchMode());
@@ -305,9 +323,11 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pMetronomeLED = new MetronomeLED( pBPMPanel, QSize( 22, 7 ) );
 	m_pMetronomeLED->move( 7, 32 );
 
-	m_pMetronomeBtn = new Button( pBPMPanel, QSize( 24, 28 ), Button::Type::Toggle,
-								  "metronome.svg", "", false, QSize( 20, 20 ),
-								  tr("Switch metronome on/off") );
+	m_pMetronomeBtn = new Button( pBPMPanel, QSize( 24, 28 ),
+								  Button::Type::Toggle, "metronome.svg", "",
+								  false, QSize( 20, 20 ),
+								  tr("Switch metronome on/off"),
+								  false, true );
 	m_pMetronomeBtn->move( 6, 2 );
 	connect( m_pMetronomeBtn, SIGNAL( pressed() ), this, SLOT( metronomeButtonClicked() ) );
 	pAction = std::make_shared<Action>("TOGGLE_METRONOME");
@@ -327,9 +347,12 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	/*: Using the JACK the audio/midi input and output ports of any
 	  number of application can be connected.*/
-	m_pJackTransportBtn = new Button( pJackPanel, QSize( 53, 16 ), Button::Type::Toggle,
-									  "", pCommonStrings->getJackTransportButton(), false, QSize(),
-									  tr("JACK transport on/off") );
+	m_pJackTransportBtn = new Button( pJackPanel, QSize( 53, 16 ),
+									  Button::Type::Toggle, "",
+									  pCommonStrings->getJackTransportButton(),
+									  false, QSize(),
+									  tr("JACK transport on/off"),
+									  false, true );
 	m_pJackTransportBtn->hide();
 	if ( pPref->m_bJackTransportMode == Preferences::USE_JACK_TRANSPORT ) {
 		m_pJackTransportBtn->setChecked( true );
@@ -345,9 +368,11 @@ connected programs can broadcast both speed and measure information to
 all other connected applications in order to have a more fine-grained
 transport control.*/
 	m_sJackMasterModeToolTip = tr("JACK Timebase master on/off");
-	m_pJackMasterBtn = new Button( pJackPanel, QSize( 53, 16 ), Button::Type::Toggle,
-								   "", pCommonStrings->getJackMasterButton(), false, QSize(),
-								   m_sJackMasterModeToolTip );
+	m_pJackMasterBtn = new Button( pJackPanel, QSize( 53, 16 ),
+								   Button::Type::Toggle, "",
+								   pCommonStrings->getJackMasterButton(), false,
+								   QSize(), m_sJackMasterModeToolTip,
+								   false, true );
 	m_pJackMasterBtn->hide();
 	if ( m_pJackTransportBtn->isChecked() &&
 		 pPref->m_bJackMasterMode == Preferences::USE_JACK_TIME_MASTER &&

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -667,6 +667,11 @@ void PreferencesDialog::on_okBtn_clicked()
 {
 	//	m_bNeedDriverRestart = true;
 
+	auto changes =
+		static_cast<H2Core::Preferences::Changes>( H2Core::Preferences::Changes::Font |
+												   H2Core::Preferences::Changes::Colors |
+												   H2Core::Preferences::Changes::AppearanceTab );
+
 	Preferences *pPref = Preferences::get_instance();
 
 	MidiMap *mM = MidiMap::get_instance();
@@ -760,16 +765,20 @@ void PreferencesDialog::on_okBtn_clicked()
 
 	pPref->setMaxBars( sBmaxBars->value() );
 	pPref->setMaxLayers( sBmaxLayers->value() );
-	pPref->m_nAutosavesPerHour = autosaveSpinBox->value();
+
+	if ( pPref->m_nAutosavesPerHour != autosaveSpinBox->value() ) {
+		pPref->m_nAutosavesPerHour = autosaveSpinBox->value();
+		changes =
+			static_cast<H2Core::Preferences::Changes>( changes |
+													   H2Core::Preferences::Changes::GeneralTab );
+	}
 
 	Hydrogen::get_instance()->setBcOffsetAdjust();
 
 	pPref->setTheme( m_pCurrentTheme );
-
+	
 	HydrogenApp *pH2App = HydrogenApp::get_instance();
-	pH2App->changePreferences( static_cast<H2Core::Preferences::Changes>( H2Core::Preferences::Changes::Font |
-																		  H2Core::Preferences::Changes::Colors |
-																		  H2Core::Preferences::Changes::AppearanceTab ) );
+	pH2App->changePreferences( changes );
 
 	SongEditorPanel* pSongEditorPanel = pH2App->getSongEditorPanel();
 	SongEditor * pSongEditor = pSongEditorPanel->getSongEditor();

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -129,12 +129,21 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	// Two buttons sharing the same position and either of them is
 	// shown unpressed.
-	m_pModeActionSingleBtn = new Button( pBackPanel, QSize( 23, 19 ), Button::Type::Push, "single_layer.svg", "", false, QSize( 15, 11 ), tr( "single pattern mode") );
+	m_pModeActionSingleBtn = new Button( pBackPanel, QSize( 23, 19 ),
+										 Button::Type::Push, "single_layer.svg",
+										 "", false, QSize( 15, 11 ),
+										 tr( "single pattern mode"),
+										 false, true );
 	m_pModeActionSingleBtn->move( 170, 26 );
 	m_pModeActionSingleBtn->setVisible( pPref->patternModePlaysSelected() );
 	connect( m_pModeActionSingleBtn, SIGNAL( pressed() ), this, SLOT( modeActionBtnPressed() ) );
 
-	m_pModeActionMultipleBtn = new Button( pBackPanel, QSize( 23, 19 ), Button::Type::Push, "multiple_layers.svg", "", false, QSize( 19, 15 ), tr( "stacked pattern mode") );
+	m_pModeActionMultipleBtn = new Button( pBackPanel, QSize( 23, 19 ),
+										   Button::Type::Push,
+										   "multiple_layers.svg", "", false,
+										   QSize( 19, 15 ),
+										   tr( "stacked pattern mode"),
+										   false, true );
 	m_pModeActionMultipleBtn->move( 170, 26 );
 	m_pModeActionMultipleBtn->hide();
 	m_pModeActionMultipleBtn->setVisible( pPref->patternModePlaysSelected() );
@@ -171,7 +180,11 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	connect( m_pPlaybackTrackFader, SIGNAL( valueChanged( WidgetWithInput* ) ), this, SLOT( faderChanged( WidgetWithInput* ) ) );
 
 	// mute playback track toggle button
-	m_pMutePlaybackBtn = new Button( pBackPanel, QSize( 34, 17 ), Button::Type::Toggle, "", pCommonStrings->getBigMuteButton(), true, QSize(), tr( "Mute playback track" ) );
+	m_pMutePlaybackBtn = new Button( pBackPanel, QSize( 34, 17 ),
+									 Button::Type::Toggle, "",
+									 pCommonStrings->getBigMuteButton(),
+									 true, QSize(), tr( "Mute playback track" ),
+									 false, true );
 	m_pMutePlaybackBtn->move( 158, 4 );
 	m_pMutePlaybackBtn->hide();
 	connect( m_pMutePlaybackBtn, SIGNAL( pressed() ), this, SLOT( mutePlaybackTrackBtnPressed() ) );
@@ -759,6 +772,7 @@ void SongEditorPanel::modeActionBtnPressed( )
 		m_pModeActionMultipleBtn->hide();
 	}
 	Hydrogen::get_instance()->setPlaysSelected( bWasStacked );
+	Hydrogen::get_instance()->setIsModified( true );
 	EventQueue::get_instance()->push_event( EVENT_STACKED_MODE_ACTIVATION, bWasStacked ? 0 : 1 );
 	updateAll();
 }

--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -215,6 +215,7 @@ void AutomationPathView::mousePressEvent(QMouseEvent *event)
 		m_fOriginY = y;
 		m_bPointAdded = false;
 	}
+	H2Core::Hydrogen::get_instance()->setIsModified( true );
 
 	update();
 
@@ -267,6 +268,7 @@ void AutomationPathView::mouseMoveEvent(QMouseEvent *event)
 
 	if(m_bIsHolding) {
 		_selectedPoint = _path->move(_selectedPoint, x, y);
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
 	}
 
 	update();
@@ -286,6 +288,8 @@ void AutomationPathView::keyPressEvent(QKeyEvent *event)
 			float y = _selectedPoint->second;
 			_path->remove_point(_selectedPoint->first);
 			_selectedPoint = _path->end();
+			
+			H2Core::Hydrogen::get_instance()->setIsModified( true );
 
 			emit pointRemoved( x, y );
 			update();

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -34,7 +34,7 @@
 #include <core/Preferences/Theme.h>
 #include <core/Hydrogen.h>
 
-Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, const QString& sText, bool bUseRedBackground, QSize iconSize, QString sBaseTooltip, bool bColorful )
+Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, const QString& sText, bool bUseRedBackground, QSize iconSize, QString sBaseTooltip, bool bColorful, bool bModifyOnChange )
 	: QPushButton( pParent )
 	, m_size( size )
 	, m_iconSize( iconSize )
@@ -47,6 +47,7 @@ Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, c
 	, m_bIsActive( true )
 	, m_bUseRedBackground( bUseRedBackground )
 	, m_nFixedFontSize( -1 )
+	, m_bModifyOnChange( bModifyOnChange )
 {
 	setAttribute( Qt::WA_OpaquePaintEvent );
 	setFocusPolicy( Qt::NoFocus );
@@ -83,6 +84,12 @@ Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, c
 	updateTooltip();
 	
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &Button::onPreferencesChanged );
+
+	if ( type == Type::Toggle ) {
+		connect( this, SIGNAL(toggled(bool)), this, SLOT(onToggled(bool)));
+	} else {
+		connect( this, SIGNAL(clicked(bool)), this, SLOT(onToggled(bool)));
+	}
 }
 
 Button::~Button() {
@@ -331,5 +338,11 @@ void Button::onPreferencesChanged( H2Core::Preferences::Changes changes ) {
 
 	if ( changes & H2Core::Preferences::Changes::AppearanceTab ) {
 		updateIcon();
+	}
+}
+
+void Button::onToggled( bool bChecked ) {
+	if ( m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
 	}
 }

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -88,6 +88,9 @@ public:
 	 * to exist in both subfolders "black" and "white" in the "icons"
 	 * folder. If the button is not checked, the black version is used
 	 * and if checked, the white one is used instead.
+	 * \param bModifyOnChange Whether Hydrogen::setIsModified() is
+	 * invoked with `true` as soon as the value of the widget does
+	 * change.
 	 */
 	Button(
 		   QWidget *pParent,
@@ -98,7 +101,8 @@ public:
 		   bool bUseRedBackground = false,
 		   QSize iconSize = QSize( 0, 0 ),
 		   QString sBaseTooltip = "",
-		   bool bColorful = false
+		   bool bColorful = false,
+		   bool bModifyOnChange = false
 		   );
 	virtual ~Button();
 	
@@ -119,6 +123,9 @@ public:
 
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
+
+private slots:
+	void onToggled( bool );
 
 signals:
 	void clicked(Button *pBtn);
@@ -147,6 +154,10 @@ private:
 	bool m_bLastCheckedState;
 
 	bool m_bIsActive;
+	
+	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+		soon as the value of the widget does change.*/
+	bool m_bModifyOnChange;
 
 	virtual void mousePressEvent(QMouseEvent *ev) override;
 	virtual void paintEvent( QPaintEvent* ev) override;

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -28,10 +28,11 @@
 
 #include <core/Globals.h>
 
-ClickableLabel::ClickableLabel( QWidget *pParent, QSize size, QString sText, Color color  )
+ClickableLabel::ClickableLabel( QWidget *pParent, QSize size, QString sText, Color color, bool bModifyOnChange )
 	: QLabel( pParent )
 	, m_size( size )
 	, m_color( color )
+	, m_bModifyOnChange( bModifyOnChange )
 {
 	if ( ! size.isNull() ) {
 		setFixedSize( size );
@@ -133,8 +134,16 @@ void ClickableLabel::onPreferencesChanged( H2Core::Preferences::Changes changes 
 }
 
 void ClickableLabel::setText( const QString& sNewText ) {
+	if ( text() == sNewText ) {
+		return;
+	}
+	
 	auto pPref = H2Core::Preferences::get_instance();
 	
 	QLabel::setText( sNewText );
 	updateFont( pPref->getLevel3FontFamily(), pPref->getFontSize() );
+
+	if ( m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
 }

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -51,7 +51,7 @@ public:
 		Dark
 	};
 	
-	explicit ClickableLabel( QWidget *pParent, QSize size = QSize( 0, 0 ), QString sText = "", Color color = Color::Bright );
+	explicit ClickableLabel( QWidget *pParent, QSize size = QSize( 0, 0 ), QString sText = "", Color color = Color::Bright, bool bModifyOnChange = true );
 	virtual void mousePressEvent( QMouseEvent * e ) override;
 
 public slots:
@@ -67,6 +67,10 @@ private:
 
 	QSize m_size;
 	Color m_color;
+
+	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+		soon as the value of the widget does change.*/
+	bool m_bModifyOnChange;
 };
 
 

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -34,14 +34,15 @@
 #include <core/Hydrogen.h>
 #include <core/Preferences/Preferences.h>
 
-Fader::Fader( QWidget *pParent, Type type, QString sBaseTooltip, bool bUseIntSteps, bool bWithoutKnob, float fMin, float fMax )
+Fader::Fader( QWidget *pParent, Type type, QString sBaseTooltip, bool bUseIntSteps, bool bWithoutKnob, float fMin, float fMax, bool bModifyOnChange )
 	: WidgetWithInput( pParent,
 					   bUseIntSteps,
 					   sBaseTooltip,
 					   1, // nScrollSpeed
 					   5, // nScrollSpeedFast
 					   fMin,
-					   fMax  )
+					   fMax,
+					   bModifyOnChange )
 	, m_type( type )
 	, m_bWithoutKnob( bWithoutKnob )
 	, m_fPeakValue_L( 0.01f )

--- a/src/gui/src/Widgets/Fader.h
+++ b/src/gui/src/Widgets/Fader.h
@@ -52,7 +52,7 @@ public:
 		Master
 	};
 	
-	Fader( QWidget *pParent, Type type, QString sBaseTooltip, bool bUseIntSteps = false, bool bWithoutKnob = false, float fMin = 0.0, float fMax = 1.0 );
+	Fader( QWidget *pParent, Type type, QString sBaseTooltip, bool bUseIntSteps = false, bool bWithoutKnob = false, float fMin = 0.0, float fMax = 1.0, bool bModifyOnChange = true );
 	~Fader();
 
 	void setMaxPeak( float fMax );

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -27,10 +27,11 @@
 #include <core/Globals.h>
 
 
-LCDCombo::LCDCombo( QWidget *pParent, QSize size )
+LCDCombo::LCDCombo( QWidget *pParent, QSize size, bool bModifyOnChange )
 	: QComboBox( pParent )
 	, m_size( size )
 	, m_bEntered( false )
+	, m_bModifyOnChange( bModifyOnChange )
 {
 	setFocusPolicy( Qt::ClickFocus );
 
@@ -42,6 +43,8 @@ LCDCombo::LCDCombo( QWidget *pParent, QSize size )
 	updateStyleSheet();
 
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &LCDCombo::onPreferencesChanged );
+	connect( this, SIGNAL( currentIndexChanged(int) ), this,
+			 SLOT( onCurrentIndexChanged(int) ) );
 }
 
 LCDCombo::~LCDCombo() {
@@ -105,4 +108,10 @@ void LCDCombo::enterEvent( QEvent* ev ) {
 void LCDCombo::leaveEvent( QEvent* ev ) {
 	QComboBox::leaveEvent( ev );
 	m_bEntered = false;
+}
+
+void LCDCombo::onCurrentIndexChanged( int ) {
+	if ( m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
 }

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -38,17 +38,24 @@ class LCDCombo : public QComboBox, protected WidgetWithScalableFont<6, 8, 9>, pu
 	Q_OBJECT
 
 public:
-	explicit LCDCombo( QWidget *pParent, QSize size = QSize( 0, 0 ) );
+	explicit LCDCombo( QWidget *pParent, QSize size = QSize( 0, 0 ), bool bModifyOnChange = true );
 	~LCDCombo();
 
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
+
+private slots:
+	void onCurrentIndexChanged( int );
 
 private:
 	void updateStyleSheet();
 	QSize m_size;
 
 	bool m_bEntered;
+
+	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+		soon as the value of the widget does change.*/
+	bool m_bModifyOnChange;
 		
 	virtual void paintEvent( QPaintEvent *ev ) override;
 	virtual void enterEvent( QEvent *ev ) override;

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -69,7 +69,7 @@ public:
 		PatternSizeDenominator
 	};
 
-	LCDSpinBox( QWidget *pParent, QSize size = QSize(), Type type = Type::Int, double fMin = 0.0, double fMax = 1.0 );
+	LCDSpinBox( QWidget *pParent, QSize size = QSize(), Type type = Type::Int, double fMin = 0.0, double fMax = 1.0, bool bModifyOnChange = true );
 	~LCDSpinBox();
 
 	void setKind( Kind kind );
@@ -81,6 +81,10 @@ public:
 	void setSize( QSize size );
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
+	void setValue( double fValue );
+
+private slots:
+	void valueChanged( double fNewValue );
 
 signals:
 	void slashKeyPressed();
@@ -94,6 +98,10 @@ private:
 	
 	bool m_bEntered;
 	bool m_bIsActive;
+
+	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+		soon as the value of the widget does change.*/
+	bool m_bModifyOnChange;
 
 	virtual QString textFromValue( double fValue ) const override;
 	virtual double valueFromText( const QString& sText ) const override;	

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -31,14 +31,15 @@
 
 #include <core/Globals.h>
 
-Rotary::Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSteps, float fMin, float fMax )
+Rotary::Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSteps, float fMin, float fMax, bool bModifyOnChange )
 	: WidgetWithInput( parent,
 					   bUseIntSteps,
 					   sBaseTooltip,
 					   1, //nScrollSpeed,
 					   5, // nScrollSpeedFast,
 					   fMin,
-					   fMax )
+					   fMax,
+					   bModifyOnChange )
 	, m_type( type ) {
 
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &Rotary::onPreferencesChanged );

--- a/src/gui/src/Widgets/Rotary.h
+++ b/src/gui/src/Widgets/Rotary.h
@@ -60,7 +60,7 @@ public:
 	Rotary(const Rotary&) = delete;
 	Rotary& operator=( const Rotary& rhs ) = delete;
 	
-	Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSteps, float fMin = 0.0, float fMax = 1.0 );
+	Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSteps, float fMin = 0.0, float fMax = 1.0, bool bModifyOnChange = true );
 	~Rotary();
 
 public slots:

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -33,7 +33,7 @@
 #    include <sys/time.h>
 #endif
 
-WidgetWithInput::WidgetWithInput( QWidget* parent, bool bUseIntSteps, QString sBaseTooltip, int nScrollSpeed, int nScrollSpeedFast, float fMin, float fMax )
+WidgetWithInput::WidgetWithInput( QWidget* parent, bool bUseIntSteps, QString sBaseTooltip, int nScrollSpeed, int nScrollSpeedFast, float fMin, float fMax, bool bModifyOnChange )
 	: QWidget( parent )
 	, m_bUseIntSteps( bUseIntSteps )
 	, m_sBaseTooltip( sBaseTooltip )
@@ -53,7 +53,8 @@ WidgetWithInput::WidgetWithInput( QWidget* parent, bool bUseIntSteps, QString sB
 	, m_sInputBuffer( "" )
 	, m_inputBufferTimeout( 2.0 )
 	, m_sRegisteredMidiEvent( "" )
-	, m_nRegisteredMidiParameter( 0 ){
+	, m_nRegisteredMidiParameter( 0 )
+	, m_bModifyOnChange( bModifyOnChange ) {
 	
 	setAttribute( Qt::WA_Hover );
 	setFocusPolicy( Qt::ClickFocus );
@@ -118,6 +119,10 @@ void WidgetWithInput::setValue( float fValue )
 		emit valueChanged( this );
 		updateTooltip();
 		update();
+
+		if ( m_bModifyOnChange ) {
+			H2Core::Hydrogen::get_instance()->setIsModified( true );
+		}
 	}
 }
 

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -60,7 +60,7 @@ class WidgetWithInput : public QWidget, public MidiLearnable {
 	Q_OBJECT
 
 public:
-	WidgetWithInput( QWidget* parent, bool bUseIntSteps, QString sBaseTooltip, int nScrollSpeed, int nScrollSpeedFast, float fMin, float fMax );
+	WidgetWithInput( QWidget* parent, bool bUseIntSteps, QString sBaseTooltip, int nScrollSpeed, int nScrollSpeedFast, float fMin, float fMax, bool bModifyOnChange );
 	~WidgetWithInput();
 	void setMin( float fMin );
 	float getMin() const;
@@ -114,7 +114,7 @@ protected:
 	int m_nWidgetHeight;
 
 	int m_nScrollSpeed;
-	// Fast version used when the Control modifier is pressed.
+	/** Fast version used when the Control modifier is pressed.*/
 	int m_nScrollSpeedFast;
 
 	float m_fMin;
@@ -129,15 +129,19 @@ protected:
 	float m_fMousePressValue;
 	float m_fMousePressY;
 
-	// All key input will be appended to this string.
+	/** All key input will be appended to this string.*/
 	QString m_sInputBuffer;
 	timeval m_inputBufferTimeval;
-	// Number of seconds before #m_sInputBuffer will be flushed
-	// (happens asynchronically whenever the next key input occurs.)
+	/** Number of seconds before #m_sInputBuffer will be flushed
+		(happens asynchronically whenever the next key input occurs.)*/
 	double m_inputBufferTimeout;
 
 	QString m_sRegisteredMidiEvent;
 	int m_nRegisteredMidiParameter;
+
+	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+		soon as the value of the widget does change.*/
+	bool m_bModifyOnChange;
 };
 
 inline float WidgetWithInput::getValue() const {

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -517,31 +517,6 @@ int main(int argc, char *argv[])
 		
 		H2Core::Hydrogen::get_instance()->startNsmClient();
 
-		// When using the Non Session Management system, the new Song
-		// will be loaded by the NSM client singleton itself and not
-		// by the MainForm. The latter will just access the already
-		// loaded Song.
-		if ( ! H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ){
-			std::shared_ptr<H2Core::Song>pSong = nullptr;
-
-			if ( sSongFilename.isEmpty() ) {
-				if ( pPref->isRestoreLastSongEnabled() ) {
-					sSongFilename = pPref->getLastSongFilename();
-				}
-			}
-
-			if ( !sSongFilename.isEmpty() ) {
-				pSong = H2Core::Song::load( sSongFilename );
-			}
-
-			if ( pSong == nullptr ) {
-				pSong = H2Core::Song::getEmptySong();
-				pSong->setFilename( sSongFilename );
-			}
-
-			H2Core::Hydrogen::get_instance()->getCoreActionController()->openSong( pSong );
-		}
-
 		// If the NSM_URL variable is present, Hydrogen will not
 		// initialize the audio driver and leaves this to the callback
 		// function nsm_open_cb of the NSM client (which will be
@@ -556,7 +531,7 @@ int main(int argc, char *argv[])
 			QApplication::restoreOverrideCursor();
 		}
 
-		MainForm *pMainForm = new MainForm( pQApp );
+		MainForm *pMainForm = new MainForm( pQApp, sSongFilename );
 		pMainForm->show();
 		
 		pSplash->finish( pMainForm );


### PR DESCRIPTION
- the frequency of the autosave backup can now be set or disabled altogether in the preferences.
- setting a new autosave value will take effect immediately
- there was a bug in the propagation of the Preferences::Changes causing several callback functions to not execute their code
- if a new song was opened and the user did not provided a filename using "Save As", the filename still pointed to the read-only systems user folder on Linux and the autosave file could not be stored. Now, whenever the path of the autosave file is not writable, it will be written to the users H2 song data folder instead
- empty songs (filename has to be manually removed) are now saved as autosave.h2song in the song data folder instead of the current working directory. (To not clutter the user's folders)
- when changing the filename of a song, e.g. by hitting "Save As", the corresponding autosave file will be stored in a different place. On quitting, only the last one got removed. Now, Hydrogen does clean up after all autosave file it had used within a session.
- keep autosave file if changes are discarded
- code to open a song and a demo song using QFileDialog have been commonized
- autosave files are now stored as hidden files (prefixed with ".") as it does not seem to be possible to exclude them in the song open dialog using name filters.
- when opening a Song via the GUI or restoring it on startup Hydrogen will now check whether there is an autosave file next to it with a newer modification date than the actual song (both the former visible and the new hidden format are supported). Hydrogen will ask the user whether it should recover the unsaved changes. If yes, the autosave file is loaded instead but the filename of the actual song is kept
- all relevant widgets does now inform there core whether there was a change of value and the song should be set as modified

Fixes #1463 
Fixes #454 
Supersedes #458 