### PR TITLE
Widgets: fix zero of WidgetWithInput

### DIFF
--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -101,7 +101,17 @@ void WidgetWithInput::setValue( float fValue, bool bTriggeredByUserInteraction )
 	
 	if ( m_bUseIntSteps ) {
 		fValue = std::round( fValue );
+	} else {
+		if ( std::abs( fValue ) < 1E-6 ) {
+			// The calculation of the increment when altering the
+			// value via drag or mouse wheel - (m_fMax - m_fMin)/100.0
+			// - introduces rounding errors. These become dominant
+			// when trying to reset the widget's value to zero and
+			// cause a mismatch.
+			fValue = 0.0;
+		}
 	}
+			
 	
 	if ( fValue == m_fValue ) {
 		return;
@@ -199,6 +209,7 @@ void WidgetWithInput::wheelEvent ( QWheelEvent *ev )
 	if ( ev->angleDelta().y() < 0 ) {
 		fDelta *= -1.;
 	}
+
 	setValue( getValue() + ( fDelta * fStepFactor ), true );
 	
 	QToolTip::showText(


### PR DESCRIPTION
when altering the value of a `WidgetWithInput` - a `Rotary` or `Fader` - an increment is calculated based on the range of allowed values. During this process a tiny rounding error is introduced which itself does no harm when setting values bigger or smaller than zero. But when trying to reset the widget to 0.0, it will be set to e.g. 3e-08 instead. To prevent this from happening, all values bigger than 1e-06 or smaller than -1e-06 are now truncated to 0.0