### PR TITLE
More small fixes

### DIFF
--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -848,13 +848,13 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 			}
 		}
 		sOutput.append( QString( "%1" ).arg( m_pInstrumentList->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( ", m_pComponents:" ) );
+			.append( QString( ", m_pComponents: [" ) );
 		for ( auto cc : *m_pComponents ) {
 			if ( cc != nullptr ) {
 				sOutput.append( QString( "%1" ).arg( cc->toQString( sPrefix + s + s, bShort ) ) );
 			}
 		}
-		sOutput.append( QString( ", m_sFilename: %1" ).arg( m_sFilename ) )
+		sOutput.append( QString( "], m_sFilename: %1" ).arg( m_sFilename ) )
 			.append( QString( ", m_loopMode: %1" ).arg( static_cast<int>(m_loopMode) ) )
 			.append( QString( ", m_fHumanizeTimeValue: %1" ).arg( m_fHumanizeTimeValue ) )
 			.append( QString( ", m_fHumanizeVelocityValue: %1" ).arg( m_fHumanizeVelocityValue ) )

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -863,26 +863,27 @@ bool CoreActionController::loadDrumkit( const QString& sDrumkitName, bool bCondi
 		return false;
 	}
 
-	return loadDrumkit( pDrumkit, bConditional );
+	int nRet = loadDrumkit( pDrumkit, bConditional );
+	delete pDrumkit;
+
+	return nRet;
 }
 
 bool CoreActionController::loadDrumkit( Drumkit* pDrumkit, bool bConditional ) {
-	bool bReturnValue = true;
-	
+
 	if ( pDrumkit != nullptr ) {
 		if ( Hydrogen::get_instance()->loadDrumkit( pDrumkit, bConditional ) == 0 ) {
 			EventQueue::get_instance()->push_event( EVENT_DRUMKIT_LOADED, 0 );
 		} else {
 			ERRORLOG( "Unable to load drumkit" );
-			bReturnValue = false;
+			return false;
 		}
-		delete pDrumkit;
 	} else {
 		ERRORLOG( "Provided Drumkit is not valid" );
-		bReturnValue =  false;
+		return false;
 	}
 	
-	return bReturnValue;
+	return true;
 }
 
 bool CoreActionController::upgradeDrumkit( const QString& sDrumkitPath, const QString& sNewPath ) {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -219,6 +219,10 @@ void Hydrogen::sequencer_stop()
 
 	m_pAudioEngine->stop();
 	Preferences::get_instance()->setRecordEvents(false);
+
+	// Delete redundant instruments still alive after switching the
+	// drumkit to a smaller one.
+	__kill_instruments();
 }
 
 bool Hydrogen::setPlaybackTrackState( const bool state )
