### PR TITLE
Phil further fixes

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -510,7 +510,7 @@ int main(int argc, char *argv[])
 		}
 
 		pSong = nullptr;
-		delete pPlaylist;
+		delete Playlist::get_instance();
 
 		preferences->savePreferences();
 		delete pHydrogen;
@@ -523,10 +523,8 @@ int main(int argc, char *argv[])
 		___INFOLOG( "Quitting..." );
 		delete Logger::get_instance();
 
-		int nObj = Base::objects_count();
-		if (nObj != 0) {
-			std::cerr << "\n\n\n " << nObj << " alive objects\n\n" << std::endl << std::endl;
-			Base::write_objects_map_to_cerr();
+		if (H2Core::Base::count_active()) {
+			H2Core::Base::write_objects_map_to_cerr();
 		}
 	}
 	catch ( const H2Exception& ex ) {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -509,13 +509,12 @@ int main(int argc, char *argv[])
 			pHydrogen->sequencer_stop();
 		}
 
-		//delete pSong;
 		pSong = nullptr;
 		delete pPlaylist;
 
-		delete pQueue;
 		preferences->savePreferences();
 		delete pHydrogen;
+		delete pQueue;
 		delete preferences;
 
 		delete MidiMap::get_instance();

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -162,7 +162,6 @@ AudioEngine::AudioEngine()
 #ifdef H2CORE_HAVE_LADSPA
 	Effects::create_instance();
 #endif
-
 }
 
 AudioEngine::~AudioEngine()
@@ -1241,7 +1240,10 @@ void AudioEngine::setAudioDriver( AudioOutput* pAudioDriver ) {
 		setupLadspaFX();
 	}
 
+	
 	handleDriverChange();
+
+	EventQueue::get_instance()->push_event( EVENT_DRIVER_CHANGED, 0 );
 }
 
 void AudioEngine::stopAudioDrivers()
@@ -2711,7 +2713,7 @@ bool AudioEngine::testTransportProcessing() {
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 	
 	pCoreActionController->activateTimeline( false );
-	pCoreActionController->activateLoopMode( true, false );
+	pCoreActionController->activateLoopMode( true );
 
 	lock( RIGHT_HERE );
 
@@ -3253,7 +3255,7 @@ bool AudioEngine::testSongSizeChange() {
 	nNextTick += pSong->lengthInTicks();
 	
 	unlock();
-	pCoreActionController->activateLoopMode( true, false );
+	pCoreActionController->activateLoopMode( true );
 	pCoreActionController->locateToTick( nNextTick );
 	lock( RIGHT_HERE );
 	
@@ -3282,7 +3284,7 @@ bool AudioEngine::testSongSizeChangeInLoopMode() {
 	auto pPref = Preferences::get_instance();
 	
 	pCoreActionController->activateTimeline( false );
-	pCoreActionController->activateLoopMode( true, false );
+	pCoreActionController->activateLoopMode( true );
 
 	lock( RIGHT_HERE );
 
@@ -3389,7 +3391,7 @@ bool AudioEngine::testNoteEnqueuing() {
 	auto pPref = Preferences::get_instance();
 
 	pCoreActionController->activateTimeline( false );
-	pCoreActionController->activateLoopMode( false, false );
+	pCoreActionController->activateLoopMode( false );
 	pCoreActionController->activateSongMode( true );
 	lock( RIGHT_HERE );
 

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -145,13 +145,10 @@ void Song::setBpm( float fBpm ) {
 	} else {
 		m_fBpm = fBpm;
 	}
-	setIsModified( true );
 }
 
 void Song::setActionMode( Song::ActionMode actionMode ) {
 	m_actionMode = actionMode;
-
-	setIsModified( true );
 }
 
 long Song::lengthInTicks() const {
@@ -290,7 +287,6 @@ void Song::setSwingFactor( float factor )
 	}
 
 	m_fSwingFactor = factor;
-	setIsModified( true );
 }
 
 void Song::setIsModified( bool bIsModified )
@@ -422,7 +418,6 @@ void Song::readTempPatternList( const QString& sFilename )
 	} else {
 		WARNINGLOG( "no sequence node not found" );
 	}
-	setIsModified( true );
 }
 
 bool Song::writeTempPatternList( const QString& sFilename )

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -429,7 +429,6 @@ inline bool Song::getIsMuted() const
 inline void Song::setIsMuted( bool bIsMuted )
 {
 	m_bIsMuted = bIsMuted;
-	setIsModified( true );
 }
 
 inline unsigned Song::getResolution() const
@@ -440,7 +439,6 @@ inline unsigned Song::getResolution() const
 inline void Song::setResolution( unsigned resolution )
 {
 	m_resolution = resolution;
-	setIsModified( true );
 }
 
 inline float Song::getBpm() const
@@ -451,7 +449,6 @@ inline float Song::getBpm() const
 inline void Song::setName( const QString& sName )
 {
 	m_sName = sName;
-	setIsModified( true );
 }
 
 inline const QString& Song::getName() const
@@ -467,7 +464,6 @@ inline float Song::getVolume() const
 inline void Song::setVolume( float fValue )
 {
 	m_fVolume = fValue;
-	setIsModified( true );
 }
 
 inline float Song::getMetronomeVolume() const
@@ -478,7 +474,6 @@ inline float Song::getMetronomeVolume() const
 inline void Song::setMetronomeVolume( float fValue )
 {
 	m_fMetronomeVolume = fValue;
-	setIsModified( true );
 }
 
 inline bool Song::getIsModified() const 
@@ -523,7 +518,6 @@ inline void Song::setPatternGroupVector( std::vector<PatternList*>* pGroupVector
 inline void Song::setNotes( const QString& sNotes )
 {
 	m_sNotes = sNotes;
-	setIsModified( true );
 }
 
 inline const QString& Song::getNotes() const
@@ -534,7 +528,6 @@ inline const QString& Song::getNotes() const
 inline void Song::setLicense( const QString& sLicense )
 {
 	m_sLicense = sLicense;
-	setIsModified( true );
 }
 
 inline const QString& Song::getLicense() const
@@ -545,7 +538,6 @@ inline const QString& Song::getLicense() const
 inline void Song::setAuthor( const QString& sAuthor )
 {
 	m_sAuthor = sAuthor;
-	setIsModified( true );
 }
 
 inline const QString& Song::getAuthor() const
@@ -561,7 +553,6 @@ inline const QString& Song::getFilename() const
 inline void Song::setFilename( const QString& sFilename )
 {
 	m_sFilename = sFilename;
-	setIsModified( true );
 }
 
 inline bool Song::isLoopEnabled() const
@@ -577,7 +568,6 @@ inline Song::LoopMode Song::getLoopMode() const
 inline void Song::setLoopMode( Song::LoopMode loopMode )
 {
 	m_loopMode = loopMode;
-	setIsModified( true );
 }
 
 inline Song::PatternMode Song::getPatternMode() const
@@ -597,7 +587,6 @@ inline float Song::getHumanizeTimeValue() const
 inline void Song::setHumanizeTimeValue( float fValue )
 {
 	m_fHumanizeTimeValue = fValue;
-	setIsModified( true );
 }
 
 inline float Song::getHumanizeVelocityValue() const
@@ -608,7 +597,6 @@ inline float Song::getHumanizeVelocityValue() const
 inline void Song::setHumanizeVelocityValue( float fValue )
 {
 	m_fHumanizeVelocityValue = fValue;
-	setIsModified( true );
 }
 
 inline float Song::getSwingFactor() const
@@ -624,7 +612,6 @@ inline Song::Mode Song::getMode() const
 inline void Song::setMode( Song::Mode mode )
 {
 	m_mode = mode;
-	setIsModified( true );
 }
 
 inline std::vector<DrumkitComponent*>* Song::getComponents() const
@@ -649,7 +636,6 @@ inline int Song::getLatestRoundRobin( float fStartVelocity )
 inline void Song::setLatestRoundRobin( float fStartVelocity, int nLatestRoundRobin )
 {
 	m_latestRoundRobins[ fStartVelocity ] = nLatestRoundRobin;
-	setIsModified( true );
 }
 
 inline const QString& Song::getPlaybackTrackFilename() const
@@ -660,7 +646,6 @@ inline const QString& Song::getPlaybackTrackFilename() const
 inline void Song::setPlaybackTrackFilename( const QString sFilename )
 {
 	m_sPlaybackTrackFilename = sFilename;
-	setIsModified( true );
 }
 
 inline bool Song::getPlaybackTrackEnabled() const
@@ -674,7 +659,6 @@ inline bool Song::setPlaybackTrackEnabled( const bool bEnabled )
 		return false;
 	}
 	m_bPlaybackTrackEnabled = bEnabled;
-	setIsModified( true );
 	return bEnabled;
 }
 
