### PR TITLE
Fix crash on moving Automation Path Nodes introduced in #1515

### DIFF
--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -53,11 +53,13 @@ void AutomationPathView::onPreferencesChanged( H2Core::Preferences::Changes chan
 
 void AutomationPathView::setAutomationPath(AutomationPath *path)
 {
-	_path = path;
-	if(_path) {
-		_selectedPoint = _path->end();
+	if ( path == _path ) {
+		return;
 	}
-
+	_path = path;
+	if ( _path ) {
+		_selectedPoint = path->end();
+	}
 	update();
 }
 
@@ -279,7 +281,7 @@ void AutomationPathView::mouseMoveEvent(QMouseEvent *event)
 	float x = p.first;
 	float y = p.second;
 
-	if(m_bIsHolding) {
+	if ( m_bIsHolding && _path && _selectedPoint != _path->end() ) {
 		_selectedPoint = _path->move(_selectedPoint, x, y);
 		H2Core::Hydrogen::get_instance()->setIsModified( true );
 	}


### PR DESCRIPTION
  - don't reset _selectedPoint or update widget unless path has
    really been changed (fixes the crash introduced in #1515), and

  - don't dereference _selectedPoint if _path is null (prevents null deref if the song changes by OSC or other source while the user is dragging)