### PR TITLE
Fix drumkit export

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -68,7 +68,7 @@ static struct option long_opts[] = {
 	{"install", required_argument, nullptr, 'i'},
 	{"check", required_argument, nullptr, 'c'},
 	{"upgrade", required_argument, nullptr, 'u'},
-	{"extract", required_argument, nullptr, 'e'},
+	{"extract", required_argument, nullptr, 'x'},
 	{"target", required_argument, nullptr, 't'},
 	{"drumkit", required_argument, nullptr, 'k'},
 	{nullptr, 0, nullptr, 0},
@@ -106,6 +106,17 @@ void show_playlist (uint active )
 	}
 	
 	std::cout << std::endl;
+}
+
+QString makePathAbsolute( const char* path ) {
+
+	QString sPath = QString::fromLocal8Bit( path );
+	QFileInfo fileInfo( sPath );
+	if ( fileInfo.isRelative() ) {
+		sPath = fileInfo.absoluteFilePath();
+	}
+
+	return sPath;
 }
 
 #define NELEM(a) ( sizeof(a)/sizeof((a)[0]) )
@@ -172,25 +183,25 @@ int main(int argc, char *argv[])
 				break;
 			case 'i':
 				//install h2drumkit
-				drumkitName = QString::fromLocal8Bit(optarg);
+				drumkitName = makePathAbsolute( optarg );
 				break;
 			case 'c':
 				//validate h2drumkit
-				sDrumkitToValidate = QString::fromLocal8Bit(optarg);
+				sDrumkitToValidate = makePathAbsolute( optarg );
 				bValidateDrumkit = true;
 				break;
 			case 'u':
 				//upgrade h2drumkit
-				sDrumkitToUpgrade = QString::fromLocal8Bit(optarg);
+				sDrumkitToUpgrade = makePathAbsolute( optarg );
 				bUpgradeDrumkit = true;
 				break;
-			case 'e':
+			case 'x':
 				//extract h2drumkit
-				sDrumkitToExtract = QString::fromLocal8Bit(optarg);
+				sDrumkitToExtract = makePathAbsolute( optarg );
 				bExtractDrumkit = true;
 				break;
 			case 't':
-				sTarget = QString::fromLocal8Bit(optarg);
+				sTarget = makePathAbsolute( optarg );
 				break;
 			case 'k':
 				//load Drumkit
@@ -337,11 +348,11 @@ int main(int argc, char *argv[])
 			if (! pSong) {
 				___INFOLOG("Starting with empty song");
 				pSong = Song::getEmptySong();
-				pSong->setFilename( "" );
+			} else {
+				preferences->setLastSongFilename( songFilename );
 			}
 
 			pHydrogen->setSong( pSong );
