### PR TITLE
fix #1542: notes exceeding pattern length

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2417,7 +2417,7 @@ int AudioEngine::updateNoteQueue( unsigned nFrames )
 				  ++nPat ) {
 				Pattern *pPattern = m_pPlayingPatterns->get( nPat );
 				assert( pPattern != nullptr );
-				Pattern::notes_t* notes = (Pattern::notes_t*)pPattern->get_notes();
+				auto notes = pPattern->getAccessibleNotes();
 
 				// Loop over all notes at tick nPatternTickPosition
 				// (associated tick is determined by Note::__position

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -113,7 +113,12 @@ Note::Note( Note* other, std::shared_ptr<Instrument> instrument )
 	  m_nNoteStart( other->getNoteStart() ),
 	  m_fUsedTickSize( other->getUsedTickSize() )
 {
-	if ( instrument != nullptr ) __instrument = instrument;
+	// Either use the provided instrument or fall back to the one
+	// stored in the other Note
+	if ( instrument != nullptr ) {
+		__instrument = instrument;
+	}
+
 	if ( __instrument != nullptr ) {
 		__adsr = __instrument->copy_adsr();
 		__instrument_id = __instrument->get_id();
@@ -134,8 +139,12 @@ Note::~Note()
 
 static inline float check_boundary( float v, float min, float max )
 {
-	if ( v>max ) return max;
-	if ( v<min ) return min;
+	if ( v > max ) {
+		return max;
+	}
+	if ( v < min ) {
+		return min;
+	}
 	return v;
 }
 
@@ -451,9 +460,15 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2length: %3\n" ).arg( sPrefix ).arg( s ).arg( __length ) )
 			.append( QString( "%1%2pitch: %3\n" ).arg( sPrefix ).arg( s ).arg( __pitch ) )
 			.append( QString( "%1%2key: %3\n" ).arg( sPrefix ).arg( s ).arg( __key ) )
-			.append( QString( "%1%2octave: %3\n" ).arg( sPrefix ).arg( s ).arg( __octave ) )
-			.append( QString( "%1" ).arg( __adsr->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( "%1%2lead_lag: %3\n" ).arg( sPrefix ).arg( s ).arg( __lead_lag ) )
+			.append( QString( "%1%2octave: %3\n" ).arg( sPrefix ).arg( s ).arg( __octave ) );
+		if ( __adsr != nullptr ) {
+			sOutput.append( QString( "%1" )
+							.arg( __adsr->toQString( sPrefix + s, bShort ) ) );
+		} else {
+			sOutput.append( QString( "%1%2adsr: nullptr\n" ).arg( sPrefix ).arg( s ) );
+		}
+			
+		sOutput.append( QString( "%1%2lead_lag: %3\n" ).arg( sPrefix ).arg( s ).arg( __lead_lag ) )
 			.append( QString( "%1%2cut_off: %3\n" ).arg( sPrefix ).arg( s ).arg( __cut_off ) )
 			.append( QString( "%1%2resonance: %3\n" ).arg( sPrefix ).arg( s ).arg( __resonance ) )
 			.append( QString( "%1%2humanize_delay: %3\n" ).arg( sPrefix ).arg( s ).arg( __humanize_delay ) )
@@ -490,9 +505,16 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", length: %1" ).arg( __length ) )
 			.append( QString( ", pitch: %1" ).arg( __pitch ) )
 			.append( QString( ", key: %1" ).arg( __key ) )
-			.append( QString( ", octave: %1" ).arg( __octave ) )
-			.append( QString( ", [%1" ).arg( __adsr->toQString( sPrefix + s, bShort ).replace( "\n", "]" ) ) )
-			.append( QString( ", lead_lag: %1" ).arg( __lead_lag ) )
+			.append( QString( ", octave: %1" ).arg( __octave ) );
+		if ( __adsr != nullptr ) {
+			sOutput.append( QString( ", [%1" )
+							.arg( __adsr->toQString( sPrefix + s, bShort )
+								  .replace( "\n", "]" ) ) );
+		} else {
+			sOutput.append( ", adsr: nullptr" );
+		}
+			
+		sOutput.append( QString( ", lead_lag: %1" ).arg( __lead_lag ) )
 			.append( QString( ", cut_off: %1" ).arg( __cut_off ) )
 			.append( QString( ", resonance: %1" ).arg( __resonance ) )
 			.append( QString( ", humanize_delay: %1" ).arg( __humanize_delay ) )

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -64,6 +64,19 @@ Pattern::~Pattern()
 	}
 }
 
