### PR TITLE
Fix QWheelEvent compile failures on Qt<5.14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -260,14 +260,14 @@ for:
         fi
       ) | sed 's/^/DMG: /' &
 
+
     test_script: |-
       cd build
       TMPDIR=/tmp src/tests/tests --appveyor
-
-      echo "Waiting for installer creation and cache archiving"
+      res=$?
       wait
       echo "=== Build cache usage is " $( du -h $cdir | tail -1 ) "==="
-      echo "Done"
+      ( exit $res )
 
   -
     matrix:

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -111,7 +111,11 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 		return;
 	}
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
 	prepareUndoAction( ev->position().x() ); //get all old values
+#else
+	prepareUndoAction( ev->x() ); //get all old values
+#endif
 
 	float fDelta;
 	if ( ev->modifiers() == Qt::ControlModifier || ev->modifiers() == Qt::AltModifier ) {
@@ -123,7 +127,11 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 		fDelta = fDelta * -1.0;
 	}
 
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
 	int nColumn = getColumn( ev->position().x() );
+#else
+	int nColumn = getColumn( ev->x() );
+#endif
 
 	m_pPatternEditorPanel->setCursorPosition( nColumn );
 	HydrogenApp::get_instance()->setHideKeyboardCursor( true );

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -201,7 +201,12 @@ void WidgetWithInput::wheelEvent ( QWheelEvent *ev )
 	}
 	setValue( getValue() + ( fDelta * fStepFactor ) );
 	
-	QToolTip::showText( ev->globalPosition().toPoint(),
+	QToolTip::showText(
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+					    ev->globalPosition().toPoint(),
+#else
+					    ev->globalPos(),
+#endif
 						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 


### PR DESCRIPTION
Annoying API change in Qt 5.14 immediately depcrecates some methods in `QWheelEvent` and introduces wordier replacements that don't exist prior to 5.14.

So we must implement the worst of both worlds.