### PR TITLE
move preprocessor directives into renameJackPorts

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -674,9 +674,7 @@ void AudioEngine::setAudioDriver( AudioOutput* pAudioDriver ) {
 		}
 
 		if ( pSong != nullptr && pHydrogen->haveJackAudioDriver() ) {
-#if defined(H2CORE_HAVE_JACK)
 			pHydrogen->renameJackPorts( pSong );
-#endif
 		}
 		
 		setupLadspaFX();
@@ -786,17 +784,7 @@ void AudioEngine::processCheckBPMChanged() {
 	auto pSong = pHydrogen->getSong();
 
 	long long oldFrame;
-#ifdef H2CORE_HAVE_JACK
-	// if ( Hydrogen::get_instance()->haveJackTransport() && 
-	// 	 m_state != State::Playing ) {
-	// 	oldFrame = static_cast< JackAudioDriver* >( m_pAudioDriver )->m_currentPos;
-			
-	// } else {
-		oldFrame = getFrames();
-	// }
-#else
 	oldFrame = getFrames();
-#endif
 
 	float fNewBpm = getBpmAtColumn( pHydrogen->getAudioEngine()->getColumn() );
 	if ( fNewBpm != getBpm() ) {
@@ -1287,9 +1275,7 @@ void AudioEngine::setSong( std::shared_ptr<Song> pNewSong )
 		m_pPlayingPatterns->add( pNewSong->getPatternList()->get( 0 ) );
 	}
 
-#ifdef H2CORE_HAVE_JACK
 	Hydrogen::get_instance()->renameJackPorts( pNewSong );
-#endif
 	m_nSongSizeInTicks = pNewSong->lengthInTicks();
 
 	// change the current audio engine state

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -707,9 +707,7 @@ int Hydrogen::loadDrumkit( Drumkit *pDrumkitInfo, bool bConditional )
 			setSelectedInstrumentNumber( std::max( 0, pSong->getInstrumentList()->size() -1 ) );
 		}
 
-#ifdef H2CORE_HAVE_JACK
 		renameJackPorts( getSong() );
-#endif
 		m_pAudioEngine->unlock();
 	
 		m_pCoreActionController->initExternalControlInterfaces();
@@ -901,9 +899,9 @@ void Hydrogen::refreshInstrumentParameters( int nInstrument )
 	EventQueue::get_instance()->push_event( EVENT_PARAMETERS_INSTRUMENT_CHANGED, -1 );
 }
 
-#ifdef H2CORE_HAVE_JACK
 void Hydrogen::renameJackPorts( std::shared_ptr<Song> pSong )
 {
+#ifdef H2CORE_HAVE_JACK
 	if ( pSong == nullptr ) {
 		return;
 	}
@@ -922,8 +920,8 @@ void Hydrogen::renameJackPorts( std::shared_ptr<Song> pSong )
 			static_cast< JackAudioDriver* >( m_pAudioEngine->getAudioDriver() )->makeTrackOutputs( pSong );
 		}
 	}
-}
 #endif
+}
 
 /** Updates #m_nbeatsToCount
  * \param beatstocount New value*/
@@ -1069,25 +1067,27 @@ void Hydrogen::handleBeatCounter()
 }
 //~ m_nBeatCounter
 
-#ifdef H2CORE_HAVE_JACK
 void Hydrogen::offJackMaster()
 {
+#ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
 	if ( haveJackTransport() ) {
 		static_cast< JackAudioDriver* >( pAudioEngine->getAudioDriver() )->releaseTimebaseMaster();
 	}
+#endif
 }
 
 void Hydrogen::onJackMaster()
 {
+#ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
 	if ( haveJackTransport() ) {
 		static_cast< JackAudioDriver* >( pAudioEngine->getAudioDriver() )->initTimebaseMaster();
 	}
-}
 #endif
