### PR TITLE
Add path changes to allow AppImage build to run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ IF(APPLE)
     OPTION(WANT_BUNDLE      "Build a MAC OSX bundle application" ON)
 ENDIF()
 
+OPTION(WANT_APPIMAGE "Build Linux AppImage" OFF)
+
 OPTION(WANT_CPPUNIT         "Include CppUnit test suite" ON)
 
 include(Sanitizers)
@@ -131,6 +133,12 @@ IF(WANT_DEBUG)
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
 ELSE()
 	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -ffast-math")
+ENDIF()
+
+IF(WANT_APPIMAGE)
+  SET(H2CORE_HAVE_APPIMAGE TRUE)
+ELSE()
+  SET(H2CORE_HAVE_APPIMAGE FALSE)
 ENDIF()
 
 IF (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -320,7 +328,8 @@ COLOR_MESSAGE("${cyan}Installation Summary${reset}
 * core library build as        : ${H2CORE_LIBRARY_TYPE}
 * debug capabilities           : ${H2CORE_HAVE_DEBUG}
 * macosx bundle                : ${H2CORE_HAVE_BUNDLE}
-* fat build                    : ${WANT_FAT_BUILD}\n"
+* fat build                    : ${WANT_FAT_BUILD}
+* AppImage build               : ${H2CORE_HAVE_APPIMAGE}\n"
 )
 
 COLOR_MESSAGE("${cyan}Main librarires${reset}")

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -139,7 +139,11 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sys_path )
 	__usr_data_path = QDir::homePath().append( "/.hydrogen/data/" ) ;
 	__usr_cfg_path = QDir::homePath().append( "/.hydrogen/" USR_CONFIG ) ;
 #else
+#ifdef H2CORE_HAVE_APPIMAGE
+	__sys_data_path = QCoreApplication::applicationDirPath().append( "/../share/hydrogen/data/" ) ;
+#else
 	__sys_data_path = H2_SYS_PATH "/data/";
+#endif
 	__usr_data_path = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
 	__usr_cfg_path = QDir::homePath().append( "/" H2_USR_PATH "/" USR_CONFIG );
 #endif

--- a/src/core/config.h.in
+++ b/src/core/config.h.in
@@ -41,6 +41,9 @@
 #ifndef H2CORE_HAVE_BUNDLE
 #cmakedefine H2CORE_HAVE_BUNDLE
 #endif
+#ifndef H2CORE_HAVE_APPIMAGE
+#cmakedefine H2CORE_HAVE_APPIMAGE
+#endif
 #ifndef H2CORE_HAVE_LIBSNDFILE
 #cmakedefine H2CORE_HAVE_LIBSNDFILE
 #endif


### PR DESCRIPTION
Fixes #1504 

Minor changes to ifdefs and cmake config to direct portable build to find data files.

replaces #1517 