### PR TITLE
fix #1542: notes exceeding pattern length (second attempt in GUI)

### DIFF
--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -132,11 +132,9 @@ Note::~Note()
 {
 }
 
-static inline float check_boundary( float v, float min, float max )
+static inline float check_boundary( float fValue, float fMin, float fMax )
 {
-	if ( v>max ) return max;
-	if ( v<min ) return min;
-	return v;
+	return std::clamp( fValue, fMin, fMax );
 }
 
 void Note::set_velocity( float velocity )
@@ -453,9 +451,15 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2length: %3\n" ).arg( sPrefix ).arg( s ).arg( __length ) )
 			.append( QString( "%1%2pitch: %3\n" ).arg( sPrefix ).arg( s ).arg( __pitch ) )
 			.append( QString( "%1%2key: %3\n" ).arg( sPrefix ).arg( s ).arg( __key ) )
-			.append( QString( "%1%2octave: %3\n" ).arg( sPrefix ).arg( s ).arg( __octave ) )
-			.append( QString( "%1" ).arg( __adsr->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( "%1%2lead_lag: %3\n" ).arg( sPrefix ).arg( s ).arg( __lead_lag ) )
+			.append( QString( "%1%2octave: %3\n" ).arg( sPrefix ).arg( s ).arg( __octave ) );
+		if ( __adsr != nullptr ) {
+			sOutput.append( QString( "%1" )
+							.arg( __adsr->toQString( sPrefix + s, bShort ) ) );
+		} else {
+			sOutput.append( QString( "%1%2adsr: nullptr\n" ).arg( sPrefix ).arg( s ) );
+		}
+
+		sOutput.append( QString( "%1%2lead_lag: %3\n" ).arg( sPrefix ).arg( s ).arg( __lead_lag ) )
 			.append( QString( "%1%2cut_off: %3\n" ).arg( sPrefix ).arg( s ).arg( __cut_off ) )
 			.append( QString( "%1%2resonance: %3\n" ).arg( sPrefix ).arg( s ).arg( __resonance ) )
 			.append( QString( "%1%2humanize_delay: %3\n" ).arg( sPrefix ).arg( s ).arg( __humanize_delay ) )
@@ -492,9 +496,16 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", length: %1" ).arg( __length ) )
 			.append( QString( ", pitch: %1" ).arg( __pitch ) )
 			.append( QString( ", key: %1" ).arg( __key ) )
-			.append( QString( ", octave: %1" ).arg( __octave ) )
-			.append( QString( ", [%1" ).arg( __adsr->toQString( sPrefix + s, bShort ).replace( "\n", "]" ) ) )
-			.append( QString( ", lead_lag: %1" ).arg( __lead_lag ) )
+			.append( QString( ", octave: %1" ).arg( __octave ) );
+		if ( __adsr != nullptr ) {
+			sOutput.append( QString( ", [%1" )
+							.arg( __adsr->toQString( sPrefix + s, bShort )
+								  .replace( "\n", "]" ) ) );
+		} else {
+			sOutput.append( ", adsr: nullptr" );
+		}
+
+		sOutput.append( QString( ", lead_lag: %1" ).arg( __lead_lag ) )
 			.append( QString( ", cut_off: %1" ).arg( __cut_off ) )
 			.append( QString( ", resonance: %1" ).arg( __resonance ) )
 			.append( QString( ", humanize_delay: %1" ).arg( __humanize_delay ) )

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -109,6 +109,9 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 
 		void updateEditors( bool bPatternOnly = false );
 
+	void patternSizeChangedAction( int nLength, double fDenominator,
+								   int nSelectedPatternNumber );
+
 	public slots:
 		void showDrumEditor();
 		void showPianoRollEditor();
@@ -141,6 +144,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 	void updateStyleSheet();
 	
 		H2Core::Pattern *	m_pPattern;
+	int m_nSelectedPatternNumber;
 		QPixmap				m_backgroundPixmap;
 		QLabel *			m_pSLlabel;
 

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -562,6 +562,42 @@ private:
 
 // Deselect some notes and overwrite them
 /** \ingroup docGUI*/
+class SE_patternSizeChangedAction : public QUndoCommand
+{
+public:
+	SE_patternSizeChangedAction( int nNewLength, int nOldLength,
+								 double fNewDenominator, double fOldDenominator,
+								 int nSelectedPatternNumber ) {
+		setText( QObject::tr( "Altering the length of the current pattern" ) );
+		m_nNewLength = nNewLength;
+		m_nOldLength = nOldLength;
+		m_fNewDenominator = fNewDenominator;
+		m_fOldDenominator = fOldDenominator;
+		m_nSelectedPatternNumber = nSelectedPatternNumber;
+	}
+
+	virtual void undo() {
+		HydrogenApp::get_instance()->getPatternEditorPanel()
+			->patternSizeChangedAction( m_nOldLength, m_fOldDenominator,
+										m_nSelectedPatternNumber );
+	}
+
+	virtual void redo() {
+		HydrogenApp::get_instance()->getPatternEditorPanel()
+			->patternSizeChangedAction( m_nNewLength, m_fNewDenominator,
+										m_nSelectedPatternNumber );
+	}
+
+private:
+	int m_nNewLength;
+	int m_nOldLength;
+	double m_fNewDenominator;
+	double m_fOldDenominator;
+	int m_nSelectedPatternNumber;
+};
+
+// Deselect some notes and overwrite them
+/** \ingroup docGUI*/
 class SE_deselectAndOverwriteNotesAction : public QUndoCommand
 {
 public:


### PR DESCRIPTION
Second attempt to fix https://github.com/hydrogen-music/hydrogen/issues/1542.

Changing the length of a pattern does now behave like clicking the excessive notes at the same time. The GUI takes care of removing them all and wraps it along with the actual pattern length change into an undo/redo action.

Supersedes #1551 