### PR TITLE
add unit test for SSL support to 1.1 release

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,6 +19,10 @@ environment:
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
       appveyor_build_worker_image: Visual Studio 2019
       LIBJACK: libjack64.dll
+      OPENSSL_DIR: OpenSSL-Win64
+      LIBSSL: libssl-1_1-x64.dll
+      LIBCRYPTO: libcrypto-1_1-x64.dll
+
       CHOCO_ARCH:
       PROGRAM_FILES: "Program Files"
 
@@ -30,6 +34,10 @@ environment:
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
       appveyor_build_worker_image: Visual Studio 2019
       LIBJACK: libjack.dll
+      OPENSSL_DIR: OpenSSL-Win32
+      LIBSSL: libssl-1_1.dll
+      LIBCRYPTO: libcrypto-1_1.dll
+
       CHOCO_ARCH:  --x86
       PROGRAM_FILES: "Program Files (x86)"
 
@@ -117,6 +125,13 @@ for:
           dir "c:\%PROGRAM_FILES%\JACK2"
           dir "c:\%PROGRAM_FILES%\JACK2\lib"
 
+          REM *** Results are ignored since a dependency was not properly installed in 32 bit Windows. But the .dll files required are installed regardless, so we don't care.***
+
+          choco install %CHOCO_ARCH% -y openssl --version=1.1.1.1300 || cmd /c "exit /b 0"
+
+          echo "C:\%OPENSSL_DIR%"
+          dir "C:\%OPENSSL_DIR%"
+
           REM *** Install dependencies ***
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libarchive
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libsndfile
@@ -169,6 +184,9 @@ for:
           REM copy_third_party_libs.py thinks it's a system lib and
           REM won't copy it.
           copy c:\Windows\%LIBJACK% %APPVEYOR_BUILD_FOLDER%\windows\extralibs
+          copy c:\Windows\%LIBJACK% %APPVEYOR_BUILD_FOLDER%\windows\extralibs
+          copy c:\%OPENSSL_DIR%\%LIBSSL% %APPVEYOR_BUILD_FOLDER%\windows\extralibs
+          copy c:\%OPENSSL_DIR%\%LIBCRYPTO% %APPVEYOR_BUILD_FOLDER%\windows\extralibs
 
           REM *** Build installer ***
           cpack -G NSIS -v

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/src/core/include            # core headers
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_BINARY_DIR}/src                         # generated config.h
-    ${QT_INCLUDES}                                  # TODO be able to remove this
+    ${QT_INCLUDES}
     ${JACK_INCLUDE_DIRS}
     ${CPPUNIT_INCLUDE_DIRS}
     ${LIBSNDFILE_INCLUDE_DIRS}
@@ -22,6 +22,7 @@ target_link_libraries(tests
 	${CPPUNIT_LIBRARIES}
 	Qt5::Core
 	Qt5::Test
+	Qt5::Network
 )
 
 add_dependencies(tests hydrogen-core-${VERSION})

--- a/src/tests/NetworkTest.h
+++ b/src/tests/NetworkTest.h
@@ -1,0 +1,39 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#ifndef NETWORK_TEST_H
+#define NETWORK_TEST_H
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class NetworkTest : public CppUnit::TestFixture {
+	CPPUNIT_TEST_SUITE( NetworkTest );
+	CPPUNIT_TEST( testSslSupport );
+	CPPUNIT_TEST_SUITE_END();
+	
+	
+public:
+	void testSslSupport();
+
+};
+CPPUNIT_TEST_SUITE_REGISTRATION( NetworkTest );
+#endif

--- a/src/tests/NetwrokTest.cpp
+++ b/src/tests/NetwrokTest.cpp
@@ -1,0 +1,29 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include "NetworkTest.h"
+#include <QSslSocket>
+
+
+void NetworkTest::testSslSupport(){
+	CPPUNIT_ASSERT( QSslSocket::supportsSsl() );
+}


### PR DESCRIPTION
Since Qt does not ship its own OpenSSL library, we provide the required .dll in the Windows release for Hydrogen >1.1.1 .

A member of the Qt team stated in a forum that one has to ensure the exact version of OpenSSL is shipped that was also used to compile Qt5. As they might update the used version in future Qt releases we have to check whether the lib provided by us is the correct one.