@@ -686,7 +670,6 @@ inline float Song::getPlaybackTrackVolume() const
 inline void Song::setPlaybackTrackVolume( const float fVolume )
 {
 	m_fPlaybackTrackVolume = fVolume;
-	setIsModified( true );
 }
 
 inline Song::ActionMode Song::getActionMode() const {
@@ -695,7 +678,6 @@ inline Song::ActionMode Song::getActionMode() const {
 
 inline void Song::setPanLawType( int nPanLawType ) {
 	m_nPanLawType = nPanLawType;
-	setIsModified( true );
 }
 
 inline int Song::getPanLawType() const {

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -805,6 +805,12 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 		ERRORLOG( "no song set" );
 		return false;
 	}
+
+	if ( !( bActivate && pHydrogen->getMode() != Song::Mode::Song ) &&
+		 ! ( ! bActivate && pHydrogen->getMode() != Song::Mode::Pattern ) ) {
+		// No changes.
+		return true;
+	}		
 	
 	pHydrogen->sequencer_stop();
 	if ( bActivate && pHydrogen->getMode() != Song::Mode::Song ) {
@@ -824,7 +830,7 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 	return true;
 }
 
-bool CoreActionController::activateLoopMode( bool bActivate, bool bTriggerEvent ) {
+bool CoreActionController::activateLoopMode( bool bActivate ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
@@ -856,8 +862,9 @@ bool CoreActionController::activateLoopMode( bool bActivate, bool bTriggerEvent 
 		bChange = true;
 	}
 	
-	if ( bTriggerEvent && bChange ) {
-		EventQueue::get_instance()->push_event( EVENT_LOOP_MODE_ACTIVATION, static_cast<int>( bActivate ) );
+	if ( bChange ) {
+		EventQueue::get_instance()->push_event( EVENT_LOOP_MODE_ACTIVATION,
+												static_cast<int>( bActivate ) );
 	}
 	
 	return true;

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -148,6 +148,7 @@ bool CoreActionController::setMasterIsMuted( bool isMuted )
 	}
 	
 	pHydrogen->getSong()->setIsMuted( isMuted );
+	pHydrogen->setIsModified( true );
 	
 #ifdef H2CORE_HAVE_OSC
 	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "MUTE_TOGGLE" );
@@ -534,7 +535,7 @@ bool CoreActionController::setSong( std::shared_ptr<Song> pSong ) {
 			Preferences::get_instance()->setLastSongFilename( pSong->getFilename() );
 		}
 	}
-
+		
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
 		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
 	}

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -253,15 +253,10 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * Toggle loop mode of playback.
 		 *
 		 * @param bActivate If true - activates loop mode.
-		 * @param bTriggerEvent Setting this variable to true is
-		 * intended for its use as a batch function from within
-		 * Hydrogen's core, which will inform the GUI via an Event
-		 * about the change of mode. When used from the GUI itself,
-		 * this parameter has to be set to false.
 		 *
 		 * @return bool true on success
 		 */
-		bool activateLoopMode( bool bActivate, bool bTriggerEvent );
+		bool activateLoopMode( bool bActivate );
 	/** Wrapper around loadDrumkit() that allows loading drumkits by
 		name. */
 	bool loadDrumkit( const QString& sDrumkitName, bool bConditional = true );

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -165,7 +165,8 @@ enum EventType {
 	 * command. 
 	 */
 	EVENT_RELOCATION,
-	EVENT_SONG_SIZE_CHANGED
+	EVENT_SONG_SIZE_CHANGED,
+	EVENT_DRIVER_CHANGED
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -426,7 +426,7 @@ bool Filesystem::check_usr_paths()
 	if( !path_usable( plugins_dir() ) ) ret = false;
 	if( !path_usable( scripts_dir() ) ) ret = false;
 	if( !path_usable( songs_dir() ) ) ret = false;
-	if( file_exists( empty_song_path() ) ) ret = false;
+	if( file_exists( empty_song_path(), true ) ) ret = false;
 	if( !path_usable( usr_theme_dir() ) ) ret = false;
 	if( !file_writable( usr_config_path() ) ) ret = false;
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -275,13 +275,6 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 		// delete pCurrentSong;
 	}
 
-	if ( m_GUIState != GUIState::unavailable ) {
-		/* Reset GUI */
-		EventQueue::get_instance()->push_event( EVENT_SELECTED_PATTERN_CHANGED, -1 );
-		EventQueue::get_instance()->push_event( EVENT_PATTERN_CHANGED, -1 );
-		EventQueue::get_instance()->push_event( EVENT_SELECTED_INSTRUMENT_CHANGED, -1 );
-	}
-
 	// In order to allow functions like audioEngine_setupLadspaFX() to
 	// load the settings of the new song, like whether the LADSPA FX
 	// are activated, __song has to be set prior to the call of
@@ -303,11 +296,6 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, true );
 	}
 #endif
-	
-	EventQueue::get_instance()->push_event( EVENT_SONG_MODE_ACTIVATION,
-											( pSong->getMode() == Song::Mode::Song) ? 1 : 0 );
-	EventQueue::get_instance()->push_event( EVENT_TIMELINE_ACTIVATION,
-											static_cast<int>( pSong->getIsTimelineActivated() ) );
 }
 
 /* Mean: remove current song from memory */
