### PR TITLE
AppVeyor [win]: lock qt5-tools-5.15.2-2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,6 +65,7 @@ environment:
       OPENSSL_DIR: OpenSSL-Win64
       LIBSSL: libssl-1_1-x64.dll
       LIBCRYPTO: libcrypto-1_1-x64.dll
+      QT_LOCK_REPO: 'mingw/x86_64/mingw-w64-x86_64'
 
       CHOCO_ARCH:
       PROGRAM_FILES: "Program Files"
@@ -80,6 +81,7 @@ environment:
       OPENSSL_DIR: OpenSSL-Win32
       LIBSSL: libssl-1_1.dll
       LIBCRYPTO: libcrypto-1_1.dll
+      QT_LOCK_REPO: 'mingw/mingw32/mingw-w64-i686'
 
       CHOCO_ARCH:  --x86
       PROGRAM_FILES: "Program Files (x86)"
@@ -289,15 +291,9 @@ for:
           g++ --version
           choco install %CHOCO_ARCH% jack --version 1.9.17 -my
 
-          dir "c:\%PROGRAM_FILES%\JACK2"
-          dir "c:\%PROGRAM_FILES%\JACK2\lib"
-
           REM *** Results are ignored since a dependency was not properly installed in 32 bit Windows. But the .dll files required are installed regardless, so we don't care.***
 
           choco install %CHOCO_ARCH% -y openssl --version=1.1.1.1300 || cmd /c "exit /b 1"
-
-          echo "C:\%OPENSSL_DIR%"
-          dir "C:\%OPENSSL_DIR%"
 
           REM *** Install dependencies ***
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libarchive
@@ -309,6 +305,7 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-qt5
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
+          c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/%QT_LOCK_REPO%-qt5-tools-5.15.2-2-any.pkg.tar.zst
 
           ccache -M 256M
           ccache -s
@@ -373,8 +370,8 @@ on_finish:
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win64.exe || cmd /c "exit /b 1"
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win32.exe || cmd /c "exit /b 1"
+  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win64.exe || cmd /c "exit /b 1"
+  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win32.exe || cmd /c "exit /b 1"
 
 
   - cmd: |


### PR DESCRIPTION
In order to circumvent #1559 the qt5-tools library is not used directly from the qt5 bundle of pacman but, instead, downgraded to version 5.15.2-2. This is only - at least hopefully - temporary measure till pacman offers a newer, working version of the package.

In addition, a bug in the artifact upload in the Windows image has been fixed.