### PR TITLE
XSD: fix pitchOffset (releases/1.1)

### DIFF
--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -68,7 +68,7 @@
 			<xsd:element name="isSoloed"			type="h2:bool"					default="false"/>
 			<xsd:element name="pan_L"				type="h2:psfloat"				default="1.0"/>
 			<xsd:element name="pan_R"				type="h2:psfloat"				default="1.0"/>
-			<xsd:element name="pitchOffset"	type="h2:psfloat"				default="0.0"/>
+			<xsd:element name="pitchOffset"			type="xsd:float"				default="0.0"/>
 			<xsd:element name="randomPitchFactor"	type="h2:psfloat"				default="0.0"/>
 			<xsd:element name="gain"				type="xsd:float"				default="1.0"/>
 			<xsd:element name="applyVelocity"		type="h2:bool"					default="false"/>


### PR DESCRIPTION
In #1000 the `pitchOffset` variable was falsely introduced as type `h2:psfloat` - a `xsd:float` derivative with its minimum value set to 0.0 and its maximum to 1.0. But using the GUI one can set the value in the range of -24.5 till 24.5 causing all drumkits with the pitch adjusted to less than 0 or more than 1 to be invalid. The type was changed to raw `xsd:float` and the minimum and maximum values were _not_ set (as the ones used in the GUI does not seem to represent a theoretical limit).