@@ -1116,9 +1104,8 @@ void Hydrogen::__panic()
 
 bool Hydrogen::haveJackAudioDriver() const {
 #ifdef H2CORE_HAVE_JACK
-	AudioEngine* pAudioEngine = m_pAudioEngine;
-	if ( pAudioEngine->getAudioDriver() != nullptr ) {
-		if ( dynamic_cast<JackAudioDriver*>(pAudioEngine->getAudioDriver()) != nullptr ) {
+	if ( m_pAudioEngine->getAudioDriver() != nullptr ) {
+		if ( dynamic_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver()) != nullptr ) {
 			return true;
 		}
 	}
@@ -1130,9 +1117,8 @@ bool Hydrogen::haveJackAudioDriver() const {
 
 bool Hydrogen::haveJackTransport() const {
 #ifdef H2CORE_HAVE_JACK
-	AudioEngine* pAudioEngine = m_pAudioEngine;
-	if ( pAudioEngine->getAudioDriver() != nullptr ) {
-		if ( dynamic_cast<JackAudioDriver*>(pAudioEngine->getAudioDriver()) != nullptr &&
+	if ( m_pAudioEngine->getAudioDriver() != nullptr ) {
+		if ( dynamic_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver()) != nullptr &&
 			 Preferences::get_instance()->m_bJackTransportMode ==
 			 Preferences::USE_JACK_TRANSPORT ){
 			return true;

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -250,7 +250,7 @@ void Hydrogen::loadPlaybackTrack( const QString filename )
 void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 {
 	assert ( pSong );
-	
+
 	// Move to the beginning.
 	setSelectedPatternNumber( 0 );
 
@@ -1197,6 +1197,8 @@ bool Hydrogen::isPatternEditorLocked() const {
 void Hydrogen::setIsPatternEditorLocked( bool bValue ) {
 	if ( __song != nullptr ) {
 		__song->setIsPatternEditorLocked( bValue );
+
+		__song->setIsModified( true );
 			
 		EventQueue::get_instance()->push_event( EVENT_PATTERN_EDITOR_LOCKED,
 												bValue );
@@ -1382,6 +1384,12 @@ void Hydrogen::setIsModified( bool bIsModified ) {
 			getSong()->setIsModified( bIsModified );
 		}
 	}
+}
+bool Hydrogen::getIsModified() const {
+	if ( getSong() != nullptr ) {
+		return getSong()->getIsModified();
+	}
+	return false;
 }
 
 void Hydrogen::setCurrentDrumkitName( const QString& sName ) {

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -265,6 +265,9 @@ void			previewSample( Sample *pSample );
 	/** Wrapper around Song::setIsModified() that checks whether a
 		song is set.*/
 	void setIsModified( bool bIsModified );
+	/** Wrapper around Song::getIsModified() that checks whether a
+		song is set.*/
+	bool getIsModified() const;
 
 	enum ErrorMessages {
 		/**

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -962,7 +962,6 @@ void JackAudioDriver::setTrackOutput( int n, std::shared_ptr<Instrument> pInstru
 void JackAudioDriver::startTransport()
 {
 	if ( m_pClient != nullptr ) {
-		INFOLOG( "jack_transport_start()" );
 		jack_transport_start( m_pClient );
 	} else {
 		ERRORLOG( "No client registered" );
@@ -972,7 +971,6 @@ void JackAudioDriver::startTransport()
 void JackAudioDriver::stopTransport()
 {
 	if ( m_pClient != nullptr ) {
-		INFOLOG( "jack_transport_stop()" );
 		jack_transport_stop( m_pClient );
 	} else {
 		ERRORLOG( "No client registered" );
@@ -988,7 +986,6 @@ void JackAudioDriver::locateTransport( long long nFrame )
 		// re-positions the transport to a new frame number. May
 		// be called at any time by any client.
 		jack_transport_locate( m_pClient, nFrame );
-		DEBUGLOG( nFrame );
 	} else {
 		ERRORLOG( "No client registered" );
 	}

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -812,9 +812,9 @@ void OscServer::LOOP_MODE_ACTIVATION_Handler(lo_arg **argv, int argc) {
 
 	auto pController = pHydrogen->getCoreActionController();
 	if ( argv[0]->f != 0 ) {
-		pController->activateLoopMode( true, true );
+		pController->activateLoopMode( true );
 	} else {
-		pController->activateLoopMode( false, true );
+		pController->activateLoopMode( false );
 	}
 }
 

--- a/src/gui/src/AudioEngineInfoForm.cpp
+++ b/src/gui/src/AudioEngineInfoForm.cpp
@@ -257,4 +257,12 @@ void AudioEngineInfoForm::patternChangedEvent()
 	updateAudioEngineState();
 }
 
+void AudioEngineInfoForm::updateSongEvent( int nValue )
+{
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		updateAudioEngineState();
+	}
+}
+
 

--- a/src/gui/src/AudioEngineInfoForm.h
+++ b/src/gui/src/AudioEngineInfoForm.h
@@ -46,7 +46,8 @@ class AudioEngineInfoForm :  public QWidget, public Ui_AudioEngineInfoForm_UI, p
 
 		// EventListener implementation
 	virtual void stateChangedEvent( H2Core::AudioEngine::State state) override;
-		virtual void patternChangedEvent() override;
+	virtual void patternChangedEvent() override;
+	virtual void updateSongEvent(int) override;
 		//~ EventListener implementation
 
 	public:

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -310,6 +310,9 @@ CommonStrings::CommonStrings(){
 	/*: Displayed when hovering over the button in the
 	PatternEditorPanel to activate the PianoRollEditor.*/
 	m_sShowPianoRollEditorTooltip = tr( "Show piano roll editor" );
+
+	m_sJackMasterTooltip = tr("JACK Timebase master on/off");
+	m_sJackMasterDisabledTooltip = tr( "JACK timebase support is disabled in the Preferences" );
 	
 	/*: Title of the window displayed when using the MIDI learning
 	  capabilities of Hydrogen.*/

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -123,6 +123,9 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getShowPianoRollEditorTooltip() const { return m_sShowPianoRollEditorTooltip; }
 	const QString& getPatternSizeDisabledTooltip() const { return m_sPatternSizeDisabledTooltip; }
 	
+	const QString& getJackMasterTooltip() const { return m_sJackMasterTooltip; }
+	const QString& getJackMasterDisabledTooltip() const { return m_sJackMasterDisabledTooltip; }
+	
 	const QString& getMidiSenseWindowTitle() const { return m_sMidiSenseWindowTitle; }
 	const QString& getMidiSenseInput() const { return m_sMidiSenseInput; }
 	const QString& getMidiSenseUnavailable() const { return m_sMidiSenseUnavailable; }
@@ -234,6 +237,9 @@ private:
 	
 	QString m_sShowDrumkitEditorTooltip;
 	QString m_sShowPianoRollEditorTooltip;
+
+	QString m_sJackMasterTooltip;
+	QString m_sJackMasterDisabledTooltip;
 	
 	QString m_sMidiSenseWindowTitle;
 	QString m_sMidiSenseInput;

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -47,13 +47,13 @@ class EventListener
 		virtual void tempoChangedEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void updateSongEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void quitEvent( int nValue ){ UNUSED( nValue ); }
-		virtual void timelineActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void timelineActivationEvent(){}
 		virtual void timelineUpdateEvent( int nValue ){ UNUSED( nValue ); }
-		virtual void jackTransportActivationEvent( int nValue ){ UNUSED( nValue ); }
-		virtual void jackTimebaseStateChangedEvent( int nValue ){ UNUSED( nValue ); }
-		virtual void songModeActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void jackTransportActivationEvent(){}
+		virtual void jackTimebaseStateChangedEvent(){}
+		virtual void songModeActivationEvent(){}
 		virtual void stackedModeActivationEvent( int nValue ){ UNUSED( nValue ); }
-		virtual void loopModeActivationEvent( int nValue ){ UNUSED( nValue ); }
+		virtual void loopModeActivationEvent(){}
 		virtual void updatePreferencesEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void actionModeChangeEvent( int nValue ){ UNUSED( nValue ); }
     	virtual void updateSongEditorEvent( int nValue ){ UNUSED( nValue ); }
@@ -61,6 +61,7 @@ class EventListener
 	virtual void patternEditorLockedEvent( int nValue ){ UNUSED( nValue ); }
 	virtual void relocationEvent(){}
 	virtual void songSizeChangedEvent(){}
+	virtual void driverChangedEvent(){}
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/FilesystemInfoForm.cpp
+++ b/src/gui/src/FilesystemInfoForm.cpp
@@ -40,16 +40,16 @@ FilesystemInfoForm::FilesystemInfoForm( QWidget *parent ) :
 	QColor windowTextColor = H2Core::Preferences::get_instance()->getColorTheme()->m_windowTextColor;
 
 	ui->tmpDirWarningButton->setIcon( QIcon( Skin::getSvgImagePath() + "/icons/warning.svg" ) );
-	ui->tmpDirWarningButton->setStyleSheet( Skin::getWarningButtonStyleSheet( 16 ) );
 	ui->tmpDirWarningButton->setToolTip( tr( "Filesystem is not writable!" ) );
-	ui->tmpDirWarningButton->setFlat( true );
+	ui->tmpDirWarningButton->setType( Button::Type::Icon );
+	ui->tmpDirWarningButton->setSize( QSize( 16, 14 ) );
 	
 	ui->tmpDirLineEdit->setReadOnly( true );
 	
 	ui->usrDataDirWarningButton->setIcon( QIcon( Skin::getSvgImagePath() + "/icons/warning.svg" ) );
-	ui->usrDataDirWarningButton->setStyleSheet( Skin::getWarningButtonStyleSheet( 16 ) );
 	ui->usrDataDirWarningButton->setToolTip( tr( "User data folder is not writable!" ) );
-	ui->usrDataDirWarningButton->setFlat( true );
+	ui->usrDataDirWarningButton->setType( Button::Type::Icon );
+	ui->usrDataDirWarningButton->setSize( QSize( 16, 14 ) );
 	
 	ui->usrDataDirLineEdit->setReadOnly( true );
 	ui->sysDataDirLineEdit->setReadOnly( true );

--- a/src/gui/src/FilesystemInfoForm_UI.ui
+++ b/src/gui/src/FilesystemInfoForm_UI.ui
@@ -32,7 +32,7 @@
     </widget>
    </item>
    <item row="0" column="2">
-    <widget class="QPushButton" name="tmpDirWarningButton">
+    <widget class="Button" name="tmpDirWarningButton">
       <property name="enabled">
        <bool>true</bool>
       </property>
@@ -76,7 +76,7 @@ height: 18px;</string>
     </widget>
    </item>
    <item row="1" column="2">
-     <widget class="QPushButton" name="usrDataDirWarningButton">
+     <widget class="Button" name="usrDataDirWarningButton">
       <property name="styleSheet">
        <string notr="true">width: 16px;
 height: 16px</string>
@@ -129,6 +129,13 @@ height: 16px</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Button</class>
+   <extends>QPushButton</extends>
+   <header location="global">../src/Widgets/Button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -802,7 +802,7 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 
 			case EVENT_TIMELINE_ACTIVATION:
-				pListener->timelineActivationEvent( event.value );
+				pListener->timelineActivationEvent();
 				break;
 
 			case EVENT_TIMELINE_UPDATE:
@@ -810,15 +810,15 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 
 			case EVENT_JACK_TRANSPORT_ACTIVATION:
-				pListener->jackTransportActivationEvent( event.value );
+				pListener->jackTransportActivationEvent();
 				break;
 
 			case EVENT_JACK_TIMEBASE_STATE_CHANGED:
-				pListener->jackTimebaseStateChangedEvent( event.value );
+				pListener->jackTimebaseStateChangedEvent();
 				break;
 				
 			case EVENT_SONG_MODE_ACTIVATION:
-				pListener->songModeActivationEvent( event.value );
+				pListener->songModeActivationEvent();
 				break;
 
 			case EVENT_STACKED_MODE_ACTIVATION:
@@ -826,7 +826,7 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 				
 			case EVENT_LOOP_MODE_ACTIVATION:
-				pListener->loopModeActivationEvent( event.value );
+				pListener->loopModeActivationEvent();
 				break;
 
 			case EVENT_ACTION_MODE_CHANGE:
@@ -851,6 +851,10 @@ void HydrogenApp::onEventQueueTimer()
 				
 			case EVENT_SONG_SIZE_CHANGED:
 				pListener->songSizeChangedEvent();
+				break;
+
+			case EVENT_DRIVER_CHANGED:
+				pListener->driverChangedEvent();
 				break;
 
 			default:

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -271,7 +271,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 										   pCommonStrings->getIsStopNoteLabel() );
 	m_pIsStopNoteLbl->move( 59, 144 );
 
-	m_pApplyVelocity = new QCheckBox ( tr( "" ), m_pInstrumentProp );
+	m_pApplyVelocity = new QCheckBox ( "", m_pInstrumentProp );
 	m_pApplyVelocity->move( 153, 139 );
 	m_pApplyVelocity->adjustSize();
 	m_pApplyVelocity->setFixedSize( 14, 14 );
@@ -749,7 +749,7 @@ void InstrumentEditor::rotaryChanged( WidgetWithInput *ref)
 					float fCoarse = round( m_pLayerPitchCoarseRotary->getValue() );
 					float fFine = m_pLayerPitchFineRotary->getValue() / 100.0;
 					pLayer->set_pitch( fCoarse + fFine );
-					INFOLOG( tr( "layer pitch: %1" ).arg( pLayer->get_pitch() ) );
+					INFOLOG( QString( "layer pitch: %1" ).arg( pLayer->get_pitch() ) );
 				}
 			}
 		}
@@ -762,7 +762,7 @@ void InstrumentEditor::rotaryChanged( WidgetWithInput *ref)
 					float fCoarse = round( m_pLayerPitchCoarseRotary->getValue() );
 					float fFine = m_pLayerPitchFineRotary->getValue() / 100.0;
 					pLayer->set_pitch( fCoarse + fFine );
-					INFOLOG( tr( "layer pitch: %1" ).arg( pLayer->get_pitch() ) );
+					INFOLOG( QString( "layer pitch: %1" ).arg( pLayer->get_pitch() ) );
 				}
 			}
 		}

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -493,7 +493,12 @@ InstrumentEditor::~InstrumentEditor()
 	//INFOLOG( "DESTROY" );
 }
 
-
+void InstrumentEditor::updateSongEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		selectedInstrumentChangedEvent();
+	}
+}
 
 void InstrumentEditor::selectedInstrumentChangedEvent()
 {

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -104,7 +104,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	pMidiOutLbl->move( 22, 281 );
 
 	m_pMidiOutChannelLCD = new LCDSpinBox( m_pInstrumentProp, QSize( 59, 24 ),
-										   LCDSpinBox::Type::Int, -1, 16,
+										   LCDSpinBox::Type::Int, -1, 15,
 										   true, true );
 	m_pMidiOutChannelLCD->move( 98, 257 );
 	m_pMidiOutChannelLCD->setToolTip(QString(tr("Midi out channel")));

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -66,6 +66,7 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 
 		// implements EventListener interface
 		virtual void selectedInstrumentChangedEvent() override;
+	virtual void updateSongEvent( int ) override;
 		//~ implements EventListener interface
 		void update();
 		static int findFreeDrumkitComponentId( int startingPoint = 0 );

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -84,6 +84,13 @@ void InstrumentEditorPanel::drumkitLoadedEvent() {
 	m_pInstrumentEditor->selectedInstrumentChangedEvent();
 }
 
+void InstrumentEditorPanel::updateSongEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		drumkitLoadedEvent();
+	}
+}
+
 void InstrumentEditorPanel::selectLayer( int nLayer )
 {
 	m_pInstrumentEditor->selectLayer( nLayer );

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
@@ -47,6 +47,7 @@ class InstrumentEditorPanel : public QWidget, private H2Core::Object<InstrumentE
 
 		virtual void parametersInstrumentChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
+	virtual void updateSongEvent( int ) override;
 		
 		InstrumentEditor* getInstrumentEditor() const;
 

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -409,19 +409,26 @@ void LayerPreview::mouseMoveEvent( QMouseEvent *ev )
 		auto pLayer = m_pInstrument->get_component( m_nSelectedComponent )->get_layer( m_nSelectedLayer );
 		if ( pLayer ) {
 			if ( m_bMouseGrab ) {
+				bool bChanged = false;
 				if ( m_bGrabLeft ) {
 					if ( fVel < pLayer->get_end_velocity()) {
 						pLayer->set_start_velocity( fVel );
+						bChanged = true;
 						showLayerStartVelocity( pLayer, ev );
 					}
 				}
 				else {
 					if ( fVel > pLayer->get_start_velocity()) {
 						pLayer->set_end_velocity( fVel );
+						bChanged = true;
 						showLayerEndVelocity( pLayer, ev );
 					}
 				}
-				update();
+
+				if ( bChanged ) {
+					update();
+					Hydrogen::get_instance()->setIsModified( true );
+				}
 			}
 		}
 	}

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -200,6 +200,17 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 	p.drawRect( 0, y, width() - 1, m_nLayerHeight );
 }
 
