### PR TITLE
AppVeyor: fix JACK version to 1.9.17

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -287,7 +287,7 @@ for:
 
           cmake --version
           g++ --version
-          choco install %CHOCO_ARCH% -y jack
+          choco install %CHOCO_ARCH% jack --version 1.9.17 -my
 
           dir "c:\%PROGRAM_FILES%\JACK2"
           dir "c:\%PROGRAM_FILES%\JACK2\lib"


### PR DESCRIPTION
for some reasons Chocolatey is unable to install the latest 1.9.20 version of JACK in the Windows build and causing it to fail.

There were no critical changes between v1.9.17 and v1.9.20 but this should not be considered a permanent solution.