### PR TITLE
Fix windows tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -294,7 +294,7 @@ for:
 
           REM *** Results are ignored since a dependency was not properly installed in 32 bit Windows. But the .dll files required are installed regardless, so we don't care.***
 
-          choco install %CHOCO_ARCH% -y openssl --version=1.1.1.1300 || cmd /c "exit /b 0"
+          choco install %CHOCO_ARCH% -y openssl --version=1.1.1.1300 || cmd /c "exit /b 1"
 
           echo "C:\%OPENSSL_DIR%"
           dir "C:\%OPENSSL_DIR%"
@@ -337,8 +337,8 @@ for:
           SET CORE_PATH=%cd%\src\core
           echo %CORE_PATH%
           set PATH=%CORE_PATH%;%PATH%
-          src\tests\tests.exe --appveyor || cmd /c "exit /b 0"
-          7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen || cmd /c "exit  /b 0"
+          src\tests\tests.exe --appveyor || cmd /c "exit /b 1"
+          7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen || cmd /c "exit  /b 1"
           if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
 
           mkdir %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
@@ -373,8 +373,8 @@ on_finish:
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win64.exe || cmd /c "exit /b 0"
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win32.exe || cmd /c "exit /b 0"
+  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win64.exe || cmd /c "exit /b 1"
+  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win32.exe || cmd /c "exit /b 1"
 
 
   - cmd: |

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -3876,7 +3876,13 @@ bool AudioEngine::testCheckAudioConsistency( const std::vector<std::shared_ptr<N
 		}
 	}
 
-	if ( nNotesFound == 0 ) {
+	// If one of the note vectors is empty - especially the new notes
+	// - we can not test anything. But such things might happen as we
+	// try various sample sizes and all notes might be already played
+	// back and flushed.
+	if ( nNotesFound == 0 &&
+		 oldNotes.size() > 0 &&
+		 newNotes.size() > 0 ) {
 		ERRORLOG( QString( "[%1] bad test design. No notes played back." )
 				  .arg( sContext ) );
 		if ( oldNotes.size() != 0 ) {

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -724,7 +724,6 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath, b
 
 bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName, bool bRecentVersion, bool bSilent ) {
 
-#ifndef WIN32
 	if ( ! Filesystem::path_usable( sTargetDir, true, false ) ) {
 		ERRORLOG( QString( "Provided destination folder [%1] is not valid" )
 				  .arg( sTargetDir ) );
@@ -966,6 +965,7 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	return true;
 #else // No LIBARCHIVE
 
+#ifndef WIN32
 	if ( nComponentID != -1 ) {
 		// In order to add components name to the folder name we have
 		// to copy _all_ files to a temporary folder holding the same
@@ -1038,12 +1038,12 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	set_name( sOldDrumkitName );
 			
 	return true;
-#endif // LIBARCHIVE
 #else // WIN32
 	ERRORLOG( "Operation not supported on Windows" );
 	
 	return false;
 #endif
+#endif // LIBARCHIVE
 
 }
 


### PR DESCRIPTION
Drumkit export was too conservative and didn't allowed for an export in Windows even if it's compiled with and linked to libarchive. Either I messed this up or it grew naturally by having the whole export based on a system call to `tar` first and integrating libarchive support later on.

The build pipeline did not fail in case things went wrong in the Windows build.

The test checking for audio inconsistencies upon song size changes did produce transient false positives since the random sampling of audio engine parameters were introduced. I relaxed the tests so that hopefully won't happen again.