### PR TITLE
Fix crash on changing song with Automation Path showing

### DIFF
--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *
@@ -63,6 +63,16 @@ void AutomationPathView::setAutomationPath(AutomationPath *path)
 	update();
 }
 
+// Make sure we have the current automation path
+void AutomationPathView::updateAutomationPath()
+{
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong ) {
+		setAutomationPath( pSong->getVelocityAutomationPath() );
+	} else {
+		setAutomationPath( nullptr );
+	}
+}
 
 void AutomationPathView::setGridWidth( int width )
 {
@@ -129,6 +139,7 @@ void AutomationPathView::paintEvent(QPaintEvent *event)
 {
 
 	auto pPref = H2Core::Preferences::get_instance();
+	updateAutomationPath();
 
 	QPainter painter(this);
 	painter.setRenderHint(QPainter::Antialiasing);
@@ -195,6 +206,8 @@ void AutomationPathView::paintEvent(QPaintEvent *event)
  */
 void AutomationPathView::mousePressEvent(QMouseEvent *event)
 {
+	updateAutomationPath();
+
 	if (! checkBounds(event) || !_path) {
 		return;
 	}
@@ -232,6 +245,7 @@ void AutomationPathView::mousePressEvent(QMouseEvent *event)
  **/
 void AutomationPathView::mouseReleaseEvent(QMouseEvent *event)
 {
+	updateAutomationPath();
 	m_bIsHolding = false;
 
 	if (! checkBounds(event) || !_path) {
@@ -258,6 +272,7 @@ void AutomationPathView::mouseReleaseEvent(QMouseEvent *event)
  */
 void AutomationPathView::mouseMoveEvent(QMouseEvent *event)
 {
+	updateAutomationPath();
 	if (! checkBounds(event) || !_path) {
 		return;
 	}
@@ -282,6 +297,7 @@ void AutomationPathView::mouseMoveEvent(QMouseEvent *event)
  */
 void AutomationPathView::keyPressEvent(QKeyEvent *event)
 {
+	updateAutomationPath();
 	if ( event->key() == Qt::Key_Delete || event->key() == Qt::Key_Backspace ) {
 		if ( _path && _selectedPoint != _path->end() ) {
 			float x = _selectedPoint->first;

--- a/src/gui/src/Widgets/AutomationPathView.h
+++ b/src/gui/src/Widgets/AutomationPathView.h
@@ -57,6 +57,8 @@ public:
 	int  getGridWidth() const noexcept { return m_nGridWidth; }
 	void setGridWidth(int width);
 
+	void updateAutomationPath();
+
 protected:
 	void paintEvent(QPaintEvent *event) override;
 	void mousePressEvent(QMouseEvent *event) override;


### PR DESCRIPTION
The automation path keeps a pointer to the song's AutomationPath. This pointer is updated by the Song Editor, but only as a result of the event queue, which is asynchronous (and also potentially lossy). If some event (such as a paint event caused to repair the display after a confirmation dialog is closed...) is delivered to the view widget after the song is changed (and the old song destroyed) but before the Song Editor has processed the update event, the old pointer will be dereferenced, likely causing a crash.

This change fixes this race condition by explicitly updating the saved pointer from the song at the start of asynchronously delivered events. This doesn't feel quite right but is at least consistent with other editors where state is updated directly from the Song. One alternative approach would be to use a shared_ptr in the Song and the editor to ensure that the object at least still exists when it's referenced in such cases, but that feels further from the right fix as it presents inconsistent state.