### PR TITLE
Fix ALSA audio driver

### DIFF
--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -60,10 +60,6 @@
 			<jack_track_outs>false</jack_track_outs>
 		</jack_driver>
 
-		<alsa_audio_driver>
-			<alsa_audio_device>hw:0</alsa_audio_device>
-		</alsa_audio_driver>
-
 		<midi_driver>
 			<driverName>ALSA</driverName>
 			<port_name>None</port_name>

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1392,7 +1392,6 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	 * audio processing. Returning the special return value "2" enables the disk 
 	 * writer driver to repeat the processing of the current data.
 	 */
-				
 	if ( !pAudioEngine->tryLockFor( std::chrono::microseconds( (int)(1000.0*fSlackTime) ),
 							  RIGHT_HERE ) ) {
 		___ERRORLOG( QString( "Failed to lock audioEngine in allowed %1 ms, missed buffer" ).arg( fSlackTime ) );

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -674,9 +674,7 @@ void Hydrogen::stopExportSession()
 	
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
- 	pAudioEngine->stopAudioDrivers();
-	
-	pAudioEngine->startAudioDrivers();
+ 	pAudioEngine->restartAudioDrivers();
 	if ( pAudioEngine->getAudioDriver() == nullptr ) {
 		ERRORLOG( "Unable to restart previous audio driver after exporting song." );
 	}

--- a/src/core/IO/AlsaAudioDriver.cpp
+++ b/src/core/IO/AlsaAudioDriver.cpp
@@ -181,22 +181,37 @@ int AlsaAudioDriver::connect()
 	int err;
 
 	// provo ad aprire il device per verificare se e' libero ( non bloccante )
-	if ( ( err = snd_pcm_open( &m_pPlayback_handle, m_sAlsaAudioDevice.toLocal8Bit(), SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK ) ) < 0 ) {
-		ERRORLOG( QString( "ALSA: cannot open audio device %1:%2" ).arg( m_sAlsaAudioDevice ).arg( snd_strerror( err ) ) );
+	if ( ( err = snd_pcm_open( &m_pPlayback_handle,
+							   m_sAlsaAudioDevice.toLocal8Bit(),
+							   SND_PCM_STREAM_PLAYBACK,
+							   SND_PCM_NONBLOCK ) ) < 0 ) {
+		ERRORLOG( QString( "Cannot open audio device [%1] nonblocking: %2" )
+				  .arg( m_sAlsaAudioDevice )
+				  .arg( snd_strerror( err ) ) );
 
-		// il dispositivo e' occupato..provo con "default"
+		// Use the default device as a fallback.
 		m_sAlsaAudioDevice = "default";
-		if ( ( err = snd_pcm_open( &m_pPlayback_handle, m_sAlsaAudioDevice.toLocal8Bit(), SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK ) ) < 0 ) {
-			ERRORLOG( QString( "ALSA: cannot open audio device %1:%2" ).arg( m_sAlsaAudioDevice ) .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+		if ( ( err = snd_pcm_open( &m_pPlayback_handle,
+								   m_sAlsaAudioDevice.toLocal8Bit(),
+								   SND_PCM_STREAM_PLAYBACK,
+								   SND_PCM_NONBLOCK ) ) < 0 ) {
+			ERRORLOG( QString( "Cannot open default audio device [%1] either: %2" )
+					  .arg( m_sAlsaAudioDevice )
+					  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 			return 1;
 		}
-		WARNINGLOG( "Using alsa device: " + m_sAlsaAudioDevice );
+		WARNINGLOG( QString( "Using ALSA device [%1] instead." )
+					.arg( m_sAlsaAudioDevice ) );
 	}
 	snd_pcm_close( m_pPlayback_handle );
 
 	// Apro il device ( bloccante )
-	if ( ( err = snd_pcm_open( &m_pPlayback_handle, m_sAlsaAudioDevice.toLocal8Bit(), SND_PCM_STREAM_PLAYBACK, 0 ) ) < 0 ) {
-		ERRORLOG( QString( "ALSA: cannot open audio device %1:%2" ).arg( m_sAlsaAudioDevice ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	if ( ( err = snd_pcm_open( &m_pPlayback_handle,
+							   m_sAlsaAudioDevice.toLocal8Bit(),
+							   SND_PCM_STREAM_PLAYBACK, 0 ) ) < 0 ) {
+		ERRORLOG( QString( "Cannot open audio device [%1]: %2" )
+				  .arg( m_sAlsaAudioDevice )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 
@@ -208,25 +223,37 @@ int AlsaAudioDriver::connect()
 	}
 
 	if ( ( err = snd_pcm_hw_params_any( m_pPlayback_handle, hw_params ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params_any: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+		ERRORLOG( QString( "error in snd_pcm_hw_params_any: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 //	snd_pcm_hw_params_set_access( m_pPlayback_handle, hw_params, SND_PCM_ACCESS_MMAP_INTERLEAVED  );
 
-	if ( ( err = snd_pcm_hw_params_set_access( m_pPlayback_handle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params_set_access: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	if ( ( err = snd_pcm_hw_params_set_access( m_pPlayback_handle,
+											   hw_params,
+											   SND_PCM_ACCESS_RW_INTERLEAVED ) ) < 0 ) {
+		ERRORLOG( QString( "error in snd_pcm_hw_params_set_access: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 
-	if ( ( err = snd_pcm_hw_params_set_format( m_pPlayback_handle, hw_params, SND_PCM_FORMAT_S16_LE ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params_set_format: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	if ( ( err = snd_pcm_hw_params_set_format( m_pPlayback_handle,
+											   hw_params,
+											   SND_PCM_FORMAT_S16_LE ) ) < 0 ) {
+		ERRORLOG( QString( "error in snd_pcm_hw_params_set_format: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 
-	snd_pcm_hw_params_set_rate_near( m_pPlayback_handle, hw_params, &m_nSampleRate, nullptr );
+	snd_pcm_hw_params_set_rate_near( m_pPlayback_handle,
+									 hw_params,
+									 &m_nSampleRate,
+									 nullptr );
 
-	if ( ( err = snd_pcm_hw_params_set_channels( m_pPlayback_handle, hw_params, nChannels ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params_set_channels: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	if ( ( err = snd_pcm_hw_params_set_channels( m_pPlayback_handle,
+												 hw_params, nChannels ) ) < 0 ) {
+		ERRORLOG( QString( "error in snd_pcm_hw_params_set_channels: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 
@@ -238,22 +265,31 @@ int AlsaAudioDriver::connect()
 	// of data.
 	//
 	unsigned nPeriods = 2;
-	if ( ( err = snd_pcm_hw_params_set_periods_near( m_pPlayback_handle, hw_params, &nPeriods, nullptr ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params_set_periods: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	if ( ( err = snd_pcm_hw_params_set_periods_near( m_pPlayback_handle,
+													 hw_params,
+													 &nPeriods,
+													 nullptr ) ) < 0 ) {
+		ERRORLOG( QString( "error in snd_pcm_hw_params_set_periods_near: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 	INFOLOG( QString( "nPeriods: %1" ).arg( nPeriods ) );
 
 	snd_pcm_uframes_t period_size = m_nBufferSize;
 
-	if ( ( err = snd_pcm_hw_params_set_period_size_near( m_pPlayback_handle, hw_params, &period_size, nullptr ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params_set_period_size: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	if ( ( err = snd_pcm_hw_params_set_period_size_near( m_pPlayback_handle,
+														 hw_params,
+														 &period_size,
+														 nullptr ) ) < 0 ) {
+		ERRORLOG( QString( "error in snd_pcm_hw_params_set_period_size_near: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 	m_nBufferSize = period_size;
 
 	if ( ( err = snd_pcm_hw_params( m_pPlayback_handle, hw_params ) ) < 0 ) {
-		ERRORLOG( QString( "error in snd_pcm_hw_params: %1" ).arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+		ERRORLOG( QString( "error in snd_pcm_hw_params: %1" )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
 	}
 
@@ -286,8 +322,8 @@ int AlsaAudioDriver::connect()
 
 void AlsaAudioDriver::disconnect()
 {
-	INFOLOG( "[disconnect]" );
-
+	INFOLOG( "" );
+	
 	m_bIsRunning = false;
 
 	pthread_join( alsaAudioDriverThread, nullptr );

--- a/src/core/IO/AlsaAudioDriver.cpp
+++ b/src/core/IO/AlsaAudioDriver.cpp
@@ -27,6 +27,7 @@
 #include <pthread.h>
 #include <iostream>
 #include <core/Preferences/Preferences.h>
+#include <core/EventQueue.h>
 
 namespace H2Core
 {
@@ -71,7 +72,8 @@ void* alsaAudioDriver_processCaller( void* param )
 
 	int err;
 	if ( ( err = snd_pcm_prepare( pDriver->m_pPlayback_handle ) ) < 0 ) {
-		__ERRORLOG( QString( "Cannot prepare audio interface for use: %1" ).arg( snd_strerror ( err ) ) );
+		__ERRORLOG( QString( "Cannot prepare audio interface for use: %1" )
+					.arg( snd_strerror ( err ) ) );
 	}
 
 	int nFrames = pDriver->m_nBufferSize;
@@ -80,6 +82,8 @@ void* alsaAudioDriver_processCaller( void* param )
 
 	float *pOut_L = pDriver->m_pOut_L;
 	float *pOut_R = pDriver->m_pOut_R;
+
+	int nTimeoutInMilliseconds = 100;
 
 	while ( pDriver->m_bIsRunning ) {
 		// prepare the audio data
@@ -90,21 +94,54 @@ void* alsaAudioDriver_processCaller( void* param )
 			pBuffer[ i * 2 + 1 ] = ( short )( pOut_R[ i ] * 32768.0 );
 		}
 
-		if ( ( err = snd_pcm_writei( pDriver->m_pPlayback_handle, pBuffer, nFrames ) ) < 0 ) {
-			__ERRORLOG( "XRUN" );
-
-			if ( alsa_xrun_recovery( pDriver->m_pPlayback_handle, err ) < 0 ) {
-				__ERRORLOG( "Can't recover from XRUN" );
+		// Check whether the playback stream is ready to process
+		// input.
+		if ( ( err = snd_pcm_wait( pDriver->m_pPlayback_handle,
+								   nTimeoutInMilliseconds ) ) < 1 ) {
+			// Playback stream is not ready. Since we opened the stream
+			// in blocking mode, the call to snd_pcm_writei() may take
+			// forever and cause the audio engine to stop working
+			// entirely. In addition, this also prevents the audio
+			// driver to be stopped and thus prevents the user from
+			// selecting a different/working version.
+			if ( err == 0 ) {
+				___ERRORLOG( QString( "timeout after [%1] milliseconds" )
+							 .arg( nTimeoutInMilliseconds ) );
+			} else {
+				___ERRORLOG( QString( "Error while waiting for playback stream: %1" )
+							 .arg( snd_strerror( err ) ) );
 			}
-			// retry
+			pDriver->m_nXRuns++;
+			EventQueue::get_instance()->push_event( EVENT_XRUN, 0 );
+		} else {
+
+			// Playback stream is ready, let's write out the audio
+			// buffer.
 			if ( ( err = snd_pcm_writei( pDriver->m_pPlayback_handle, pBuffer, nFrames ) ) < 0 ) {
-				__ERRORLOG( "XRUN 2" );
-				if ( alsa_xrun_recovery( pDriver->m_pPlayback_handle, err ) < 0 ) {
-					__ERRORLOG( "Can't recover from XRUN" );
+				___ERRORLOG( QString( "Error while writing playback stream: %1" )
+							 .arg( snd_strerror( err ) ) );
+
+				// Try to bring the playback device in a nice state
+				// again and retry writing the output buffer.
+				if ( ( err = snd_pcm_recover( pDriver->m_pPlayback_handle, err, 0 ) ) == 0 ) {
+					___INFOLOG( "Successfully recovered from error. Attempt to write buffer again." );
+					if ( ( err = snd_pcm_writei( pDriver->m_pPlayback_handle, pBuffer, nFrames ) ) < 0 ) {
+						___ERRORLOG( QString( "Unable to write playback stream again: %1" )
+									 .arg( snd_strerror( err ) ) );
+						pDriver->m_nXRuns++;
+						EventQueue::get_instance()->push_event( EVENT_XRUN, 0 );
+						if ( ( err = snd_pcm_recover( pDriver->m_pPlayback_handle, err, 0 ) ) < 0 ) {
+							__ERRORLOG( QString( "Can't recover from XRUN: %1" )
+										.arg( snd_strerror( err ) ) );
+						}
+					}
+				} else {
+					__ERRORLOG( QString( "Can't recover from XRUN: %1" )
+								.arg( snd_strerror( err ) ) );
+					pDriver->m_nXRuns++;
+					EventQueue::get_instance()->push_event( EVENT_XRUN, 0 );
 				}
 			}
-
-			pDriver->m_nXRuns++;
 		}
 	}
 	return nullptr;
@@ -175,7 +212,7 @@ int AlsaAudioDriver::init( unsigned nBufferSize )
 
 int AlsaAudioDriver::connect()
 {
-	INFOLOG( "alsa device: " + m_sAlsaAudioDevice );
+	INFOLOG( "to: " + m_sAlsaAudioDevice );
 	int nChannels = 2;
 
 	int err;
@@ -185,7 +222,7 @@ int AlsaAudioDriver::connect()
 							   m_sAlsaAudioDevice.toLocal8Bit(),
 							   SND_PCM_STREAM_PLAYBACK,
 							   SND_PCM_NONBLOCK ) ) < 0 ) {
-		ERRORLOG( QString( "Cannot open audio device [%1] nonblocking: %2" )
+		ERRORLOG( QString( "Cannot open audio device [%1] (non-blocking): %2" )
 				  .arg( m_sAlsaAudioDevice )
 				  .arg( snd_strerror( err ) ) );
 
@@ -195,7 +232,7 @@ int AlsaAudioDriver::connect()
 								   m_sAlsaAudioDevice.toLocal8Bit(),
 								   SND_PCM_STREAM_PLAYBACK,
 								   SND_PCM_NONBLOCK ) ) < 0 ) {
-			ERRORLOG( QString( "Cannot open default audio device [%1] either: %2" )
+			ERRORLOG( QString( "Cannot open default audio device [%1] (non-blocking) either: %2" )
 					  .arg( m_sAlsaAudioDevice )
 					  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 			return 1;
@@ -203,13 +240,17 @@ int AlsaAudioDriver::connect()
 		WARNINGLOG( QString( "Using ALSA device [%1] instead." )
 					.arg( m_sAlsaAudioDevice ) );
 	}
-	snd_pcm_close( m_pPlayback_handle );
+	if ( ( err = snd_pcm_close( m_pPlayback_handle ) ) < 0 ) {
+		ERRORLOG( QString( "Unable to close non-blocking playback stream of audio device [%1]: %2" )
+				  .arg( m_sAlsaAudioDevice )
+				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
+	}
 
 	// Apro il device ( bloccante )
 	if ( ( err = snd_pcm_open( &m_pPlayback_handle,
 							   m_sAlsaAudioDevice.toLocal8Bit(),
 							   SND_PCM_STREAM_PLAYBACK, 0 ) ) < 0 ) {
-		ERRORLOG( QString( "Cannot open audio device [%1]: %2" )
+		ERRORLOG( QString( "Cannot open audio device [%1] (blocking): %2" )
 				  .arg( m_sAlsaAudioDevice )
 				  .arg( QString::fromLocal8Bit(snd_strerror(err)) ) );
 		return 1;
@@ -356,7 +397,6 @@ float* AlsaAudioDriver::getOut_R()
 {
 	return m_pOut_R;
 }
-
 };
 
 #endif // H2CORE_HAVE_ALSA

--- a/src/core/IO/AlsaAudioDriver.h
+++ b/src/core/IO/AlsaAudioDriver.h
@@ -43,9 +43,9 @@ public:
 	unsigned long m_nBufferSize;
 	float* m_pOut_L;
 	float* m_pOut_R;
-	int m_nXRuns;
 	QString m_sAlsaAudioDevice;
 	audioProcessCallback m_processCallback;
+	int m_nXRuns;
 
 	AlsaAudioDriver( audioProcessCallback processCallback );
 	~AlsaAudioDriver();
@@ -58,6 +58,9 @@ public:
 	virtual float* getOut_L() override;
 	virtual float* getOut_R() override;
 	static QStringList getDevices();
+
+	virtual int getXRuns() const override { return m_nXRuns; }
+	
 private:
 
 	unsigned int m_nSampleRate;

--- a/src/core/IO/AudioOutput.h
+++ b/src/core/IO/AudioOutput.h
@@ -56,6 +56,10 @@ public:
 	{
 		return getBufferSize();
 	}
+	/** Get the number of XRuns that occured since the audio driver
+	 *	has started.
+	 */
+	virtual int getXRuns() const { return 0; }
 	virtual float* getOut_L() = 0;
 	virtual float* getOut_R() = 0;
 

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -82,11 +82,13 @@ void JackAudioDriver::jackDriverShutdown( void* arg )
 }
 int JackAudioDriver::jackXRunCallback( void *arg ) {
 	UNUSED( arg );
+	++JackAudioDriver::jackServerXRuns;
 	EventQueue::get_instance()->push_event( EVENT_XRUN, 0 );
 	return 0;
 }
 
 unsigned long JackAudioDriver::jackServerSampleRate = 0;
+int JackAudioDriver::jackServerXRuns = 0;
 jack_nframes_t JackAudioDriver::jackServerBufferSize = 0;
 JackAudioDriver* JackAudioDriver::pJackDriverInstance = nullptr;
 
@@ -1166,6 +1168,11 @@ float JackAudioDriver::getMasterBpm() const {
 	}
 	
 	return static_cast<float>(m_JackTransportPos.beats_per_minute );
+}
+
+
+int JackAudioDriver::getXRuns() const {
+	return JackAudioDriver::jackServerXRuns;
 }
 
 void JackAudioDriver::printState() const {

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -157,6 +157,8 @@ public:
 	/** \return Global variable #jackServerSampleRate. */
 	virtual unsigned getSampleRate() override;
 
+	virtual int getXRuns() const override;
+
 	/** Resets the buffers contained in #m_pTrackOutputPortsL and
 	 * #m_pTrackOutputPortsR.
 	 * 
@@ -316,6 +318,8 @@ public:
 	 * Instance of the JackAudioDriver.
 	 */
 	static JackAudioDriver*		pJackDriverInstance;
+	/** Number of XRuns since the driver started.*/
+	static int jackServerXRuns;
 
 	/**
 	 * Callback function for the JACK audio server to set the sample

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -42,6 +42,7 @@
 #include <core/MidiMap.h>
 #include <core/Version.h>
 #include <core/Helpers/Filesystem.h>
+#include <core/IO/AlsaAudioDriver.h>
 
 #include <QDir>
 //#include <QApplication>
@@ -179,7 +180,28 @@ Preferences::Preferences()
 	m_sCoreAudioDevice = QString();
 
 	//___  alsa audio driver properties ___
-	m_sAlsaAudioDevice = QString("hw:0");
+
+#ifdef H2CORE_HAVE_ALSA
+	// Ensure the device read from the local preferences does
+	// exist. If not, we try to replace it with a valid one.
+	QStringList alsaDevices = AlsaAudioDriver::getDevices();
+	if ( alsaDevices.size() == 0 ||
+		 alsaDevices.contains( "hw:0" ) ) {
+		m_sAlsaAudioDevice = "hw:0";
+	} else {
+		// Fall back to a device found on the system (but not the
+		// "null" one).
+		if ( alsaDevices[ 0 ] != "null" ) {
+			m_sAlsaAudioDevice = alsaDevices[ 0 ];
+		} else if ( alsaDevices.size() > 1 ) {
+			m_sAlsaAudioDevice = alsaDevices[ 1 ];
+		} else {
+			m_sAlsaAudioDevice = "hw:0";
+		}
+	}
+#else
+	m_sAlsaAudioDevice = "hw:0";
+#endif
 
 	//___  jack driver properties ___
 	m_sJackPortName1 = QString("alsa_pcm:playback_1");

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -582,6 +582,12 @@ void HydrogenApp::setStatusBarMessage( const QString& msg, int msec )
 	}
 }
 
+void HydrogenApp::XRunEvent() {
+	setStatusBarMessage( QString( "XRUNS [%1]!!!" )
+						 .arg( Hydrogen::get_instance()->getAudioOutput()->getXRuns() ),
+						 5000 );
+}
+
 void HydrogenApp::updateWindowTitle()
 {
 	auto pSong = Hydrogen::get_instance()->getSong();

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -266,6 +266,7 @@ private slots:
 
 		void setupSinglePanedInterface();
 		virtual void songModifiedEvent() override;
+	virtual void XRunEvent() override;
 
 		/** Handles the loading and saving of the H2Core::Preferences
 		 * from the core part of H2Core::Hydrogen.

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -649,37 +649,46 @@ void PreferencesDialog::audioDeviceTxtChanged( const QString& )
 
 void PreferencesDialog::updateDriverPreferences() {
 	Preferences *pPref = Preferences::get_instance();
+	auto pAudioDriver = Hydrogen::get_instance()->getAudioOutput();
 
 	// Selected audio driver
-	if (driverComboBox->currentText() == "Auto" ) {
-		pPref->m_sAudioDriver = "Auto";
-	}
-	else if (driverComboBox->currentText() == "JACK" ) {
+	if (driverComboBox->currentText() == "JACK" ) {
 		pPref->m_sAudioDriver = "JACK";
 	}
-	else if (driverComboBox->currentText() == "ALSA" ) {
+	else if ( driverComboBox->currentText() == "ALSA" ||
+			  ( driverComboBox->currentText() == "Auto" &&
+				dynamic_cast<H2Core::AlsaAudioDriver*>(pAudioDriver) != nullptr ) ) {
 		pPref->m_sAudioDriver = "ALSA";
 		pPref->m_sAlsaAudioDevice = m_pAudioDeviceTxt->lineEdit()->text();
 	}
-	else if (driverComboBox->currentText() == "OSS" ) {
+	else if ( driverComboBox->currentText() == "OSS" ||
+			  ( driverComboBox->currentText() == "Auto" &&
+				dynamic_cast<H2Core::OssDriver*>(pAudioDriver) != nullptr ) ) {
 		pPref->m_sAudioDriver = "OSS";
 		pPref->m_sOSSDevice = m_pAudioDeviceTxt->lineEdit()->text();
 	}
-	else if (driverComboBox->currentText() == "PortAudio" ) {
+	else if (driverComboBox->currentText() == "PortAudio" ||
+			 ( driverComboBox->currentText() == "Auto" &&
+			   dynamic_cast<H2Core::PortAudioDriver*>(pAudioDriver) != nullptr ) ) {
 		pPref->m_sAudioDriver = "PortAudio";
 		pPref->m_sPortAudioDevice = m_pAudioDeviceTxt->lineEdit()->text();
 		pPref->m_sPortAudioHostAPI = portaudioHostAPIComboBox->currentText();
 		pPref->m_nLatencyTarget = latencyTargetSpinBox->value();
 	}
-	else if (driverComboBox->currentText() == "CoreAudio" ) {
+	else if (driverComboBox->currentText() == "CoreAudio" ||
+			 ( driverComboBox->currentText() == "Auto" &&
+			   dynamic_cast<H2Core::CoreAudioDriver*>(pAudioDriver) != nullptr ) ) {
 		pPref->m_sAudioDriver = "CoreAudio";
 		pPref->m_sCoreAudioDevice = m_pAudioDeviceTxt->lineEdit()->text();
 	}
 	else if (driverComboBox->currentText() == "PulseAudio" ) {
 		pPref->m_sAudioDriver = "PulseAudio";
 	}
+	else if (driverComboBox->currentText() == "Auto" ) {
+		pPref->m_sAudioDriver = "Auto";
+	}
 	else {
-		ERRORLOG( "[okBtnClicked] Invalid audio driver:" + driverComboBox->currentText() );
+		ERRORLOG( "[okBtnClicked] Invalid audio driver: " + driverComboBox->currentText() );
 	}
 
 	// JACK
@@ -925,7 +934,6 @@ void PreferencesDialog::updateDriverInfo()
 	bPulseAudio_support = true;
 #endif
 
-	m_pAudioDeviceTxt->setDriver( driverComboBox->currentText() );
 	if ( driverComboBox->currentText() == "Auto" ) {
 		info += tr("Automatic driver selection");
 		
@@ -949,6 +957,7 @@ void PreferencesDialog::updateDriverInfo()
 		} else if ( dynamic_cast<H2Core::OssDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoOss();
 		} else {
+			m_pAudioDeviceTxt->setDriver( "Null" );
 			m_pAudioDeviceTxt->setIsActive( false );
 			m_pAudioDeviceTxt->lineEdit()->setText( "" );
 			bufferSizeSpinBox->setIsActive( false );
@@ -1057,6 +1066,7 @@ void PreferencesDialog::updateDriverInfo()
 void PreferencesDialog::setDriverInfoOss() {
 	auto pPref = H2Core::Preferences::get_instance();
 	
+	m_pAudioDeviceTxt->setDriver( "OSS" );
 	m_pAudioDeviceTxt->setIsActive(true);
 	m_pAudioDeviceTxt->lineEdit()->setText( pPref->m_sOSSDevice );
 	bufferSizeSpinBox->setIsActive(true);
@@ -1080,7 +1090,8 @@ void PreferencesDialog::setDriverInfoOss() {
 
 void PreferencesDialog::setDriverInfoAlsa() {
 	auto pPref = H2Core::Preferences::get_instance();
-	
+
+	m_pAudioDeviceTxt->setDriver( "ALSA" );
 	m_pAudioDeviceTxt->setIsActive(true);
 	m_pAudioDeviceTxt->lineEdit()->setText( pPref->m_sAlsaAudioDevice );
 	bufferSizeSpinBox->setIsActive(true);
@@ -1104,7 +1115,8 @@ void PreferencesDialog::setDriverInfoAlsa() {
 
 void PreferencesDialog::setDriverInfoJack() {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
+
+	m_pAudioDeviceTxt->setDriver( "JACK" );
 	m_pAudioDeviceTxt->setIsActive(false);
 	m_pAudioDeviceTxt->lineEdit()->setText( "" );
 	bufferSizeSpinBox->setIsActive(false);
@@ -1134,7 +1146,8 @@ void PreferencesDialog::setDriverInfoJack() {
 
 void PreferencesDialog::setDriverInfoCoreAudio() {
 	auto pPref = H2Core::Preferences::get_instance();
-	
+
+	m_pAudioDeviceTxt->setDriver( "CoreAudio" );
 	m_pAudioDeviceTxt->setIsActive( true );
 	m_pAudioDeviceTxt->lineEdit()->setText( pPref->m_sCoreAudioDevice );
 	bufferSizeSpinBox->setIsActive( false );
@@ -1158,7 +1171,8 @@ void PreferencesDialog::setDriverInfoCoreAudio() {
 
 void PreferencesDialog::setDriverInfoPortAudio() {
 	auto pPref = H2Core::Preferences::get_instance();
-	
+
+	m_pAudioDeviceTxt->setDriver( "PortAudio" );
 	m_pAudioDeviceTxt->setIsActive( true );
 	m_pAudioDeviceTxt->lineEdit()->setText( pPref->m_sPortAudioDevice );
 	bufferSizeSpinBox->setIsActive(false);
@@ -1182,6 +1196,8 @@ void PreferencesDialog::setDriverInfoPortAudio() {
 }
 
 void PreferencesDialog::setDriverInfoPulseAudio() {
+	
+	m_pAudioDeviceTxt->setDriver( "PulseAudio" );
 	m_pAudioDeviceTxt->setIsActive(false);
 	m_pAudioDeviceTxt->lineEdit()->setText("");
 	bufferSizeSpinBox->setIsActive(true);


### PR DESCRIPTION
I was lucky enough to get the ALSA driver in such a bricked state that both the transport/playback was not working anymore and Hydrogen did freeze when trying to set a different audio driver in the PreferencesDialog. The latter is indeed a quite serious problem. In case the user sets a "wrong" configuration, it can not be changed via the Preferences anymore but, instead, has to be manually reverted in the hydrogen.conf file. After some debugging I found that the processing thread of the ALSA driver did freeze after two cycles. The state of the playback stream itself was still nice but the corresponding resource "temporary unavailable". Since the device is opened in blocking mode in AlsaAudioDriver::connect() the process thread did freeze at snd_pcm_writei(). The call to AlsaAudioDriver::disconnect() (required to restart/start a new audio driver) is waiting for the thread to finisih which is not going to happen. Thats why Hydrogen did freeze at both shutdown and restarting the driver in the Preferences.

One possible way to fix this is to open the device in non-blocking mode. But this would be quite an invasive change and I am not too familiar with ALSA. So, instead, I introduced a call to the snd_pcm_wait() function which returns as soon as the opened device is ready to process data or returns with an error after a provided timeout. AFAIU this is also done internally in snd_pcm_writei() in blocking mode and will thus only introduce a minimal overhead. On the other hand, it is able to discard the audio output in case the ALSA device is not working anymore. Instead of freezing, it now attempts to annoy the user with error log messages as well as flashing XRun indications and status messages in the GUI in order to indicate a change of the audio driver is required.

I used 100 milliseconds for the timeout. It is enough to make the transport run way to slow to indicate a problem. Smaller values of e.g. 10ms did cause glitches with working ALSA devices.

In addition, I made the ALSA driver use our XRUN event and used the snd_pcm_recover() functions over our custom alsa_xrun_recovery() as the former is part of the ALSA API and recovers from one more error code than our custom one.

Further changes:
- tweaking/formatting log messages used in the process of starting an audio driver
- instead of just using the default "hw:0" device for the ALSA driver the preferences does now check whether this device actually exists on the system. If not, it falls back to the first device returned by AlsaAudioDriver::getDevices() that is not "null".
- the "alsa_audio_driver" node was removed deliberately from the default config file in order for the system to pick a proper default value of an existing device.
- In case the "Auto" driver is selected, the device combobox is now properly showing the content associated with the underlying driver. In addition, all values set there, in the host API combo box or the one for the latency are now properly written to the Preferences too.
- number of XRuns are now shown in the GUI (status message)
-  display ALSA device in PreferencesDialog info
    
    The AlsaAudioDriver tries to establish a connection to the device selected by the user via the Preferences. If this fails, it tries instead to connect to the "default" device which usually works. This change of devices is, however, only shown in the log and users may easily miss it. Now, the currently connected ALSA device is shown in the info section on the right of the audio driver tab.