+}
 
 void Hydrogen::setPlaysSelected( bool bPlaysSelected )
 {

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -337,14 +337,12 @@ void			previewSample( Sample *pSample );
 
 	void			refreshInstrumentParameters( int nInstrument );
 
-#if defined(H2CORE_HAVE_JACK) || _DOXYGEN_
 	/**
 	 * Calls audioEngine_renameJackPorts() if
 	 * Preferences::m_bJackTrackOuts is set to true.
 	 * \param pSong Handed to audioEngine_renameJackPorts().
 	 */
 	void			renameJackPorts(std::shared_ptr<Song> pSong);
-#endif
 
 	/** Starts/stops the OSC server
 	 * \param bEnable `true` = start, `false` = stop.*/

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1623,9 +1623,7 @@ void DrumPatternEditor::functionMoveInstrumentAction( int nSourceInstrument,  in
 
 		pInstrumentList->move( nSourceInstrument, nTargetInstrument );
 
-		#ifdef H2CORE_HAVE_JACK
 		pHydrogen->renameJackPorts( pSong );
-		#endif
 
 		m_pAudioEngine->unlock();
 		pHydrogen->setSelectedInstrumentNumber( nTargetInstrument );
@@ -1653,12 +1651,12 @@ void  DrumPatternEditor::functionDropInstrumentUndoAction( int nTargetInstrument
 		}
 	}
 
-	m_pAudioEngine->lock( RIGHT_HERE );
-#ifdef H2CORE_HAVE_JACK
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	pHydrogen->renameJackPorts( pSong );
-#endif
-	m_pAudioEngine->unlock();
+	if ( pHydrogen->haveJackAudioDriver() ) {
+		m_pAudioEngine->lock( RIGHT_HERE );
+		pHydrogen->renameJackPorts( pHydrogen->getSong() );
+		m_pAudioEngine->unlock();
+	}
+	
 	updateEditor();
 }
 
@@ -1737,9 +1735,7 @@ void  DrumPatternEditor::functionDropInstrumentRedoAction( QString sDrumkitName,
 
 		pHydrogen->getSong()->getInstrumentList()->add( pNewInstrument );
 
-		#ifdef H2CORE_HAVE_JACK
 		pHydrogen->renameJackPorts( pHydrogen->getSong() );
-		#endif
 
 		pHydrogen->setIsModified( true );
 		m_pAudioEngine->unlock();
@@ -1825,9 +1821,7 @@ void DrumPatternEditor::functionDeleteInstrumentUndoAction( std::list< H2Core::N
 	m_pAudioEngine->lock( RIGHT_HERE );
 	pHydrogen->getSong()->getInstrumentList()->add( pNewInstrument );
 
-	#ifdef H2CORE_HAVE_JACK
 	pHydrogen->renameJackPorts( pHydrogen->getSong() );
-	#endif
 
 	pHydrogen->setIsModified( true );
 	m_pAudioEngine->unlock();	// unlock the audio engine
@@ -1866,12 +1860,14 @@ void DrumPatternEditor::functionAddEmptyInstrumentUndo()
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	pHydrogen->removeInstrument( pHydrogen->getSong()->getInstrumentList()->size() -1 );
 
-	m_pAudioEngine->lock( RIGHT_HERE );
-#ifdef H2CORE_HAVE_JACK
-	pHydrogen->renameJackPorts( pHydrogen->getSong() );
-#endif
+	if ( pHydrogen->haveJackAudioDriver() ) {
+		m_pAudioEngine->lock( RIGHT_HERE );
+		pHydrogen->renameJackPorts( pHydrogen->getSong() );
+		m_pAudioEngine->unlock();
+	}
+	
 	pHydrogen->setIsModified( true );
-	m_pAudioEngine->unlock();
+	
 	updateEditor();
 }
 
@@ -1896,9 +1892,7 @@ void DrumPatternEditor::functionAddEmptyInstrumentRedo()
 	auto pNewInstr = std::make_shared<Instrument>( nID, "New instrument");
 	pList->add( pNewInstr );
 
-	#ifdef H2CORE_HAVE_JACK
 	pHydrogen->renameJackPorts( pSong );
-	#endif
 
 	pHydrogen->setIsModified( true );
 	m_pAudioEngine->unlock();

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -498,12 +498,11 @@ void InstrumentLine::functionRenameInstrument()
 	if ( bIsOkPressed  ) {
 		pSelectedInstrument->set_name( sNewName );
 
-#ifdef H2CORE_HAVE_JACK
-		pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
-		Hydrogen *engine = Hydrogen::get_instance();
-		engine->renameJackPorts(engine->getSong());
-		pHydrogen->getAudioEngine()->unlock();
-#endif
+		if ( pHydrogen->haveJackAudioDriver() ) {
+			pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
+			pHydrogen->renameJackPorts( pHydrogen->getSong() );
+			pHydrogen->getAudioEngine()->unlock();
+		}
 
 		// this will force an update...
 		EventQueue::get_instance()->push_event( EVENT_SELECTED_INSTRUMENT_CHANGED, -1 );


### PR DESCRIPTION
This was at least the second time I missed the #ifdef for H2CORE_HAVE_JACK around Hydrogen::renameJackPorts.

I moved the preprocessor directives into the function itself. Now it is defined regardless of the JACK support and this kind of compilation error hopefully does not occur anymore.