### PR TITLE
More small fixes for 1.1.1

### DIFF
--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -742,13 +742,13 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 			}
 		}
 		sOutput.append( QString( "%1" ).arg( m_pInstrumentList->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( ", m_pComponents:" ) );
+			.append( QString( ", m_pComponents: [" ) );
 		for ( auto cc : *m_pComponents ) {
 			if ( cc != nullptr ) {
 				sOutput.append( QString( "%1" ).arg( cc->toQString( sPrefix + s + s, bShort ) ) );
 			}
 		}
-		sOutput.append( QString( ", m_sFilename: %1" ).arg( m_sFilename ) )
+		sOutput.append( QString( "], m_sFilename: %1" ).arg( m_sFilename ) )
 			.append( QString( ", m_bIsLoopEnabled: %1" ).arg( m_bIsLoopEnabled ) )
 			.append( QString( ", m_fHumanizeTimeValue: %1" ).arg( m_fHumanizeTimeValue ) )
 			.append( QString( ", m_fHumanizeVelocityValue: %1" ).arg( m_fHumanizeVelocityValue ) )

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -1348,6 +1348,7 @@ void InstrumentEditor::compoChangeAddDelete(QAction* pAction)
 		std::vector<DrumkitComponent*>* pDrumkitComponents = pEngine->getSong()->getComponents();
 
 		if(pDrumkitComponents->size() == 1){
+			ERRORLOG( "There is just a single component remaining. This one can not be deleted." );
 			return;
 		}
 
@@ -1380,6 +1381,8 @@ void InstrumentEditor::compoChangeAddDelete(QAction* pAction)
 		}
 
 		m_nSelectedComponent = pDrumkitComponents->front()->get_id();
+
+		delete pDrumkitComponent;
 
 		selectedInstrumentChangedEvent();
 		// this will force an update...

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -1084,7 +1084,7 @@ void InstrumentEditor::labelCompoClicked( ClickableLabel* pRef )
 		return;
 	}
 	DrumkitComponent* pComponent = pSong->getComponent( m_nSelectedComponent );
-	if ( pComponent != nullptr ) {
+	if ( pComponent == nullptr ) {
 		return;
 	}
 	QString sOldName = pComponent->get_name();


### PR DESCRIPTION
- fix renaming of components

- fix memory leakage when deleting DrumkitComponent

   When deleting a DrumkitComponent via the popup menu in the InstrumentEditor, the component is properly removed from all instruments as well as from the list of DrumkitComponents in the song. However, the object itself does never get deleted. (But its a rather tiny object.)
