### PR TITLE
fix segfault in #1474

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -120,7 +120,7 @@ for:
 
           cmake --version
           g++ --version
-          choco install %CHOCO_ARCH% -y jack
+          choco install %CHOCO_ARCH% jack --version 1.9.17 -my
 
           dir "c:\%PROGRAM_FILES%\JACK2"
           dir "c:\%PROGRAM_FILES%\JACK2\lib"

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1023,7 +1023,10 @@ inline void audioEngine_process_playNotes( unsigned long nframes )
 				delete pNote;
 			}
 
-			EventQueue::get_instance()->push_event( EVENT_NOTEON, nInstrument );
+			// Check whether the instrument could be found.
+			if ( nInstrument != -1 ) {
+				EventQueue::get_instance()->push_event( EVENT_NOTEON, nInstrument );
+			}
 			continue;
 		} else {
 			// this note will not be played

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -262,7 +262,7 @@ void Mixer::soloClicked(MixerLine* ref)
 	CoreActionController* pController = pEngine->getCoreActionController();
 	Song *pSong = pEngine->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
-	int nInstruments = pInstrList->size();
+	int nInstruments = std::min( pInstrList->size(), MAX_INSTRUMENTS );
 
 	int nLine = findMixerLineByRef(ref);
 
@@ -282,9 +282,15 @@ void Mixer::soloClicked(MixerLine* ref)
 /// used in PatternEditorInstrumentList
 void Mixer::soloClicked(uint nLine)
 {
+	if ( nLine < 0 || nLine >= MAX_INSTRUMENTS ) {
+		ERRORLOG( QString( "Selected MixerLine [%1] out of bound [0,%2)" )
+				  .arg( nLine ).arg( MAX_INSTRUMENTS ) );
+		return;
+	}
+
 	MixerLine * pMixerLine = m_pMixerLine[ nLine ];
 
-	if( pMixerLine ){
+	if( pMixerLine != nullptr ){
 		pMixerLine->setSoloClicked( !pMixerLine->isSoloClicked() );
 		soloClicked( pMixerLine );
 	}
@@ -292,12 +298,17 @@ void Mixer::soloClicked(uint nLine)
 
 }
 
-bool Mixer::isSoloClicked( uint n )
+bool Mixer::isSoloClicked( uint nLine )
 {
-	if ( n >= MAX_INSTRUMENTS || m_pMixerLine[ n ] == nullptr ) {
+	if ( nLine < 0 || nLine >= MAX_INSTRUMENTS ) {
+		ERRORLOG( QString( "Selected MixerLine [%1] out of bound [0,%2)" )
+				  .arg( nLine ).arg( MAX_INSTRUMENTS ) );
 		return false;
 	}
-	return m_pMixerLine[ n ]->isSoloClicked();
+	if ( m_pMixerLine[ nLine ] == nullptr ) {
+		return false;
+	}
+	return m_pMixerLine[ nLine ]->isSoloClicked();
 }
 
 void Mixer::noteOnClicked( MixerLine* ref )
@@ -712,8 +723,13 @@ void Mixer::knobChanged(MixerLine* ref, int nKnob) {
 
 void Mixer::noteOnEvent( int nInstrument )
 {
-	if ( m_pMixerLine[ nInstrument ] ) {
-		m_pMixerLine[ nInstrument ]->setActivity( 100 );
+	if ( nInstrument >= 0 && nInstrument < MAX_INSTRUMENTS ) {
+		if ( m_pMixerLine[ nInstrument ] != nullptr ) {
+			m_pMixerLine[ nInstrument ]->setActivity( 100 );
+		}
+	} else {
+		ERRORLOG( QString( "Selected MixerLine [%1] out of bound [0,%2)" )
+				  .arg( nInstrument ).arg( MAX_INSTRUMENTS ) );
 	}
 }
 
@@ -821,7 +837,12 @@ void Mixer::ladspaVolumeChanged( LadspaFXMixerLine* ref)
 
 void Mixer::getPeaksInMixerLine( uint nMixerLine, float& fPeak_L, float& fPeak_R )
 {
-	if ( nMixerLine < MAX_INSTRUMENTS ) {
+	if ( nMixerLine < 0 || nMixerLine >= MAX_INSTRUMENTS ) {
+		ERRORLOG( QString( "Selected MixerLine [%1] out of bound [0,%2)" )
+				  .arg( nMixerLine ).arg( MAX_INSTRUMENTS ) );
+		return;
+	}
+	if ( m_pMixerLine[ nMixerLine ] != nullptr ) {
 		fPeak_L = m_pMixerLine[ nMixerLine ]->getPeak_L();
 		fPeak_R = m_pMixerLine[ nMixerLine ]->getPeak_R();
 	}


### PR DESCRIPTION
That one was quite weird. It had nothing to do with the instrument/drumkit cleanup but was due to an access of an array in the Mixer without any boundchecks. But it did only happen when shutting down the application.

When handing a Note to the Sampler the AudioEngine queues a EVENT_NOTEON and provides the instrument number of the current note. The latter is aquired by comparing Note::__instrument with all the instruments of a song. However, if the Drumkit was recently switched to a smaller one, some instruments at the end of the songs instrument list are removed and all their corresponding notes being purged from the patterns. But there is still an intermediate buffer that is missed in here: the notes of the purged instruments might been already added to the AudioEngine::m_songNoteQueue but not being handed to the sampler (due to the lookahead). The instruments of these notes do not reside in the Song::m_pInstrumentList but in Hydrogen::__instrument_death_row. Therefore, when handing the notes to the Sampler the AudioEngine can not find the corresponding instrument in Song::m_pInstrumentList and triggers an EVENT_NOTEON with a value of `-1`. This will be used in the Mixer as index for a C-style array without further checks and causes a segfault.

I have added both boundary checks for the provided indices in Mixer as well as checking whether the instrument could be found before triggering the EVENT_NOTEON