### PR TITLE
fix song save

### DIFF
--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -127,19 +127,19 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 */
 		bool saveSong();
 		/**
-		 * Saves the current #H2Core::Song to the path provided in @a songPath.
+		 * Saves the current #H2Core::Song to the path provided in @a sNewFilename.
 		 *
 		 * The intended use of this function for session
 		 * management. Therefore, the function will *not* store the
-		 * provided @a songPath in
+		 * provided @a sNewFilename in
 		 * #H2Core::Preferences::m_lastSongFilename and Hydrogen won't
 		 * resume with the corresponding song on restarting.
 		 *
-		 * \param songPath Absolute path to the file to store the
+		 * \param sNewFilename Absolute path to the file to store the
 		 *   current #H2Core::Song in.
 		 * \return true on success
 		 */
-		bool saveSongAs( const QString& songPath );
+		bool saveSongAs( const QString& sNewFilename );
 		/**
 		 * Saves the current state of the #H2Core::Preferences.
 		 *
@@ -347,6 +347,17 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * \return true on success
 		 */
 		bool setSong( std::shared_ptr<Song> pSong );
+
+	/**
+	 * Add @a sFilename to the list of recent songs in
+	 * Preferences::m_recentFiles.
+	 *
+	 * The function will also take care of removing any duplicates in
+	 * the list in case @a sFilename is already present.
+	 *
+	 * \param sFilename New song to be added on top of the list.
+	 */
+	void insertRecentFile( const QString sFilename );
 		
 		const int m_nDefaultMidiFeedbackChannel;
 };

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -291,13 +291,11 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 	// like OSC clients.
 	m_pCoreActionController->initExternalControlInterfaces();
 
-	if ( isUnderSessionManagement() ) {
 #ifdef H2CORE_HAVE_OSC
+	if ( isUnderSessionManagement() ) {
 		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, true );
-#endif
-	} else {		
-		Preferences::get_instance()->setLastSongFilename( pSong->getFilename() );
 	}
+#endif
 	
 	EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION,
 											( pSong->getMode() == Song::Mode::Song) ? 1 : 0 );

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -1265,38 +1265,6 @@ void Preferences::setMostRecentFX( QString FX_name )
 	m_recentFX.push_front( FX_name );
 }
 
-void Preferences::insertRecentFile( const QString sFilename ){
-
-	bool bAlreadyContained =
-		std::find( m_recentFiles.begin(), m_recentFiles.end(),
-				   sFilename ) != m_recentFiles.end();
-	
-	m_recentFiles.insert( m_recentFiles.begin(), sFilename );
-
-	if ( bAlreadyContained ) {
-		// Eliminate all duplicates in the list while keeping the one
-		// inserted at the beginning.
-		setRecentFiles( m_recentFiles );
-	}
-}
-
-void Preferences::setRecentFiles( const std::vector<QString> recentFiles )
-{
-	// find single filenames. (skip duplicates)
-	std::vector<QString> sTmpVec;
-	for ( const auto& ssFilename : recentFiles ) {
-		if ( std::find( sTmpVec.begin(), sTmpVec.end(), ssFilename) ==
-			 sTmpVec.end() ) {
-			// Particular file is not contained yet.
-			sTmpVec.push_back( ssFilename );
-		}
-	}
-
-	m_recentFiles = sTmpVec;
-}
-
-
-
 /// Read the xml nodes related to window properties
 WindowProperties Preferences::readWindowProperties( QDomNode parent, const QString& windowName, WindowProperties defaultProp )
 {

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -448,9 +448,8 @@ public:
 	void			setQuantizeEvents( bool value );
 	bool			getQuantizeEvents();
 
-	const std::vector<QString> 		getRecentFiles();
+	std::vector<QString> 		getRecentFiles() const;
 	void			setRecentFiles( const std::vector<QString> recentFiles );
-	void			insertRecentFile( const QString sFilename ); 
 
 	QStringList		getRecentFX();
 	void			setMostRecentFX( QString );
@@ -1138,7 +1137,10 @@ inline bool Preferences::getQuantizeEvents() {
 	return quantizeEvents;
 }
 
-inline const std::vector<QString> Preferences::getRecentFiles() {
+inline void Preferences::setRecentFiles( const std::vector<QString> recentFiles ) {
+	m_recentFiles = recentFiles;
+}
+inline std::vector<QString> Preferences::getRecentFiles() const {
 	return m_recentFiles;
 }
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -113,7 +113,15 @@ public slots:
 		 */
 		void action_file_open();
 		void action_file_openDemo();
-		void action_file_save();
+	/**
+	 * Saves the current song to disk.
+	 *
+	 * As Song::m_sFilename is not set by the GUI but by the core,
+	 * this function serves both the "save as" functionality (with
+	 * sNewFilename being non-empty) and the "save" one.
+	 */
+		void action_file_save( const QString& sNewFilename );
+	void action_file_save();
 		
 		/**
 		 * Project > Save As / Export from Session handling function.


### PR DESCRIPTION
When using "save as" to store the current song under a different filename via the GUI, the new filename was not inserted into the list of recently used filenames and not set as lost song filename in the Preferences. In addition, the SONG_SAVE_AS OSC command did only store the current song under a different filename but did not overwrite Song::m_sFilename. Subsequent SONG_SAVE OSC commands would have stored changes in the previous file.

This did not affect 1.1.1.