### PR TITLE
Fail gracefully on missing playback track

### DIFF
--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1031,6 +1031,14 @@ std::shared_ptr<Song> SongReader::readSong( const QString& sFileName )
 	bool bPlaybackTrackEnabled = LocalFileMng::readXmlBool( songNode, "playbackTrackEnabled", false );
 	float fPlaybackTrackVolume = LocalFileMng::readXmlFloat( songNode, "playbackTrackVolume", 0.0 );
 
+	// Check the file of the playback track and resort to the default
+	// in case the file can not be found.
+	if ( ! Filesystem::file_exists( sPlaybackTrack, true ) ) {
+		ERRORLOG( QString( "Provided playback track file [%1] does not exist. Using empty string instead" )
+				  .arg( sPlaybackTrack ) );
+		sPlaybackTrack = "";
+	}
+
 	Song::ActionMode actionMode = static_cast<Song::ActionMode>( LocalFileMng::readXmlInt( songNode, "action_mode",
 																						   static_cast<int>( Song::ActionMode::selectMode ) ) );
 	bool bIsPatternEditorLocked = LocalFileMng::readXmlBool( songNode, "isPatternEditorLocked", false );

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -125,9 +125,23 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		 * will be played back.*/
 		Selected = 1,
 		/** Null element used to indicate that either no song is
-		 * present to Song::Mode::Song was selected
+		 * present or Song::Mode::Song was selected
 		 */
 		None = 2
+	};
+
+	/** Determines the state of the Playback track with respect to
+		audio processing*/
+	enum class PlaybackTrack {
+		/** No proper playback track file set yet*/
+		Unavailable = 0,
+		/** Valid file set but the playback track is muted via the GUI*/
+		Muted = 1,
+		/** Valid file set and ready for playback.*/
+		Enabled = 2,
+		/** Null element used to indicate that either no song is
+		 * present*/
+		None = 3
 	};
 
 		Song( const QString& sName, const QString& sAuthor, float fBpm, float fVolume );
@@ -243,17 +257,17 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		bool			getPlaybackTrackEnabled() const;
 		/** Specifies whether a playback track should be used.
 		 *
-		 * If #m_sPlaybackTrackFilename is set to nullptr,
-		 * #m_bPlaybackTrackEnabled will be set to false
-		 * regardless of the choice in @a bEnabled.
-		 *
 		 * \param bEnabled Sets #m_bPlaybackTrackEnabled. */
-		bool			setPlaybackTrackEnabled( const bool bEnabled );
+		void			setPlaybackTrackEnabled( const bool bEnabled );
 							
 		/** \return #m_fPlaybackTrackVolume */
 		float			getPlaybackTrackVolume() const;
 		/** \param fVolume Sets #m_fPlaybackTrackVolume. */
 		void			setPlaybackTrackVolume( const float fVolume );
+
+	PlaybackTrack getPlaybackTrackState() const;
+
+	
 		ActionMode		getActionMode() const;
 		void			setActionMode( const ActionMode actionMode );
 
@@ -653,13 +667,9 @@ inline bool Song::getPlaybackTrackEnabled() const
 	return m_bPlaybackTrackEnabled;
 }
 
-inline bool Song::setPlaybackTrackEnabled( const bool bEnabled )
+inline void Song::setPlaybackTrackEnabled( const bool bEnabled )
 {
-	if ( m_sPlaybackTrackFilename == nullptr ) {
-		return false;
-	}
 	m_bPlaybackTrackEnabled = bEnabled;
-	return bEnabled;
 }
 
 inline float Song::getPlaybackTrackVolume() const