-			preferences->setLastSongFilename( songFilename );
 		}
 
 		if ( ! drumkitToLoad.isEmpty() ){
@@ -614,10 +625,10 @@ void showUsage()
 	std::cout << "                        one is upgraded in place. If a compressed drumkit" << std::endl;
 	std::cout << "                        is provided as first argument, the upgraded" << std::endl;
 	std::cout << "                        drumkit will be compressed as well." << std::endl;
-	std::cout << "   -e, --extract FILE - extracts the content of a drumkit (.h2drumkit)" << std::endl;
+	std::cout << "   -x, --extract FILE - extracts the content of a drumkit (.h2drumkit)" << std::endl;
 	std::cout << "                        If no target is specified using the -t option" << std::endl;
 	std::cout << "                        this command behaves like --install." << std::endl;
-	std::cout << "   -t, --target FOLDER - target folder the extracted (-e) or upgraded (-u)" << std::endl;
+	std::cout << "   -t, --target FOLDER - target folder the extracted (-x) or upgraded (-u)" << std::endl;
 	std::cout << "                         drumkit will be stored in. The folder is created" << std::endl;
 	std::cout << "                         if it not exists yet." << std::endl;
 	std::cout << std::endl;

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -93,12 +93,12 @@ Drumkit::~Drumkit()
 
 Drumkit* Drumkit::load_by_name( const QString& dk_name, const bool load_samples, Filesystem::Lookup lookup )
 {
-	QString dir = Filesystem::drumkit_path_search( dk_name, lookup );
-	if ( dir.isEmpty() ) {
+	QString sDrumkitPath = Filesystem::drumkit_path_search( dk_name, lookup );
+	if ( sDrumkitPath.isEmpty() ) {
 		return nullptr;
 	}
 	
-	return load( dir, load_samples );
+	return load( sDrumkitPath, load_samples );
 }
 
 Drumkit* Drumkit::load( const QString& dk_dir, const bool load_samples, bool bUpgrade, bool bSilent )

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -261,18 +261,14 @@ void Drumkit::unload_samples()
 }
 
 QString Drumkit::getFolderName() const {
-
-	// Ensure the name will be a valid filename
-	QString sValidName = __name;
-	sValidName.remove( QRegExp( "[^a-zA-Z0-9._]" ) );
-
-	return sValidName;
+	return Filesystem::validateFilePath( __name );
 }
 
 QString Drumkit::getExportName( const QString& sComponentName, bool bRecentVersion ) const {
 	QString sExportName = getFolderName();
 	if ( ! sComponentName.isEmpty() ) {
-		sExportName.append( "_" + sComponentName );
+		sExportName.append( "_" +
+							Filesystem::validateFilePath( sComponentName ) );
 		if ( ! bRecentVersion ) {
 			sExportName.append( "_legacy" );
 		}

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -269,6 +269,18 @@ QString Drumkit::getFolderName() const {
 	return sValidName;
 }
 
+QString Drumkit::getExportName( const QString& sComponentName, bool bRecentVersion ) const {
+	QString sExportName = getFolderName();
+	if ( ! sComponentName.isEmpty() ) {
+		sExportName.append( "_" + sComponentName );
+		if ( ! bRecentVersion ) {
+			sExportName.append( "_legacy" );
+		}
+	}
+	
+	return sExportName;
+}
+
 bool Drumkit::save( const QString&					sName,
                     const QString&					sAuthor,
                     const QString&					sInfo,
@@ -714,8 +726,9 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath, b
 #endif
 }
 
-bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName, bool bRecentVersion, bool bSilent ) const {
+bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName, bool bRecentVersion, bool bSilent ) {
 
+#ifndef WIN32
 	if ( ! Filesystem::path_usable( sTargetDir, true, false ) ) {
 		ERRORLOG( QString( "Provided destination folder [%1] is not valid" )
 				  .arg( sTargetDir ) );
@@ -727,11 +740,24 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 		return false;
 	}
 
-	QString sTargetName = sTargetDir + "/" + getFolderName();
-	if ( ! sComponentName.isEmpty() ) {
-		sTargetName.append( "_" + sComponentName );
-	}
-	sTargetName.append( Filesystem::drumkit_ext );
+	// When performing an export of a single component, the resulting
+	// file will be <DRUMKIT_NAME>_<COMPONENT_NAME>.h2drumkit. This
+	// itself is nice because the user can not choose the name of the
+	// resulting file and it would not be possible to store the export
+	// of multiple components in a single folder otherwise. But if all
+	// those different .h2drumkit would be extracted into the same
+	// folder there would be easily confusion or maybe even loss of
+	// data. We thus temporary rename the drumkit within this
+	// function.
+	// If a legacy export is asked for (!bRecentVersion) the suffix
+	// "_legacy" will be appended as well in order to provide unique
+	// filenames for all export options of a drumkit that can be
+	// selected in the GUI.
+	QString sOldDrumkitName = __name;
+	QString sDrumkitName = getExportName( sComponentName, bRecentVersion );
+	
+	QString sTargetName = sTargetDir + "/" + sDrumkitName +
+		Filesystem::drumkit_ext;
 	
 	if ( ! bSilent ) {
 		QString sMsg( "Export ");
@@ -770,6 +796,7 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 		for ( auto pComponent : *__components ) {
 			if( pComponent->get_name().compare( sComponentName ) == 0) {
 				nComponentID = pComponent->get_id();
+				set_name( sDrumkitName );
 				break;
 			}
 		}
@@ -777,6 +804,7 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 			ERRORLOG( QString( "Component [%1] could not be found in current Drumkit [%2]" )
 					  .arg( sComponentName )
 					  .arg( toQString( "", true ) ) );
+			set_name( sOldDrumkitName );
 			return false;
 		}
 		if ( ! save_file( Filesystem::drumkit_file( tmpFolder.path() ),
@@ -789,6 +817,7 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	if ( ! Filesystem::dir_readable( __path, true ) ) {
 		ERRORLOG( QString( "Unabled to access folder associated with drumkit [%1]" )
 				  .arg( __path ) );
+		set_name( sOldDrumkitName );
 		return false;
 	}
 	
@@ -886,13 +915,14 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	if ( ret != ARCHIVE_OK ) {
 		ERRORLOG( QString("Couldn't create archive [%0]" )
 			.arg( sTargetName ) );
+		set_name( sOldDrumkitName );
 		return false;
 	}
 
 	bool bFoundFileInRightComponent;
 	for ( const auto& sFilename : filesUsed ) {
 		QFileInfo ffileInfo( sFilename );
-		QString sTargetFilename = getFolderName() + "/" + ffileInfo.fileName();
+		QString sTargetFilename = sDrumkitName + "/" + ffileInfo.fileName();
 
 		// Small sanity check since the libarchive code won't fail
 		// gracefully but segfaults if the provided file does not
@@ -900,6 +930,7 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 		if ( ! Filesystem::file_readable( sFilename, true ) ) {
 			ERRORLOG( QString( "Unable to export drumkit. File [%1] does not exists or is not readable." )
 					  .arg( sFilename ) );
+			set_name( sOldDrumkitName );
 			return false;
 		}
 
@@ -933,41 +964,52 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	// working. Else, it's probably worth inspecting its content (and
 	// the system will clean it up anyway).
 	Filesystem::rm( tmpFolder.path(), true, true );
+	
+	set_name( sOldDrumkitName );
 
 	return true;
-#elif !defined(WIN32)
+#else // No LIBARCHIVE
 
 	if ( nComponentID != -1 ) {
+		// In order to add components name to the folder name we have
+		// to copy _all_ files to a temporary folder holding the same
+		// name. This is unarguably a quite expensive operation. But
+		// exporting is only down sparsely and almost all versions of
+		// Hydrogen should come with libarchive support anyway. On the
+		// other hand, being consistent and prevent confusion and loss
+		// of data beats sparsely excessive copying.
+		QString sDirName = getFolderName();
 
-		// Backup original drumkit.xml file.
-		if ( ! Filesystem::file_copy( sourceDir.filePath( Filesystem::drumkit_xml() ),
-									  sourceDir.filePath( Filesystem::drumkit_xml() ) +
-									  ".original", true, true ) ) {
-			ERRORLOG( QString( "Unable to backup original [%1] file." )
-					  .arg( sourceDir.filePath( Filesystem::drumkit_xml() ) ) );
-			return false;
+		QDir sTmpSourceDir( tmpFolder.path() + "/" + sDirName );
+		if ( sTmpSourceDir.exists() ) {
+			sTmpSourceDir.removeRecursively();
 		}
-
-		// Copy component-wise one into the source folder.
-		if ( ! Filesystem::file_copy( Filesystem::drumkit_file( tmpFolder.path() ),
-									  sourceDir.filePath( Filesystem::drumkit_xml() ),
+		if ( ! Filesystem::path_usable( tmpFolder.path() + "/" + sDirName,
 									  true, true ) ) {
-			ERRORLOG( QString( "Unable to copy component-wise [%1] file into source folder [%2]." )
-					  .arg( Filesystem::drumkit_file( tmpFolder.path() ) )
-					  .arg( sourceDir.filePath( Filesystem::drumkit_xml() ) ) );
-
-			// Restore the original drumkit file
-			Filesystem::file_copy( sourceDir.filePath( Filesystem::drumkit_xml() ) +
-								   ".original",
-								   sourceDir.filePath( Filesystem::drumkit_xml() ),
-								   true, true );
-			Filesystem::rm( sourceDir.filePath( Filesystem::drumkit_xml() ) +
-							".original", false, true );
+			ERRORLOG( QString( "Unable to create tmp folder [%1]" )
+					  .arg( tmpFolder.path() + "/" + sDirName ) );
+			set_name( sOldDrumkitName );
 			return false;
 		}
 
-		filesUsed = filesUsed.replaceInStrings( tmpFolder.path(),
-												sourceDir.absolutePath() );
+		QString sNewFilePath;
+		QStringList copiedFiles;
+		for ( const auto& ssFile : filesUsed ) {
+			QString sNewFilePath( ssFile );
+			sNewFilePath.replace( sNewFilePath.left( sNewFilePath.lastIndexOf( "/" ) ),
+								  tmpFolder.path() + "/" + sDirName );
+			if ( ! Filesystem::file_copy( ssFile, sNewFilePath, true, true ) ) {
+				ERRORLOG( QString( "Unable to copy file [%1] to [%2]." )
+						  .arg( ssFile ).arg( sNewFilePath ) );
+				set_name( sOldDrumkitName );
+				return false;
+			}
+
+			copiedFiles << sNewFilePath;
+		}
+
+		filesUsed = copiedFiles;
+		sourceDir = QDir( tmpFolder.path() + "/" + sDirName );
 	}
 
 	// Since there is no way to alter the target names of the files
@@ -985,19 +1027,10 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 		.arg( filesUsed.join( "\" \"" ) );
 	int nRet = std::system( sCmd.toLocal8Bit() );
 
-	if ( nComponentID != -1 ) {
-		// Restore the original drumkit file
-		Filesystem::file_copy( sourceDir.filePath( Filesystem::drumkit_xml() ) +
-							   ".original",
-							   sourceDir.filePath( Filesystem::drumkit_xml() ),
-							   true, true );
-		Filesystem::rm( sourceDir.filePath( Filesystem::drumkit_xml() ) +
-						".original", false, true );
-	}
-
 	if ( nRet != 0 ) {
 		ERRORLOG( QString( "Unable to export drumkit using system command:\n%1" )
 				  .arg( sCmd ) );
+			set_name( sOldDrumkitName );
 		return false;
 	}
 
@@ -1006,9 +1039,13 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	// the system will clean it up anyway).
 	Filesystem::rm( tmpFolder.path(), true, true );
 
+	set_name( sOldDrumkitName );
+			
 	return true;
+#endif // LIBARCHIVE
 #else // WIN32
-	ERRORLOG( "Operation not supported" );
+	ERRORLOG( "Operation not supported on Windows" );
+	
 	return false;
 #endif
 

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -134,6 +134,16 @@ class Drumkit : public H2Core::Object<Drumkit>
 	 * the associated drumkit folder but it does not have to.
 	 */
 	QString getFolderName() const;
+	/**
+	 * Returns the base name used when exporting the drumkit.
+	 *
+	 * \param sComponentName Name of a particular component used in
+	 * case just a single component should be exported.
+	 * \param bRecentVersion Whether the drumkit format should be
+	 * supported by Hydrogen 0.9.7 or higher (whether it should be
+	 * composed of DrumkitComponents).
+	 */
+	QString getExportName( const QString& sComponentName, bool bRecentVersion ) const;
 		
 		/** 
 		 * Saves the current drumkit to dk_path, but makes a backup. 
@@ -242,7 +252,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 	 *
 	 * \return true on success 
 	 */
-	bool exportTo( const QString& sTargetDir, const QString& sComponentName = "", bool bRecentVersion = true, bool bSilent = false ) const;
+	bool exportTo( const QString& sTargetDir, const QString& sComponentName = "", bool bRecentVersion = true, bool bSilent = false );
 		/**
 		 * remove a drumkit from the disk
 		 * \param dk_name the drumkit name

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -169,11 +169,14 @@ class Drumkit : public H2Core::Object<Drumkit>
 		 * \param dk_path the path to save the drumkit into
 		 * \param overwrite allows to write over existing drumkit file
 		 * \param component_id to chose the component to save or -1 for all
-		 * \return true on success
 		 * \param bSilent if set to true, all log messages except of
 		 * errors and warnings are suppressed.
+		 *
+		 * \return true on success
 		 */
-		bool save_file( const QString& dk_path, bool overwrite=false, int component_id=-1, bool bSilent = false ) const;
+		bool save_file( const QString& dk_path, bool overwrite=false,
+						int component_id=-1, bool bRecentVersion = true,
+						bool bSilent = false ) const;
 		/**
 		 * save a drumkit instruments samples into a directory
 		 * \param dk_dir the directory to save the samples into
@@ -319,8 +322,12 @@ class Drumkit : public H2Core::Object<Drumkit>
 		/*
 		 * save the drumkit within the given XMLNode
 		 * \param node the XMLNode to feed
+		 * \param component_id to chose the component to save or -1 for all
+		 * \param bRecentVersion Whether the drumkit format should be
+		 * supported by Hydrogen 0.9.7 or higher (whether it should be
+		 * composed of DrumkitComponents).
 		 */
-		void save_to( XMLNode* node, int component_id=-1 ) const;
+	void save_to( XMLNode* node, int component_id=-1, bool bRecentVersion = true ) const;
 		/**
 		 * load a drumkit from an XMLNode
 		 * \param node the XMLDode to read from

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -346,7 +346,7 @@ void Instrument::unload_samples()
 	}
 }
 
-void Instrument::save_to( XMLNode* node, int component_id )
+void Instrument::save_to( XMLNode* node, int component_id, bool bRecentVersion )
 {
 	XMLNode InstrumentNode = node->createNode( "instrument" );
 	InstrumentNode.write_int( "id", __id );
@@ -391,8 +391,9 @@ void Instrument::save_to( XMLNode* node, int component_id )
 		InstrumentNode.write_float( QString( "FX%1Level" ).arg( i+1 ), __fx_level[i] );
 	}
 	for ( auto& pComponent : *__components ) {
-		if( component_id == -1 || pComponent->get_drumkit_componentID() == component_id ) {
-			pComponent->save_to( &InstrumentNode, component_id );
+		if( component_id == -1 ||
+			pComponent->get_drumkit_componentID() == component_id ) {
+			pComponent->save_to( &InstrumentNode, component_id, bRecentVersion );
 		}
 	}
 }

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -116,8 +116,11 @@ class Instrument : public H2Core::Object<Instrument>
 		 * \param node the XMLNode to feed
 		 * \param component_id Identifier of the corresponding
 		 * component.
+		 * \param bRecentVersion Whether the drumkit format should be
+		 * supported by Hydrogen 0.9.7 or higher (whether it should be
+		 * composed of DrumkitComponents).
 		 */
-		void save_to( XMLNode* node, int component_id );
+		void save_to( XMLNode* node, int component_id, bool bRecentVersion = true );
 		/**
 		 * load an instrument from an XMLNode
 		 * \param node the XMLDode to read from

--- a/src/core/Basics/InstrumentComponent.cpp
+++ b/src/core/Basics/InstrumentComponent.cpp
@@ -118,18 +118,18 @@ std::shared_ptr<InstrumentComponent> InstrumentComponent::load_from( XMLNode* no
 	return pInstrumentComponent;
 }
 
-void InstrumentComponent::save_to( XMLNode* node, int component_id )
+void InstrumentComponent::save_to( XMLNode* node, int component_id, bool bRecentVersion )
 {
 	XMLNode component_node;
-	if( component_id == -1 ) {
+	if ( bRecentVersion ) {
 		component_node = node->createNode( "instrumentComponent" );
 		component_node.write_int( "component_id", __related_drumkit_componentID );
 		component_node.write_float( "gain", __gain );
 	}
 	for ( int n = 0; n < m_nMaxLayers; n++ ) {
 		auto pLayer = get_layer( n );
-		if( pLayer ) {
-			if( component_id == -1 ) {
+		if( pLayer != nullptr ) {
+			if( bRecentVersion ) {
 				pLayer->save_to( &component_node );
 			} else {
 				pLayer->save_to( node );

--- a/src/core/Basics/InstrumentComponent.h
+++ b/src/core/Basics/InstrumentComponent.h
@@ -47,7 +47,7 @@ class InstrumentComponent : public H2Core::Object<InstrumentComponent>
 		InstrumentComponent( std::shared_ptr<InstrumentComponent> other );
 		~InstrumentComponent();
 
-		void				save_to( XMLNode* node, int component_id );
+		void				save_to( XMLNode* node, int component_id, bool bRecentVersion = true );
 		static std::shared_ptr<InstrumentComponent> 	load_from( XMLNode* node,
 																   const QString& dk_path,
 																   bool bSilent = false );

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -84,11 +84,11 @@ InstrumentList* InstrumentList::load_from( XMLNode* node, const QString& dk_path
 	return instruments;
 }
 
-void InstrumentList::save_to( XMLNode* node, int component_id )
+	void InstrumentList::save_to( XMLNode* node, int component_id, bool bRecentVersion )
 {
 	XMLNode instruments_node = node->createNode( "instrumentList" );
 	for ( int i = 0; i < size(); i++ ) {
-		( *this )[i]->save_to( &instruments_node, component_id );
+		( *this )[i]->save_to( &instruments_node, component_id, bRecentVersion );
 	}
 }
 

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -274,6 +274,15 @@ QString InstrumentList::toQString( const QString& sPrefix, bool bShort ) const {
 	return sOutput;
 }
 
+
+std::vector<std::shared_ptr<Instrument>>::iterator InstrumentList::begin() {
+	return __instruments.begin();
+}
+
+std::vector<std::shared_ptr<Instrument>>::iterator InstrumentList::end() {
+	return __instruments.end();
+}
+
 };
 
 /* vim: set softtabstop=4 noexpandtab: */

--- a/src/core/Basics/InstrumentList.h
+++ b/src/core/Basics/InstrumentList.h
@@ -197,6 +197,10 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 		 * \return String presentation of current object.*/
 		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
 
+		/** Iteration */
+	std::vector<std::shared_ptr<Instrument>>::iterator begin();
+	std::vector<std::shared_ptr<Instrument>>::iterator end();
+
 	private:
 		std::vector<std::shared_ptr<Instrument>> __instruments;            ///< the list of instruments
 };

--- a/src/core/Basics/InstrumentList.h
+++ b/src/core/Basics/InstrumentList.h
@@ -147,8 +147,11 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 		 * \param node the XMLNode to feed
 		 * \param component_id Identifier of the corresponding
 		 * component.
+		 * \param bRecentVersion Whether the drumkit format should be
+		 * supported by Hydrogen 0.9.7 or higher (whether it should be
+		 * composed of DrumkitComponents).
 		 */
-		void save_to( XMLNode* node, int component_id );
+	void save_to( XMLNode* node, int component_id, bool bRecentVersion = true );
 		/**
 		 * load an instrument list from an XMLNode
 		 * \param node the XMLDode to read from

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -866,6 +866,16 @@ bool Filesystem::isSongPathValid( const QString& sSongPath, bool bCheckExistance
 	return true;
 }
 
+QString Filesystem::validateFilePath( const QString& sPath ) {
+
+	// Ensure the name will be a valid filename
+	QString sValidName( sPath );
+	sValidName.replace( " ", "_" );
+	sValidName.remove( QRegExp( "[^a-zA-Z0-9_-]" ) );
+
+	return sValidName;
+}
+
 QStringList Filesystem::theme_list( )
 {
 	return QDir( sys_theme_dir() ).entryList( QStringList( THEME_FILTER ), QDir::Files | QDir::Readable | QDir::NoDotAndDotDot ) +

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -325,6 +325,13 @@ namespace H2Core
 		 */
 		static bool isSongPathValid( const QString& sSongPath, bool bCheckExistance = false );
 
+		/**
+		 * Takes an arbitrary path, replaces white spaces by
+		 * underscores and removes all characters apart from latin
+		 * characters, arabic numbers, underscores and dashes.
+		 */
+		static QString validateFilePath( const QString& sPath );
+
 		static QStringList theme_list();
 
 		/** send current settings information to logger with INFO severity */

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -21,6 +21,8 @@
  */
 
 #include "SoundLibraryExportDialog.h"
+#include "../HydrogenApp.h"
+#include "../CommonStrings.h"
 
 #include <core/Hydrogen.h>
 #include <core/Helpers/Filesystem.h>
@@ -54,6 +56,10 @@ SoundLibraryExportDialog::SoundLibraryExportDialog( QWidget* pParent,  const QSt
 	, m_sPreselectedKit( sSelectedKit )
 	, m_preselectedKitLookup( lookup )
 {
+	// updating the drumkit list might take a while. Therefore, we
+	// show the user that this is expected behavior by showing a wait cursor.
+	QApplication::setOverrideCursor(Qt::WaitCursor);
+	
 	setupUi( this );
 	
 	setWindowTitle( tr( "Export Sound Library" ) );
@@ -62,6 +68,8 @@ SoundLibraryExportDialog::SoundLibraryExportDialog( QWidget* pParent,  const QSt
 	adjustSize();
 	setFixedSize( width(), height() );
 	drumkitPathTxt->setText( Preferences::get_instance()->getLastExportDrumkitDirectory() );
+	
+	QApplication::restoreOverrideCursor();
 }
 
 
@@ -104,9 +112,46 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 							   tr("Unable to retrieve drumkit from sound library" ) );
 		return;
 	}
+
+	QString sTargetComponent;
+	if ( componentList->currentIndex() == 0 && bRecentVersion ) {
+		// Exporting all components
+		sTargetComponent = "";
+	} else {
+		sTargetComponent = componentList->currentText();
+	}
+
+	// Check whether the resulting file does already exist and ask the
+	// user if it should be overwritten.
+	QString sTargetName = drumkitPathTxt->text() + "/" + pDrumkit->getFolderName();
+	if ( ! sTargetComponent.isEmpty() ) {
+		sTargetName.append( "_" + sTargetComponent );
+	}
+	sTargetName.append( Filesystem::drumkit_ext );
+	if ( Filesystem::file_exists( sTargetName, true ) ) {
+		auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+		QMessageBox msgBox;
+		msgBox.setWindowTitle("Hydrogen");
+		msgBox.setIcon( QMessageBox::Warning );
+		msgBox.setText( tr( "The file [%1] does already exist and will be overwritten.")
+						.arg( sTargetName ) );
+
+		msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Cancel );
+		msgBox.setButtonText(QMessageBox::Ok,
+							 pCommonStrings->getButtonOk() );
+		msgBox.setButtonText(QMessageBox::Cancel,
+							 pCommonStrings->getButtonCancel());
+		msgBox.setDefaultButton(QMessageBox::Ok);
+
+		if ( msgBox.exec() == QMessageBox::Cancel ) {
+			QApplication::restoreOverrideCursor();
+			delete pDrumkit;
+			return;
+		}
+	}
 	
 	if ( ! pDrumkit->exportTo( drumkitPathTxt->text(), // Target folder
-							   componentList->currentText(), // Selected component
+							   sTargetComponent, // Selected component
 							   bRecentVersion ) ) {
 		QApplication::restoreOverrideCursor();
 		QMessageBox::critical( this, "Hydrogen", tr("Unable to export drumkit") );
@@ -157,6 +202,15 @@ void SoundLibraryExportDialog::on_drumkitList_currentIndexChanged( QString str )
 {
 	componentList->clear();
 
+	if ( versionList->currentIndex() == 0 ) {
+		// Only kit version 0.9.7 or newer support components. For
+		// them we can support to export all or individual ones. For
+		// older versions one component must pretend to be the whole
+		// kit.
+		componentList->addItem( tr( "All" ) );
+		componentList->insertSeparator( 1 );
+	}
+
 	QStringList p_compoList = m_kit_components[str];
 
 	for (QStringList::iterator it = p_compoList.begin() ; it != p_compoList.end(); ++it) {
@@ -168,11 +222,7 @@ void SoundLibraryExportDialog::on_drumkitList_currentIndexChanged( QString str )
 
 void SoundLibraryExportDialog::on_versionList_currentIndexChanged( int index )
 {
-	if( index == 0 ) {
-		componentList->setEnabled( false );
-	} else if( index == 1 ) {
-		componentList->setEnabled(  true );
-	}
+	on_drumkitList_currentIndexChanged( drumkitList->currentText() );
 }
 
 void SoundLibraryExportDialog::updateDrumkitList()

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog_UI.ui
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog_UI.ui
@@ -69,6 +69,12 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="text">
            <string>Version</string>
           </property>
@@ -106,20 +112,54 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <layout class="QFormLayout" name="formLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="labelDrumkit">
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelComponent">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Component</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelDrumkit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>60</width>
+            <height>0</height>
+           </size>
           </property>
           <property name="text">
            <string>Drumkit</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
           <property name="wordWrap">
            <bool>true</bool>
@@ -133,25 +173,6 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="labelComponent">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Component</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
In https://github.com/hydrogen-music/hydrogen/pull/1490 I messed up the drumkit export via the GUI a little because I misunderstood the way the former implementation was meant to work.

There is now a bigger change in the export UX: Previously, when selecting format version `>=0.9.7` the component spinbox was locked to the first component but not hidden which - at least for me - suggest the export of a single component. In the older format the user was able to alter the index of the spinbox. Now, the spinbox is active regardless of the format selected. For the recent format the default option is "All" indicating that all components will be exported. But the user is free to select a single one and export a valid drumkit containing only this component. The former format works as before.

Also, the `h2cli` short option `-e` for `--export` was renamed to `-x` to match the naming of `tar` which we wrap and is also working with .h2drumkit files.

The export does now omit all sample which do not belong to the selected components. This is also true in case "All" components were selected for the recent drumkit format. This means superfluous audio files not used by the drumkit anymore will _not_ be exported. All meta files, like LICENSE, README, drumkit image, are kept (which was not the case for the previous implementation of the legacy export).

Since the user is not allowed to choose the name of the resulting .h2drumkit file herself - just the folder it will be stored to - exporting different versions, like full kit, individual components, and a legacy version, caused each export to overwrite the other. To prevent this from happening and provide a more descriptive file name, the component name is appended to the drumkit name using "_" and in case an export for Hydrogen versions <= 0.9.6 is requested an additional "_legacy" too. To make things consistent, the exported drumkits will have their drumkit name matching the base name of the compressed kit, e.g. GMRockKit_Main_legacy.

The validation of the base name to use for the resulting .h2drumkit was moved to the Filesystem class as other classes might have a use for it too. In addition, it now allows dashes to remain in the string (as I do not see how they are harmful and they are already present in a number of kits), removes dots (as their might be some code left using the base name of the file without checking whether this matches the completeBaseName() in Qt5 terms), and replaces whitespaces by underscores (to improve readability of the resulting filename). Also, the component name integrated in the filename is also validated as this could be another vector to mess up the export.

Further change list:
- when opening the export dialog the cursor is changed to the wait cursor since the list of drumkits gets updated and (depending on how many are installed) this can take a few seconds.
- when export the drumkit to an existing file the user is prompted whether she wants to overwrite it.
- `begin()` and `end()` iterators have been introduced to the `InstrumentList` class
- SoundLibraryExportDialog: shortcuts for buttons
- SoundLibraryExportDialog: more descriptive popup dialogs
- SoundLibraryExportDialog: alignment of labels and spin boxes