### PR TITLE
Fix notes stuck in Sampler queue

### DIFF
--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -947,7 +947,9 @@ bool Sampler::renderNoteNoResample(
 	}
 
 
-	retValue = pADSR->applyADSR( buffer_L, buffer_R, nTimes, nNoteEnd, 1 );
+	if ( pADSR->applyADSR( buffer_L, buffer_R, nTimes, nNoteEnd, 1 ) ) {
+		retValue = true;
+	}
 	bool bFilterIsActive = pInstrument->is_filter_active();
 	// Low pass resonant filter
 
@@ -1221,7 +1223,9 @@ bool Sampler::renderNoteResample(
 		fSamplePos += fStep;
 	}
 
-	retValue = pADSR->applyADSR( buffer_L, buffer_R, nTimes, nNoteEnd, 1 );
+	if ( pADSR->applyADSR( buffer_L, buffer_R, nTimes, nNoteEnd, 1 ) ) {
+		retValue = true;
+	}
 
 	// Mix rendered sample buffer to track and mixer output
 	for ( int nBufferPos = nInitialBufferPos; nBufferPos < nTimes; ++nBufferPos ) {


### PR DESCRIPTION
Old notes could get stuck in the sampler queue if the ADSR envelope extends past the end of the sample (eg. due to rounding errors on resampling). Make sure that ADSR will only shorten a note rather than prolong it.