@@ -670,6 +680,17 @@ inline float Song::getPlaybackTrackVolume() const
 inline void Song::setPlaybackTrackVolume( const float fVolume )
 {
 	m_fPlaybackTrackVolume = fVolume;
+}
+inline Song::PlaybackTrack Song::getPlaybackTrackState() const {
+	if ( m_sPlaybackTrackFilename.isEmpty() ) {
+		return PlaybackTrack::Unavailable;
+	}
+
+	if ( ! m_bPlaybackTrackEnabled ) {
+		return PlaybackTrack::Muted;
+	}
+
+	return PlaybackTrack::Enabled;
 }
 
 inline Song::ActionMode Song::getActionMode() const {

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -166,7 +166,8 @@ enum EventType {
 	 */
 	EVENT_RELOCATION,
 	EVENT_SONG_SIZE_CHANGED,
-	EVENT_DRIVER_CHANGED
+	EVENT_DRIVER_CHANGED,
+	EVENT_PLAYBACK_TRACK_CHANGED
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -229,22 +229,52 @@ void Hydrogen::sequencer_stop()
 	__kill_instruments();
 }
 
-bool Hydrogen::setPlaybackTrackState( const bool state )
-{
-	std::shared_ptr<Song> pSong = getSong();
-	if ( pSong == nullptr ) {
-		return false;
+Song::PlaybackTrack Hydrogen::getPlaybackTrackState() const {
+
+	if ( __song == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return Song::PlaybackTrack::None;
 	}
 
-	return pSong->setPlaybackTrackEnabled(state);
+	return __song->getPlaybackTrackState();
+}
+	
+void Hydrogen::mutePlaybackTrack( const bool bMuted )
+{
+	if ( __song == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
+
+	__song->setPlaybackTrackEnabled( bMuted );
+
+	EventQueue::get_instance()->push_event( EVENT_PLAYBACK_TRACK_CHANGED, 0 );
 }
 
-void Hydrogen::loadPlaybackTrack( const QString filename )
+void Hydrogen::loadPlaybackTrack( QString sFilename )
 {
-	std::shared_ptr<Song> pSong = getSong();
-	pSong->setPlaybackTrackFilename(filename);
+	if ( __song == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
+
+	if ( ! sFilename.isEmpty() &&
+		 ! Filesystem::file_exists( sFilename, true ) ) {
+		ERRORLOG( QString( "Invalid playback track filename [%1]. File does not exist." )
+				  .arg( sFilename ) );
+		sFilename = "";
+	}
+
+	if ( sFilename.isEmpty() ) {
+		INFOLOG( "Disable playback track" );
+		__song->setPlaybackTrackEnabled( false );
+	}
+	
+	__song->setPlaybackTrackFilename( sFilename );
 
 	m_pAudioEngine->getSampler()->reinitializePlaybackTrack();
+	
+	EventQueue::get_instance()->push_event( EVENT_PLAYBACK_TRACK_CHANGED, 0 );
 }
 
 void Hydrogen::setSong( std::shared_ptr<Song> pSong )

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -313,7 +313,8 @@ void			previewSample( Sample *pSample );
 		 * Unable to start the OSC server with the given
 		 * port number. 
 		 */
-		OSC_CANNOT_CONNECT_TO_PORT
+		OSC_CANNOT_CONNECT_TO_PORT,
+		PLAYBACK_TRACK_INVALID
 	};
 
 	void			onTapTempoAccelEvent();
@@ -392,33 +393,17 @@ void			previewSample( Sample *pSample );
 	/********************** Playback track **********************/
 	/**
 	 * Wrapper around Song::setPlaybackTrackEnabled().
-	 *
-	 * \param state Whether the playback track is enabled. It will
-	 * be replaced by false, if no Song was selected (getSong()
-	 * return nullptr).
 	 */
-	bool			setPlaybackTrackState( const bool state );
+	void			mutePlaybackTrack( const bool bMuted );
 	/**
-	 * Wrapper around Song::getPlaybackTrackEnabled().
-	 *
-	 * \return Whether the playback track is enabled or false, if
-	 * no Song was selected (getSong() return nullptr).
+	 * Wrapper around Song::getPlaybackTrackState().
 	 */
-	bool			getPlaybackTrackState() const;
+	Song::PlaybackTrack		getPlaybackTrackState() const;
 	/**
 	 * Wrapper function for loading the playback track.
-	 *
-	 * Calls Song::setPlaybackTrackFilename() and
-	 * Sampler::reinitialize_playback_track(). While the former
-	 * one is responsible to store metadata about the playback
-	 * track, the latter one does load it to a new
-	 * InstrumentLayer. The function is called by
-	 * SongEditorPanel::editPlaybackTrackBtnPressed()
-	 *
-	 * \param filename Name of the file to load as the playback
-	 * track
 	 */
-	void			loadPlaybackTrack( const QString filename );
+	void			loadPlaybackTrack( QString sFilename );
+	/************************************************************/
 
 	/** Specifies the state of the Qt GUI*/
 	enum class		GUIState {
@@ -636,19 +621,6 @@ inline bool Hydrogen::getIsExportSessionActive() const
 
 inline AudioEngine* Hydrogen::getAudioEngine() const {
 	return m_pAudioEngine;
-}
-
-inline bool Hydrogen::getPlaybackTrackState() const
-{
-	std::shared_ptr<Song> pSong = getSong();
-	bool  bState;
-
-	if(!pSong){
-		bState = false;
-	} else {
-		bState = pSong->getPlaybackTrackEnabled();
-	}
-	return 	bState;
 }
 
 inline Hydrogen::GUIState Hydrogen::getGUIState() const {

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -698,19 +698,30 @@ bool Sampler::processPlaybackTrack(int nBufferSize)
 	auto pAudioEngine = Hydrogen::get_instance()->getAudioEngine();
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return true;
+	}
 
-	if ( !pSong->getPlaybackTrackEnabled() ||
+	if ( pHydrogen->getPlaybackTrackState() != Song::PlaybackTrack::Enabled ||
 		 ( pAudioEngine->getState() != AudioEngine::State::Playing ||
 		   pAudioEngine->getState() == AudioEngine::State::Testing ) ||
-		 pHydrogen->getMode() != Song::Mode::Song )
-	{
-		return false;
+		 pHydrogen->getMode() != Song::Mode::Song ) {
+		return true;
 	}
 
 	auto pCompo = m_pPlaybackTrackInstrument->get_components()->front();
 	auto pSample = pCompo->get_layer(0)->get_sample();
 
-	assert(pSample);
+	if ( pSample == nullptr ) {
+		ERRORLOG( "Unable to process playback track" );
+		EventQueue::get_instance()->push_event( EVENT_ERROR,
+												Hydrogen::ErrorMessages::PLAYBACK_TRACK_INVALID );
+		// Disable the playback track
+		pHydrogen->loadPlaybackTrack( "" );
+		reinitializePlaybackTrack();
+		return true;
+	}
 
 	float fVal_L;
 	float fVal_R;
@@ -1487,10 +1498,15 @@ bool Sampler::isInstrumentPlaying( std::shared_ptr<Instrument> instrument )
 void Sampler::reinitializePlaybackTrack()
 {
 	Hydrogen*	pHydrogen = Hydrogen::get_instance();
-	std::shared_ptr<Song> 		pSong = pHydrogen->getSong();
+	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	std::shared_ptr<Sample>	pSample;
 
-	if(!pSong->getPlaybackTrackFilename().isEmpty()){
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
+
+	if( pHydrogen->getPlaybackTrackState() != Song::PlaybackTrack::Unavailable ){
 		pSample = Sample::load( pSong->getPlaybackTrackFilename() );
 	}
 	

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -62,6 +62,7 @@ class EventListener
 	virtual void relocationEvent(){}
 	virtual void songSizeChangedEvent(){}
 	virtual void driverChangedEvent(){}
+	virtual void playbackTrackChangedEvent(){}
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -857,6 +857,10 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->driverChangedEvent();
 				break;
 
+			case EVENT_PLAYBACK_TRACK_CHANGED:
+				pListener->playbackTrackChangedEvent();
+				break;
+
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1958,6 +1958,10 @@ void MainForm::errorEvent( int nErrorCode )
 		msg = QString( tr( "OSC Server: Cannot connect to given port, using port %1 instead" ) ).arg( Preferences::get_instance()->m_nOscTemporaryPort );
 		break;
 
+	case Hydrogen::PLAYBACK_TRACK_INVALID:
+		msg = tr( "Playback track couldn't be read" );
+		break;
+
 	default:
 		msg = QString( tr( "Unknown error %1" ) ).arg( nErrorCode );
 	}

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -64,6 +64,8 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	Hydrogen*	pHydrogen = Hydrogen::get_instance();
 	std::shared_ptr<Song> 		pSong = pHydrogen->getSong();
 
+	assert( pSong );
+
 	setWindowTitle( tr( "Song Editor" ) );
 
 	// background
@@ -213,14 +215,13 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	m_pViewPlaybackBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Toggle, "", pCommonStrings->getPlaybackTrackButton(), false, QSize(), tr( "View playback track" ) );
 	m_pViewPlaybackBtn->setObjectName( "ViewPlaybackBtn" );
 	connect( m_pViewPlaybackBtn, SIGNAL( pressed() ), this, SLOT( viewPlaybackTrackBtnPressed() ) );
-	m_pViewPlaybackBtn->setChecked( false );
+	m_pViewPlaybackBtn->setChecked( pPref->getShowPlaybackTrack() );
 	
 	// Playback Fader
 	m_pPlaybackTrackFader = new Fader( pBackPanel, Fader::Type::Vertical, tr( "Playback track volume" ), false, false, 0.0, 1.5 );
 	m_pPlaybackTrackFader->move( 6, 1 );
 	m_pPlaybackTrackFader->setValue( pSong->getPlaybackTrackVolume() );
 	m_pPlaybackTrackFader->hide();
-	m_pPlaybackTrackFader->setIsActive( ! H2Core::Hydrogen::get_instance()->getSong()->getPlaybackTrackFilename().isEmpty() );
 	connect( m_pPlaybackTrackFader, SIGNAL( valueChanged( WidgetWithInput* ) ), this, SLOT( faderChanged( WidgetWithInput* ) ) );
 
 	// mute playback track toggle button
@@ -231,9 +232,17 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 									 false, true );
 	m_pMutePlaybackBtn->move( 158, 4 );
 	m_pMutePlaybackBtn->hide();
-	m_pMutePlaybackBtn->setChecked( pHydrogen->getPlaybackTrackState() );
-	connect( m_pMutePlaybackBtn, SIGNAL( pressed() ), this, SLOT( mutePlaybackTrackBtnPressed() ) );
-	m_pMutePlaybackBtn->setChecked( !pSong->getPlaybackTrackEnabled() );
+	connect( m_pMutePlaybackBtn, &QPushButton::clicked, [=](bool bChecked){
+		Hydrogen::get_instance()->mutePlaybackTrack( ! bChecked );
+	});
+
+	if ( pHydrogen->getPlaybackTrackState() == Song::PlaybackTrack::Unavailable ) {
+		m_pPlaybackTrackFader->setIsActive( false );
+		m_pMutePlaybackBtn->setChecked( true );
+		m_pMutePlaybackBtn->setIsActive( false );
+	} else {
+		m_pMutePlaybackBtn->setChecked( ! pSong->getPlaybackTrackEnabled() );
+	}
 	
 	// edit playback track toggle button
 	m_pEditPlaybackBtn = new Button( pBackPanel, QSize( 34, 17 ), Button::Type::Push, "", pCommonStrings->getEditButton(), false, QSize(), tr( "Choose playback track") );
@@ -245,7 +254,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	// timeline view toggle button
 	m_pViewTimelineBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Toggle, "", pCommonStrings->getTimelineButton(), false, QSize(), tr( "View timeline" ) );
 	connect( m_pViewTimelineBtn, SIGNAL( pressed() ), this, SLOT( viewTimelineBtnPressed() ) );
-	m_pViewTimelineBtn->setChecked( true );
+	m_pViewTimelineBtn->setChecked( ! pPref->getShowPlaybackTrack() );
 	
 	
 	QHBoxLayout *pHZoomLayout = new QHBoxLayout();
@@ -546,15 +555,40 @@ void SongEditorPanel::patternModifiedEvent() {
  	m_pAutomationPathView->setAutomationPath( pSong->getVelocityAutomationPath() );
 
 	resyncExternalScrollBar();
-
-	m_pPlaybackTrackFader->setIsActive( ! pSong->getPlaybackTrackFilename().isEmpty() );
 }
 
 void SongEditorPanel::updatePlaybackTrackIfNecessary()
 {
-	if( Preferences::get_instance()->getShowPlaybackTrack() ) {
-		auto pCompo = Hydrogen::get_instance()->getAudioEngine()->getSampler()->getPlaybackTrackInstrument()->get_components()->front();
-		m_pPlaybackTrackWaveDisplay->updateDisplay( pCompo->get_layer(0) );
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+	
+	if ( Preferences::get_instance()->getShowPlaybackTrack() &&
+		 pSong != nullptr ) {
+
+		if ( pHydrogen->getPlaybackTrackState() == Song::PlaybackTrack::Unavailable ) {
+			// No playback track chosen
+			m_pPlaybackTrackFader->setIsActive( false );
+			m_pMutePlaybackBtn->setChecked( true );
+			m_pMutePlaybackBtn->setIsActive( false );
+			
+			m_pPlaybackTrackWaveDisplay->updateDisplay( nullptr );
+		}
+		else {
+			// Playback track was selected by the user and is ready to
+			// use.
+			m_pPlaybackTrackFader->setIsActive( true );
+			m_pMutePlaybackBtn->setIsActive( true );
+			if ( pHydrogen->getPlaybackTrackState() == Song::PlaybackTrack::Muted ) {
+				m_pMutePlaybackBtn->setChecked( true );
+			} else {
+				m_pMutePlaybackBtn->setChecked( false );
+			}
+
+			auto pPlaybackCompo = pHydrogen->getAudioEngine()->getSampler()->
+				getPlaybackTrackInstrument()->get_components()->front();
+			
+			m_pPlaybackTrackWaveDisplay->updateDisplay( pPlaybackCompo->get_layer(0) );
+		}
 	}
 }
 
@@ -709,7 +743,12 @@ void SongEditorPanel::updateSongEvent( int nValue ) {
 		songModeActivationEvent();
 		timelineActivationEvent();
 		selectedPatternChangedEvent();
+		updatePlaybackTrackIfNecessary();
 	}
+}
+
+void SongEditorPanel::playbackTrackChangedEvent() {
+	updatePlaybackTrackIfNecessary();
 }
 
 void SongEditorPanel::patternEditorLockedEvent( int ) {
@@ -796,6 +835,8 @@ void SongEditorPanel::showPlaybackTrack()
 		m_pViewPlaybackBtn->setChecked( true );
 	}
 	Preferences::get_instance()->setShowPlaybackTrack( true );
+
+	updatePlaybackTrackIfNecessary();
 }
 
 void SongEditorPanel::viewTimelineBtnPressed()
@@ -814,17 +855,6 @@ void SongEditorPanel::viewPlaybackTrackBtnPressed()
 	} else {
 		showTimeline();
 	}
-}
-
-
-void SongEditorPanel::mutePlaybackTrackBtnPressed()
-{
-	Hydrogen* pHydrogen = Hydrogen::get_instance();
-
-	bool bState = ! m_pMutePlaybackBtn->isChecked();
-
-	bState = pHydrogen->setPlaybackTrackState( ! bState );
-	m_pMutePlaybackBtn->setChecked( bState );
 }
 
 void SongEditorPanel::editPlaybackTrackBtnPressed()
@@ -880,8 +910,6 @@ void SongEditorPanel::editPlaybackTrackBtnPressed()
 	}
 
 	pHydrogen->loadPlaybackTrack( filenameList[2] );
-	
-	updateAll();
 }
 
 void SongEditorPanel::stackedModeActivationEvent( int )

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -105,6 +105,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 	virtual void stackedModeActivationEvent( int ) override;
 	virtual void updateSongEvent( int ) override;
 	virtual void songModeActivationEvent() override;
+	virtual void playbackTrackChangedEvent() override;
 
 	public slots:
 		void showHideTimeline( bool bPressed ) {
@@ -129,7 +130,6 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		void timelineBtnPressed();
 		void viewTimelineBtnPressed();
 		void viewPlaybackTrackBtnPressed();
-		void mutePlaybackTrackBtnPressed();
 		void editPlaybackTrackBtnPressed();
 
 		void zoomInBtnPressed();


### PR DESCRIPTION
As a user noted in #1536 Hydrogen does crash if the filename of the playback track points to non-existing file. The changes in here do, firstly, check for the existance of the file during song load and, secondly, perform a sanity check in the Sampler and deactivate the playback track in case a invalid file did slip through. If the Sampler does encounter a non-valid Sample, it just disables the playback track and tells the GUI to pop up a error dialog and to update.

In addition, I did a little refactoring of the code in order to make the state of the playback track more clear from the perspective of the GUI (using one variable instead of juggling two).