+void LayerPreview::drumkitLoadedEvent() {
+	selectedInstrumentChangedEvent();
+}
+
+void LayerPreview::updateSongEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		selectedInstrumentChangedEvent();
+	}
+}
+
 void LayerPreview::selectedInstrumentChangedEvent()
 {
 	Hydrogen::get_instance()->getAudioEngine()->lock( RIGHT_HERE );

--- a/src/gui/src/InstrumentEditor/LayerPreview.h
+++ b/src/gui/src/InstrumentEditor/LayerPreview.h
@@ -95,6 +95,8 @@ public slots:
 		void showLayerEndVelocity( const std::shared_ptr<H2Core::InstrumentLayer> pLayer, const QMouseEvent* pEvent );
 
 		virtual void selectedInstrumentChangedEvent() override;
+	virtual void drumkitLoadedEvent() override;
+	virtual void updateSongEvent(int) override;
 		/** Used to detect changed in the font*/
 		int getPointSizeButton() const;
 };

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2371,7 +2371,6 @@ void MainForm::startPlaybackAtCursor( QObject* pObject ) {
 			
 		if ( pHydrogen->getMode() != Song::Mode::Song ) {
 			pCoreActionController->activateSongMode( true );
-			pApp->getPlayerControl()->songModeActivationEvent( 1 );
 		}
 
 		int nCursorColumn = pApp->getSongEditorPanel()->getSongEditor()->getCursorColumn();

--- a/src/gui/src/Mixer/MixerSettingsDialog.cpp
+++ b/src/gui/src/Mixer/MixerSettingsDialog.cpp
@@ -155,6 +155,8 @@ void MixerSettingsDialog::on_okBtn_clicked() {
 	*/
 	pSong->setPanLawKNorm( - 6.0206 / fdBCenterCompensation );
 
+	Hydrogen::get_instance()->setIsModified( true );
+
 	accept();
 }
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -859,9 +859,8 @@ std::vector< Pattern *> PatternEditor::getPatternsToShow( void )
 }
 
 
-void PatternEditor::songModeActivationEvent( int nValue )
+void PatternEditor::songModeActivationEvent()
 {
-	UNUSED( nValue );
 	// May need to draw (or hide) other background patterns
 	update();
 }

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -154,7 +154,7 @@ public:
 	virtual void mouseDragEndEvent( QMouseEvent *ev ) override;
 
 
-	virtual void songModeActivationEvent( int nValue ) override;
+	virtual void songModeActivationEvent() override;
 	virtual void stackedModeActivationEvent( int nValue ) override;
 
 	static constexpr int nMargin = 20;

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -327,7 +327,7 @@ void InstrumentLine::selectInstrumentNotes()
 void InstrumentLine::mousePressEvent(QMouseEvent *ev)
 {
 	Hydrogen::get_instance()->setSelectedInstrumentNumber( m_nInstrumentNumber );
-	HydrogenApp::get_instance()->getPatternEditorPanel()->updatePianorollEditor();
+	HydrogenApp::get_instance()->getPatternEditorPanel()->getDrumPatternEditor()->updateEditor();
 
 	if ( ev->button() == Qt::LeftButton ) {
 		const int width = m_pMuteBtn->x() - 5; // clickable field width
@@ -739,7 +739,8 @@ PatternEditorInstrumentList::~PatternEditorInstrumentList()
 InstrumentLine* PatternEditorInstrumentList::createInstrumentLine()
 {
 	InstrumentLine *pLine = new InstrumentLine(this);
-	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, pLine, &InstrumentLine::onPreferencesChanged );
+	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
+			 pLine, &InstrumentLine::onPreferencesChanged );
 	return pLine;
 }
 
@@ -808,7 +809,6 @@ void PatternEditorInstrumentList::updateInstrumentLines()
 
 				int newHeight = m_nGridHeight * nInstruments + 1;
 				resize( width(), newHeight );
-
 			}
 			continue;
 		}

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -96,7 +96,10 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 	m_pSoloBtn->setObjectName( "SoloButton" );
 	connect(m_pSoloBtn, SIGNAL( pressed() ), this, SLOT(soloClicked()));
 
-	m_pSampleWarning = new Button( this, QSize( 15, 13 ), Button::Type::Push, "warning.svg", "", false, QSize(), tr( "Some samples for this instrument failed to load." ), true );
+	m_pSampleWarning = new Button( this, QSize( 15, 13 ), Button::Type::Icon,
+								   "warning.svg", "", false, QSize(),
+								   tr( "Some samples for this instrument failed to load." ),
+								   true );
 	m_pSampleWarning->move( 128, 5 );
 	m_pSampleWarning->hide();
 	connect(m_pSampleWarning, SIGNAL( pressed() ), this, SLOT( sampleWarningClicked() ));

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -501,7 +501,8 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pPropertiesVBox->setMargin( 0 );
 
 
-	m_pPropertiesCombo = new LCDCombo( nullptr, QSize( m_pInstrumentList->width(), 18 ) );
+	m_pPropertiesCombo =
+		new LCDCombo( nullptr, QSize( m_pInstrumentList->width(), 18 ), false );
 	m_pPropertiesCombo->setToolTip( tr( "Select note properties" ) );
 	m_pPropertiesCombo->addItem( tr("Velocity") );
 	m_pPropertiesCombo->addItem( tr("Pan") );
@@ -607,7 +608,6 @@ PatternEditorPanel::~PatternEditorPanel()
 void PatternEditorPanel::drumkitLoadedEvent() {
 	updateSLnameLabel();
 	getDrumPatternEditor()->updateEditor();
-	updatePianorollEditor();
 	
 }
 
@@ -1088,11 +1088,6 @@ void PatternEditorPanel::propertiesComboChanged( int nSelected )
 	else {
 		ERRORLOG( QString( "unhandled value : %1" ).arg( nSelected ) );
 	}
-}
-
-void PatternEditorPanel::updatePianorollEditor()
-{
-	m_pDrumPatternEditor->updateEditor(); // force an update
 }
 
 int PatternEditorPanel::getCursorPosition()

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -928,7 +928,7 @@ void PatternEditorPanel::patternChangedEvent() {
 	updateEditors( true );
 }
 
