### PR TITLE
Further small bug fixes and tweaks

### DIFF
--- a/data/drumkits/GMRockKit/drumkit.xml
+++ b/data/drumkits/GMRockKit/drumkit.xml
@@ -61,7 +61,7 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Kick-Soft.wav</filename>
      <min>0.202899</min>
-     <max>0.376812</max>
+     <max>0.369565</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -81,7 +81,7 @@ p, li { white-space: pre-wrap; }
     </layer>
     <layer>
      <filename>Kick-Hardest.wav</filename>
-     <min>0.855072</min>
+     <min>0.865942</min>
      <max>1</max>
      <gain>1</gain>
      <pitch>0</pitch>
@@ -124,14 +124,14 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>SideStick-Softest.wav</filename>
      <min>0</min>
-     <max>0.181159</max>
+     <max>0.188406</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>SideStick-Soft.wav</filename>
      <min>0.188406</min>
-     <max>0.398551</max>
+     <max>0.402174</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -151,7 +151,7 @@ p, li { white-space: pre-wrap; }
     </layer>
     <layer>
      <filename>SideStick-Hardest.wav</filename>
-     <min>0.768116</min>
+     <min>0.782609</min>
      <max>1</max>
      <gain>1</gain>
      <pitch>0</pitch>
@@ -194,21 +194,21 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Snare-Softest.wav</filename>
      <min>0</min>
-     <max>0.206522</max>
+     <max>0.202899</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Snare-Soft.wav</filename>
      <min>0.202899</min>
-     <max>0.380435</max>
+     <max>0.376812</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Snare-Med.wav</filename>
      <min>0.376812</min>
-     <max>0.572464</max>
+     <max>0.568841</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -306,28 +306,28 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>SnareRimshot-Softest.wav</filename>
      <min>0</min>
-     <max>0.192029</max>
+     <max>0.188406</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>SnareRimshot-Soft.wav</filename>
      <min>0.188406</min>
-     <max>0.387681</max>
+     <max>0.380435</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>SnareRimshot-Med.wav</filename>
      <min>0.380435</min>
-     <max>0.597826</max>
+     <max>0.594203</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>SnareRimshot-Hard.wav</filename>
      <min>0.594203</min>
-     <max>0.731884</max>
+     <max>0.728261</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -383,7 +383,7 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>TomFloor-Soft.wav</filename>
      <min>0.199275</min>
-     <max>0.391304</max>
+     <max>0.394928</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -453,14 +453,14 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>HatClosed-Soft.wav</filename>
      <min>0.173913</min>
-     <max>0.376812</max>
+     <max>0.373188</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatClosed-Med.wav</filename>
      <min>0.373188</min>
-     <max>0.572464</max>
+     <max>0.576087</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -523,21 +523,21 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Tom2-Soft.wav</filename>
      <min>0.177536</min>
-     <max>0.376812</max>
+     <max>0.373188</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Tom2-Med.wav</filename>
      <min>0.373188</min>
-     <max>0.572464</max>
+     <max>0.576087</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Tom2-Hard.wav</filename>
      <min>0.576087</min>
-     <max>0.786232</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -586,28 +586,28 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>HatPedal-Softest.wav</filename>
      <min>0</min>
-     <max>0.206522</max>
+     <max>0.210145</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatPedal-Soft.wav</filename>
      <min>0.210145</min>
-     <max>0.391304</max>
+     <max>0.384058</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatPedal-Med.wav</filename>
      <min>0.384058</min>
-     <max>0.59058</max>
+     <max>0.594203</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatPedal-Hard.wav</filename>
      <min>0.594203</min>
-     <max>0.793478</max>
+     <max>0.797101</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -663,21 +663,21 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Tom1-Soft.wav</filename>
      <min>0.202899</min>
-     <max>0.398551</max>
+     <max>0.394928</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Tom1-Med.wav</filename>
      <min>0.394928</min>
-     <max>0.601449</max>
+     <max>0.605072</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Tom1-Hard.wav</filename>
      <min>0.605072</min>
-     <max>0.789855</max>
+     <max>0.786232</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -733,21 +733,21 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>HatOpen-Soft.wav</filename>
      <min>0.202899</min>
-     <max>0.394928</max>
+     <max>0.398551</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatOpen-Med.wav</filename>
      <min>0.398551</min>