@@ -1137,23 +1141,25 @@ void Hydrogen::addInstrumentToDeathRow( std::shared_ptr<Instrument> pInstr ) {
 
 void Hydrogen::__kill_instruments()
 {
-	std::shared_ptr<Instrument> pInstr = nullptr;
-	while ( __instrument_death_row.size()
-			&& __instrument_death_row.front()->is_queued() == 0 ) {
-		pInstr = __instrument_death_row.front();
-		__instrument_death_row.pop_front();
-		INFOLOG( QString( "Deleting unused instrument (%1). "
-						  "%2 unused remain." )
-				 . arg( pInstr->get_name() )
-				 . arg( __instrument_death_row.size() ) );
-		pInstr = nullptr;
-	}
-	if ( __instrument_death_row.size() ) {
-		pInstr = __instrument_death_row.front();
-		INFOLOG( QString( "Instrument %1 still has %2 active notes. "
-						  "Delaying 'delete instrument' operation." )
-				 . arg( pInstr->get_name() )
-				 . arg( pInstr->is_queued() ) );
+	if ( __instrument_death_row.size() > 0 ) {
+		std::shared_ptr<Instrument> pInstr = nullptr;
+		while ( __instrument_death_row.size()
+				&& __instrument_death_row.front()->is_queued() == 0 ) {
+			pInstr = __instrument_death_row.front();
+			__instrument_death_row.pop_front();
+			INFOLOG( QString( "Deleting unused instrument (%1). "
+							  "%2 unused remain." )
+					 . arg( pInstr->get_name() )
+					 . arg( __instrument_death_row.size() ) );
+			pInstr = nullptr;
+		}
+		if ( __instrument_death_row.size() ) {
+			pInstr = __instrument_death_row.front();
+			INFOLOG( QString( "Instrument %1 still has %2 active notes. "
+							  "Delaying 'delete instrument' operation." )
+					 . arg( pInstr->get_name() )
+					 . arg( pInstr->is_queued() ) );
+		}
 	}
 }
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -1352,6 +1352,7 @@ void InstrumentEditor::compoChangeAddDelete(QAction* pAction)
 		std::vector<DrumkitComponent*>* pDrumkitComponents = pHydrogen->getSong()->getComponents();
 
 		if(pDrumkitComponents->size() == 1){
+			ERRORLOG( "There is just a single component remaining. This one can not be deleted." );
 			return;
 		}
 
@@ -1378,6 +1379,8 @@ void InstrumentEditor::compoChangeAddDelete(QAction* pAction)
 		}
 
 		m_nSelectedComponent = pDrumkitComponents->front()->get_id();
+
+		delete pDrumkitComponent;
 
 		selectedInstrumentChangedEvent();
 		// this will force an update...

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -1079,7 +1079,7 @@ void InstrumentEditor::labelCompoClicked( ClickableLabel* pRef )
 		return;
 	}
 	DrumkitComponent* pComponent = pSong->getComponent( m_nSelectedComponent );
-	if ( pComponent != nullptr ) {
+	if ( pComponent == nullptr ) {
 		return;
 	}
 	QString sOldName = pComponent->get_name();

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -578,7 +578,8 @@ void SoundLibraryPanel::on_drumkitLoadAction()
 			msgBox.setIcon( QMessageBox::Warning );
 			msgBox.setText( tr( "The existing kit has %1 instruments but the new one only has %2.\nThe first %2 instruments will be replaced with the new instruments and will keep their notes, but some of the remaining instruments have notes.\nWould you like to keep or discard the remaining instruments and notes?\n").arg( QString::number( oldCount ),QString::number( newCount ) ) );
 
-			msgBox.setStandardButtons(QMessageBox::Save);
+			msgBox.setStandardButtons( QMessageBox::Save | QMessageBox::Discard |
+									   QMessageBox::Cancel );
 			msgBox.setButtonText(QMessageBox::Save, tr("Keep"));
 			msgBox.setButtonText(QMessageBox::Discard,
 								 pCommonStrings->getButtonDiscard() );


### PR DESCRIPTION
- less conservative instrument removal

   if a drumkit was loaded with less instruments than the original one and the user decided to discard the additional ones, those instruments were either deleted right away, on the next drumkit load with less instruments+removal or when quitting Hydrogen. As this just affects notes that are either played by the Sampler or queued in the AudioEngine::m_songNoteQueue the moment the drumkit switch occurs, this behavior is quit conservative. The notes are almost certainly flushed in the next seconds and there is no reason to hold all samples of the instrument till Hydrogen is terminated. Instead, Hydrogen will now check every time the transport is stopped whether there are instruments in the Hydrogen::__instrument_death_row that can be removed (are not queued anymore).
- fix SoundLibrary drumkit load dialog buttons bug introduced a couple of PRs ago
- fix bug in drumkit load introduced after 1.1.1
- fix renaming of components
- fix memory leakage when deleting DrumkitComponent

   When deleting a DrumkitComponent via the popup menu in the InstrumentEditor, the component is properly removed from all instruments as well as from the list of DrumkitComponents in the song. However, the object itself does never get deleted. (But its a rather tiny object.)