-void PatternEditorPanel::songModeActivationEvent( int ) {
+void PatternEditorPanel::songModeActivationEvent() {
 	if ( Hydrogen::get_instance()->getPatternMode() ==
 		 Song::PatternMode::Stacked ) {
 		updateEditors( true );
@@ -1023,7 +1023,12 @@ void PatternEditorPanel::dropEvent( QDropEvent *event )
 void PatternEditorPanel::updateSongEvent( int nValue ) {
 	// A new song got loaded
 	if ( nValue == 0 ) {
+		// Performs an editor update with updateEditor() (and no argument).
+		selectedPatternChangedEvent();
+		selectedInstrumentChangedEvent();
 		updateSLnameLabel();
+		updateEditors( true );
+		m_pPatternEditorRuler->updatePosition();
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -96,7 +96,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 	virtual void patternChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
 	virtual void updateSongEvent( int nValue ) override;
-	virtual void songModeActivationEvent( int ) override;
+	virtual void songModeActivationEvent() override;
 	virtual void stackedModeActivationEvent( int ) override;
 		//~ Implements EventListener interface
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -87,7 +87,6 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 	
 
 		void updateSLnameLabel();
-		void updatePianorollEditor();
 
 		// Implements EventListener interface
 		virtual void selectedPatternChangedEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -143,13 +143,6 @@ void PatternEditorRuler::relocationEvent() {
 	updatePosition();
 }
 
-void PatternEditorRuler::updateSongEvent( int nValue ) {
-
-	if ( nValue == 0 ) { // new song loaded
-		updatePosition();
-	}
-}
-
 void PatternEditorRuler::updateStart(bool start) {
 	if (start) {
 		m_pTimer->start(50);	// update ruler at 20 fps
@@ -549,7 +542,7 @@ void PatternEditorRuler::zoomOut()
 }
 
 
-void PatternEditorRuler::songModeActivationEvent( int )
+void PatternEditorRuler::songModeActivationEvent()
 {
 	updatePosition();
 }
@@ -561,7 +554,6 @@ void PatternEditorRuler::stateChangedEvent( H2Core::AudioEngine::State )
 	
 void PatternEditorRuler::selectedPatternChangedEvent()
 {
-	createBackground();
 	updateEditor( true );
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -87,7 +87,7 @@ PatternEditorRuler::~PatternEditorRuler() {
 }
 
 void PatternEditorRuler::updatePosition( bool bForce ) {
-
+	
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 	
@@ -214,6 +214,7 @@ void PatternEditorRuler::mousePressEvent( QMouseEvent* ev ) {
 
 		if ( pHydrogen->getMode() != Song::Mode::Pattern ) {
 			pCoreActionController->activateSongMode( false );
+			pHydrogen->setIsModified( true );
 		}
 
 		pCoreActionController->locateToTick( nNewTick );

--- a/src/gui/src/PatternEditor/PatternEditorRuler.h
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.h
@@ -109,9 +109,8 @@ class PatternEditorRuler :  public QWidget, protected WidgetWithScalableFont<8, 
 		// Implements EventListener interface
 		virtual void selectedPatternChangedEvent() override;
 	virtual void stateChangedEvent( H2Core::AudioEngine::State ) override;
-	virtual void songModeActivationEvent( int ) override;
+	virtual void songModeActivationEvent() override;
 	virtual void relocationEvent() override;
-	virtual void updateSongEvent( int ) override;
 		//~ Implements EventListener interface
 };
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -140,7 +140,6 @@ void PianoRollEditor::selectedInstrumentChangedEvent()
 
 void PianoRollEditor::selectedPatternChangedEvent()
 {
-	updatePatternInfo();
 	updateEditor();
 }
 

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -58,10 +58,10 @@ public:
 	void showScrollMessage( const QString& msg, int msec, bool test );
 	void resetStatusLabel();
 
-	virtual void timelineActivationEvent( int ) override;
+	virtual void timelineActivationEvent() override;
 	virtual void tempoChangedEvent( int nValue ) override;
-	virtual void jackTransportActivationEvent( int nValue ) override;
-	virtual void jackTimebaseStateChangedEvent( int nValue ) override;
+	virtual void jackTransportActivationEvent() override;
+	virtual void jackTimebaseStateChangedEvent() override;
 	/**
 	 * Shared GUI update when activating Song or Pattern mode via
 	 * button click or via OSC command.
@@ -69,7 +69,10 @@ public:
 	 * @param nValue If 0, Pattern mode will be activate. Else,
 	 * Song mode will be activated instead.
 	 */
-	void songModeActivationEvent( int nValue ) override;
+	virtual void songModeActivationEvent() override;
+	virtual void updateSongEvent( int nValue ) override;
+	virtual void loopModeActivationEvent() override;
+	virtual void driverChangedEvent() override;
 
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
@@ -79,15 +82,12 @@ private slots:
 	void playBtnClicked();
 	void stopBtnClicked();
 	void updatePlayerControl();
-	void songModeBtnClicked();
-	void patternModeBtnClicked();
 	void jackTransportBtnClicked();
 	//jack time master
 	void jackMasterBtnClicked();	//~ jack time master
 	void bpmChanged( double );
 	void fastForwardBtnClicked();
 	void rewindBtnClicked();
-	void songLoopBtnClicked();
 	void metronomeButtonClicked();
 	void onStatusTimerEvent();
 	void onScrollTimerEvent();
@@ -111,14 +111,12 @@ private:
 	/** Ensure that the full width of the status label is used without
 	 * cutting of the beginning of the message.*/
 	void updateStatusLabel();
-	/**
-	 * Shared GUI update when activating loop mode via button
-	 * click or via OSC command.
-	 *
-	 * @param nValue If 0, loop mode will be deactivate.
-	 */
-	void loopModeActivationEvent( int nValue ) override;
 	void midiActivityEvent() override;
+
+	/** Ensures both the song and pattern mode button stay checked
+		when pressed twice*/
+	void songModeBtnClicked();
+	
 	H2Core::Hydrogen *m_pHydrogen;
 	QPixmap m_background;
 
@@ -149,7 +147,6 @@ private:
 	Button *m_pJackTransportBtn;
 	//jack time master
 	Button *m_pJackMasterBtn;
-	QString m_sJackMasterModeToolTip;
 	//~ jack time master
 
 	CpuLoadWidget *m_pCpuLoadWidget;

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -361,6 +361,7 @@ void SampleEditor::on_PrevChangesPushButton_clicked()
 	getAllLocalFrameInfos();
 	createNewLayer();
 	setClean();
+	Hydrogen::get_instance()->setIsModified( true );
 	QApplication::restoreOverrideCursor();
 	InstrumentEditorPanel::get_instance()->updateWaveDisplay();
 }

--- a/src/gui/src/Skin.cpp
+++ b/src/gui/src/Skin.cpp
@@ -141,20 +141,6 @@ void Skin::setPalette( QApplication *pQApp ) {
 	pQApp->setStyleSheet( getGlobalStyleSheet() );
 }
 
-QString Skin::getWarningButtonStyleSheet( int nSize) {
-	auto pPref = H2Core::Preferences::get_instance();
-	
-	return QString( "\
-width: %1px; \
-height: %1px; \
-color: %2; \
-background-color: %3; \
-border-color: %3;" )
-		.arg( nSize )
-		.arg( pPref->getColorTheme()->m_windowTextColor.name() )
-		.arg( pPref->getColorTheme()->m_windowColor.name() );
-}
-
 void Skin::drawListBackground( QPainter* p, QRect rect, QColor background,
 							   bool bHovered ) {
 

--- a/src/gui/src/Skin.h
+++ b/src/gui/src/Skin.h
@@ -55,19 +55,6 @@ public:
 	It will get the most recent color values from the #H2Core::Preferences.*/
 	static void setPalette( QApplication *pQApp );
 
-	/** Get the style sheet used for warning icons. 
-	 *
-	 * In addition, the icon of the warning button has to be set to
-	 * Skin::getSvgImagePath() + "/icons/warning.svg".
-	 *
-	 * \param nSize Size in pixel (value will be used as both width
-	 * and height).
-	 *
-	 * \return Argument used of the setStyleSheet() method of the
-	 * warning button.
-	 */
-	static QString getWarningButtonStyleSheet( int nSize );
-
 	/**
 	 * Draws the background of a row in both the pattern list of the
 	 * SongEditor and the instrument list in the PatternEditor using

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2729,6 +2729,7 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 
 			if ( m_pHydrogen->getMode() == Song::Mode::Pattern ) {
 				pCoreActionController->activateSongMode( true );
+				m_pHydrogen->setIsModified( true );
 			}
 
 			m_pHydrogen->getCoreActionController()->locateToColumn( nColumn );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1630,9 +1630,7 @@ void SongEditorPatternList::updateEditor()
 	update();
 }
 
-void SongEditorPatternList::songModeActivationEvent( int nValue ) {
-
-	UNUSED( nValue );
+void SongEditorPatternList::songModeActivationEvent() {
 
 	// Refresh pattern list display if in stacked mode
 	if ( Hydrogen::get_instance()->getPatternMode() ==
@@ -2648,18 +2646,18 @@ bool SongEditorPositionRuler::event( QEvent* ev ) {
 	return QWidget::event( ev );
 }
 
-void SongEditorPositionRuler::songModeActivationEvent( int ) {
+void SongEditorPositionRuler::songModeActivationEvent() {
 	updatePosition();
 	createBackground();
 	update();
 }
 
-void SongEditorPositionRuler::timelineActivationEvent( int ) {
+void SongEditorPositionRuler::timelineActivationEvent() {
 	createBackground();
 	update();
 }
 
-void SongEditorPositionRuler::jackTimebaseStateChangedEvent( int ) {
+void SongEditorPositionRuler::jackTimebaseStateChangedEvent() {
 	createBackground();
 	update();
 }
@@ -2668,6 +2666,7 @@ void SongEditorPositionRuler::updateSongEvent( int nValue ) {
 
 	if ( nValue == 0 ) { // different song opened
 		updatePosition();
+		songSizeChangedEvent();
 	}
 }
 

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -329,7 +329,7 @@ class SongEditorPatternList :  public QWidget
 		void togglePattern( int );
 
 		virtual void patternChangedEvent() override;
-		virtual void songModeActivationEvent( int nValue ) override;
+		virtual void songModeActivationEvent() override;
 	virtual void stackedModeActivationEvent( int nValue ) override;
 
 	void setRowSelection( RowSelection rowSelection );
@@ -360,17 +360,17 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 
 		uint getGridWidth();
 		void setGridWidth (uint width);
-	void tempoChangedEvent( int ) override;
-	void patternChangedEvent() override;
-	void songModeActivationEvent( int nValue ) override;
-	void relocationEvent() override;
-	void songSizeChangedEvent() override;
-	void patternModifiedEvent() override;
-	void updateSongEvent( int ) override;
+	virtual void tempoChangedEvent( int ) override;
+	virtual void patternChangedEvent() override;
+	virtual void songModeActivationEvent() override;
+	virtual void relocationEvent() override;
+	virtual void songSizeChangedEvent() override;
+	virtual void patternModifiedEvent() override;
+	virtual void updateSongEvent( int ) override;
 	
-	void timelineActivationEvent( int nValue ) override;
-	void timelineUpdateEvent( int nValue ) override;
-	void jackTimebaseStateChangedEvent( int nValue ) override;
+	virtual void timelineActivationEvent() override;
+	virtual void timelineUpdateEvent( int nValue ) override;
+	virtual void jackTimebaseStateChangedEvent() override;
 													   
 
 	public slots:

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -762,6 +762,7 @@ void SongEditorPanel::drawModeBtnPressed()
 
 void SongEditorPanel::timelineBtnPressed() {
 	setTimelineActive( ! m_pTimelineBtn->isChecked() );
+	Hydrogen::get_instance()->setIsModified( true );
 }
 
 void SongEditorPanel::showTimeline()

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -260,7 +260,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	QWidget *pHScrollbarPanel = new QWidget();
 	pHScrollbarPanel->setLayout( pHZoomLayout );
 
-	songModeActivationEvent(0);
+	songModeActivationEvent();
 
 	//~ ZOOM
 
@@ -705,11 +705,10 @@ void SongEditorPanel::updateSongEvent( int nValue ) {
 		patternEditorLockedEvent( 0 );
 		actionModeChangeEvent( 0 );
 		stackedModeActivationEvent( 0 );
-		jackTimebaseStateChangedEvent( 0 );
-		songModeActivationEvent( 0 );
-		timelineActivationEvent( 0 );
-
-		updateAll();
+		jackTimebaseStateChangedEvent();
+		songModeActivationEvent();
+		timelineActivationEvent();
+		selectedPatternChangedEvent();
 	}
 }
 
@@ -998,7 +997,7 @@ void SongEditorPanel::toggleAutomationAreaVisibility()
 }
 
 
-void SongEditorPanel::jackTimebaseStateChangedEvent( int ) {
+void SongEditorPanel::jackTimebaseStateChangedEvent() {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	auto pHydrogen = Hydrogen::get_instance();
 	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
@@ -1010,7 +1009,7 @@ void SongEditorPanel::jackTimebaseStateChangedEvent( int ) {
 	}
 }
 
-void SongEditorPanel::songModeActivationEvent( int ) {
+void SongEditorPanel::songModeActivationEvent() {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	if ( pHydrogen->getMode() == Song::Mode::Pattern ) {
@@ -1041,7 +1040,7 @@ void SongEditorPanel::songModeActivationEvent( int ) {
 	}
 }
 
-void SongEditorPanel::timelineActivationEvent( int ){
+void SongEditorPanel::timelineActivationEvent(){
 	auto pHydrogen = Hydrogen::get_instance();
 	if ( ! pHydrogen->isTimelineEnabled() && m_pTimelineBtn->isChecked() ) {
 		setTimelineActive( false );

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -87,7 +87,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		
 		// Implements EventListener interface
 		virtual void selectedPatternChangedEvent() override;
-		virtual void timelineActivationEvent( int nValue ) override;
+		virtual void timelineActivationEvent() override;
 		/** Updates the associated buttons if the action mode was
 		 * changed within the core.
 		 *
@@ -97,14 +97,14 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		void updateSongEditorEvent( int nValue ) override;
 	void patternModifiedEvent() override;
 
-		virtual void jackTimebaseStateChangedEvent( int ) override;
+		virtual void jackTimebaseStateChangedEvent() override;
 
 		virtual void patternChangedEvent() override;
 
 	virtual void patternEditorLockedEvent( int ) override;
 	virtual void stackedModeActivationEvent( int ) override;
 	virtual void updateSongEvent( int ) override;
-		virtual void songModeActivationEvent( int nValue ) override;
+	virtual void songModeActivationEvent() override;
 
 	public slots:
 		void showHideTimeline( bool bPressed ) {

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -88,11 +88,7 @@ Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, c
 	
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &Button::onPreferencesChanged );
 
-	if ( type == Type::Toggle ) {
-		connect( this, SIGNAL(toggled(bool)), this, SLOT(onToggled(bool)));
-	} else {
-		connect( this, SIGNAL(clicked(bool)), this, SLOT(onToggled(bool)));
-	}
+	connect( this, SIGNAL(clicked()), this, SLOT(onClick()));
 }
 
 Button::~Button() {
@@ -457,7 +453,7 @@ void Button::onPreferencesChanged( H2Core::Preferences::Changes changes ) {
 	}
 }
 
-void Button::onToggled( bool bChecked ) {
+void Button::onClick() {
 	if ( m_bModifyOnChange ) {
 		H2Core::Hydrogen::get_instance()->setIsModified( true );
 	}

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -37,6 +37,7 @@
 Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, const QString& sText, bool bUseRedBackground, QSize iconSize, QString sBaseTooltip, bool bColorful, bool bModifyOnChange, const QString& sBorderRadius )
 	: QPushButton( pParent )
 	, m_size( size )
+	, m_type( type )
 	, m_iconSize( iconSize )
 	, m_sBaseTooltip( sBaseTooltip )
 	, m_sRegisteredMidiEvent( "" )
@@ -50,7 +51,6 @@ Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, c
 	, m_bModifyOnChange( bModifyOnChange )
 	, m_sBorderRadius( sBorderRadius )
 {
-	setAttribute( Qt::WA_OpaquePaintEvent );
 	setFocusPolicy( Qt::NoFocus );
 	
 	if ( size.isNull() || size.isEmpty() ) {
@@ -80,6 +80,10 @@ Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, c
 		setCheckable( true );
 	} else {
 		setCheckable( false );
+	}
+
+	if ( type == Type::Icon ) {
+		setFlat( true );
 	}
 
 	updateFont();
@@ -126,6 +130,12 @@ void Button::setUseRedBackground( bool bUseRedBackground ) {
 
 void Button::updateStyleSheet() {
 
+	if ( m_type == Type::Icon ) {
+		// Make background transparent
+		setStyleSheet( "background-color: none" );
+		return;
+	}
+
 	auto pPref = H2Core::Preferences::get_instance();
 	
 	int nFactorGradient = 126;
@@ -137,43 +147,35 @@ void Button::updateStyleSheet() {
 	float x2 = 1;
 	float y1 = 0;
 	float y2 = 1;
-	
-	QColor backgroundLight = pPref->getColorTheme()->m_widgetColor.lighter( nFactorGradient );
-	QColor backgroundDark = pPref->getColorTheme()->m_widgetColor.darker( nFactorGradient );
-	QColor backgroundLightHover = pPref->getColorTheme()->m_widgetColor.lighter( nFactorGradient + nHover );
-	QColor backgroundDarkHover = pPref->getColorTheme()->m_widgetColor.darker( nFactorGradient + nHover );
-	QColor backgroundShadowLight = pPref->getColorTheme()->m_widgetColor.lighter( nFactorGradientShadow );
-	QColor backgroundShadowDark = pPref->getColorTheme()->m_widgetColor.darker( nFactorGradientShadow );
-	QColor backgroundShadowLightHover = pPref->getColorTheme()->m_widgetColor.lighter( nFactorGradientShadow + nHover );
-	QColor backgroundShadowDarkHover = pPref->getColorTheme()->m_widgetColor.darker( nFactorGradientShadow + nHover );
+
+	QColor baseColorBackground = pPref->getColorTheme()->m_widgetColor;
+	QColor backgroundLight = baseColorBackground.lighter( nFactorGradient );
+	QColor backgroundDark = baseColorBackground.darker( nFactorGradient );
+	QColor backgroundLightHover = baseColorBackground.lighter( nFactorGradient + nHover );
+	QColor backgroundDarkHover = baseColorBackground.darker( nFactorGradient + nHover );
+	QColor backgroundShadowLight = baseColorBackground.lighter( nFactorGradientShadow );
+	QColor backgroundShadowDark = baseColorBackground.darker( nFactorGradientShadow );
+	QColor backgroundShadowLightHover = baseColorBackground.lighter( nFactorGradientShadow + nHover );
+	QColor backgroundShadowDarkHover = baseColorBackground.darker( nFactorGradientShadow + nHover );
 	QColor border = Qt::black;
 
-	QColor backgroundCheckedLight, backgroundCheckedDark,
-		backgroundCheckedLightHover, backgroundCheckedDarkHover,
-		backgroundShadowCheckedLight, backgroundShadowCheckedDark,
-		backgroundShadowCheckedLightHover, backgroundShadowCheckedDarkHover,
-		textChecked;
+	QColor baseColorBackgroundChecked, textChecked;
 	if ( ! m_bUseRedBackground ) {
-		backgroundCheckedLight = pPref->getColorTheme()->m_accentColor.lighter( nFactorGradient );
-		backgroundCheckedDark = pPref->getColorTheme()->m_accentColor.darker( nFactorGradient );
-		backgroundCheckedLightHover = pPref->getColorTheme()->m_accentColor.lighter( nFactorGradient + nHover );
-		backgroundCheckedDarkHover = pPref->getColorTheme()->m_accentColor.darker( nFactorGradient + nHover );
-		backgroundShadowCheckedLight = pPref->getColorTheme()->m_accentColor.lighter( nFactorGradientShadow );
-		backgroundShadowCheckedDark = pPref->getColorTheme()->m_accentColor.darker( nFactorGradientShadow );
-		backgroundShadowCheckedLightHover = pPref->getColorTheme()->m_accentColor.lighter( nFactorGradientShadow + nHover );
-		backgroundShadowCheckedDarkHover = pPref->getColorTheme()->m_accentColor.darker( nFactorGradientShadow + nHover );
+		baseColorBackgroundChecked = pPref->getColorTheme()->m_accentColor;
 		textChecked = pPref->getColorTheme()->m_accentTextColor;
 	} else {
-		backgroundCheckedLight = pPref->getColorTheme()->m_buttonRedColor.lighter( nFactorGradient );
-		backgroundCheckedDark = pPref->getColorTheme()->m_buttonRedColor.darker( nFactorGradient );
-		backgroundCheckedLightHover = pPref->getColorTheme()->m_buttonRedColor.lighter( nFactorGradient + nHover );
-		backgroundCheckedDarkHover = pPref->getColorTheme()->m_buttonRedColor.darker( nFactorGradient + nHover );
-		backgroundShadowCheckedLight = pPref->getColorTheme()->m_buttonRedColor.lighter( nFactorGradientShadow );
-		backgroundShadowCheckedDark = pPref->getColorTheme()->m_buttonRedColor.darker( nFactorGradientShadow );
-		backgroundShadowCheckedLightHover = pPref->getColorTheme()->m_buttonRedColor.lighter( nFactorGradientShadow + nHover );
-		backgroundShadowCheckedDarkHover = pPref->getColorTheme()->m_buttonRedColor.darker( nFactorGradientShadow + nHover );
+		baseColorBackgroundChecked = pPref->getColorTheme()->m_buttonRedColor;
 		textChecked = pPref->getColorTheme()->m_buttonRedTextColor;
 	}
+	
+	QColor backgroundCheckedLight = baseColorBackgroundChecked.lighter( nFactorGradient );
+	QColor backgroundCheckedDark = baseColorBackgroundChecked.darker( nFactorGradient );
+	QColor backgroundCheckedLightHover = baseColorBackgroundChecked.lighter( nFactorGradient + nHover );
+	QColor backgroundCheckedDarkHover = baseColorBackgroundChecked.darker( nFactorGradient + nHover );
+	QColor backgroundShadowCheckedLight = baseColorBackgroundChecked.lighter( nFactorGradientShadow );
+	QColor backgroundShadowCheckedDark = baseColorBackgroundChecked.darker( nFactorGradientShadow );
+	QColor backgroundShadowCheckedLightHover = baseColorBackgroundChecked.lighter( nFactorGradientShadow + nHover );
+	QColor backgroundShadowCheckedDarkHover = baseColorBackgroundChecked.darker( nFactorGradientShadow + nHover );
 
 	QColor textColor = pPref->getColorTheme()->m_widgetTextColor;
 	
@@ -202,7 +204,7 @@ void Button::updateStyleSheet() {
 		Skin::makeWidgetColorInactive( backgroundShadowCheckedDark );
 	QColor backgroundShadowInactiveCheckedDarkHover = backgroundShadowInactiveCheckedDark;
 	QColor textInactiveColor = Skin::makeTextColorInactive( textColor );
-	
+
 	setStyleSheet( QString( "\
 QPushButton:enabled { \
     color: %1; \
@@ -369,6 +371,26 @@ void Button::setSize( QSize size ) {
 	}
 
 	updateFont();
+}
+
+void Button::setType( Type type ) {
+
+	if ( type == Type::Toggle ) {
+		setCheckable( true );
+	} else {
+		setCheckable( false );
+	}
+
+	if ( type == Type::Icon ) {
+		setFlat( true );
+	} else {
+		setFlat( false );
+	}
+	
+	m_type = type;
+
+	updateStyleSheet();
+	update();
 }
 
 void Button::updateFont() {

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -67,7 +67,12 @@ public:
 		/** Button is not set checkable.*/
 		Push,
 		/** Button is set checkable.*/
-		Toggle
+		Toggle,
+		/** Button is both flat and has a transparent background. It
+		 * can not be checked and its sole purpose is to show its
+		 * icon.
+		 */
+		Icon
 	};
 	
 	/**
@@ -117,6 +122,9 @@ public:
 	
 	bool getIsActive() const;
 	void setIsActive( bool bIsActive );
+
+	Type getType() const;
+	void setType( Type type );
 
 	void setSize( QSize size );
 	/**  Overwrites the automatically set value. If @a nPixelSize is
@@ -181,6 +189,9 @@ inline int Button::getFixedFontSize() const {
 }
 inline bool Button::getUseRedBackground() const {
 	return m_bUseRedBackground;
+}
+inline Button::Type Button::getType() const {
+	return m_type;
 }
 
 #endif

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -131,7 +131,7 @@ public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
 private slots:
-	void onToggled( bool );
+	void onClick();
 
 signals:
 	void clicked(Button *pBtn);

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -28,11 +28,10 @@
 
 #include <core/Globals.h>
 
-ClickableLabel::ClickableLabel( QWidget *pParent, QSize size, QString sText, Color color, bool bModifyOnChange, bool bIsEditable )
+ClickableLabel::ClickableLabel( QWidget *pParent, QSize size, QString sText, Color color, bool bIsEditable )
 	: QLabel( pParent )
 	, m_size( size )
 	, m_color( color )
-	, m_bModifyOnChange( bModifyOnChange )
 	, m_bIsEditable( bIsEditable )
 	, m_bEntered( false )
 {
@@ -190,8 +189,4 @@ void ClickableLabel::setText( const QString& sNewText ) {
 	
 	QLabel::setText( sNewText );
 	updateFont( pPref->getLevel3FontFamily(), pPref->getFontSize() );
-
-	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
-	}
 }

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -53,7 +53,7 @@ public:
 	
 	explicit ClickableLabel( QWidget *pParent, QSize size = QSize( 0, 0 ),
 							 QString sText = "", Color color = Color::Bright,
-							 bool bModifyOnChange = true, bool bIsEditable = false );
+							 bool bIsEditable = false );
 
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
@@ -72,10 +72,6 @@ private:
 	virtual void paintEvent( QPaintEvent * e ) override;
 	QSize m_size;
 	Color m_color;
-
-	/** Whether Hydrogen::setIsModified() is invoked with `true` as
-		soon as the value of the widget does change.*/
-	bool m_bModifyOnChange;
 
 	/** If set to true a highlight will be painted when hovered. This
 		should be set if a callback is connected and the user is able to

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -138,7 +138,7 @@ void Fader::mouseMoveEvent( QMouseEvent *ev )
 
 	fValue = fValue * ( m_fMax - m_fMin ) + m_fMin;
 
-	setValue( fValue );
+	setValue( fValue, true );
 	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -46,8 +46,14 @@ LCDCombo::LCDCombo( QWidget *pParent, QSize size, bool bModifyOnChange )
 	updateStyleSheet();
 
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &LCDCombo::onPreferencesChanged );
-	connect( this, SIGNAL( currentIndexChanged(int) ), this,
-			 SLOT( onCurrentIndexChanged(int) ) );
+	// Mark the current song modified if there was an user interaction
+	// with the widget.
+	connect( this, QOverload<int>::of(&QComboBox::activated),
+			 [=](int){
+				 if ( m_bModifyOnChange ) {
+					 H2Core::Hydrogen::get_instance()->setIsModified( true );
+				 }
+			 });
 }
 
 LCDCombo::~LCDCombo() {
@@ -162,12 +168,6 @@ void LCDCombo::enterEvent( QEvent* ev ) {
 void LCDCombo::leaveEvent( QEvent* ev ) {
 	QComboBox::leaveEvent( ev );
 	m_bEntered = false;
-}
-
-void LCDCombo::onCurrentIndexChanged( int ) {
-	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
-	}
 }
 
 void LCDCombo::setSize( QSize size ) {

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -51,9 +51,6 @@ public:
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
-private slots:
-	void onCurrentIndexChanged( int );
-
 private:
 	void updateStyleSheet();
 	QSize m_size;

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -48,9 +48,8 @@ LCDSpinBox::LCDSpinBox( QWidget *pParent, QSize size, Type type, double fMin, do
 
 	updateStyleSheet();
 		
-	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &LCDSpinBox::onPreferencesChanged );
-	connect( this, SIGNAL(valueChanged(double)), this,
-			 SLOT(valueChanged(double)));
+	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
+			 this, &LCDSpinBox::onPreferencesChanged );
 		
 	setMaximum( fMax );
 	setMinimum( fMin );
@@ -78,6 +77,8 @@ void LCDSpinBox::setIsActive( bool bIsActive ) {
 
 void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 	static float fCumulatedDelta;
+
+	double fOldValue = value();
 	
 	if ( m_kind == Kind::PatternSizeDenominator ) {
 
@@ -111,9 +112,15 @@ void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 		QDoubleSpinBox::wheelEvent( ev );
 
 	}
+
+	if ( fOldValue != value() && m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
 }
 
 void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
+	double fOldValue = value();
+	
 	if ( m_kind == Kind::PatternSizeDenominator &&
 		 ( ev->key() == Qt::Key_Up || ev->key() == Qt::Key_Down ||
 		   ev->key() == Qt::Key_PageUp || ev->key() == Qt::Key_PageDown ) ) {
@@ -148,6 +155,10 @@ void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 		
 	} else {
 		 QDoubleSpinBox::keyPressEvent( ev );
+	}
+	
+	if ( fOldValue != value() && m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
 	}
 }
 
@@ -260,7 +271,7 @@ void LCDSpinBox::setValue( double fValue ) {
 	if ( value() == fValue ) {
 		return;
 	}
-	
+
 	QDoubleSpinBox::setValue( fValue );
 }
 
@@ -272,6 +283,36 @@ bool LCDSpinBox::event( QEvent* ev ) {
 	}
 
 	return QDoubleSpinBox::event( ev );
+}
+
+void LCDSpinBox::mousePressEvent( QMouseEvent* ev ) {
+	double fOldValue = value();
+
+	QDoubleSpinBox::mousePressEvent( ev );
+	
+	if ( fOldValue != value() && m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
+}
+
+void LCDSpinBox::mouseMoveEvent( QMouseEvent* ev ) {
+	double fOldValue = value();
+
+	QDoubleSpinBox::mouseMoveEvent( ev );
+	
+	if ( fOldValue != value() && m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
+}
+
+void LCDSpinBox::mouseReleaseEvent( QMouseEvent* ev ) {
+	double fOldValue = value();
+
+	QDoubleSpinBox::mouseReleaseEvent( ev );
+	
+	if ( fOldValue != value() && m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
 }
 
 void LCDSpinBox::paintEvent( QPaintEvent *ev ) {
@@ -357,16 +398,5 @@ void LCDSpinBox::onPreferencesChanged( H2Core::Preferences::Changes changes ) {
 	
 	if ( changes & H2Core::Preferences::Changes::Colors ) {
 		updateStyleSheet();
-	}
-}
-
-void LCDSpinBox::valueChanged( double fNewValue ) {
-
-	if ( m_type == Type::Int ) {
-		emit valueChanged( static_cast<int>(fNewValue) );
-	}
-	
-	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
 	}
 }

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -47,7 +47,9 @@ LCDSpinBox::LCDSpinBox( QWidget *pParent, QSize size, Type type, double fMin, do
 	setFixedSize( m_size );
 
 	updateStyleSheet();
-		
+
+	connect( this, SIGNAL(valueChanged(double)), this,
+                        SLOT(valueChanged(double)));
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
 			 this, &LCDSpinBox::onPreferencesChanged );
 		
@@ -398,5 +400,11 @@ void LCDSpinBox::onPreferencesChanged( H2Core::Preferences::Changes changes ) {
 	
 	if ( changes & H2Core::Preferences::Changes::Colors ) {
 		updateStyleSheet();
+	}
+}
+
+void LCDSpinBox::valueChanged( double fNewValue ) {
+	if ( m_type == Type::Int ) {
+		emit valueChanged( static_cast<int>(fNewValue) );
 	}
 }

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -84,8 +84,12 @@ public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 	void setValue( double fValue );
 
+private slots:
+	void valueChanged( double fNewValue );
+
 signals:
 	void slashKeyPressed();
+	void valueChanged( int );
 	
 private:
 	double nextValueInPatternSizeDenominator( bool bUp, bool bAccelerated );

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -84,12 +84,8 @@ public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 	void setValue( double fValue );
 
-private slots:
-	void valueChanged( double fNewValue );
-
 signals:
 	void slashKeyPressed();
-	void valueChanged( int );
 	
 private:
 	double nextValueInPatternSizeDenominator( bool bUp, bool bAccelerated );
@@ -117,6 +113,10 @@ private:
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void wheelEvent( QWheelEvent *ev ) override;
 	virtual void keyPressEvent( QKeyEvent *ev ) override;
+	virtual void mousePressEvent(QMouseEvent *ev) override;
+	virtual void mouseReleaseEvent( QMouseEvent *ev ) override;
+	virtual void mouseMoveEvent(QMouseEvent *ev) override;
+
 	virtual bool event( QEvent* ev ) override;
 };
 

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -42,7 +42,8 @@ Rotary::Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSt
 					   bModifyOnChange )
 	, m_type( type ) {
 
-	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &Rotary::onPreferencesChanged );
+	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
+			 this, &Rotary::onPreferencesChanged );
 
 	installEventFilter( HydrogenApp::get_instance()->getMainForm() );
 

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -93,7 +93,7 @@ void WidgetWithInput::setIsActive( bool bIsActive ) {
 	update();
 }
 
-void WidgetWithInput::setValue( float fValue )
+void WidgetWithInput::setValue( float fValue, bool bTriggeredByUserInteraction )
 {
 	if ( ! m_bIsActive ) {
 		return;
@@ -120,7 +120,7 @@ void WidgetWithInput::setValue( float fValue )
 		updateTooltip();
 		update();
 
-		if ( m_bModifyOnChange ) {
+		if ( m_bModifyOnChange && bTriggeredByUserInteraction ) {
 			H2Core::Hydrogen::get_instance()->setIsModified( true );
 		}
 	}
@@ -199,7 +199,7 @@ void WidgetWithInput::wheelEvent ( QWheelEvent *ev )
 	if ( ev->angleDelta().y() < 0 ) {
 		fDelta *= -1.;
 	}
-	setValue( getValue() + ( fDelta * fStepFactor ) );
+	setValue( getValue() + ( fDelta * fStepFactor ), true );
 	
 	QToolTip::showText(
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
@@ -232,7 +232,7 @@ void WidgetWithInput::mouseMoveEvent( QMouseEvent *ev )
 	float fDeltaY = ev->y() - m_fMousePressY;
 	float fNewValue = ( m_fMousePressValue - fStepFactor * ( fDeltaY / 100.0 * fRange ) );
 
-	setValue( fNewValue );
+	setValue( fNewValue, true );
 
 	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
@@ -268,22 +268,22 @@ void WidgetWithInput::keyPressEvent( QKeyEvent *ev ) {
 		} else {
 			fIncrement *= m_nScrollSpeed;
 		}
-		setValue( m_fValue + fIncrement );
+		setValue( m_fValue + fIncrement, true );
 	} else if ( ev->key() == Qt::Key_PageUp ) {
-		setValue( m_fValue + fIncrement * m_nScrollSpeedFast );
+		setValue( m_fValue + fIncrement * m_nScrollSpeedFast, true );
 	} else if ( ev->key() == Qt::Key_Home ) {
-		setValue( m_fMax );
+		setValue( m_fMax, true );
 	} else if ( ev->key() == Qt::Key_Left || ev->key() == Qt::Key_Down ) {
 		if ( ev->modifiers() == Qt::ControlModifier ) {
 			fIncrement *= m_nScrollSpeedFast;
 		} else {
 			fIncrement *= m_nScrollSpeed;
 		}
-		setValue( m_fValue - fIncrement );
+		setValue( m_fValue - fIncrement, true );
 	} else if ( ev->key() == Qt::Key_PageDown ) {
-		setValue( m_fValue - fIncrement * m_nScrollSpeedFast );
+		setValue( m_fValue - fIncrement * m_nScrollSpeedFast, true );
 	} else if ( ev->key() == Qt::Key_Home ) {
-		setValue( m_fMin );
+		setValue( m_fMin, true );
 	} else if ( ( ev->key() >= Qt::Key_0 && ev->key() <= Qt::Key_9 ) || ev->key() == Qt::Key_Minus || ev->key() == Qt::Key_Period ) {
 
 		timeval now;
@@ -312,7 +312,7 @@ void WidgetWithInput::keyPressEvent( QKeyEvent *ev ) {
 		if ( ! bOk ) {
 			return;
 		}
-		setValue( fNewValue );
+		setValue( fNewValue, true );
 		update();
 	} else if (  ev->key() == Qt::Key_Escape ) {
 		// reset the input buffer
@@ -350,7 +350,7 @@ void WidgetWithInput::setMin( float fMin )
 		m_fMin = fMin;
 
 		if ( m_fValue < fMin ) {
-			setValue( fMin );
+			setValue( fMin, false );
 		}
 		update();
 	}
@@ -378,7 +378,7 @@ void WidgetWithInput::setMax( float fMax )
 		m_fMax = fMax;
 
 		if ( m_fValue > fMax ) {
-			setValue( fMax );
+			setValue( fMax, false );
 		}
 		update();
 	}
@@ -412,7 +412,7 @@ void WidgetWithInput::setDefaultValue( float fDefaultValue )
 
 void WidgetWithInput::resetValueToDefault()
 {
-	setValue( m_fDefaultValue );
+	setValue( m_fDefaultValue, true );
 }
 
 void WidgetWithInput::setAction( std::shared_ptr<Action> pAction ) {

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -68,7 +68,7 @@ public:
 	void setMax( float fMax );
 	float getMax() const;
 
-	virtual void setValue( float fValue );
+	virtual void setValue( float fValue, bool bTriggeredByUserInteraction = false );
 	float getValue() const;
 
 	void setDefaultValue( float fDefaultValue );

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -533,9 +533,6 @@ int main(int argc, char *argv[])
 			sl->shoot();
 		}
 
-		// TODO: remove this as well as the spurious flagging using
-		// more clean event signal processing.
-		//
 		// All GUI setup is complete, any spurious widget-driven
 		// flagging of song modified state will be complete, so clear
 		// the modification flag. This does not apply in case we are

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -43,6 +43,7 @@ void TransportTest::setUp(){
 
 	CPPUNIT_ASSERT( m_pSongDemo != nullptr );
 	CPPUNIT_ASSERT( m_pSongSizeChanged != nullptr );
+	Preferences::get_instance()->m_bUseMetronome = false;
 }
 
 void TransportTest::tearDown() {
@@ -137,7 +138,7 @@ void TransportTest::testSongSizeChange() {
 		}
 	}
 
-	pHydrogen->getCoreActionController()->activateLoopMode( false, false );
+	pHydrogen->getCoreActionController()->activateLoopMode( false );
 }		
 
 void TransportTest::testSongSizeChangeInLoopMode() {


### PR DESCRIPTION
Some more stuff to tick off the TODO list. 

- CLI: fix export 

   Due to changes in the event handling exporting a song via `h2cli` did work but the process was unable to terminate and caught in an endless loop. Destroying the EventQueue after the Hydrogen class instance resovled the issue.
- CLI: The playlist was still alive after exporting a song
- InstrumentEditor: the maximum value of the MIDI out spin box was set to 16 while only values up to 15 are supported
- Event handling: Updating of the GUI on setting a different song solely on updateSongEvent instead of a bunch of individual events.

   All buttons in the PlayerControl are now properly initialized and its event handling was refined as well as some logic moved to the core.
- Filesystem: suppress spurious error msg

   check_usr_paths does check whether the file corresponding to the current empty file name does exist. And it is expected to fail. Thus, it should not log an error message if everything works as expected.
- Fix song modified handling

   Previously a freshly opened song was marked modified right away. This has been fixed by ensuring the isModified flag is only set on user interactions. Missing flag placement has been added.

   The state the isModified handling is in right now is not ideal though. It also marks the song modified when changing the state of a variable that is stored in the Preferences and not in the Song. But I think it would only lead to missing flags in future release and to a less intuitive UX if we would remove all flags for these widgets.
- Button: Warning icons were introduced in Hydrogen as buttons with a warning icon. Previously, some of them had their background color fine tuned to match the background color of the surroundings while others were not integrated at all. Now, a new type Button::Type::Icon has been introduced, which will feature no border and a transparent background. As a result just the icon is shown.