-     <max>0.601449</max>
+     <max>0.605072</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatOpen-Hard.wav</filename>
      <min>0.605072</min>
-     <max>0.793478</max>
+     <max>0.797101</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -796,7 +796,7 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Cowbell-Softest.wav</filename>
      <min>0</min>
-     <max>0.199275</max>
+     <max>0.184783</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -810,14 +810,14 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Cowbell-Med.wav</filename>
      <min>0.384058</min>
-     <max>0.57971</max>
+     <max>0.576087</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Cowbell-Hard.wav</filename>
      <min>0.576087</min>
-     <max>0.778986</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -873,21 +873,21 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Ride-Soft.wav</filename>
      <min>0.195652</min>
-     <max>0.373188</max>
+     <max>0.376812</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Ride-Med.wav</filename>
      <min>0.376812</min>
-     <max>0.576087</max>
+     <max>0.572464</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Ride-Hard.wav</filename>
      <min>0.572464</min>
-     <max>0.775362</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -936,28 +936,28 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Crash-Softest.wav</filename>
      <min>0</min>
-     <max>0.195652</max>
+     <max>0.199275</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Crash-Soft.wav</filename>
      <min>0.199275</min>
-     <max>0.380435</max>
+     <max>0.384058</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Crash-Med.wav</filename>
      <min>0.384058</min>
-     <max>0.586957</max>
+     <max>0.59058</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Crash-Hard.wav</filename>
      <min>0.59058</min>
-     <max>0.782609</max>
+     <max>0.789855</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1090,14 +1090,14 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Splash-Med.wav</filename>
      <min>0.362319</min>
-     <max>0.565217</max>
+     <max>0.568841</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Splash-Hard.wav</filename>
      <min>0.568841</min>
-     <max>0.753623</max>
+     <max>0.75</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1146,7 +1146,7 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>HatSemiOpen-Softest.wav</filename>
      <min>0</min>
-     <max>0.192029</max>
+     <max>0.188406</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1160,14 +1160,14 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>HatSemiOpen-Med.wav</filename>
      <min>0.380435</min>
-     <max>0.583333</max>
+     <max>0.57971</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>HatSemiOpen-Hard.wav</filename>
      <min>0.57971</min>
-     <max>0.789855</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1216,14 +1216,14 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Bell-Softest.wav</filename>
      <min>0</min>
-     <max>0.217391</max>
+     <max>0.210145</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
     <layer>
      <filename>Bell-Soft.wav</filename>
      <min>0.210145</min>
-     <max>0.402174</max>
+     <max>0.405797</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1237,7 +1237,7 @@ p, li { white-space: pre-wrap; }
     <layer>
      <filename>Bell-Hard.wav</filename>
      <min>0.605072</min>
-     <max>0.782609</max>
+     <max>0.786232</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1768,6 +1768,21 @@ void AudioEngine::setState( AudioEngine::State state ) {
 	EventQueue::get_instance()->push_event( EVENT_STATE, static_cast<int>(state) );
 }
 
