### PR TITLE
SongEditorPanel: action mode setting (fix #1540)

### DIFF
--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -407,8 +407,6 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	defaultPalette.setColor( QPalette::Window, QColor( 58, 62, 72 ) );
 	this->setPalette( defaultPalette );
 
-	Hydrogen::get_instance()->getSong()->setActionMode( H2Core::Song::ActionMode::selectMode );
-
 	show();
 
 	updateAll();
@@ -718,10 +716,13 @@ void SongEditorPanel::resizeEvent( QResizeEvent *ev )
 
 void SongEditorPanel::actionModeChangeEvent( int nValue ) {
 
-	if ( nValue == 0 ) {
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+	
+	if ( pSong->getActionMode() == Song::ActionMode::selectMode ) {
 		m_pPointerActionBtn->setPressed( true );
 		m_pDrawActionBtn->setPressed( false );
-	} else if ( nValue == 1 ) {
+	} else if ( pSong->getActionMode() == Song::ActionMode::drawMode ) {
 		m_pPointerActionBtn->setPressed( false );
 		m_pDrawActionBtn->setPressed( true );
 	} else {


### PR DESCRIPTION
A spurious setting of the action mode to selectMode during the startup of the GUI prevented the corresponding value of the .h2song file to be used properly.

fixes #1540