+const std::shared_ptr<Pattern::notes_t> Pattern::getAccessibleNotes() {
+
+	std::shared_ptr<notes_t> accessibleNotes = std::make_shared<notes_t>();
+	
+	for( notes_cst_it_t it=__notes.begin(); it!=__notes.end(); it++ ) {
+		if ( it->first < __length && it->second != nullptr ) {
+			accessibleNotes->insert( std::make_pair( it->first, it->second ) );
+		}
+	}
+
+	return accessibleNotes;
+}
+
 Pattern* Pattern::load_file( const QString& pattern_path, InstrumentList* instruments )
 {
 	INFOLOG( QString( "Load pattern %1" ).arg( pattern_path ) );

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -109,6 +109,25 @@ class Pattern : public H2Core::Object<Pattern>
 		int get_denominator() const;
 		///< get the note multimap
 		const notes_t* get_notes() const;
+	/**
+	 * Creates a shared pointer to a notes_t map containing the
+	 * currently accessible notes of the pattern.
+	 *
+	 * In #__notes all notes of the pattern will be stored. If the
+	 * length of the pattern is decreased by the user in such a way
+	 * its position is equal or greater the pattern length, the note
+	 * is not accessible anymore. In order to all for redo/undo
+	 * function still to work on those notes as well as to not loose
+	 * information, those notes will still persist in
+	 * #__notes. Instead, this function generates a new map similar to
+	 * #__notes which contains only the accessible notes and provides
+	 * it as a shared pointer.
+	 *
+	 * The notes in the map themselves will _not_ be copied but only a
+	 * pointer to the ones stored in #__notes is provided. Their
+	 * livecycle will be still dictated by #__notes.
+	 */
+	const std::shared_ptr<notes_t> getAccessibleNotes();
 		///< get the virtual pattern set
 		const virtual_patterns_t* get_virtual_patterns() const;
 		///< get the flattened virtual pattern set

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -780,7 +780,6 @@ void Song::removeInstrument( int nInstrumentNumber, bool bConditional ) {
 std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 
 	std::vector<std::shared_ptr<Note>> notes;
-
 	long nColumnStartTick = 0;
 	for ( int ii = 0; ii < m_pPatternGroupSequence->size(); ++ii ) {
 
@@ -796,13 +795,14 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 			pColumn->longest_pattern_length();
 			for ( const auto& ppattern : *pColumn ) {
 				if ( ppattern != nullptr ) {
-					FOREACH_NOTE_CST_IT_BEGIN_END( ppattern->get_notes(), it ) {
+					auto pNotes = ppattern->getAccessibleNotes();
+					FOREACH_NOTE_CST_IT_BEGIN_END( pNotes, it ) {
 						if ( it->second != nullptr ) {
 							// Use the copy constructor to not mess
 							// with the song itself.
 							std::shared_ptr<Note> pNote =
 								std::make_shared<Note>( it->second );
-
+							
 							// The position property of the note
 							// specifies its position within the
 							// pattern. All we need to do is to add
@@ -810,6 +810,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 							pNote->set_position( pNote->get_position() +
 												 nColumnStartTick );
 							notes.push_back( pNote );
+
 						}
 					}
 				}

--- a/src/core/Lilipond/Lilypond.cpp
+++ b/src/core/Lilipond/Lilypond.cpp
@@ -115,20 +115,20 @@ void H2Core::LilyPond::write( const QString &sFilename ) const {
 void H2Core::LilyPond::addPatternList( const PatternList &list, notes_t &to ) {
 	to.clear();
 	for ( unsigned nPattern = 0; nPattern < list.size(); nPattern++ ) {
-		if ( const Pattern *pPattern = list.get( nPattern ) ) {
+		if ( Pattern *pPattern = list.get( nPattern ) ) {
 			addPattern( *pPattern, to );
 		}
 	}
 }
 
-void H2Core::LilyPond::addPattern( const Pattern &pattern, notes_t &notes ) {
+void H2Core::LilyPond::addPattern( Pattern &pattern, notes_t &notes ) {
 	notes.reserve( pattern.get_length() );
 	for ( unsigned nNote = 0; nNote < pattern.get_length(); nNote++ ) {
 		if ( nNote >= notes.size() ) {
 			notes.push_back( std::vector<std::pair<int, float> >() );
 		}
 
-		const Pattern::notes_t *pPatternNotes = pattern.get_notes();
+		auto pPatternNotes = pattern.getAccessibleNotes();
 		if ( !pPatternNotes ) {
 			continue;
 		}

--- a/src/core/Lilipond/Lilypond.h
+++ b/src/core/Lilipond/Lilypond.h
@@ -75,7 +75,7 @@ private:
 	 * @param pattern the Pattern where the information is
 	 * @param notes   where to store the information to
 	 */
-	static void addPattern( const Pattern &pattern, notes_t &notes );
+	static void addPattern( Pattern &pattern, notes_t &notes );
 
 	/// Write measures in LilyPond format to stream
 	void writeMeasures( std::ofstream &stream ) const;

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -176,26 +176,33 @@ void Sampler::noteOn(Note *pNote )
 {
 	assert( pNote );
 
-	pNote->get_adsr()->attack();
+	auto pAdsr = pNote->get_adsr();
+	
+	assert( pAdsr );
+
+	pAdsr->attack();
 	auto pInstr = pNote->get_instrument();
+
+	assert( pInstr );
 
 	// mute group
 	int nMuteGrp = pInstr->get_mute_group();
 	if ( nMuteGrp != -1 ) {
 		// remove all notes using the same mute group
-		for ( const auto& pNote: m_playingNotesQueue ) {	// delete older note
-			if ( ( pNote->get_instrument() != pInstr )  && ( pNote->get_instrument()->get_mute_group() == nMuteGrp ) ) {
-				pNote->get_adsr()->release();
+		for ( const auto& ppNote: m_playingNotesQueue ) {	// delete older note
+			if ( ( ppNote->get_instrument() != pInstr )  &&
+				 ( ppNote->get_instrument()->get_mute_group() == nMuteGrp ) ) {
+				ppNote->get_adsr()->release();
 			}
 		}
 	}
 
 	//note off notes
 	if( pNote->get_note_off() ){
-		for ( const auto& pNote: m_playingNotesQueue ) {
-			if ( ( pNote->get_instrument() == pInstr ) ) {
+		for ( const auto& ppNote: m_playingNotesQueue ) {
+			if ( ( ppNote->get_instrument() == pInstr ) ) {
 				//ERRORLOG("note_off");
-				pNote->get_adsr()->release();
+				ppNote->get_adsr()->release();
 			}
 		}
 	}
@@ -1409,7 +1416,7 @@ void Sampler::setPlayingNotelength( std::shared_ptr<Instrument> pInstrument, uns
 			int patternsize = pCurrentPattern->get_length();
 
 			for ( unsigned nNote = 0; nNote < pCurrentPattern->get_length(); nNote++ ) {
-				const Pattern::notes_t* notes = pCurrentPattern->get_notes();
+				auto notes = pCurrentPattern->getAccessibleNotes();
 				FOREACH_NOTE_CST_IT_BOUND(notes,it,nNote) {
 					Note *pNote = it->second;
 					if ( pNote!=nullptr ) {

--- a/src/core/Smf/Smf.cpp
+++ b/src/core/Smf/Smf.cpp
@@ -252,7 +252,7 @@ void SMFWriter::save( const QString& sFilename, std::shared_ptr<Song> pSong )
 			}
 
 			for ( unsigned nNote = 0; nNote < pPattern->get_length(); nNote++ ) {
-				const Pattern::notes_t* notes = pPattern->get_notes();
+				auto notes = pPattern->getAccessibleNotes();
 				FOREACH_NOTE_CST_IT_BOUND(notes,it,nNote) {
 					Note *pNote = it->second;
 					if ( pNote ) {

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -827,7 +827,7 @@ std::vector<DrumPatternEditor::SelectionIndex> DrumPatternEditor::elementsInters
 	int x_min = (r.left() - PatternEditor::nMargin - 1) / m_fGridWidth;
 	int x_max = (r.right() - PatternEditor::nMargin) / m_fGridWidth;
 
-	const Pattern::notes_t* notes = m_pPattern->get_notes();
+	auto notes = m_pPattern->getAccessibleNotes();
 
 	for (auto it = notes->lower_bound( x_min ); it != notes->end() && it->first <= x_max; ++it ) {
 		Note *note = it->second;
@@ -863,7 +863,9 @@ void DrumPatternEditor::selectAll()
 	}
 	
 	m_selection.clearSelection();
-	FOREACH_NOTE_CST_IT_BEGIN_END(m_pPattern->get_notes(), it) {
+
+	auto pNotes = m_pPattern->getAccessibleNotes();
+	FOREACH_NOTE_CST_IT_BEGIN_END( pNotes, it) {
 		m_selection.addToSelection( it->second );
 	}
 	m_selection.updateWidgetGroup();
@@ -1055,7 +1057,7 @@ void DrumPatternEditor::drawPattern(QPainter& painter)
 
 
 	for ( Pattern *pPattern : getPatternsToShow() ) {
-		const Pattern::notes_t *pNotes = pPattern->get_notes();
+		auto pNotes = pPattern->getAccessibleNotes();
 		if ( pNotes->size() == 0 ) {
 			continue;
 		}

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1061,7 +1061,7 @@ void NotePropertiesRuler::createNormalizedBackground(QPixmap *pixmap)
 		QPen selectedPen( selectedNoteColor() );
 		selectedPen.setWidth( 2 );
 
-		const Pattern::notes_t* notes = m_pPattern->get_notes();
+		auto notes = m_pPattern->getAccessibleNotes();
 		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
 			Note *pposNote = it->second;
 			assert( pposNote );
@@ -1151,7 +1151,7 @@ void NotePropertiesRuler::createCenteredBackground(QPixmap *pixmap)
 		QPen selectedPen( selectedNoteColor() );
 		selectedPen.setWidth( 2 );
 
-		const Pattern::notes_t* notes = m_pPattern->get_notes();
+		auto notes = m_pPattern->getAccessibleNotes();
 		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
 			Note *pposNote = it->second;
 			assert( pposNote );
@@ -1303,7 +1303,7 @@ void NotePropertiesRuler::createNoteKeyBackground(QPixmap *pixmap)
 		QPen selectedPen( selectedNoteColor() );
 		selectedPen.setWidth( 2 );
 
-		const Pattern::notes_t* notes = m_pPattern->get_notes();
+		auto notes = m_pPattern->getAccessibleNotes();
 		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
 			Note *pNote = it->second;
 			assert( pNote );
@@ -1327,7 +1327,7 @@ void NotePropertiesRuler::createNoteKeyBackground(QPixmap *pixmap)
 		QPen selectedPen( selectedNoteColor() );
 		selectedPen.setWidth( 2 );
 
-		const Pattern::notes_t* notes = m_pPattern->get_notes();
+		auto notes = m_pPattern->getAccessibleNotes();
 		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
 			Note *pNote = it->second;
 			assert( pNote );
@@ -1461,7 +1461,7 @@ std::vector<NotePropertiesRuler::SelectionIndex> NotePropertiesRuler::elementsIn
 		return std::move( result );
 	}
 	
-	const Pattern::notes_t* notes = m_pPattern->get_notes();
+	auto notes = m_pPattern->getAccessibleNotes();
 	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
 	int nSelectedInstrument = Hydrogen::get_instance()->getSelectedInstrumentNumber();
 	auto pInstrument = pSong->getInstrumentList()->get( nSelectedInstrument );

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -395,7 +395,9 @@ void PatternEditor::selectInstrumentNotes( int nInstrument )
 	auto pInstrument = pInstrumentList->get( nInstrument );
 
 	m_selection.clearSelection();
-	FOREACH_NOTE_CST_IT_BEGIN_END(m_pPattern->get_notes(), it) {
+
+	auto pNotes = m_pPattern->getAccessibleNotes();
+	FOREACH_NOTE_CST_IT_BEGIN_END( pNotes, it) {
 		if ( it->second->get_instrument() == pInstrument ) {
 			m_selection.addToSelection( it->second );
 		}

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -527,7 +527,7 @@ void InstrumentLine::functionFillNotes( int every )
 
 			for (int i = 0; i < nPatternSize; i += nResolution) {
 				bool noteAlreadyPresent = false;
-				const Pattern::notes_t* notes = pCurrentPattern->get_notes();
+				auto notes = pCurrentPattern->getAccessibleNotes();
 				FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {
 					Note *pNote = it->second;
 					if ( pNote->get_instrument() == instrRef ) {

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -376,7 +376,7 @@ void PianoRollEditor::drawPattern()
 	// for each note...
 	for ( Pattern *pPattern : getPatternsToShow() ) {
 		bool bIsForeground = ( pPattern == m_pPattern );
-		const Pattern::notes_t* notes = pPattern->get_notes();
+		auto notes = pPattern->getAccessibleNotes();
 		FOREACH_NOTE_CST_IT_BEGIN_END( notes, it ) {
 			Note *note = it->second;
 			assert( note );
@@ -1217,7 +1217,7 @@ std::vector<PianoRollEditor::SelectionIndex> PianoRollEditor::elementsIntersecti
 	int x_min = (r.left() - w - PatternEditor::nMargin) / m_fGridWidth;
 	int x_max = (r.right() + w - PatternEditor::nMargin) / m_fGridWidth;
 
-	const Pattern::notes_t* pNotes = m_pPattern->get_notes();
+	auto pNotes = m_pPattern->getAccessibleNotes();
 
 	for ( auto it = pNotes->lower_bound( x_min ); it != pNotes->end() && it->first <= x_max; ++it ) {
 		Note *pNote = it->second;


### PR DESCRIPTION
Next to `Pattern::__notes`, which is a container for all notes within the pattern, and its accessor `Pattern::get_notes()` the new function `Pattern::getAccessibleNotes()` was introduced. Its purpose is to creating a fresh map similar to `__notes` but only containing accessible notes and provide it as shared pointer. The notes itself will not be copied but only their pointers. A note is accessible if its tick position within the pattern is smaller than the pattern length.

`getAccessibleNotes()` is not used at all places as a replacement for `get_notes()` since serialization, clearing all notes/instruments, and redo/undo should still work on all notes without any loss of information. Whether a note is accessible is primarly affecting notes playback, user interaction, visual rendering, and MIDI export.

Fixes #1542 