+void AudioEngine::setNextBpm( float fNextBpm ) {
+	if ( fNextBpm > MAX_BPM ) {
+		m_fNextBpm = MAX_BPM;
+		WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
+					.arg( fNextBpm ).arg( MAX_BPM ) );
+	}
+	else if ( fNextBpm < MIN_BPM ) {
+		m_fNextBpm = MIN_BPM;
+		WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
+					.arg( fNextBpm ).arg( MIN_BPM ) );
+	}
+	
+	m_fNextBpm = fNextBpm;
+}
+
 void AudioEngine::setSong( std::shared_ptr<Song> pNewSong )
 {
 	INFOLOG( QString( "Set song: %1" ).arg( pNewSong->getName() ) );

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2980,6 +2980,7 @@ bool AudioEngine::testTransportProcessing() {
 			if ( ! testCheckTransportPosition( "pattern mode" ) ) {
 				setState( AudioEngine::State::Ready );
 				unlock();
+				pCoreActionController->activateSongMode( true );
 				return bNoMismatch;
 			}
 
@@ -2991,6 +2992,7 @@ bool AudioEngine::testTransportProcessing() {
 				bNoMismatch = false;
 				setState( AudioEngine::State::Ready );
 				unlock();
+				pCoreActionController->activateSongMode( true );
 				return bNoMismatch;
 			}
 			
@@ -3006,6 +3008,7 @@ bool AudioEngine::testTransportProcessing() {
 				bNoMismatch = false;
 				setState( AudioEngine::State::Ready );
 				unlock();
+				pCoreActionController->activateSongMode( true );
 				return bNoMismatch;
 			}
 		}
@@ -3016,7 +3019,7 @@ bool AudioEngine::testTransportProcessing() {
 	setState( AudioEngine::State::Ready );
 
 	unlock();
-
+	pCoreActionController->activateSongMode( true );
 
 	return bNoMismatch;
 }

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -1106,9 +1106,6 @@ inline unsigned int AudioEngine::getAddRealtimeNoteTickPosition() const {
 inline void AudioEngine::setAddRealtimeNoteTickPosition( unsigned int tickPosition) {
 	m_nAddRealtimeNoteTickPosition = tickPosition;
 }
-inline void AudioEngine::setNextBpm( float fNextBpm ) {
-	m_fNextBpm = fNextBpm;
-}
 inline float AudioEngine::getNextBpm() const {
 	return m_fNextBpm;
 }

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -312,8 +312,10 @@ std::shared_ptr<Sample> Note::getSample( int nComponentID, int nSelectedLayer ) 
 		// causing the sampler to just skip it. Instead, we will
 		// search for the nearest sample and play this one instead.
 		if ( possibleLayersVector.size() == 0 ){
-			WARNINGLOG( QString( "Velocity did fall into a hole between the instrument layers for component [%1] of instrument [%2]." )
-						.arg( nComponentID ).arg( __instrument->get_name() ) );
+			WARNINGLOG( QString( "Velocity [%1] did fall into a hole between the instrument layers for component [%2] of instrument [%3]." )
+						.arg( __velocity )
+						.arg( nComponentID )
+						.arg( __instrument->get_name() ) );
 			
 			float shortestDistance = 1.0f;
 			int nearestLayer = -1;

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -337,7 +337,7 @@ QString Pattern::toQString( const QString& sPrefix, bool bShort ) const {
 		}
 		sOutput.append( "]" );
 		if ( __virtual_patterns.size() != 0 ) {
-			sOutput.append( QString( ", Virtual_patterns:" ) );
+			sOutput.append( ", Virtual_patterns: {" );
 		}
 		for ( auto ii : __virtual_patterns ) {
 			if ( ii != nullptr ) {
@@ -345,12 +345,15 @@ QString Pattern::toQString( const QString& sPrefix, bool bShort ) const {
 			}
 		}
 		if ( __flattened_virtual_patterns.size() != 0 ) {
-			sOutput.append( QString( ", Flattened_virtual_patterns:" ) );
+			sOutput.append( "}, Flattened_virtual_patterns: {" );
 		}
 		for ( auto ii : __flattened_virtual_patterns ) {
 			if ( ii != nullptr ) {
 				sOutput.append( QString( "%1" ).arg( ii->toQString( sPrefix + s + s, bShort ) ) );
 			}
+		}
+		if ( __flattened_virtual_patterns.size() != 0 ) {
+			sOutput.append( "}" );
 		}
 	}	
 	return sOutput;

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -65,6 +65,30 @@ void PatternList::add( Pattern* pPattern )
 		INFOLOG( "Provided pattern is already contained" );
 		return;
 	}
+	else {
+		// Check whether the pattern is contained as a virtual
+		// pattern.
+		for ( const auto& ppPattern : __patterns ) {
+			auto pVirtualPatterns = ppPattern->get_virtual_patterns();
+			if ( pVirtualPatterns->find( pPattern ) != pVirtualPatterns->end() ) {
+				INFOLOG( "Provided pattern is already contained as virtual pattern" );
+				return;
+			}
+		}
+	}
+
+	// In case the added pattern is a virtual one, deactivate the
+	// individual patterns it encompasses in case one of them was
+	// already activated. (They will be only activated as virtual
+	// patterns from here on).
+	auto pVirtualPatterns = pPattern->get_virtual_patterns();
+	for ( int ii = __patterns.size() - 1; ii >= 0 && ii < __patterns.size(); --ii ) {
+		auto ppPattern = __patterns[ ii ];
+		if ( pVirtualPatterns->find( ppPattern ) != pVirtualPatterns->end() ) {
+			del( ii );
+		}
+	}
+	
 	__patterns.push_back( pPattern );
 }
 
@@ -277,10 +301,9 @@ QString PatternList::toQString( const QString& sPrefix, bool bShort ) const {
 		sOutput = QString( "[PatternList] " );
 		for ( auto pp : __patterns ) {
 			if ( pp != nullptr ) {
-				sOutput.append( QString( "[%1] " ).arg( pp->toQString( sPrefix + s, bShort ) ) );
+				sOutput.append( QString( "[%1] " ).arg( pp->get_name() ) );
 			}
 		}
-		sOutput.append( "]" );
 	}
 	
 	return sOutput;

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1494,7 +1494,7 @@ bool CoreActionController::toggleGridCell( int nColumn, int nRow ){
 	
 	// Update the SongEditor.
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
-		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG_EDITOR, 0 );
+		EventQueue::get_instance()->push_event( EVENT_GRID_CELL_TOGGLED, 0 );
 	}
 
 	return true;

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -151,8 +151,7 @@ enum EventType {
 	EVENT_LOOP_MODE_ACTIVATION,
 	/** Switches between select mode (0) and draw mode (1) in the *SongEditor.*/
 	EVENT_ACTION_MODE_CHANGE,
-	/** Triggers an update of the entire SongEditor*/
-	EVENT_UPDATE_SONG_EDITOR,
+	EVENT_GRID_CELL_TOGGLED,
 	/** Triggered when transport is moved into a different column
 		(either during playback or when relocated by the user)*/
 	EVENT_COLUMN_CHANGED,

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -746,7 +746,11 @@ void Hydrogen::onTapTempoAccelEvent()
 
 	oldTimeVal = now;
 
-	if ( fInterval < 1000.0 ) {
+	// We multiply by a factor of two in order to allow for tempi
+	// smaller than the minimum one enter the calculation of the
+	// average. Else the minumum one could not be reached via tap
+	// tempo and it is clambed anyway.
+	if ( fInterval < 60000.0 * 2 / static_cast<float>(MIN_BPM) ) {
 		setTapTempo( fInterval );
 	}
 #endif

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -357,29 +357,29 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 	{
 
 		// Recording + song playback mode + actually playing
-		PatternList *pPatternList = pSong->getPatternList();
-		int ipattern = pAudioEngine->getColumn(); // current column
+		PatternList* pPatternList = pSong->getPatternList();
+		auto pColumns = pSong->getPatternGroupVector();
+		int nColumn = pAudioEngine->getColumn(); // current column
 												   // or pattern group
-		if ( ipattern < 0 || ipattern >= (int) pPatternList->size() ) {
+		if ( nColumn < 0 || nColumn >= pColumns->size() ) {
 			pAudioEngine->unlock(); // unlock the audio engine
 			ERRORLOG( QString( "Provided column [%1] out of bound [%2,%3)" )
-					  .arg( ipattern ).arg( 0 )
-					  .arg( (int) pPatternList->size() ) );
+					  .arg( nColumn ).arg( 0 )
+					  .arg( pColumns->size() ) );
 			return;
 		}
-		// Locate nTickInPattern -- may need to jump back in the pattern list
+		// Locate nTickInPattern -- may need to jump back one column
 		nTickInPattern = pAudioEngine->getPatternTickPosition();
 		while ( nTickInPattern < nLookaheadTicks ) {
-			ipattern -= 1;
-			if ( ipattern < 0 || ipattern >= (int) pPatternList->size() ) {
+			nColumn -= 1;
+			if ( nColumn < 0 || nColumn >= pColumns->size() ) {
 				pAudioEngine->unlock(); // unlock the audio engine
 				ERRORLOG( "Unable to locate tick in pattern" );
 				return;
 			}
 
-			// Convert from playlist index to actual pattern index
-			std::vector<PatternList*> *pColumns = pSong->getPatternGroupVector();
-			PatternList *pColumn = ( *pColumns )[ ipattern ];
+			// Capture new notes in the bottom-most pattern.
+			PatternList *pColumn = ( *pColumns )[ nColumn ];
 			currentPatternNumber = -1;
 			for ( int n = 0; n < pColumn->size(); n++ ) {
 				Pattern *pPattern = pColumn->get( n );
@@ -389,17 +389,13 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 					currentPattern = pPattern;
 				}
 			}
-			nTickInPattern += (*pColumns)[ipattern]->longest_pattern_length();
-			// WARNINGLOG( "Undoing lookahead: corrected (" + to_string( ipattern+1 ) +
-			// "," + to_string( (int) ( nTickInPattern - currentPattern->get_length() ) -
-			// (int) lookaheadTicks ) + ") -> (" + to_string(ipattern) +
-			// "," + to_string( (int) nTickInPattern - (int) lookaheadTicks ) + ")." );
+			nTickInPattern += (*pColumns)[nColumn]->longest_pattern_length();
 		}
 		nTickInPattern -= nLookaheadTicks;
-		// Convert from playlist index to actual pattern index (if not already done above)
+		
+		// Capture new notes in the bottom-most pattern (if not already done above)
 		if ( currentPattern == nullptr ) {
-			std::vector<PatternList*> *pColumns = pSong->getPatternGroupVector();
-			PatternList *pColumn = ( *pColumns )[ ipattern ];
+			PatternList *pColumn = ( *pColumns )[ nColumn ];
 			currentPatternNumber = -1;
 			for ( int n = 0; n < pColumn->size(); n++ ) {
 				Pattern *pPattern = pColumn->get( n );
@@ -412,7 +408,7 @@ void Hydrogen::addRealtimeNote(	int		instrument,
 		}
 
 		// Cancel recording if punch area disagrees
-		doRecord = pPreferences->inPunchArea( ipattern );
+		doRecord = pPreferences->inPunchArea( nColumn );
 
 	} else { // Not song-record mode
 		PatternList *pPatternList = pSong->getPatternList();

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -56,7 +56,7 @@ class EventListener
 		virtual void loopModeActivationEvent(){}
 		virtual void updatePreferencesEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void actionModeChangeEvent( int nValue ){ UNUSED( nValue ); }
-    	virtual void updateSongEditorEvent( int nValue ){ UNUSED( nValue ); }
+    	virtual void gridCellToggledEvent(){}
 	virtual void drumkitLoadedEvent(){}
 	virtual void patternEditorLockedEvent( int nValue ){ UNUSED( nValue ); }
 	virtual void relocationEvent(){}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -833,8 +833,8 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->actionModeChangeEvent( event.value );
 				break;
 
-			case EVENT_UPDATE_SONG_EDITOR:
-				pListener->updateSongEditorEvent( event.value );
+			case EVENT_GRID_CELL_TOGGLED:
+				pListener->gridCellToggledEvent();
 				break;
 
 			case EVENT_DRUMKIT_LOADED:

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -208,6 +208,8 @@ PlayerControl::PlayerControl(QWidget *parent)
 		m_pPatternModeBtn->setChecked( true );
 		m_pSongModeLED->setActivated( false );
 		m_pPatternModeLED->setActivated( true );
+
+		m_pSongLoopBtn->setIsActive( false );
 	}
 	
 
@@ -697,6 +699,9 @@ void PlayerControl::songModeActivationEvent()
 		m_pSongModeLED->setActivated( true );
 		m_pSongModeBtn->setChecked( true );
 		m_pPatternModeBtn->setChecked( false );
+
+		m_pSongLoopBtn->setIsActive( true );
+		
 		pHydrogenApp->setStatusBarMessage(tr("Song mode selected."), 5000);
 	} else {
 		// Pattern mode
@@ -704,6 +709,8 @@ void PlayerControl::songModeActivationEvent()
 		m_pSongModeLED->setActivated( false );
 		m_pSongModeBtn->setChecked( false );
 		m_pPatternModeBtn->setChecked( true );
+
+		m_pSongLoopBtn->setIsActive( false );
 		
 		pHydrogenApp->setStatusBarMessage(tr("Pattern mode selected."), 5000);
 	}

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -1094,11 +1094,8 @@ void SongEditorPanel::setTimelineEnabled( bool bEnabled ) {
 	HydrogenApp::get_instance()->setStatusBarMessage( sMessage, 5000);
 }
 
-void SongEditorPanel::updateSongEditorEvent( int nValue ) {
-	// A new song got loaded
-	if ( nValue == 0 ) {
-		updateAll();
-	}
+void SongEditorPanel::gridCellToggledEvent() {
+	updateAll();
 }
 
 void SongEditorPanel::patternChangedEvent() {

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -93,9 +93,9 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		 *
 		 * \param nValue 0 - select mode and 1 - draw mode.
 		 */
-		void actionModeChangeEvent( int nValue ) override;
-		void updateSongEditorEvent( int nValue ) override;
-	void patternModifiedEvent() override;
+		virtual void actionModeChangeEvent( int nValue ) override;
+		virtual void gridCellToggledEvent() override;
+	virtual void patternModifiedEvent() override;
 
 		virtual void jackTimebaseStateChangedEvent() override;
 

--- a/src/tests/data/song/AE_songSizeChanged.h2song
+++ b/src/tests/data/song/AE_songSizeChanged.h2song
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <song>
- <version>1.1.1-'6d238646'</version>
+ <version>1.1.1-'dc98157c'</version>
  <bpm>100</bpm>
  <volume>0.73</volume>
  <metronomeVolume>0.5</metronomeVolume>
@@ -14,6 +14,7 @@
  <playbackTrackEnabled>false</playbackTrackEnabled>
  <playbackTrackVolume>0</playbackTrackVolume>
  <action_mode>0</action_mode>
+ <isPatternEditorLocked>false</isPatternEditorLocked>
  <isTimelineActivated>true</isTimelineActivated>
  <mode>song</mode>
  <pan_law_type>RATIO_STRAIGHT_POLYGONAL</pan_law_type>
@@ -94,7 +95,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.202899</min>
-     <max>0.376812</max>
+     <max>0.369565</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -144,7 +145,7 @@
      <rubberdivider>1</rubberdivider>
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
-     <min>0.855072</min>
+     <min>0.865942</min>
      <max>1</max>
      <gain>1</gain>
      <pitch>0</pitch>
@@ -172,7 +173,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>999</Release>
+   <Release>1000</Release>
    <pitchOffset>0</pitchOffset>
    <randomPitchFactor>0</randomPitchFactor>
    <muteGroup>-1</muteGroup>
@@ -199,7 +200,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.181159</max>
+     <max>0.188406</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -216,7 +217,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.188406</min>
-     <max>0.398551</max>
+     <max>0.402174</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -266,7 +267,7 @@
      <rubberdivider>1</rubberdivider>
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
-     <min>0.768116</min>
+     <min>0.782609</min>
      <max>1</max>
      <gain>1</gain>
      <pitch>0</pitch>
@@ -321,7 +322,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.206522</max>
+     <max>0.202899</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -338,7 +339,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.202899</min>
-     <max>0.380435</max>
+     <max>0.376812</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -355,7 +356,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.376812</min>
-     <max>0.572464</max>
+     <max>0.568841</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -416,7 +417,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>999</Release>
+   <Release>1000</Release>
    <pitchOffset>0</pitchOffset>
    <randomPitchFactor>0</randomPitchFactor>
    <muteGroup>-1</muteGroup>
@@ -497,7 +498,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.192029</max>
+     <max>0.188406</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -514,7 +515,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.188406</min>
-     <max>0.387681</max>
+     <max>0.380435</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -531,7 +532,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.380435</min>
-     <max>0.597826</max>
+     <max>0.594203</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -548,7 +549,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.594203</min>
-     <max>0.731884</max>
+     <max>0.728261</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -636,7 +637,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.199275</min>
-     <max>0.391304</max>
+     <max>0.394928</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -758,7 +759,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.173913</min>
-     <max>0.376812</max>
+     <max>0.373188</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -775,7 +776,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.373188</min>
-     <max>0.572464</max>
+     <max>0.576087</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -880,7 +881,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.177536</min>
-     <max>0.376812</max>
+     <max>0.373188</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -897,7 +898,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.373188</min>
-     <max>0.572464</max>
+     <max>0.576087</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -914,7 +915,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.576087</min>
-     <max>0.786232</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -985,7 +986,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.206522</max>
+     <max>0.210145</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1002,7 +1003,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.210145</min>
-     <max>0.391304</max>
+     <max>0.384058</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1019,7 +1020,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.384058</min>
-     <max>0.59058</max>
+     <max>0.594203</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1036,7 +1037,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.594203</min>
-     <max>0.793478</max>
+     <max>0.797101</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1124,7 +1125,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.202899</min>
-     <max>0.398551</max>
+     <max>0.394928</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1141,7 +1142,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.394928</min>
-     <max>0.601449</max>
+     <max>0.605072</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1158,7 +1159,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.605072</min>
-     <max>0.789855</max>
+     <max>0.786232</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1246,7 +1247,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.202899</min>
-     <max>0.394928</max>
+     <max>0.398551</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1263,7 +1264,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.398551</min>
-     <max>0.601449</max>
+     <max>0.605072</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1280,7 +1281,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.605072</min>
-     <max>0.793478</max>
+     <max>0.797101</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1351,7 +1352,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.199275</max>
+     <max>0.184783</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1385,7 +1386,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.384058</min>
-     <max>0.57971</max>
+     <max>0.576087</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1402,7 +1403,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.576087</min>
-     <max>0.778986</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1490,7 +1491,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.195652</min>
-     <max>0.373188</max>
+     <max>0.376812</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1507,7 +1508,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.376812</min>
-     <max>0.576087</max>
+     <max>0.572464</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1524,7 +1525,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.572464</min>
-     <max>0.775362</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1595,7 +1596,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.195652</max>
+     <max>0.199275</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1612,7 +1613,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.199275</min>
-     <max>0.380435</max>
+     <max>0.384058</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1629,7 +1630,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.384058</min>
-     <max>0.586957</max>
+     <max>0.59058</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1646,7 +1647,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.59058</min>
-     <max>0.782609</max>
+     <max>0.789855</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1812,7 +1813,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>999</Release>
+   <Release>1000</Release>
    <pitchOffset>0</pitchOffset>
    <randomPitchFactor>0</randomPitchFactor>
    <muteGroup>-1</muteGroup>
@@ -1873,7 +1874,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.362319</min>
-     <max>0.565217</max>
+     <max>0.568841</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1890,7 +1891,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.568841</min>
-     <max>0.753623</max>
+     <max>0.75</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1961,7 +1962,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.192029</max>
+     <max>0.188406</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -1995,7 +1996,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.380435</min>
-     <max>0.583333</max>
+     <max>0.57971</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -2012,7 +2013,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.57971</min>
-     <max>0.789855</max>
+     <max>0.782609</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -2056,7 +2057,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>999</Release>
+   <Release>1000</Release>
    <pitchOffset>0</pitchOffset>
    <randomPitchFactor>0</randomPitchFactor>
    <muteGroup>-1</muteGroup>
@@ -2083,7 +2084,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0</min>
-     <max>0.217391</max>
+     <max>0.210145</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -2100,7 +2101,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.210145</min>
-     <max>0.402174</max>
+     <max>0.405797</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>
@@ -2134,7 +2135,7 @@
      <rubberCsettings>4</rubberCsettings>
      <rubberPitch>1</rubberPitch>
      <min>0.605072</min>
-     <max>0.782609</max>
+     <max>0.786232</max>
      <gain>1</gain>
      <pitch>0</pitch>
     </layer>


### PR DESCRIPTION
- Because of a bug introduced recently note recording was only possible in the first couple of patterns
- UPDATE_SONG_EDITOR_EVENT was renamed to GRID_CELL_TOGGLED_EVENT  in order to use the description of the event itself instead of what it is intended to do for its name
- The button used for loop transport is now deactivated once pattern mode is selected. In pattern mode transport is always looped and it might be confusing if the button is still usable but does not affect transport. (Fixes #1522)
- Now that #1521 is fixed we can also test the note enqueuing in the Sampler
- Previously, tempo could only be set as low as 60 bpm using the Tap Tempo feature. Now, the whole possible range of BPM is supported
- There were both tiny holes and overlaps between the layers of the GMRockKit. Since both of them were present and considering their small sizes I guess they were not introduced on purpose. I have aligned the layers the Sampler is less efficient in case a note is falling in such a hole.
- When activating a pattern/adding it to a pattern list it is now checked whether the pattern was already present as part of a virtual one. If so, it will not be activated. In the same vain all individual activations will be removed if a virtual pattern is added that contains the already activated patterns. (Fixes #1527)