### PR TITLE
Small fixes

### DIFF
--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -216,7 +216,9 @@ bool Song::save( const QString& sFilename )
 
 std::shared_ptr<Song> Song::getEmptySong()
 {
-	std::shared_ptr<Song> pSong = std::make_shared<Song>( "Untitled", "hydrogen", 120, 0.5 );
+	std::shared_ptr<Song> pSong =
+		std::make_shared<Song>( Filesystem::untitled_song_name(), "hydrogen",
+								120, 0.5 );
 
 	pSong->setMetronomeVolume( 0.5 );
 	pSong->setNotes( "..." );

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -709,6 +709,42 @@ bool CoreActionController::deleteTempoMarker( int nPosition ) {
 	return true;
 }
 
+bool CoreActionController::addTag( int nPosition, const QString& sText ) {
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pTimeline = pHydrogen->getTimeline();
+
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+
+	pTimeline->deleteTag( nPosition );
+	pTimeline->addTag( nPosition, sText );
+
+	pHydrogen->setIsModified( true );
+
+	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
+
+	return true;
+}
+
+bool CoreActionController::deleteTag( int nPosition ) {
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pAudioEngine = pHydrogen->getAudioEngine();
+	
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+
+	pHydrogen->getTimeline()->deleteTag( nPosition );
+	
+	pHydrogen->setIsModified( true );
+	EventQueue::get_instance()->push_event( EVENT_TIMELINE_UPDATE, 0 );
+
+	return true;
+}
+
 bool CoreActionController::activateJackTransport( bool bActivate ) {
 	
 #ifdef H2CORE_HAVE_JACK

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -439,8 +439,8 @@ bool CoreActionController::newSong( const QString& sSongPath ) {
 	auto pSong = Song::getEmptySong();
 	
 	// Check whether the provided path is valid.
-	if ( !isSongPathValid( sSongPath ) ) {
-		// isSongPathValid takes care of the error log message.
+	if ( !Filesystem::isSongPathValid( sSongPath ) ) {
+		// Filesystem::isSongPathValid takes care of the error log message.
 
 		return false;
 	}
@@ -470,8 +470,8 @@ bool CoreActionController::openSong( const QString& sSongPath, const QString& sR
 	}
 	
 	// Check whether the provided path is valid.
-	if ( !isSongPathValid( sSongPath ) ) {
-		// isSongPathValid takes care of the error log message.
+	if ( !Filesystem::isSongPathValid( sSongPath, true ) ) {
+		// Filesystem::isSongPathValid takes care of the error log message.
 		return false;
 	}
 
@@ -587,8 +587,8 @@ bool CoreActionController::saveSongAs( const QString& sSongPath ) {
 	auto pSong = pHydrogen->getSong();
 	
 	// Check whether the provided path is valid.
-	if ( !isSongPathValid( sSongPath ) ) {
-		// isSongPathValid takes care of the error log message.
+	if ( !Filesystem::isSongPathValid( sSongPath ) ) {
+		// Filesystem::isSongPathValid takes care of the error log message.
 		return false;
 	}
 	
@@ -636,38 +636,6 @@ bool CoreActionController::quit() {
 		ERRORLOG( QString( "Error: Closing the application via the core part is not supported yet!" ) );
 		return false;
 		
-	}
-	
-	return true;
-}
-
-bool CoreActionController::isSongPathValid( const QString& sSongPath ) {
-	
-	QFileInfo songFileInfo = QFileInfo( sSongPath );
-
-	if ( !songFileInfo.isAbsolute() ) {
-		ERRORLOG( QString( "Error: Unable to handle path [%1]. Please provide an absolute file path!" )
-						.arg( sSongPath.toLocal8Bit().data() ));
-		return false;
-	}
-	
-	if ( songFileInfo.exists() ) {
-		if ( !songFileInfo.isReadable() ) {
-			ERRORLOG( QString( "Error: Unable to handle path [%1]. You must have permissions to read the file!" )
-						.arg( sSongPath.toLocal8Bit().data() ));
-			return false;
-		}
-		if ( !songFileInfo.isWritable() ) {
-			WARNINGLOG( QString( "You don't have permissions to write to the Song found in path [%1]. It will be opened as read-only (no autosave)." )
-						.arg( sSongPath.toLocal8Bit().data() ));
-			EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
-		}
-	}
-	
-	if ( songFileInfo.suffix() != "h2song" ) {
-		ERRORLOG( QString( "Error: Unable to handle path [%1]. The provided file must have the suffix '.h2song'!" )
-					.arg( sSongPath.toLocal8Bit().data() ));
-		return false;
 	}
 	
 	return true;

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -195,6 +195,26 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 */
 		bool deleteTempoMarker( int nPosition );
 		/**
+		 * Adds a tag to the Timeline.
+		 *
+		 * @param nPosition Location of the tag in bars.
+		 * @param sText Message associated with the tag.
+		 *
+		 * @return bool true on success
+		 */
+		bool addTag( int nPosition, const QString& sText );
+		/**
+		 * Delete a tag from the Timeline.
+		 *
+		 * If no tag is present at @a nPosition, the function
+		 * will return true as well.
+		 *
+		 * @param nPosition Location of the tag in bars.
+		 *
+		 * @return bool true on success
+		 */
+		bool deleteTag( int nPosition );
+		/**
 		 * (De)activates the usage of Jack transport.
 		 *
 		 * Note that this function will fail if Jack is not used as

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -315,23 +315,6 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * @return bool true on success
 		 */
     	bool toggleGridCell( int nColumn, int nRow );
-		
-		// -----------------------------------------------------------
-		// Helper functions
-		
-		/**
-		 * Checks the path of the .h2song provided via OSC.
-		 *
-		 * It will be checked whether @a songPath
-		 * - is absolute
-		 * - has the '.h2song' suffix
-		 * - is writable (if it exists)
-		 *
-		 * \param songPath Absolute path to an .h2song file.
-		 * \return true - if valid.
-		 */
-		bool isSongPathValid( const QString& songPath );
-		
 	private:
 		
 		/**

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -67,14 +67,12 @@ enum EventType {
 	/** Event indicating the triggering of the
 	 * #H2Core::AudioEngine::m_pMetronomeInstrument.
 	 *
-	 * In audioEngine_updateNoteQueue() the pushing of this Event is
+	 * In AudioEngine::updateNoteQueue() the pushing of this Event is
 	 * decoupled from the creation and queuing of the corresponding
 	 * Note itself.
 	 *
-	 * In Director it triggers a change in the displayed number,
-	 * color, tag, and triggers Director::update(). In case the
-	 * provided value is 3, instead of performing the changes above,
-	 * the Director loads the metadata a the current Song.
+	 * In Director it triggers a change in the displayed column
+	 * number, tempo, and tag.
 	 *
 	 * The associated values do correspond to the following actions:
 	 * - 0: Beat at the beginning of a Pattern in
@@ -88,13 +86,6 @@ enum EventType {
 	 *      be created with a pitch of 0 and velocity of 0.8.
 	 *      Sets MetronomeWidget::m_state to
 	 *      MetronomeWidget::METRO_FIRST and triggers
-	 *      MetronomeWidget::updateWidget().
-	 * - 2: Signals MetronomeWidget to neither update nor setting
-	 *      MetronomeWidget::m_state.
-	 * - 3: Tells the Director that a new Song was loaded and triggers
-	 *      its Director::update().
-	 *      Sets MetronomeWidget::m_state to
-	 *      MetronomeWidget::METRO_ON and triggers
 	 *      MetronomeWidget::updateWidget().
 	 *
 	 * Handled by EventListener::metronomeEvent().
@@ -139,8 +130,8 @@ enum EventType {
 
 	/** Enables/disables the usage of the Timeline.*/ 
 	EVENT_TIMELINE_ACTIVATION,
-	/** Tells the GUI some parts of the Timeline - currently
-		adding/deleting of tempo markers - were modified.*/
+	/** Tells the GUI some parts of the Timeline (tempo markers or
+		tags) were modified.*/
 	EVENT_TIMELINE_UPDATE,
 	/** Toggles the button indicating the usage Jack transport.*/
 	EVENT_JACK_TRANSPORT_ACTIVATION,

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -72,7 +72,7 @@
 
 #define AUTOSAVE        "autosave"
 
-#define UNTITLED_SONG		"untitled.h2song"
+#define UNTITLED_SONG		"Untitled Song"
 #define UNTITLED_PLAYLIST	"untitled.h2playlist"
 
 // filters
@@ -457,7 +457,8 @@ QString Filesystem::empty_song_path() {
 
 	return sPath;
 }
-QString Filesystem::untitled_song_file_name()
+
+QString Filesystem::untitled_song_name()
 {
 	return UNTITLED_SONG;
 }

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -22,6 +22,7 @@
 
 #include <core/LocalFileMng.h>
 #include <core/config.h>
+#include <core/EventQueue.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Hydrogen.h>
 
@@ -810,6 +811,41 @@ QStringList Filesystem::song_list_cleared( )
 bool Filesystem::song_exists( const QString& sg_name )
 {
 	return QDir( songs_dir() ).exists( sg_name );
+}
+
+bool Filesystem::isSongPathValid( const QString& sSongPath, bool bCheckExistance ) {
+	
+	QFileInfo songFileInfo = QFileInfo( sSongPath );
+
+	if ( !songFileInfo.isAbsolute() ) {
+		ERRORLOG( QString( "Error: Unable to handle path [%1]. Please provide an absolute file path!" )
+						.arg( sSongPath.toLocal8Bit().data() ));
+		return false;
+	}
+	
+	if ( songFileInfo.exists() ) {
+		if ( !songFileInfo.isReadable() ) {
+			ERRORLOG( QString( "Unable to handle path [%1]. You must have permissions to read the file!" )
+						.arg( sSongPath.toLocal8Bit().data() ));
+			return false;
+		}
+		if ( !songFileInfo.isWritable() ) {
+			WARNINGLOG( QString( "You don't have permissions to write to the Song found in path [%1]. It will be opened as read-only (no autosave)." )
+						.arg( sSongPath.toLocal8Bit().data() ));
+			EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 2 );
+		}
+	} else if ( bCheckExistance ) {
+		ERRORLOG( QString( "Provided song [%1] does not exist" ).arg( sSongPath ) );
+		return false;
+	}
+	
+	if ( songFileInfo.suffix() != "h2song" ) {
+		ERRORLOG( QString( "Unable to handle path [%1]. The provided file must have the suffix '.h2song'!" )
+					.arg( sSongPath.toLocal8Bit().data() ));
+		return false;
+	}
+	
+	return true;
 }
 
 QStringList Filesystem::theme_list( )

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -126,8 +126,8 @@ namespace H2Core
 		/** Default option to offer the user when saving an empty song
 			to disk.*/
 		static QString default_song_name();
-		/** returns untitled song file name */
-		static QString untitled_song_file_name();
+		/** returns untitled song name */
+		static QString untitled_song_name();
 		/** Returns a string containing the path to the
 		    _click.wav_ file used in the metronome. 
 			*

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -293,6 +293,25 @@ namespace H2Core
 		 * \param sg_name the song name
 		 */
 		static bool song_exists( const QString& sg_name );
+		
+		/**
+		 * Checks the path pointing to a .h2song.
+		 *
+		 * It will be checked whether @a songPath
+		 * - is absolute
+		 * - exists (if @a bCheckExistance is set to true)
+		 * - has the '.h2song' suffix
+		 * - is writable (read-only songs are considered valid as well
+		 * and the function returns true. But it also triggers an
+		 * event informing the GUI to show a read-only warning.)
+		 *
+		 * \param sSongPath Absolute path to an .h2song file.
+		 * \param bCheckExistance Whether the existance of the file is
+		 * checked (should be true for opening and false for creating
+		 * a new song)
+		 * \return true - if valid.
+		 */
+		static bool isSongPathValid( const QString& sSongPath, bool bCheckExistance = false );
 
 		static QStringList theme_list();
 

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -201,6 +201,12 @@ void MidiActionManager::create_instance() {
 }
 
 bool MidiActionManager::play( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	if ( pHydrogen->getAudioEngine()->getState() == AudioEngine::State::Ready ) {
 		pHydrogen->sequencer_play();
 	}
@@ -208,17 +214,35 @@ bool MidiActionManager::play( std::shared_ptr<Action> pAction, Hydrogen* pHydrog
 }
 
 bool MidiActionManager::pause( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->sequencer_stop();
 	return true;
 }
 
 bool MidiActionManager::stop( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->sequencer_stop();
 	pHydrogen->getCoreActionController()->locateToColumn( 0 );
 	return true;
 }
 
 bool MidiActionManager::play_stop_pause_toggle( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	QString sActionString = pAction->getType();
 	switch ( pHydrogen->getAudioEngine()->getState() )
 	{
@@ -243,21 +267,45 @@ bool MidiActionManager::play_stop_pause_toggle( std::shared_ptr<Action> pAction,
 
 //mutes the master, not a single strip
 bool MidiActionManager::mute( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->getCoreActionController()->setMasterIsMuted( true );
 	return true;
 }
 
 bool MidiActionManager::unmute( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->getCoreActionController()->setMasterIsMuted( false );
 	return true;
 }
 
 bool MidiActionManager::mute_toggle( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->getCoreActionController()->setMasterIsMuted( !pHydrogen->getSong()->getIsMuted() );
 	return true;
 }
 
 bool MidiActionManager::strip_mute_toggle( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	
 	bool ok;
 	bool bSucccess = true;
@@ -283,6 +331,11 @@ bool MidiActionManager::strip_mute_toggle( std::shared_ptr<Action> pAction, Hydr
 }
 
 bool MidiActionManager::strip_solo_toggle( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 	
 	bool ok;
 	bool bSucccess = true;
@@ -308,16 +361,34 @@ bool MidiActionManager::strip_solo_toggle( std::shared_ptr<Action> pAction, Hydr
 }
 
 bool MidiActionManager::beatcounter( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->handleBeatCounter();
 	return true;
 }
 
 bool MidiActionManager::tap_tempo( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->onTapTempoAccelEvent();
 	return true;
 }
 
 bool MidiActionManager::select_next_pattern( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int row = pAction->getParameter1().toInt(&ok,10);
 	if( row > pHydrogen->getSong()->getPatternList()->size() - 1 ||
@@ -336,6 +407,12 @@ bool MidiActionManager::select_next_pattern( std::shared_ptr<Action> pAction, Hy
 }
 
 bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int row = pAction->getParameter1().toInt(&ok,10);
 	if( row > pHydrogen->getSong()->getPatternList()->size() -1 ||
@@ -354,6 +431,12 @@ bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pActio
 }
 
 bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	if(!Preferences::get_instance()->patternModePlaysSelected()) {
 		return true;
@@ -371,6 +454,12 @@ bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pA
 }
 
 bool MidiActionManager::select_next_pattern_cc_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int row = pAction->getValue().toInt(&ok,10);
 	
@@ -392,6 +481,12 @@ bool MidiActionManager::select_next_pattern_cc_absolute( std::shared_ptr<Action>
 }
 
 bool MidiActionManager::select_and_play_pattern( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	if ( ! select_next_pattern( pAction, pHydrogen ) ) {
 		return false;
 	}
@@ -404,6 +499,12 @@ bool MidiActionManager::select_and_play_pattern( std::shared_ptr<Action> pAction
 }
 
 bool MidiActionManager::select_instrument( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int  nInstrumentNumber = pAction->getValue().toInt(&ok,10) ;
 	
@@ -419,6 +520,12 @@ bool MidiActionManager::select_instrument( std::shared_ptr<Action> pAction, Hydr
 }
 
 bool MidiActionManager::effect_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int fx_param = pAction->getValue().toInt(&ok,10);
@@ -451,6 +558,12 @@ bool MidiActionManager::effect_level_absolute( std::shared_ptr<Action> pAction, 
 }
 
 bool MidiActionManager::effect_level_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int fx_param = pAction->getValue().toInt(&ok,10);
@@ -485,6 +598,11 @@ bool MidiActionManager::effect_level_relative( std::shared_ptr<Action> pAction, 
 
 //sets the volume of a master output to a given level (percentage)
 bool MidiActionManager::master_volume_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	bool ok;
 	int vol_param = pAction->getValue().toInt(&ok,10);
@@ -502,6 +620,11 @@ bool MidiActionManager::master_volume_absolute( std::shared_ptr<Action> pAction,
 
 //increments/decrements the volume of the whole song
 bool MidiActionManager::master_volume_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	bool ok;
 	int vol_param = pAction->getValue().toInt(&ok,10);
@@ -525,6 +648,11 @@ bool MidiActionManager::master_volume_relative( std::shared_ptr<Action> pAction,
 
 //sets the volume of a mixer strip to a given level (percentage)
 bool MidiActionManager::strip_volume_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
@@ -557,6 +685,11 @@ bool MidiActionManager::strip_volume_absolute( std::shared_ptr<Action> pAction, 
 
 //increments/decrements the volume of one mixer strip
 bool MidiActionManager::strip_volume_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
@@ -595,6 +728,11 @@ bool MidiActionManager::strip_volume_relative( std::shared_ptr<Action> pAction, 
 
 // sets the absolute panning of a given mixer channel
 bool MidiActionManager::pan_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
@@ -626,6 +764,11 @@ bool MidiActionManager::pan_absolute( std::shared_ptr<Action> pAction, Hydrogen*
 // changes the panning of a given mixer channel
 // this is useful if the panning is set by a rotary control knob
 bool MidiActionManager::pan_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
@@ -661,6 +804,12 @@ bool MidiActionManager::pan_relative( std::shared_ptr<Action> pAction, Hydrogen*
 }
 
 bool MidiActionManager::gain_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int gain_param = pAction->getValue().toInt(&ok,10);
@@ -707,6 +856,12 @@ bool MidiActionManager::gain_level_absolute( std::shared_ptr<Action> pAction, Hy
 }
 
 bool MidiActionManager::pitch_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int pitch_param = pAction->getValue().toInt(&ok,10);
@@ -752,6 +907,12 @@ bool MidiActionManager::pitch_level_absolute( std::shared_ptr<Action> pAction, H
 }
 
 bool MidiActionManager::filter_cutoff_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int filter_cutoff_param = pAction->getValue().toInt(&ok,10);
@@ -789,6 +950,11 @@ bool MidiActionManager::filter_cutoff_level_absolute( std::shared_ptr<Action> pA
  * this is useful if the bpm is set by a rotary control knob
  */
 bool MidiActionManager::bpm_cc_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 
@@ -831,6 +997,11 @@ bool MidiActionManager::bpm_cc_relative( std::shared_ptr<Action> pAction, Hydrog
  * this is useful if the bpm is set by a rotary control knob
  */
 bool MidiActionManager::bpm_fine_cc_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
 
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 
@@ -867,6 +1038,12 @@ bool MidiActionManager::bpm_fine_cc_relative( std::shared_ptr<Action> pAction, H
 }
 
 bool MidiActionManager::bpm_increase( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 
 	bool ok;
@@ -883,6 +1060,12 @@ bool MidiActionManager::bpm_increase( std::shared_ptr<Action> pAction, Hydrogen*
 }
 
 bool MidiActionManager::bpm_decrease( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 
 	bool ok;
@@ -899,12 +1082,24 @@ bool MidiActionManager::bpm_decrease( std::shared_ptr<Action> pAction, Hydrogen*
 }
 
 bool MidiActionManager::next_bar( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->getCoreActionController()->locateToColumn( pHydrogen->getAudioEngine()->getColumn() +1 );
 	return true;
 }
 
 
 bool MidiActionManager::previous_bar( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	pHydrogen->getCoreActionController()->locateToColumn( pHydrogen->getAudioEngine()->getColumn() -1 );
 	return true;
 }
@@ -916,9 +1111,15 @@ bool setSong( int nSongNumber, Hydrogen * pHydrogen ) {
 			Playlist::get_instance()->setNextSongByNumber( nSongNumber );
 		}
 	} else {
-		___ERRORLOG( QString( "Provided song number [%1] out of bound [0,%2]" )
-				  .arg( nSongNumber )
-				  .arg( pHydrogen->getSong()->getPatternList()->size() - 1 ) );
+		// Preventive measure to avoid bad things.
+		if ( pHydrogen->getSong() == nullptr ) {
+			___ERRORLOG( "No song set yet" );
+		} else {
+			___ERRORLOG( QString( "Provided song number [%1] out of bound [0,%2]" )
+						 .arg( nSongNumber )
+						 .arg( pHydrogen->getSong()->getPatternList()->size() - 1 ) );
+		}
+		return false;
 	}
 	return true;
 }
@@ -940,6 +1141,12 @@ bool MidiActionManager::playlist_previous_song( std::shared_ptr<Action> pAction,
 }
 
 bool MidiActionManager::record_ready( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	if ( pHydrogen->getAudioEngine()->getState() != AudioEngine::State::Playing ) {
 		if (!Preferences::get_instance()->getRecordEvents()) {
 			Preferences::get_instance()->setRecordEvents(true);
@@ -951,7 +1158,13 @@ bool MidiActionManager::record_ready( std::shared_ptr<Action> pAction, Hydrogen*
 	return true;
 }
 
-bool MidiActionManager::record_strobe_toggle( std::shared_ptr<Action> , Hydrogen* ) {
+bool MidiActionManager::record_strobe_toggle( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	if (!Preferences::get_instance()->getRecordEvents()) {
 		Preferences::get_instance()->setRecordEvents(true);
 	}
@@ -961,21 +1174,39 @@ bool MidiActionManager::record_strobe_toggle( std::shared_ptr<Action> , Hydrogen
 	return true;
 }
 
-bool MidiActionManager::record_strobe( std::shared_ptr<Action> , Hydrogen* ) {
+bool MidiActionManager::record_strobe( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	if (!Preferences::get_instance()->getRecordEvents()) {
 		Preferences::get_instance()->setRecordEvents(true);
 	}
 	return true;
 }
 
-bool MidiActionManager::record_exit( std::shared_ptr<Action> , Hydrogen* ) {
+bool MidiActionManager::record_exit( std::shared_ptr<Action> , Hydrogen* pHydrogen) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	if (Preferences::get_instance()->getRecordEvents()) {
 		Preferences::get_instance()->setRecordEvents(false);
 	}
 	return true;
 }
 
-bool MidiActionManager::toggle_metronome( std::shared_ptr<Action> , Hydrogen* ) {
+bool MidiActionManager::toggle_metronome( std::shared_ptr<Action> , Hydrogen* pHydrogen) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+	
 	Preferences::get_instance()->m_bUseMetronome = !Preferences::get_instance()->m_bUseMetronome;
 	return true;
 }

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -153,8 +153,15 @@ int OscServer::generic_handler(const char *	path,
 							   lo_message	data,
 							   void *		user_data)
 {
-	H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
-	H2Core::CoreActionController* pController = pHydrogen->getCoreActionController();
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pController = pHydrogen->getCoreActionController();
+	auto pSong = pHydrogen->getSong();
+
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return 0;
+	}
+	
 	int nNumberOfStrips = pHydrogen->getSong()->getInstrumentList()->size();
 	
 	//First we're trying to map TouchOSC messages from multi-fader widgets
@@ -324,6 +331,7 @@ void OscServer::PLAY_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAY");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -332,6 +340,7 @@ void OscServer::PLAY_STOP_TOGGLE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAY/STOP_TOGGLE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -340,6 +349,7 @@ void OscServer::PLAY_PAUSE_TOGGLE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAY/PAUSE_TOGGLE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -348,6 +358,7 @@ void OscServer::STOP_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("STOP");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -356,6 +367,7 @@ void OscServer::PAUSE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PAUSE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -364,6 +376,7 @@ void OscServer::RECORD_READY_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("RECORD_READY");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -372,6 +385,7 @@ void OscServer::RECORD_STROBE_TOGGLE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("RECORD/STROBE_TOGGLE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -380,6 +394,7 @@ void OscServer::RECORD_STROBE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("RECORD_STROBE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -388,6 +403,7 @@ void OscServer::RECORD_EXIT_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("RECORD_EXIT");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -396,6 +412,7 @@ void OscServer::MUTE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("MUTE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -404,6 +421,7 @@ void OscServer::UNMUTE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("UNMUTE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -412,6 +430,7 @@ void OscServer::MUTE_TOGGLE_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("MUTE_TOGGLE");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -420,6 +439,7 @@ void OscServer::NEXT_BAR_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>(">>_NEXT_BAR");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -428,6 +448,7 @@ void OscServer::PREVIOUS_BAR_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("<<_PREVIOUS_BAR");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -438,6 +459,7 @@ void OscServer::BPM_INCR_Handler(lo_arg **argv,int i)
 	
 	pAction->setParameter1( QString::number( argv[0]->f, 'f', 0 ));
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -448,6 +470,7 @@ void OscServer::BPM_DECR_Handler(lo_arg **argv,int i)
 
 	pAction->setParameter1( QString::number( argv[0]->f, 'f', 0 ));
 	
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -456,6 +479,7 @@ void OscServer::MASTER_VOLUME_ABSOLUTE_Handler(lo_arg **argv,int i)
 	H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
 	H2Core::CoreActionController* pController = pHydrogen->getCoreActionController();
 
+	// Null song handling done in MidiActionManager.
 	pController->setMasterVolume( argv[0]->f );
 }
 
@@ -465,6 +489,7 @@ void OscServer::MASTER_VOLUME_RELATIVE_Handler(lo_arg **argv,int i)
 	pAction->setParameter2( QString::number( argv[0]->f, 'f', 0 ));
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -473,6 +498,7 @@ void OscServer::STRIP_VOLUME_ABSOLUTE_Handler(int param1, float param2)
 	H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
 	H2Core::CoreActionController* pController = pHydrogen->getCoreActionController();
 
+	// Null song handling done in MidiActionManager.
 	pController->setStripVolume( param1, param2, false );
 }
 
@@ -483,6 +509,7 @@ void OscServer::STRIP_VOLUME_RELATIVE_Handler(QString param1, QString param2)
 	pAction->setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -492,6 +519,7 @@ void OscServer::SELECT_NEXT_PATTERN_Handler(lo_arg **argv,int i)
 	pAction->setParameter1(  QString::number( argv[0]->f, 'f', 0 ) );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -501,6 +529,7 @@ void OscServer::SELECT_AND_PLAY_PATTERN_Handler(lo_arg **argv,int i)
 	pAction->setParameter1(  QString::number( argv[0]->f, 'f', 0 ) );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -511,6 +540,7 @@ void OscServer::PAN_ABSOLUTE_Handler(QString param1, QString param2)
 	pAction->setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -521,6 +551,7 @@ void OscServer::PAN_ABSOLUTE_SYM_Handler(QString param1, QString param2)
 	pAction->setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -531,6 +562,7 @@ void OscServer::PAN_RELATIVE_Handler(QString param1, QString param2)
 	pAction->setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -541,6 +573,7 @@ void OscServer::FILTER_CUTOFF_LEVEL_ABSOLUTE_Handler(QString param1, QString par
 	pAction->setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -549,6 +582,7 @@ void OscServer::BEATCOUNTER_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("BEATCOUNTER");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -557,6 +591,7 @@ void OscServer::TAP_TEMPO_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("TAP_TEMPO");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -567,6 +602,7 @@ void OscServer::PLAYLIST_SONG_Handler(lo_arg **argv,int i)
 
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();	
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -575,6 +611,7 @@ void OscServer::PLAYLIST_NEXT_SONG_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAYLIST_NEXT_SONG");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -583,6 +620,7 @@ void OscServer::PLAYLIST_PREV_SONG_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAYLIST_PREV_SONG");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -591,6 +629,7 @@ void OscServer::TOGGLE_METRONOME_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("TOGGLE_METRONOME");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -601,6 +640,7 @@ void OscServer::SELECT_INSTRUMENT_Handler(lo_arg **argv,int i)
 
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();	
 
+	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
 }
 
@@ -609,6 +649,7 @@ void OscServer::UNDO_ACTION_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("UNDO_ACTION");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// This one does also work the current song being nullptr.
 	pActionManager->handleAction( pAction );
 }
 
@@ -617,6 +658,7 @@ void OscServer::REDO_ACTION_Handler(lo_arg **argv,int i)
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("REDO_ACTION");
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
+	// This one does also work the current song being nullptr.
 	pActionManager->handleAction( pAction );
 }
 
@@ -624,46 +666,66 @@ void OscServer::REDO_ACTION_Handler(lo_arg **argv,int i)
 // Actions required for session management.
 
 void OscServer::NEW_SONG_Handler(lo_arg **argv, int argc) {
-	
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->newSong( QString::fromUtf8( &argv[0]->s ) );
 }
 
 void OscServer::OPEN_SONG_Handler(lo_arg **argv, int argc) {
-
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->openSong( QString::fromUtf8( &argv[0]->s ) );
 }
 
 void OscServer::SAVE_SONG_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->saveSong();
 }
 
 void OscServer::SAVE_SONG_AS_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->saveSongAs( QString::fromUtf8( &argv[0]->s ) );
 }
 
 void OscServer::SAVE_PREFERENCES_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 	
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->savePreferences();
 }
 
 void OscServer::QUIT_Handler(lo_arg **argv, int argc) {
-	
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->quit();
 }
 
 // -------------------------------------------------------------------
 
 void OscServer::TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 
 	if ( argv[0]->f != 0 ) { 
 		pController->activateTimeline( true );
@@ -673,21 +735,36 @@ void OscServer::TIMELINE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 }
 
 void OscServer::TIMELINE_ADD_MARKER_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->addTempoMarker( static_cast<int>(std::round( argv[0]->f )),
 								 argv[1]->f);
 }
 
 void OscServer::TIMELINE_DELETE_MARKER_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->deleteTempoMarker( static_cast<int>( std::round( argv[0]->f ) ) );
 }
 
 void OscServer::JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 	
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 
 	if ( argv[0]->f != 0 ) {
 		pController->activateJackTransport( true );
@@ -697,8 +774,13 @@ void OscServer::JACK_TRANSPORT_ACTIVATION_Handler(lo_arg **argv, int argc) {
 }
 
 void OscServer::JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	if ( argv[0]->f != 0 ) {
 		pController->activateJackTimebaseMaster( true );
 	} else {
@@ -707,8 +789,13 @@ void OscServer::JACK_TIMEBASE_MASTER_ACTIVATION_Handler(lo_arg **argv, int argc)
 }
 
 void OscServer::SONG_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	if ( argv[0]->f != 0 ) {
 		pController->activateSongMode( true );
 	} else {
@@ -717,8 +804,13 @@ void OscServer::SONG_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 }
 
 void OscServer::LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	if ( argv[0]->f != 0 ) {
 		pController->activateLoopMode( true, true );
 	} else {
@@ -727,38 +819,68 @@ void OscServer::LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 }
 
 void OscServer::RELOCATE_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	H2Core::Hydrogen::get_instance()->getCoreActionController()->locateToColumn( static_cast<int>(std::round( argv[0]->f ) ) );
+	pHydrogen->getCoreActionController()->locateToColumn( static_cast<int>(std::round( argv[0]->f ) ) );
 }
 
 void OscServer::NEW_PATTERN_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 	
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->newPattern( QString::fromUtf8( &argv[0]->s ) );
 }
 
 void OscServer::OPEN_PATTERN_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->openPattern( QString::fromUtf8( &argv[0]->s ) );
 }
 
 void OscServer::REMOVE_PATTERN_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->removePattern( static_cast<int>(std::round( argv[0]->f )) );
 }
 
 void OscServer::SONG_EDITOR_TOGGLE_GRID_CELL_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 	pController->toggleGridCell( static_cast<int>(std::round( argv[0]->f )),
 								 static_cast<int>(std::round( argv[1]->f )) );
 }
 
 void OscServer::LOAD_DRUMKIT_Handler(lo_arg **argv, int argc) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
 	
-	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+	auto pController = pHydrogen->getCoreActionController();
 
 	bool bConditionalLoad = true;
 	if ( argc > 1 ) {
@@ -949,10 +1071,7 @@ bool OscServer::init()
 																						lo_address_get_port( a ) );
 										m_pClientRegistry.push_back( newAddr );
 										
-										H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
-										H2Core::CoreActionController* pController = pHydrogen->getCoreActionController();
-										
-										pController->initExternalControlInterfaces();
+										H2Core::Hydrogen::get_instance()->getCoreActionController()->initExternalControlInterfaces();
 									}
 									
 									// Returning 1 means that the

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -54,6 +54,7 @@
 
 #include "Director.h"
 #include "HydrogenApp.h"
+#include "Skin.h"
 #include "Widgets/PixmapWidget.h"
 
 #include <core/Preferences/Preferences.h>
@@ -71,15 +72,24 @@ Director::Director ( QWidget* pParent )
 
 	HydrogenApp::get_instance()->addEventListener( this );
 	setupUi ( this );
-	//
+
+	auto pPref = H2Core::Preferences::get_instance();
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pAudioEngine = pHydrogen->getAudioEngine();
+	
 	setWindowTitle ( tr ( "Director" ) );
 
+	m_fBpm = pAudioEngine->getBpm();
+	m_nBar = pAudioEngine->getColumn() + 1;
+	if ( m_nBar <= 0 ){
+		m_nBar = 1;
+	}
+	
 	m_nCounter = 1;	// to compute the right beat
-	m_nFadeAlpha = 255;	//default alpha
-	m_nBar = 1;	// default bar
+	m_Color = pPref->getColorTheme()->m_accentColor;
+	m_Color.setAlpha( 0 );
 	m_nFlashingArea = width() * 5/100;
 
-	m_fBpm = Hydrogen::get_instance()->getSong()->getBpm();
 	m_pTimer = new QTimer( this );
 	connect( m_pTimer, SIGNAL( timeout() ), this, SLOT( updateMetronomBackground() ) );
 }
@@ -102,16 +112,19 @@ void Director::closeEvent( QCloseEvent* ev )
 	HydrogenApp::get_instance()->showDirector();
 }
 
-void Director::metronomeEvent( int nValue )
-{
+void Director::updateSongEvent( int nValue ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
 
-	//load a new song
-	if( nValue == 3 ){
+	if ( nValue == 0 || // new song loaded
+		 nValue == 1 ) { // current one saved
 
-		//update songname
-		QStringList list = pHydrogen->getSong()->getFilename().split("/");
+		// Update song name
+		QStringList list = pSong->getFilename().split("/");
 
 		if ( !list.isEmpty() ){
 			m_sSongName = list.last().replace( Filesystem::songs_ext, "" );
@@ -122,9 +135,41 @@ void Director::metronomeEvent( int nValue )
 			}
 		}
 
+		timelineUpdateEvent( 0 );
+
 		update();
-		return;
 	}
+}
+
+void Director::timelineUpdateEvent( int nValue ) {
+
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pAudioEngine = pHydrogen->getAudioEngine();
+	
+	m_fBpm = pAudioEngine->getBpm();
+	m_nBar = pAudioEngine->getColumn() + 1;
+
+	if ( m_nBar <= 0 ){
+		m_nBar = 1;
+	}
+	
+	// get tags
+	auto pTimeline = pHydrogen->getTimeline();
+
+	if ( pTimeline->hasColumnTag( m_nBar ) ) {
+		m_sTAG = pTimeline->getTagAtColumn( m_nBar );
+	} else {
+		m_sTAG = "";
+	}
+	m_sTAG2 = pTimeline->getTagAtColumn( m_nBar - 1 );
+	update();
+}
+
+void Director::metronomeEvent( int nValue )
+{
+
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pPref = H2Core::Preferences::get_instance();
 
 	//bpm
 	m_fBpm = pHydrogen->getSong()->getBpm();
@@ -138,18 +183,9 @@ void Director::metronomeEvent( int nValue )
 	// 1000 ms / bpm / 60s
 	m_pTimer->start( static_cast<int>( 1000 / ( m_fBpm / 60 )) / 2 );
 	m_nFlashingArea = width() * 5/100;
-	m_nFadeAlpha = 255;
-
-	if ( nValue == 2 ){
-		m_nFadeAlpha = 0;
-		update();
-		m_sTAG="";
-		m_sTAG2="";
-		return;
-	}
 
 	if ( nValue == 1 ) {	//foregroundcolor "rect" for first blink
-		m_Color = QColor( 255, 50, 1 ,255 );
+		m_Color = pPref->getColorTheme()->m_buttonRedColor;
 		m_nCounter = 1;
 	}
 	else {	//foregroundcolor "rect" for all other blinks
@@ -158,9 +194,9 @@ void Director::metronomeEvent( int nValue )
 			m_nFlashingArea = width() * 52.5/100;
 		}
 
-		m_Color = QColor( 24, 250, 31, 255 );
+		m_Color = pPref->getColorTheme()->m_accentColor;
 	}
-
+	
 	// get tags
 	auto pTimeline = pHydrogen->getTimeline();
 
@@ -170,6 +206,7 @@ void Director::metronomeEvent( int nValue )
 		m_sTAG = "";
 	}
 	m_sTAG2 = pTimeline->getTagAtColumn( m_nBar - 1 );
+	
 	update();
 }
 
@@ -186,21 +223,26 @@ void Director::paintEvent( QPaintEvent* ev )
 {
 	QPainter painter(this);
 
+	auto pPref = H2Core::Preferences::get_instance();
+	QString sFontFamily = pPref->getApplicationFontFamily();
+
 	//draw the songname
-	painter.setFont(QFont("Arial", height() * 14/100 ));
+	painter.setFont(QFont( sFontFamily, height() * 14/100 ));
 	QRect rect(QPoint( width() * 5/100 , height () * 2/100 ), QSize( width() * 90/100, height() * 21/100));
 	painter.drawText( rect, Qt::AlignCenter,  QString( m_sSongName ) );
 
 
 	//draw the metronome
-	painter.setPen( QPen(QColor( 249, 235, 116, 200 ) ,1 , Qt::SolidLine ) );
+	
+	painter.setPen( QPen( pPref->getColorTheme()->m_highlightColor, 1 , Qt::SolidLine ) );
 	painter.setBrush( m_Color );
 	painter.drawRect (  m_nFlashingArea, height() * 25/100, width() * 42.5/100, height() * 35/100);
 
 
 	//draw bars
-	painter.setPen(Qt::white);
-	painter.setFont(QFont("Arial", height() * 25/100 ));
+	QColor textColor = pPref->getColorTheme()->m_windowTextColor;
+	painter.setPen( textColor );
+	painter.setFont(QFont( sFontFamily, height() * 25/100 ));
 	QRect r1(QPoint( width() * 5/100 , height() * 25/100 ), QSize( width() * 42.5/100, height() * 35/100));
 	painter.drawText( r1, Qt::AlignCenter, QString("%1").arg( m_nBar) );
 
@@ -213,14 +255,23 @@ void Director::paintEvent( QPaintEvent* ev )
 	}
 	
 	//draw current bar tag
-	painter.setPen(Qt::white);
-	painter.setFont(QFont("Arial", height() * 8/100 ));
+	painter.setFont(QFont( sFontFamily, height() * 8/100 ));
 	QRect r3(QPoint ( width() * 5/100 , height() * 65/100 ), QSize( width() * 90/100, height() * 14/100));
 	painter.drawText( r3, Qt::AlignCenter, QString( (m_sTAG) ) );
 
 	//draw next bar tag
-	painter.setPen(Qt::gray);
-	painter.setFont(QFont("Arial", height() * 6/100 ));
+	painter.setPen( Skin::makeTextColorInactive( textColor ) );
+	painter.setFont(QFont( sFontFamily, height() * 6/100 ));
 	QRect r4(QPoint ( width() * 5/100 , height() * 83/100 ), QSize( width() * 90/100, height() * 11/100));
 	painter.drawText( r4, Qt::AlignCenter, QString( m_sTAG2 ) );
+}
+
+void Director::onPreferencesChanged( H2Core::Preferences::Changes changes ) {
+	auto pPref = H2Core::Preferences::get_instance();
+	
+	if ( changes & ( H2Core::Preferences::Changes::Colors |
+					 H2Core::Preferences::Changes::Font ) ) {
+			 
+		update();
+	}
 }

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -45,10 +45,15 @@ public:
 	Director(const Director&) = delete;
 	Director& operator=( const Director& rhs ) = delete;
 
+	virtual void updateSongEvent( int nValue ) override;
+	virtual void timelineUpdateEvent( int nValue ) override;
 	virtual void metronomeEvent( int nValue ) override;
 	virtual void paintEvent( QPaintEvent*) override;
 	virtual void keyPressEvent( QKeyEvent* ev ) override;
 	virtual void closeEvent( QCloseEvent* ev ) override;
+
+public slots:
+	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
 private slots:
 	void updateMetronomBackground();
@@ -59,7 +64,6 @@ private:
 	QColor				m_Color;
 	QPalette			m_BlinkerPalette;
 	int					m_nCounter;
-	int					m_nFadeAlpha;
 	float				m_fBpm;
 	int					m_nBar;
 	int					m_nFlashingArea;

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -992,10 +992,6 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
 		getSongEditorPanel()->updatePositionRuler();
 	
-		// Trigger a reset of the Director and MetronomeWidget.
-		EventQueue::get_instance()->push_event( EVENT_METRONOME, 2 );
-		EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
-	
 		m_pSongEditorPanel->updateAll();
 		m_pPatternEditorPanel->updateSLnameLabel();
 		updateWindowTitle();
@@ -1007,7 +1003,6 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		// Song was saved.
 		setScrollStatusBarMessage( tr("Song saved.") + QString(" Into: ") + filename, 2000 );
 		updateWindowTitle();
-		EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
 		
 	} else if ( nValue == 2 ) {
 

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -978,7 +978,11 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 
 void HydrogenApp::updateSongEvent( int nValue ) {
 
-	Hydrogen* pHydrogen = Hydrogen::get_instance();	
+	auto pHydrogen = Hydrogen::get_instance();	
+	auto pSong = pHydrogen->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
 	
 	if ( nValue == 0 ) {
 		// Cleanup
@@ -986,22 +990,14 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		m_pUndoStack->clear();
 		
 		// Update GUI components
-		m_pSongEditorPanel->updateAll();
-		m_pPatternEditorPanel->updateSLnameLabel();
-		updateWindowTitle();
-		getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
-		getSongEditorPanel()->updatePositionRuler();
-	
-		m_pSongEditorPanel->updateAll();
-		m_pPatternEditorPanel->updateSLnameLabel();
 		updateWindowTitle();
 		
 	} else if ( nValue == 1 ) {
 		
-		QString filename = pHydrogen->getSong()->getFilename();
+		QString sFilename = pSong->getFilename();
 		
 		// Song was saved.
-		setScrollStatusBarMessage( tr("Song saved.") + QString(" Into: ") + filename, 2000 );
+		setScrollStatusBarMessage( tr("Song saved as: ") + sFilename, 2000 );
 		updateWindowTitle();
 		
 	} else if ( nValue == 2 ) {
@@ -1012,12 +1008,6 @@ void HydrogenApp::updateSongEvent( int nValue ) {
 		// sure.
 		QMessageBox::information( m_pMainForm, "Hydrogen", tr("Song is read-only.\nUse 'Save as' to enable autosave." ) );
 	}
-}
-
-void HydrogenApp::quitEvent( int nValue ) {
-
-	m_pMainForm->closeAll();
-	
 }
 
 void HydrogenApp::changePreferences( H2Core::Preferences::Changes changes ) {

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -296,12 +296,6 @@ private slots:
 		 *     opened in read-only mode.
 		 */
 		virtual void updateSongEvent( int nValue ) override;
-		/**
-		 * Calls closeAll() to shutdown Hydrogen.
-		 *
-		 * \param nValue unused
-		 */
-		virtual void quitEvent( int nValue ) override;
 	virtual void drumkitLoadedEvent() override;
 	
 };

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -284,7 +284,7 @@ void MainForm::createMenuBar()
 	
 	m_pFileMenu->addAction( sLabelNew, this, SLOT( action_file_new() ), QKeySequence( "Ctrl+N" ) );
 	
-	m_pFileMenu->addAction( tr( "Show &Info" ), this, SLOT( action_file_songProperties() ), QKeySequence( "" ) );
+	m_pFileMenu->addAction( tr( "Song Properties" ), this, SLOT( action_file_songProperties() ), QKeySequence( "" ) );
 	
 	m_pFileMenu->addSeparator();				// -----
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2321,6 +2321,10 @@ void MainForm::updateSongEvent( int nValue ) {
 	}
 }
 
+void MainForm::quitEvent( int ) {
+	closeAll();
+}
+
 void MainForm::startPlaybackAtCursor( QObject* pObject ) {
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1967,9 +1967,15 @@ void MainForm::jacksessionEvent( int nEvent )
 
 void MainForm::action_file_songProperties()
 {
+	if ( H2Core::Hydrogen::get_instance()->getSong() == nullptr ) {
+		return;
+	}
+	
 	SongPropertiesDialog *pDialog = new SongPropertiesDialog( this );
-	if ( pDialog->exec() == QDialog::Accepted ) {
-		Hydrogen::get_instance()->setIsModified( true );
+	if ( pDialog->exec() ) {
+		// Ensure the update name is taken into account in the window
+		// title.
+		HydrogenApp::get_instance()->updateWindowTitle();
 	}
 	delete pDialog;
 }

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -192,9 +192,6 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 
 	//beatcouter
 	Hydrogen::get_instance()->setBcOffsetAdjust();
-	// director
-	EventQueue::get_instance()->push_event( EVENT_METRONOME, 1 );
-	EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
 
 	m_pUndoView = new QUndoView(h2app->m_pUndoStack);
 	m_pUndoView->setWindowTitle(tr("Undo history"));
@@ -629,11 +626,6 @@ void MainForm::action_file_new()
 	h2app->openSong( pSong );
 	h2app->getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
 	h2app->getSongEditorPanel()->updatePositionRuler();
-
-	// update director tags
-	EventQueue::get_instance()->push_event( EVENT_METRONOME, 2 );
-	// update director songname
-	EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
 }
 
 
@@ -746,13 +738,10 @@ void MainForm::action_file_save()
 	bool saved = false;
 	saved = pSong->save( filename );
 
-
 	if(! saved) {
 		QMessageBox::warning( this, "Hydrogen", tr("Could not save song.") );
 	} else {
-
 		h2app->setScrollStatusBarMessage( tr("Song saved.") + QString(" Into: ") + filename, 2000 );
-		EventQueue::get_instance()->push_event( EVENT_METRONOME, 3 );
 	}
 }
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -58,6 +58,7 @@ class MainForm :  public QMainWindow, protected WidgetWithScalableFont<8, 10, 12
 		virtual void jacksessionEvent( int nValue) override;
 		virtual void playlistLoadSongEvent(int nIndex) override;
 		virtual void updateSongEvent( int nValue ) override;
+	virtual void quitEvent( int ) override;
 
 		/** Handles the loading and saving of the H2Core::Preferences
 		 * from the core part of H2Core::Hydrogen.

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -111,7 +111,7 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 		return;
 	}
 
-	prepareUndoAction( ev->x() ); //get all old values
+	prepareUndoAction( ev->position().x() ); //get all old values
 
 	float fDelta;
 	if ( ev->modifiers() == Qt::ControlModifier || ev->modifiers() == Qt::AltModifier ) {
@@ -123,7 +123,7 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 		fDelta = fDelta * -1.0;
 	}
 
-	int nColumn = getColumn( ev->x() );
+	int nColumn = getColumn( ev->position().x() );
 
 	m_pPatternEditorPanel->setCursorPosition( nColumn );
 	HydrogenApp::get_instance()->setHideKeyboardCursor( true );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1015,7 +1015,12 @@ void PatternEditorPanel::dropEvent( QDropEvent *event )
 	m_pInstrumentList->dropEvent( event );
 }
 
-
+void PatternEditorPanel::updateSongEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		updateSLnameLabel();
+	}
+}
 
 void PatternEditorPanel::propertiesComboChanged( int nSelected )
 {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -93,6 +93,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
+	virtual void updateSongEvent( int nValue ) override;
 		//~ Implements EventListener interface
 
 		void ensureCursorVisible();

--- a/src/gui/src/Skin.cpp
+++ b/src/gui/src/Skin.cpp
@@ -76,15 +76,15 @@ QComboBox { \
 QComboBox QAbstractItemView { \
     background-color: #babfcf; \
 } \
-QLineEdit { \
-    color: %14; \
-    background-color: %15; \
+QLineEdit, QTextEdit { \
+    color: %12; \
+    background-color: %13; \
 } \
 QDoubleSpinBox, QSpinBox { \
-    color: %16; \
-    background-color: %17; \
-    selection-color: %16; \
-    selection-background-color: %18; \
+    color: %14; \
+    background-color: %15; \
+    selection-color: %14; \
+    selection-background-color: %16; \
 }"
 					)
 		.arg( pPref->getColorTheme()->m_toolTipTextColor.name() )
@@ -96,8 +96,6 @@ QDoubleSpinBox, QSpinBox { \
 		.arg( buttonBackgroundCheckedLightHover.name() ).arg( buttonBackgroundCheckedDarkHover.name() )
 		.arg( pPref->getColorTheme()->m_widgetTextColor.name() )
 		.arg( pPref->getColorTheme()->m_widgetColor.name() )
-		.arg( pPref->getColorTheme()->m_windowTextColor.name() )
-		.arg( pPref->getColorTheme()->m_windowColor.name() )
 		.arg( pPref->getColorTheme()->m_spinBoxTextColor.name() )
 		.arg( pPref->getColorTheme()->m_spinBoxColor.name() )
 		.arg( spinBoxSelection.name() );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2711,24 +2711,7 @@ void SongEditorPositionRuler::updatePosition()
 	update();
 }
 
-void SongEditorPositionRuler::editTagAction( QString text, int position, QString textToReplace)
-{
-	auto pTimeline = m_pHydrogen->getTimeline();
-
-	const QString sTag = pTimeline->getTagAtColumn( position );
-	pTimeline->deleteTag( position );
-	pTimeline->addTag( position, text );
-	
-	createBackground();
-}
-
-void SongEditorPositionRuler::deleteTagAction( QString text, int position )
-{
-	auto pTimeline = m_pHydrogen->getTimeline();
-
-	const QString sTag = pTimeline->getTagAtColumn( position );
-	pTimeline->deleteTag( position );
-	
+void SongEditorPositionRuler::timelineUpdateEvent( int nValue ) {
 	createBackground();
 }
 

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -334,14 +334,13 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 
 		uint getGridWidth();
 		void setGridWidth (uint width);
-		void editTagAction( QString text, int position, QString textToReplace );
-		void deleteTagAction( QString text, int position );
-
 	int getPlayheadWidth() const;
 	void tempoChangedEvent( int ) override;
 	void columnChangedEvent( int ) override;
 	void songModeActivationEvent( int nValue ) override;
+	
 	void timelineActivationEvent( int nValue ) override;
+	void timelineUpdateEvent( int nValue ) override;
 	void jackTimebaseStateChangedEvent( int nValue ) override;
 													   
 

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -978,8 +978,11 @@ void SongEditorPanel::setTimelineEnabled( bool bEnabled ) {
 	HydrogenApp::get_instance()->setStatusBarMessage( sMessage, 5000);
 }
 
-void SongEditorPanel::updateSongEditorEvent( int ) {
-	updateAll();
+void SongEditorPanel::updateSongEditorEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		updateAll();
+	}
 }
 
 void SongEditorPanel::columnChangedEvent( int ) {

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -61,12 +61,30 @@ void SongPropertiesDialog::on_cancelBtn_clicked()
 
 void SongPropertiesDialog::on_okBtn_clicked()
 {
-	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 
-	pSong->setName( songNameTxt->text() );
-	pSong->setAuthor( authorTxt->text() );
-	pSong->setNotes( notesTxt->toPlainText() );
-	pSong->setLicense( licenseTxt->text() );
+	bool bIsModified = false;
+	if ( songNameTxt->text() != pSong->getName() ) {
+		pSong->setName( songNameTxt->text() );
+		bIsModified = true;
+	}
+	if ( pSong->getAuthor() != authorTxt->text() ) {
+		pSong->setAuthor( authorTxt->text() );
+		bIsModified = true;
+	}
+	if ( pSong->getNotes() != notesTxt->toPlainText() ) {
+		pSong->setNotes( notesTxt->toPlainText() );
+		bIsModified = true;
+	}
+	if ( pSong->getLicense() != licenseTxt->text() ) {
+		pSong->setLicense( licenseTxt->text() );
+		bIsModified = true;
+	}
+
+	if ( bIsModified ) {
+		pHydrogen->setIsModified( true );
+	}
 
 	accept();
 }

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -919,3 +919,10 @@ void SoundLibraryPanel::onPreferencesChanged( H2Core::Preferences::Changes chang
 		}
 	}
 }
+
+void SoundLibraryPanel::updateSongEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		update_background_color();
+	}
+}

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.h
@@ -58,6 +58,7 @@ public:
 	void test_expandedItems();
 	void update_background_color();
 	virtual void drumkitLoadedEvent() override;
+	virtual void updateSongEvent( int nValue ) override;
 	const QString& getMessageFailedPreDrumkitLoad() const;
 
 public slots:

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -430,41 +430,34 @@ private:
 class SE_editTagAction : public QUndoCommand
 {
 public:
-	SE_editTagAction( QString text, QString oldText, int position ){
+	SE_editTagAction( const QString& sText, const QString& sOldText, int nPosition ){
 		setText( QObject::tr( "Edit timeline tag" ) );
-		__text = text;
-		__oldText = oldText;
-		__position = position;
+		m_sText = sText;
+		m_sOldText = sOldText;
+		m_nPosition = nPosition;
 
 	}
-	virtual void undo()
-	{
-		//qDebug() <<  "edit timeline tag undo";
-		HydrogenApp* h2app = HydrogenApp::get_instance();
-		if( __oldText != "" ){
-			h2app->getSongEditorPanel()->getSongEditorPositionRuler()->editTagAction( __oldText, __position , __text );
-		}else
-		{
-			h2app->getSongEditorPanel()->getSongEditorPositionRuler()->deleteTagAction( __text,  __position );
+	virtual void undo() {
+		auto pCoreActionController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+		if ( ! m_sOldText.isEmpty() ){
+			pCoreActionController->addTag( m_nPosition, m_sOldText );
+		} else {
+			pCoreActionController->deleteTag( m_nPosition );
 		}
-
 	}
 
-	virtual void redo()
-	{
-		//qDebug() <<  "edit timeline tag redo";
-		HydrogenApp* h2app = HydrogenApp::get_instance();
-		if( __text == "" ){
-			h2app->getSongEditorPanel()->getSongEditorPositionRuler()->deleteTagAction( __oldText,  __position );
-		}else
-		{
-			h2app->getSongEditorPanel()->getSongEditorPositionRuler()->editTagAction( __text, __position, __oldText );
+	virtual void redo() {
+		auto pCoreActionController = H2Core::Hydrogen::get_instance()->getCoreActionController();
+		if ( ! m_sText.isEmpty() ){
+			pCoreActionController->addTag( m_nPosition, m_sText );
+		} else {
+			pCoreActionController->deleteTag( m_nPosition );
 		}
 	}
 private:
-	QString __text;
-	QString __oldText;
-	int __position;
+	QString m_sText;
+	QString m_sOldText;
+	int m_nPosition;
 };
 
 //~time line commands

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -201,7 +201,8 @@ void WidgetWithInput::wheelEvent ( QWheelEvent *ev )
 	}
 	setValue( getValue() + ( fDelta * fStepFactor ) );
 	
-	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
+	QToolTip::showText( ev->globalPosition().toPoint(),
+						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
 

--- a/src/tests/CoreActionControllerTest.cpp
+++ b/src/tests/CoreActionControllerTest.cpp
@@ -131,12 +131,12 @@ void CoreActionControllerTest::testSessionManagement() {
 void CoreActionControllerTest::testIsSongPathValid() {
 	
 	// Is not absolute.
-	CPPUNIT_ASSERT( !m_pController->isSongPathValid( "test.h2song" ) );
+	CPPUNIT_ASSERT( !Filesystem::isSongPathValid( "test.h2song" ) );
 
 	// Improper suffix.
-	CPPUNIT_ASSERT( !m_pController->isSongPathValid( "test.test" ) );
+	CPPUNIT_ASSERT( !Filesystem::isSongPathValid( "test.test" ) );
 	
 	QString sValidPath = QString( "%1/test.h2song" ).arg( QDir::tempPath() );
-	CPPUNIT_ASSERT( m_pController->isSongPathValid( sValidPath ) );
+	CPPUNIT_ASSERT( Filesystem::isSongPathValid( sValidPath ) );
 	
 }

--- a/src/tests/CoreActionControllerTest.h
+++ b/src/tests/CoreActionControllerTest.h
@@ -54,6 +54,6 @@ public:
 	// CoreActionController::saveSongAs() methods.
 	void testSessionManagement();
 	
-	// Tests CoreActionController::isSongPathValid()
+	// Tests Filesystem::isSongPathValid()
 	void testIsSongPathValid();
 };


### PR DESCRIPTION
One bug fix and a couple of other smaller things I came across while debugging something else

- fix segfault when loading invalid song on startup using the -s option, providing an invalid name, and sending a MIDI or OSC command immediately.

   What happens is the following: Hydrogen can not load the selected song - since it is invalid - and displays a popup dialog which tells that the song could not be loaded. Only after this popup is closed an empty song will be set for Hydrogen::m_pSong. All incoming MIDI and OSC - which the core is already able to handle - will be executed on a pSong == nullptr.

   I introduced checks on all API endpoints for empty song. (This bug does not affect 1.1.1 since the popup dialog was not implemented there.)
- MainForm: rename "Show Info" -> "Song Properties"

   only after ready a reply by mauser in an issue I realized that one can actually change the properties of a song, like name, author, and license, via the main menu.

   I think "Song Properites" is both a more descriptive and a less confusing name to call this action. "Show Info" reads like some read-only content and maybe a remnant that did not got moved into the Info menu.
- move tag adding/deleting into CoreActionController to ensures that with every tag modification the song is marked modified and an TIMELINE_UPDATE_EVENT is issues allowing the GUI to react on the changes.
- tweak METRONOME_EVENT handling + Director UI & routing

   Triggering/updating of the Director was previously done in a outdated and error-prone way. It did not react on event of the core but solely EventQueue events issued by the GUI (?!). To accomplish this the METRONOME_EVENT did contain not just its two "natural" states of 0 - bar and 1 - emphasised (first) bar but also two more representing an update of the tags (only issued when switching songs!) and an update of the song. Now, the Director does directly listen to `SONG_UPDATE_EVENT` and `TIMELINE_UPDATE_EVENT` and is updated every time a tag is changed.

   In addition, the hardcoded colors have been dropped in favor of those defined in the ColorTheme.
- MainForm: handle song save via CoreActionController instead calling the bare Song::save() function.
- GUI: disentangle song update process]

   Previously, the HydrogenApp did react on both the update song and quit event by doing some stuff and telling a lot of other components of the GUI to update as well. This quite complex information flow did grew naturally and is, unfortunately, not that easy to debug. Instead, now the individual parts of the GUI do directly listen to the UPDATE_SONG_EVENT and QUIT_EVENT and do their update stuff without interacting with one another. (Attention: this probably just disentangled _some_ part of the song load process and not the whole thing altogether)
- fix window title for new song

   I did touch the default song name when reworking the empty/default song retrieval. This caused the window name to be off when creating a new Song.

   While at it I also fixed https://github.com/hydrogen-music/hydrogen/issues/687: For a new song, "Untitled Song" or a different Song::m_sName if set will be shown (since there is no file associated with an empty song.). If Song::m_sName was not touched by the user but the song already has a Song::m_sFilename (it was saved to disk) the file name including suffix will be shown (previous behavior). If, however, the complete basename of the song file and Song::m_sName do differ the window title now displays them both as "SONG NAME [FILE_NAME.h2song]". This should point users immediately to any mismatch
- SongPropertiesDialog: immediate feedback by updating the window title.
- Skin: update QLineEdit + add QTextEdit color

   background color of QLineEdit was changed to the brighted widget color (whichs purpose is to be distinct from the windowColor the QLineEdit is embedded into). This makes edible regions in various properties dialogs way more easy to spot.

   Also, color and background of QTextEdit has been aligned to the one of QLineEdit for a more consistent look
- finally fixed those two compiler warnings