### PR TITLE
XSD, OSC, and test tweaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -117,6 +117,7 @@
 		- Add command /Hydrogen/UPGRADE_DRUMKIT
 		- Add command /Hydrogen/VALIDATE_DRUMKIT
 		- Add command /Hydrogen/EXTRACT_DRUMKIT
+		- Add command /Hydrogen/BPM
 	* H2CLI
 		- Add `--upgrade` option to upgrade a drumkit
 		- Add `--check` option to validate a drumkit

--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -33,7 +33,7 @@
 	<xsd:complexType>
 		<xsd:sequence>
 			<xsd:element name="component_id"	type="xsd:integer"/>
-			<xsd:element name="gain"			type="xsd:float"	default="1.0"/>
+			<xsd:element name="gain"			type="xsd:float"/>
 			<xsd:sequence>
 				<xsd:element ref="h2:layer" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>
@@ -47,7 +47,7 @@
 		<xsd:sequence>
 			<xsd:element name="id"		type="xsd:integer"/>
 			<xsd:element name="name"	type="xsd:string"/>
-			<xsd:element name="volume"	type="xsd:float"	default="1.0"/>
+			<xsd:element name="volume"	type="xsd:float"/>
 		</xsd:sequence>
 	</xsd:complexType>
 </xsd:element>
@@ -57,10 +57,10 @@
 	<xsd:complexType>
 		<xsd:sequence>
 			<xsd:element name="filename"	type="xsd:string"/>
-			<xsd:element name="min"			type="xsd:float"	default="0.0"/>
-			<xsd:element name="max"			type="xsd:float"	default="1.0"/>
-			<xsd:element name="gain"		type="xsd:float"	default="1.0"/>
-			<xsd:element name="pitch"		type="xsd:float"	default="0.0"/>
+			<xsd:element name="min"			type="xsd:float"/>
+			<xsd:element name="max"			type="xsd:float"/>
+			<xsd:element name="gain"		type="xsd:float"/>
+			<xsd:element name="pitch"		type="xsd:float"/>
 		</xsd:sequence>
 	</xsd:complexType>
 </xsd:element>
@@ -71,39 +71,39 @@
 		<xsd:sequence>
 			<xsd:element name="id"					type="xsd:integer"/>
 			<xsd:element name="name"				type="xsd:string"/>
-			<xsd:element name="volume"				type="xsd:decimal"				default="1.0"/>
-			<xsd:element name="isMuted"				type="h2:bool"					default="false"/>
-			<xsd:element name="isSoloed"			type="h2:bool"					default="false"/>
+			<xsd:element name="volume"				type="xsd:decimal"/>
+			<xsd:element name="isMuted"				type="h2:bool"/>
+			<xsd:element name="isSoloed"			type="h2:bool"/>
 			<xsd:choice minOccurs="0" maxOccurs="1">
 			  <xsd:sequence>
-				<xsd:element name="pan_L"		type="h2:psfloat"		default="0.5"/>
-				<xsd:element name="pan_R"		type="h2:psfloat"		default="0.5"/>
+				<xsd:element name="pan_L"		type="h2:psfloat"/>
+				<xsd:element name="pan_R"		type="h2:psfloat"/>
 			  </xsd:sequence>
-			  <xsd:element name = "pan"		type="h2:psfloat_sym"		default="0.0"/>
+			  <xsd:element name = "pan"		type="h2:psfloat_sym"/>
 			</xsd:choice>
-			<xsd:element name="pitchOffset"			type="xsd:float"				default="0.0"/>
-			<xsd:element name="randomPitchFactor"	type="h2:psfloat"				default="0.0"/>
-			<xsd:element name="gain"				type="xsd:float"				default="1.0"/>
-			<xsd:element name="applyVelocity"		type="h2:bool"					default="false"/>
-			<xsd:element name="filterActive"		type="h2:bool"					default="false"/>
-			<xsd:element name="filterCutoff"		type="h2:psfloat"				default="1.0"/>
-			<xsd:element name="filterResonance"		type="h2:psfloat"				default="0.0"/>
-			<xsd:element name="Attack"				type="xsd:nonNegativeInteger"	default="0"/>
-			<xsd:element name="Decay"				type="xsd:nonNegativeInteger"	default="0"/>
-			<xsd:element name="Sustain"				type="h2:psfloat"				default="1.0"/>
-			<xsd:element name="Release"				type="xsd:nonNegativeInteger"	default="5800"/>
-			<xsd:element name="muteGroup"			type="xsd:integer"				default="-1"/>
-			<xsd:element name="midiOutChannel"		type="xsd:integer"				default="-1"	minOccurs="0"/>
+			<xsd:element name="pitchOffset"			type="xsd:float"/>
+			<xsd:element name="randomPitchFactor"	type="h2:psfloat"/>
+			<xsd:element name="gain"				type="xsd:float"/>
+			<xsd:element name="applyVelocity"		type="h2:bool"/>
+			<xsd:element name="filterActive"		type="h2:bool"/>
+			<xsd:element name="filterCutoff"		type="h2:psfloat"/>
+			<xsd:element name="filterResonance"		type="h2:psfloat"/>
+			<xsd:element name="Attack"				type="xsd:nonNegativeInteger"/>
+			<xsd:element name="Decay"				type="xsd:nonNegativeInteger"/>
+			<xsd:element name="Sustain"				type="h2:psfloat"/>
+			<xsd:element name="Release"				type="xsd:nonNegativeInteger"/>
+			<xsd:element name="muteGroup"			type="xsd:integer"/>
+			<xsd:element name="midiOutChannel"		type="xsd:integer"	minOccurs="0"/>
 			<xsd:element name="midiOutNote"			type="xsd:integer"								minOccurs="0"/>
-			<xsd:element name="isStopNote"			type="h2:bool"					default="false"	minOccurs="0"/>
-			<xsd:element name="sampleSelectionAlgo"	type="xsd:string"				default="VELOCITY"/>
-			<xsd:element name="isHihat"				type="xsd:integer"				default="-1"/>
-			<xsd:element name="lower_cc"			type="xsd:integer"				default="0"/>
-			<xsd:element name="higher_cc"			type="xsd:integer"				default="0"/>
-			<xsd:element name="FX1Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
-			<xsd:element name="FX2Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
-			<xsd:element name="FX3Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
-			<xsd:element name="FX4Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="isStopNote"			type="h2:bool"	minOccurs="0"/>
+			<xsd:element name="sampleSelectionAlgo"	type="xsd:string"/>
+			<xsd:element name="isHihat"				type="xsd:integer"/>
+			<xsd:element name="lower_cc"			type="xsd:integer"/>
+			<xsd:element name="higher_cc"			type="xsd:integer"/>
+			<xsd:element name="FX1Level"			type="xsd:decimal"	minOccurs="0"/>
+			<xsd:element name="FX2Level"			type="xsd:decimal"	minOccurs="0"/>
+			<xsd:element name="FX3Level"			type="xsd:decimal"	minOccurs="0"/>
+			<xsd:element name="FX4Level"			type="xsd:decimal"	minOccurs="0"/>
 			<xsd:sequence>
 				<xsd:element ref="h2:instrumentComponent" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>

--- a/data/xsd/drumkit_pattern.xsd
+++ b/data/xsd/drumkit_pattern.xsd
@@ -40,22 +40,22 @@
 <xsd:element name="note">
 	<xsd:complexType>
 		<xsd:sequence>
-			<xsd:element name="position"	type="xsd:nonNegativeInteger"	default="0"/>
-			<xsd:element name="leadlag"		type="xsd:float"		default="0.0"/>
-			<xsd:element name="velocity"	type="h2:psfloat"		default="0.8"/>
+			<xsd:element name="position"	type="xsd:nonNegativeInteger"/>
+			<xsd:element name="leadlag"		type="xsd:float"/>
+			<xsd:element name="velocity"	type="h2:psfloat"/>
 			<xsd:choice minOccurs="0" maxOccurs="1">
 			  <xsd:sequence>
-				<xsd:element name="pan_L"		type="h2:psfloat5"		default="0.5"/>
-				<xsd:element name="pan_R"		type="h2:psfloat5"		default="0.5"/>
+				<xsd:element name="pan_L"		type="h2:psfloat5"/>
+				<xsd:element name="pan_R"		type="h2:psfloat5"/>
 			  </xsd:sequence>
-			  <xsd:element name = "pan"		type="h2:psfloat_sym"		default="0.0"/>
+			  <xsd:element name = "pan"		type="h2:psfloat_sym"/>
 			</xsd:choice>
-			<xsd:element name="pitch"		type="xsd:float"		default="0.0"/>
-			<xsd:element name="key"			type="xsd:string"		default="C0"/>
-			<xsd:element name="length"		type="xsd:integer"		default="-1"/>
+			<xsd:element name="pitch"		type="xsd:float"/>
+			<xsd:element name="key"			type="xsd:string"/>
+			<xsd:element name="length"		type="xsd:integer"/>
 			<xsd:element name="instrument"	type="xsd:integer"/>
-			<xsd:element name="note_off"	type="h2:bool"			default="false"/>
-			<xsd:element name="probability"	type="xsd:float"		default="1.0"/>
+			<xsd:element name="note_off"	type="h2:bool"/>
+			<xsd:element name="probability"	type="xsd:float"/>
 		</xsd:sequence>
 </xsd:complexType>
 </xsd:element>
@@ -63,9 +63,9 @@
 <xsd:element name="pattern">
 	<xsd:complexType>
 		<xsd:sequence>
-			<xsd:element name="name"		type="xsd:string"		default="unknown"/>
+			<xsd:element name="name"		type="xsd:string"/>
 			<xsd:element name="info"		type="xsd:string"/>
-			<xsd:element name="category"	type="xsd:string"		default="unknown"/>
+			<xsd:element name="category"	type="xsd:string"/>
 			<xsd:element name="size"		type="xsd:nonNegativeInteger"/>
 			<xsd:element name="denominator"	type="xsd:nonNegativeInteger" minOccurs="0"/>
 			<xsd:element name="noteList">

--- a/data/xsd/playlist.xsd
+++ b/data/xsd/playlist.xsd
@@ -18,7 +18,7 @@
 		<xsd:sequence>
 			<xsd:element name="path"			type="xsd:string"/>
 			<xsd:element name="scriptPath"		type="xsd:string"/>
-			<xsd:element name="scriptEnabled"	type="h2:bool"		default="false"/>
+			<xsd:element name="scriptEnabled"	type="h2:bool"/>
 		</xsd:sequence>
 </xsd:complexType>
 </xsd:element>

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2659,25 +2659,25 @@ bool AudioEngine::testFrameToTickConversion() {
 	long long nFrame3Computed = computeFrameFromTick( fTick3, &fFrameOffset3 );
 	
 	if ( nFrame1Computed != nFrame1 || std::abs( fFrameOffset1 ) > 1e-10 ) {
-		ERRORLOG( QString( "[1] nFrame: %1, fTick: %2, nFrameComputed: %3, fFrameOffset: %4, frame diff: %5" )
-				  .arg( nFrame1 ).arg( fTick1, 0, 'f' ).arg( nFrame1Computed )
-				  .arg( fFrameOffset1, 0, 'E', -1 )
-				  .arg( nFrame1Computed - nFrame1 )
-				  .toLocal8Bit().data() );
+		qDebug() << QString( "[testFrameToTickConversion] [1] nFrame: %1, fTick: %2, nFrameComputed: %3, fFrameOffset: %4, frame diff: %5" )
+			.arg( nFrame1 ).arg( fTick1, 0, 'f' ).arg( nFrame1Computed )
+			.arg( fFrameOffset1, 0, 'E', -1 )
+			.arg( nFrame1Computed - nFrame1 )
+			.toLocal8Bit().data();
 		bNoMismatch = false;
 	}
 	if ( nFrame2Computed != nFrame2 || std::abs( fFrameOffset2 ) > 1e-10 ) {
-		ERRORLOG( QString( "[2] nFrame: %1, fTick: %2, nFrameComputed: %3, fFrameOffset: %4, frame diff: %5" )
-				  .arg( nFrame2 ).arg( fTick2, 0, 'f' ).arg( nFrame2Computed )
-				  .arg( fFrameOffset2, 0, 'E', -1 )
-				  .arg( nFrame2Computed - nFrame2 ).toLocal8Bit().data() );
+		qDebug() << QString( "[testFrameToTickConversion] [2] nFrame: %1, fTick: %2, nFrameComputed: %3, fFrameOffset: %4, frame diff: %5" )
+			.arg( nFrame2 ).arg( fTick2, 0, 'f' ).arg( nFrame2Computed )
+			.arg( fFrameOffset2, 0, 'E', -1 )
+			.arg( nFrame2Computed - nFrame2 ).toLocal8Bit().data();
 		bNoMismatch = false;
 	}
 	if ( nFrame3Computed != nFrame3 || std::abs( fFrameOffset3 ) > 1e-6 ) {
-		ERRORLOG( QString( "[3] nFrame: %1, fTick: %2, nFrameComputed: %3, fFrameOffset: %4, frame diff: %5" )
-				  .arg( nFrame3 ).arg( fTick3, 0, 'f' ).arg( nFrame3Computed )
-				  .arg( fFrameOffset3, 0, 'E', -1 )
-				  .arg( nFrame3Computed - nFrame3 ).toLocal8Bit().data() );
+		qDebug() << QString( "[testFrameToTickConversion] [3] nFrame: %1, fTick: %2, nFrameComputed: %3, fFrameOffset: %4, frame diff: %5" )
+			.arg( nFrame3 ).arg( fTick3, 0, 'f' ).arg( nFrame3Computed )
+			.arg( fFrameOffset3, 0, 'E', -1 )
+			.arg( nFrame3Computed - nFrame3 ).toLocal8Bit().data();
 		bNoMismatch = false;
 	}
 
@@ -2696,26 +2696,26 @@ bool AudioEngine::testFrameToTickConversion() {
 	
 	
 	if ( abs( fTick4Computed - fTick4 ) > 1e-9 ) {
-		ERRORLOG( QString( "[4] nFrame: %1, fTick: %2, fTickComputed: %3, fFrameOffset: %4, tick diff: %5" )
-				  .arg( nFrame4 ).arg( fTick4, 0, 'f' ).arg( fTick4Computed, 0, 'f' )
-				  .arg( fFrameOffset4, 0, 'E' )
-				  .arg( fTick4Computed - fTick4 ).toLocal8Bit().data() );
+		qDebug() << QString( "[testFrameToTickConversion] [4] nFrame: %1, fTick: %2, fTickComputed: %3, fFrameOffset: %4, tick diff: %5" )
+			.arg( nFrame4 ).arg( fTick4, 0, 'f' ).arg( fTick4Computed, 0, 'f' )
+			.arg( fFrameOffset4, 0, 'E' )
+			.arg( fTick4Computed - fTick4 ).toLocal8Bit().data();
 		bNoMismatch = false;
 	}
 
 	if ( abs( fTick5Computed - fTick5 ) > 1e-9 ) {
-		ERRORLOG( QString( "[5] nFrame: %1, fTick: %2, fTickComputed: %3, fFrameOffset: %4, tick diff: %5" )
-				  .arg( nFrame5 ).arg( fTick5, 0, 'f' ).arg( fTick5Computed, 0, 'f' )
-				  .arg( fFrameOffset5, 0, 'E' )
-				  .arg( fTick5Computed - fTick5 ).toLocal8Bit().data() );
+		qDebug() << QString( "[testFrameToTickConversion] [5] nFrame: %1, fTick: %2, fTickComputed: %3, fFrameOffset: %4, tick diff: %5" )
+			.arg( nFrame5 ).arg( fTick5, 0, 'f' ).arg( fTick5Computed, 0, 'f' )
+			.arg( fFrameOffset5, 0, 'E' )
+			.arg( fTick5Computed - fTick5 ).toLocal8Bit().data();
 		bNoMismatch = false;
 	}
 
 	if ( abs( fTick6Computed - fTick6 ) > 1e-6 ) {
-		ERRORLOG( QString( "[6] nFrame: %1, fTick: %2, fTickComputed: %3, fFrameOffset: %4, tick diff: %5" )
-				  .arg( nFrame6 ).arg( fTick6, 0, 'f' ).arg( fTick6Computed, 0, 'f' )
-				  .arg( fFrameOffset6, 0, 'E' )
-				  .arg( fTick6Computed - fTick6 ).toLocal8Bit().data() );
+		qDebug() << QString( "[testFrameToTickConversion] [6] nFrame: %1, fTick: %2, fTickComputed: %3, fFrameOffset: %4, tick diff: %5" )
+			.arg( nFrame6 ).arg( fTick6, 0, 'f' ).arg( fTick6Computed, 0, 'f' )
+			.arg( fFrameOffset6, 0, 'E' )
+			.arg( fTick6Computed - fTick6 ).toLocal8Bit().data();
 		bNoMismatch = false;
 	}
 
@@ -2769,14 +2769,14 @@ bool AudioEngine::testTransportProcessing() {
 
 		incrementTransportPosition( nFrames );
 
-		if ( ! testCheckTransportPosition( "constant tempo" ) ) {
+		if ( ! testCheckTransportPosition( "[testTransportProcessing] constant tempo" ) ) {
 			bNoMismatch = false;
 			break;
 		}
 
 		if ( getFrames() - nFrames != nLastFrame ) {
-			ERRORLOG( QString( "[constant tempo] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3" )
-					  .arg( getFrames() ).arg( nFrames ).arg( nLastFrame ) );
+			qDebug() << QString( "[testTransportProcessing] [constant tempo] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3" )
+				.arg( getFrames() ).arg( nFrames ).arg( nLastFrame );
 			bNoMismatch = false;
 			break;
 		}
@@ -2785,12 +2785,12 @@ bool AudioEngine::testTransportProcessing() {
 		nn++;
 
 		if ( nn > nMaxCycles ) {
-			ERRORLOG( QString( "[constant tempo] end of the song wasn't reached in time. getFrames(): %1, ticks: %2, getTickSize(): %3, m_fSongSizeInTicks: %4, nMaxCycles: %5" )
-					  .arg( getFrames() )
-					  .arg( getDoubleTick(), 0, 'f' )
-					  .arg( getTickSize(), 0, 'f' )
-					  .arg( m_fSongSizeInTicks, 0, 'f' )
-					  .arg( nMaxCycles ) );
+			qDebug() << QString( "[testTransportProcessing] [constant tempo] end of the song wasn't reached in time. getFrames(): %1, ticks: %2, getTickSize(): %3, m_fSongSizeInTicks: %4, nMaxCycles: %5" )
+				.arg( getFrames() )
+				.arg( getDoubleTick(), 0, 'f' )
+				.arg( getTickSize(), 0, 'f' )
+				.arg( m_fSongSizeInTicks, 0, 'f' )
+				.arg( nMaxCycles );
 			bNoMismatch = false;
 			break;
 		}
@@ -2826,7 +2826,7 @@ bool AudioEngine::testTransportProcessing() {
 
 			incrementTransportPosition( nFrames );
 
-			if ( ! testCheckTransportPosition( "variable tempo" ) ) {
+			if ( ! testCheckTransportPosition( "[testTransportProcessing] variable tempo" ) ) {
 				setState( AudioEngine::State::Ready );
 				unlock();
 				return bNoMismatch;
@@ -2837,11 +2837,11 @@ bool AudioEngine::testTransportProcessing() {
 				 ( cc == 0 &&
 				   abs( ( getFrames() - nFrames - nLastFrame ) /
 						getFrames() ) > 1e-8 ) ) {
-				ERRORLOG( QString( "[variable tempo] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3, cc: %4, fLastBpm: %5, fBpm: %6, nPrevLastFrame: %7" )
-						  .arg( getFrames() ).arg( nFrames )
-						  .arg( nLastFrame ).arg( cc )
-						  .arg( fLastBpm, 0, 'f' ).arg( fBpm, 0, 'f' )
-						  .arg( nPrevLastFrame ) );
+				qDebug() << QString( "[testTransportProcessing] [variable tempo] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3, cc: %4, fLastBpm: %5, fBpm: %6, nPrevLastFrame: %7" )
+					.arg( getFrames() ).arg( nFrames )
+					.arg( nLastFrame ).arg( cc )
+					.arg( fLastBpm, 0, 'f' ).arg( fBpm, 0, 'f' )
+					.arg( nPrevLastFrame );
 				bNoMismatch = false;
 				setState( AudioEngine::State::Ready );
 				unlock();
@@ -2855,8 +2855,8 @@ bool AudioEngine::testTransportProcessing() {
 			// even in case a tempo change was issued by the user.
 			nTotalFrames += nFrames;
 			if ( getFrames() - m_nFrameOffset != nTotalFrames ) {
-				ERRORLOG( QString( "[variable tempo] frame offset incorrect. getFrames(): %1, m_nFrameOffset: %2, nTotalFrames: %3" )
-						  .arg( getFrames() ).arg( m_nFrameOffset ).arg( nTotalFrames ) );
+				qDebug() << QString( "[testTransportProcessing] [variable tempo] frame offset incorrect. getFrames(): %1, m_nFrameOffset: %2, nTotalFrames: %3" )
+					.arg( getFrames() ).arg( m_nFrameOffset ).arg( nTotalFrames );
 				bNoMismatch = false;
 				setState( AudioEngine::State::Ready );
 				unlock();
@@ -2869,7 +2869,7 @@ bool AudioEngine::testTransportProcessing() {
 		nn++;
 
 		if ( nn > nMaxCycles ) {
-			ERRORLOG( "[variable tempo] end of the song wasn't reached in time." );
+			qDebug() << "[testTransportProcessing] [variable tempo] end of the song wasn't reached in time.";
 			bNoMismatch = false;
 			break;
 		}
@@ -2894,7 +2894,7 @@ bool AudioEngine::testTransportProcessing() {
 	setState( AudioEngine::State::Testing );
 
 	// Check consistency after switching on the Timeline
-	if ( ! testCheckTransportPosition( "timeline: off" ) ) {
+	if ( ! testCheckTransportPosition( "[testTransportProcessing] timeline: off" ) ) {
 		bNoMismatch = false;
 	}
 	
@@ -2907,14 +2907,14 @@ bool AudioEngine::testTransportProcessing() {
 
 		incrementTransportPosition( nFrames );
 
-		if ( ! testCheckTransportPosition( "timeline" ) ) {
+		if ( ! testCheckTransportPosition( "[testTransportProcessing] timeline" ) ) {
 			bNoMismatch = false;
 			break;
 		}
 
 		if ( getFrames() - nFrames != nLastFrame ) {
-			ERRORLOG( QString( "[timeline] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3" )
-					  .arg( getFrames() ).arg( nFrames ).arg( nLastFrame ) );
+			qDebug() << QString( "[testTransportProcessing] [timeline] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3" )
+				.arg( getFrames() ).arg( nFrames ).arg( nLastFrame );
 			bNoMismatch = false;
 			break;
 		}
@@ -2923,7 +2923,7 @@ bool AudioEngine::testTransportProcessing() {
 		nn++;
 
 		if ( nn > nMaxCycles ) {
-			ERRORLOG( "[timeline] end of the song wasn't reached in time." );
+			qDebug() << "[testTransportProcessing] [timeline] end of the song wasn't reached in time.";
 			bNoMismatch = false;
 			break;
 		}
@@ -2939,7 +2939,7 @@ bool AudioEngine::testTransportProcessing() {
 	lock( RIGHT_HERE );
 	setState( AudioEngine::State::Testing );
 
-	if ( ! testCheckTransportPosition( "timeline: off" ) ) {
+	if ( ! testCheckTransportPosition( "[testTransportProcessing] timeline: off" ) ) {
 		bNoMismatch = false;
 	}
 
@@ -2977,7 +2977,7 @@ bool AudioEngine::testTransportProcessing() {
 
 			incrementTransportPosition( nFrames );
 
-			if ( ! testCheckTransportPosition( "pattern mode" ) ) {
+			if ( ! testCheckTransportPosition( "[testTransportProcessing] pattern mode" ) ) {
 				setState( AudioEngine::State::Ready );
 				unlock();
 				pCoreActionController->activateSongMode( true );
@@ -2987,8 +2987,8 @@ bool AudioEngine::testTransportProcessing() {
 			if ( ( cc > 0 && getFrames() - nFrames != nLastFrame ) ||
 				 // errors in the rescaling of nLastFrame are omitted.
 				 ( cc == 0 && abs( getFrames() - nFrames - nLastFrame ) > 1 ) ) {
-				ERRORLOG( QString( "[pattern mode] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3" )
-						  .arg( getFrames() ).arg( nFrames ).arg( nLastFrame ) );
+				qDebug() << QString( "[testTransportProcessing] [pattern mode] inconsistent frame update. getFrames(): %1, nFrames: %2, nLastFrame: %3" )
+					.arg( getFrames() ).arg( nFrames ).arg( nLastFrame );
 				bNoMismatch = false;
 				setState( AudioEngine::State::Ready );
 				unlock();
@@ -3003,8 +3003,8 @@ bool AudioEngine::testTransportProcessing() {
 			// even in case a tempo change was issued by the user.
 			nTotalFrames += nFrames;
 			if ( getFrames() - m_nFrameOffset != nTotalFrames ) {
-				ERRORLOG( QString( "[pattern mode] frame offset incorrect. getFrames(): %1, m_nFrameOffset: %2, nTotalFrames: %3" )
-						  .arg( getFrames() ).arg( m_nFrameOffset ).arg( nTotalFrames ) );
+				qDebug() << QString( "[testTransportProcessing] [pattern mode] frame offset incorrect. getFrames(): %1, m_nFrameOffset: %2, nTotalFrames: %3" )
+					.arg( getFrames() ).arg( m_nFrameOffset ).arg( nTotalFrames );
 				bNoMismatch = false;
 				setState( AudioEngine::State::Ready );
 				unlock();
@@ -3063,7 +3063,7 @@ bool AudioEngine::testTransportRelocation() {
 
 		locate( fNewTick, false );
 
-		if ( ! testCheckTransportPosition( "mismatch tick-based" ) ) {
+		if ( ! testCheckTransportPosition( "[testTransportRelocation] mismatch tick-based" ) ) {
 			bNoMismatch = false;
 			break;
 		}
@@ -3072,7 +3072,7 @@ bool AudioEngine::testTransportRelocation() {
 		nNewFrame = frameDist( randomEngine );
 		locateToFrame( nNewFrame );
 
-		if ( ! testCheckTransportPosition( "mismatch frame-based" ) ) {
+		if ( ! testCheckTransportPosition( "[testTransportRelocation] mismatch frame-based" ) ) {
 			bNoMismatch = false;
 			break;
 		}
@@ -3136,31 +3136,30 @@ bool AudioEngine::testComputeTickInterval() {
 			 // perfectly constant. For certain tick ranges more
 			 // frames are enclosed than for others (Moire effect). 
 			 std::abs( nLastLeadLagFactor - nLeadLagFactor ) > 1 ) {
-			ERRORLOG( QString( "[constant tempo] There should not be altering lead lag with constant tempo [new: %1, prev: %2].")
-					  .arg( nLeadLagFactor ).arg( nLastLeadLagFactor ) );
+			qDebug() << QString( "[testComputeTickInterval] [constant tempo] There should not be altering lead lag with constant tempo [new: %1, prev: %2].")
+				.arg( nLeadLagFactor ).arg( nLastLeadLagFactor );
 			bNoMismatch = false;
 		}
 		nLastLeadLagFactor = nLeadLagFactor;	
 
 		if ( nn == 0 && fTickStart != 0 ){
-			ERRORLOG( QString( "[constant tempo] First interval [%1,%2] does not start at 0.")
-					  .arg( fTickStart, 0, 'f' ).arg( fTickEnd, 0, 'f' ) );
+			qDebug() << QString( "[testComputeTickInterval] [constant tempo] First interval [%1,%2] does not start at 0.")
+				.arg( fTickStart, 0, 'f' ).arg( fTickEnd, 0, 'f' );
 			bNoMismatch = false;
 		}
 
 		if ( fTickStart != fLastTickEnd ) {
-			ERRORLOG( QString( "[variable tempo] Interval [%1,%2] does not align with previous one [%3,%4]. nFrames: %5, curr tick: %6, curr frames: %7, bpm: %8, tick size: %9, nLeadLagFactor: %10")
-					  .arg( fTickStart, 0, 'f' )
-					  .arg( fTickEnd, 0, 'f' )
-					  .arg( fLastTickStart, 0, 'f' )
-					  .arg( fLastTickEnd, 0, 'f' )
-					  .arg( nFrames )
-					  .arg( getDoubleTick(), 0, 'f' )
-					  .arg( getFrames() )
-					  .arg( getBpm(), 0, 'f' )
-					  .arg( getTickSize(), 0, 'f' )
-					  .arg( nLeadLagFactor )
-					  );
+			qDebug() << QString( "[testComputeTickInterval] [variable tempo] Interval [%1,%2] does not align with previous one [%3,%4]. nFrames: %5, curr tick: %6, curr frames: %7, bpm: %8, tick size: %9, nLeadLagFactor: %10")
+				.arg( fTickStart, 0, 'f' )
+				.arg( fTickEnd, 0, 'f' )
+				.arg( fLastTickStart, 0, 'f' )
+				.arg( fLastTickEnd, 0, 'f' )
+				.arg( nFrames )
+				.arg( getDoubleTick(), 0, 'f' )
+				.arg( getFrames() )
+				.arg( getBpm(), 0, 'f' )
+				.arg( getTickSize(), 0, 'f' )
+				.arg( nLeadLagFactor );
 			bNoMismatch = false;
 		}
 		
@@ -3192,32 +3191,37 @@ bool AudioEngine::testComputeTickInterval() {
 												  nFrames );
 
 			if ( cc == 0 && tt == 0 && fTickStart != 0 ){
-				ERRORLOG( QString( "[variable tempo] First interval [%1,%2] does not start at 0.")
-						  .arg( fTickStart, 0, 'f' )
-						  .arg( fTickEnd, 0, 'f' ) );
+				qDebug() << QString( "[testComputeTickInterval] [variable tempo] First interval [%1,%2] does not start at 0.")
+					.arg( fTickStart, 0, 'f' )
+					.arg( fTickEnd, 0, 'f' );
 				bNoMismatch = false;
+				break;
 			}
 
 			if ( fTickStart != fLastTickEnd ) {
-				ERRORLOG( QString( "[variable tempo] Interval [%1,%2] does not align with previous one [%3,%4]. nFrames: %5, curr tick: %6, curr frames: %7, bpm: %8, tick size: %9, nLeadLagFactor: %10")
-						  .arg( fTickStart, 0, 'f' )
-						  .arg( fTickEnd, 0, 'f' )
-						  .arg( fLastTickStart, 0, 'f' )
-						  .arg( fLastTickEnd, 0, 'f' )
-						  .arg( nFrames )
-						  .arg( getDoubleTick(), 0, 'f' )
-						  .arg( getFrames() )
-						  .arg( getBpm(), 0, 'f' )
-						  .arg( getTickSize(), 0, 'f' )
-						  .arg( nLeadLagFactor )
-						  );
+				qDebug() << QString( "[variable tempo] Interval [%1,%2] does not align with previous one [%3,%4]. nFrames: %5, curr tick: %6, curr frames: %7, bpm: %8, tick size: %9, nLeadLagFactor: %10")
+					.arg( fTickStart, 0, 'f' )
+					.arg( fTickEnd, 0, 'f' )
+					.arg( fLastTickStart, 0, 'f' )
+					.arg( fLastTickEnd, 0, 'f' )
+					.arg( nFrames )
+					.arg( getDoubleTick(), 0, 'f' )
+					.arg( getFrames() )
+					.arg( getBpm(), 0, 'f' )
+					.arg( getTickSize(), 0, 'f' )
+					.arg( nLeadLagFactor );
 				bNoMismatch = false;
+				break;
 			}
 
 			fLastTickStart = fTickStart;
 			fLastTickEnd = fTickEnd;
 
 			incrementTransportPosition( nFrames );
+		}
+
+		if ( ! bNoMismatch ) {
+			break;
 		}
 	}
 	
@@ -3245,14 +3249,14 @@ bool AudioEngine::testSongSizeChange() {
 	pCoreActionController->locateToColumn( 4 );
 	lock( RIGHT_HERE );
 
-	if ( ! testCheckConsistency( 1, 1, "prior" ) ) {
+	if ( ! testCheckConsistency( 1, 1, "[testSongSizeChange] prior" ) ) {
 		setState( AudioEngine::State::Ready );
 		unlock();
 		return false;
 	}
 		
 	// Toggle a grid cell after to the current transport position
-	if ( ! testCheckConsistency( 6, 6, "after" ) ) {
+	if ( ! testCheckConsistency( 6, 6, "[testSongSizeChange] after" ) ) {
 		setState( AudioEngine::State::Ready );
 		unlock();
 		return false;
@@ -3263,8 +3267,8 @@ bool AudioEngine::testSongSizeChange() {
 	int nTestColumn = 4;
 	long nNextTick = pHydrogen->getTickForColumn( nTestColumn );
 	if ( nNextTick == -1 ) {
-		ERRORLOG( QString( "Bad test design: there is no column [%1]" )
-				  .arg( nTestColumn ) );
+		qDebug() << QString( "[testSongSizeChange] Bad test design: there is no column [%1]" )
+			.arg( nTestColumn );
 		setState( AudioEngine::State::Ready );
 		unlock();
 		return false;
@@ -3277,14 +3281,14 @@ bool AudioEngine::testSongSizeChange() {
 	pCoreActionController->locateToTick( nNextTick );
 	lock( RIGHT_HERE );
 	
-	if ( ! testCheckConsistency( 1, 1, "looped:prior" ) ) {
+	if ( ! testCheckConsistency( 1, 1, "[testSongSizeChange] looped:prior" ) ) {
 		setState( AudioEngine::State::Ready );
 		unlock();
 		return false;
 	}
 		
 	// Toggle a grid cell after to the current transport position
-	if ( ! testCheckConsistency( 6, 6, "looped:after" ) ) {
+	if ( ! testCheckConsistency( 6, 6, "[testSongSizeChange] looped:after" ) ) {
 		setState( AudioEngine::State::Ready );
 		unlock();
 		return false;
@@ -3334,14 +3338,14 @@ bool AudioEngine::testSongSizeChangeInLoopMode() {
 
 		locate( fInitialSongSize + frameDist( randomEngine ) );
 
-		if ( ! testCheckTransportPosition( "relocation" ) ) {
+		if ( ! testCheckTransportPosition( "[testSongSizeChangeInLoopMode] relocation" ) ) {
 			bNoMismatch = false;
 			break;
 		}
 
 		incrementTransportPosition( nFrames );
 
-		if ( ! testCheckTransportPosition( "first increment" ) ) {
+		if ( ! testCheckTransportPosition( "[testSongSizeChangeInLoopMode] first increment" ) ) {
 			bNoMismatch = false;
 			break;
 		}
@@ -3352,21 +3356,21 @@ bool AudioEngine::testSongSizeChangeInLoopMode() {
 		pCoreActionController->toggleGridCell( nNewColumn, 0 );
 		lock( RIGHT_HERE );
 
-		if ( ! testCheckTransportPosition( "first toggling" ) ) {
+		if ( ! testCheckTransportPosition( "[testSongSizeChangeInLoopMode] first toggling" ) ) {
 			bNoMismatch = false;
 			break;
 		}
 
 		if ( fInitialSongSize == m_fSongSizeInTicks ) {
-			ERRORLOG( QString( "[first toggling] no song enlargement %1")
-					  .arg( m_fSongSizeInTicks ) );
+			qDebug() << QString( "[testSongSizeChangeInLoopMode] [first toggling] no song enlargement %1")
+				.arg( m_fSongSizeInTicks );
 			bNoMismatch = false;
 			break;
 		}
 
 		incrementTransportPosition( nFrames );
 
-		if ( ! testCheckTransportPosition( "second increment" ) ) {
+		if ( ! testCheckTransportPosition( "[testSongSizeChange] second increment" ) ) {
 			bNoMismatch = false;
 			break;
 		}
@@ -3375,21 +3379,21 @@ bool AudioEngine::testSongSizeChangeInLoopMode() {
 		pCoreActionController->toggleGridCell( nNewColumn, 0 );
 		lock( RIGHT_HERE );
 
-		if ( ! testCheckTransportPosition( "second toggling" ) ) {
+		if ( ! testCheckTransportPosition( "[testSongSizeChange] second toggling" ) ) {
 			bNoMismatch = false;
 			break;
 		}
 		
 		if ( fInitialSongSize != m_fSongSizeInTicks ) {
-			ERRORLOG( QString( "[second toggling] song size mismatch original: %1, new: %2" )
-					  .arg( fInitialSongSize ).arg( m_fSongSizeInTicks ) );
+			qDebug() << QString( "[testSongSizeChange] [second toggling] song size mismatch original: %1, new: %2" )
+				.arg( fInitialSongSize ).arg( m_fSongSizeInTicks );
 			bNoMismatch = false;
 			break;
 		}
 
 		incrementTransportPosition( nFrames );
 
-		if ( ! testCheckTransportPosition( "third increment" ) ) {
+		if ( ! testCheckTransportPosition( "[testSongSizeChange] third increment" ) ) {
 			bNoMismatch = false;
 			break;
 		}
@@ -3469,7 +3473,7 @@ bool AudioEngine::testNoteEnqueuing() {
 		// }
 		
 		if ( nn > nMaxCleaningCycles ) {
-			ERRORLOG("Sampler is in weird state");
+			qDebug() << "[testNoteEnqueuing] Sampler is in weird state";
 			return false;
 		}
 	}
@@ -3507,12 +3511,12 @@ bool AudioEngine::testNoteEnqueuing() {
 
 		++nn;
 		if ( nn > nMaxCycles ) {
-			ERRORLOG( QString( "end of the song wasn't reached in time. getFrames(): %1, ticks: %2, getTickSize(): %3, m_fSongSizeInTicks: %4, nMaxCycles: %5" )
-					  .arg( getFrames() )
-					  .arg( getDoubleTick(), 0, 'f' )
-					  .arg( getTickSize(), 0, 'f' )
-					  .arg( m_fSongSizeInTicks, 0, 'f' )
-					  .arg( nMaxCycles ) );
+			qDebug() << QString( "[testNoteEnqueuing] end of the song wasn't reached in time. getFrames(): %1, ticks: %2, getTickSize(): %3, m_fSongSizeInTicks: %4, nMaxCycles: %5" )
+				.arg( getFrames() )
+				.arg( getDoubleTick(), 0, 'f' )
+				.arg( getTickSize(), 0, 'f' )
+				.arg( m_fSongSizeInTicks, 0, 'f' )
+				.arg( nMaxCycles );
 			bNoMismatch = false;
 			break;
 		}
@@ -3520,7 +3524,7 @@ bool AudioEngine::testNoteEnqueuing() {
 
 	if ( notesInSongQueue.size() !=
 		 notesInSong.size() ) {
-		QString sMsg = QString( "[song mode] Mismatch between notes count in Song [%1] and NoteQueue [%2]. Song:\n" )
+		QString sMsg = QString( "[testNoteEnqueuing] [song mode] Mismatch between notes count in Song [%1] and NoteQueue [%2]. Song:\n" )
 			.arg( notesInSong.size() ).arg( notesInSongQueue.size() );
 		for ( int ii = 0; ii < notesInSong.size(); ++ii  ) {
 			auto note = notesInSong[ ii ];
@@ -3542,7 +3546,7 @@ bool AudioEngine::testNoteEnqueuing() {
 						 .arg( note->get_velocity() ) );
 		}
 
-		ERRORLOG( sMsg );
+		qDebug() << sMsg;
 		bNoMismatch = false;
 	}
 
@@ -3552,7 +3556,7 @@ bool AudioEngine::testNoteEnqueuing() {
 	if ( notesInSamplerQueue.size() !=
 		 notesInSong.size() &&
 		 pPref->m_nBufferSize < 1024 ) {
-		QString sMsg = QString( "[song mode] Mismatch between notes count in Song [%1] and Sampler [%2]. Song:\n" )
+		QString sMsg = QString( "[testNoteEnqueuing] [song mode] Mismatch between notes count in Song [%1] and Sampler [%2]. Song:\n" )
 			.arg( notesInSong.size() ).arg( notesInSamplerQueue.size() );
 		for ( int ii = 0; ii < notesInSong.size(); ++ii  ) {
 			auto note = notesInSong[ ii ];
@@ -3574,7 +3578,7 @@ bool AudioEngine::testNoteEnqueuing() {
 						 .arg( note->get_velocity() ) );
 		}
 
-		ERRORLOG( sMsg );
+		qDebug() << sMsg;
 		bNoMismatch = false;
 	}
 
@@ -3628,7 +3632,7 @@ bool AudioEngine::testNoteEnqueuing() {
 		// }
 		
 		if ( nn > nMaxCleaningCycles ) {
-			ERRORLOG("[pattern mode] Sampler is in weird state");
+			qDebug() << "[testNoteEnqueuing] [pattern mode] Sampler is in weird state";
 			return false;
 		}
 	}
@@ -3637,8 +3641,8 @@ bool AudioEngine::testNoteEnqueuing() {
 	auto pPattern = 
 		pSong->getPatternList()->get( pHydrogen->getSelectedPatternNumber() );
 	if ( pPattern == nullptr ) {
-		ERRORLOG( QString( "null pattern selected [%1]" )
-				  .arg( pHydrogen->getSelectedPatternNumber() ) );
+		qDebug() << QString( "[testNoteEnqueuing] null pattern selected [%1]" )
+			.arg( pHydrogen->getSelectedPatternNumber() );
 		return false;
 	}
 
@@ -3685,13 +3689,13 @@ bool AudioEngine::testNoteEnqueuing() {
 
 		++nn;
 		if ( nn > nMaxCycles ) {
-			ERRORLOG( QString( "end of the pattern wasn't reached in time. getFrames(): %1, ticks: %2, getTickSize(): %3, pattern length: %4, nMaxCycles: %5, nLoops: %6" )
-					  .arg( getFrames() )
-					  .arg( getDoubleTick(), 0, 'f' )
-					  .arg( getTickSize(), 0, 'f' )
-					  .arg( pPattern->get_length() )
-					  .arg( nMaxCycles )
-					  .arg( nLoops ));
+			qDebug() << QString( "[testNoteEnqueuing] end of the pattern wasn't reached in time. getFrames(): %1, ticks: %2, getTickSize(): %3, pattern length: %4, nMaxCycles: %5, nLoops: %6" )
+				.arg( getFrames() )
+				.arg( getDoubleTick(), 0, 'f' )
+				.arg( getTickSize(), 0, 'f' )
+				.arg( pPattern->get_length() )
+				.arg( nMaxCycles )
+				.arg( nLoops );
 			bNoMismatch = false;
 			break;
 		}
@@ -3723,7 +3727,7 @@ bool AudioEngine::testNoteEnqueuing() {
 
 	if ( notesInSongQueue.size() !=
 		 notesInPattern.size() ) {
-		QString sMsg = QString( "[pattern mode] Mismatch between notes count in Pattern [%1] and NoteQueue [%2]. Pattern:\n" )
+		QString sMsg = QString( "[testNoteEnqueuing] [pattern mode] Mismatch between notes count in Pattern [%1] and NoteQueue [%2]. Pattern:\n" )
 			.arg( notesInPattern.size() ).arg( notesInSongQueue.size() );
 		for ( int ii = 0; ii < notesInPattern.size(); ++ii  ) {
 			auto note = notesInPattern[ ii ];
@@ -3745,7 +3749,7 @@ bool AudioEngine::testNoteEnqueuing() {
 						 .arg( note->get_velocity() ) );
 		}
 
-		ERRORLOG( sMsg );
+		qDebug() << sMsg;
 		bNoMismatch = false;
 	}
 
@@ -3755,7 +3759,7 @@ bool AudioEngine::testNoteEnqueuing() {
 	if ( notesInSamplerQueue.size() !=
 		 notesInPattern.size() &&
 		 pPref->m_nBufferSize < 1024 ) {
-		QString sMsg = QString( "[pattern mode] Mismatch between notes count in Pattern [%1] and Sampler [%2]. Pattern:\n" )
+		QString sMsg = QString( "[testNoteEnqueuing] [pattern mode] Mismatch between notes count in Pattern [%1] and Sampler [%2]. Pattern:\n" )
 			.arg( notesInPattern.size() ).arg( notesInSamplerQueue.size() );
 		for ( int ii = 0; ii < notesInPattern.size(); ++ii  ) {
 			auto note = notesInPattern[ ii ];
@@ -3777,7 +3781,7 @@ bool AudioEngine::testNoteEnqueuing() {
 						 .arg( note->get_velocity() ) );
 		}
 
-		ERRORLOG( sMsg );
+		qDebug() << sMsg;
 		bNoMismatch = false;
 	}
 
@@ -3846,22 +3850,21 @@ bool AudioEngine::testCheckTransportPosition( const QString& sContext) const {
 	if ( abs( fCheckTick + fTickMismatch - getDoubleTick() ) > 1e-9 ||
 		 abs( fTickMismatch - m_fTickMismatch ) > 1e-9 ||
 		 nCheckFrame != getFrames() ) {
-		ERRORLOG( QString( "[%9] mismatch. frame: %1, check frame: %2, tick: %3, check tick: %4, offset: %5, check offset: %6, tick size: %7, bpm: %8, fCheckTick + fTickMismatch - getDoubleTick(): %10, fTickMismatch - m_fTickMismatch: %11, nCheckFrame - getFrames(): %12" )
-				  .arg( getFrames() )
-				  .arg( nCheckFrame )
-				  .arg( getDoubleTick(), 0 , 'f', 9 )
-				  .arg( fCheckTick, 0 , 'f', 9 )
-				  .arg( m_fTickMismatch, 0 , 'f', 9 )
-				  .arg( fTickMismatch, 0 , 'f', 9 )
-				  .arg( getTickSize(), 0 , 'f' )
-				  .arg( getBpm(), 0 , 'f' )
-				  .arg( sContext )
-				  .arg( fCheckTick + fTickMismatch - getDoubleTick(), 0, 'E' )
-				  .arg( fTickMismatch - m_fTickMismatch, 0, 'E' )
-				  .arg( nCheckFrame - getFrames() )
-				  );
-		return false;
-	}
+		qDebug() << QString( "[testCheckTransportPosition] [%9] mismatch. frame: %1, check frame: %2, tick: %3, check tick: %4, offset: %5, check offset: %6, tick size: %7, bpm: %8, fCheckTick + fTickMismatch - getDoubleTick(): %10, fTickMismatch - m_fTickMismatch: %11, nCheckFrame - getFrames(): %12" )
+			.arg( getFrames() )
+			.arg( nCheckFrame )
+			.arg( getDoubleTick(), 0 , 'f', 9 )
+			.arg( fCheckTick, 0 , 'f', 9 )
+			.arg( m_fTickMismatch, 0 , 'f', 9 )
+			.arg( fTickMismatch, 0 , 'f', 9 )
+			.arg( getTickSize(), 0 , 'f' )
+			.arg( getBpm(), 0 , 'f' )
+			.arg( sContext )
+			.arg( fCheckTick + fTickMismatch - getDoubleTick(), 0, 'E' )
+			.arg( fTickMismatch - m_fTickMismatch, 0, 'E' )
+			.arg( nCheckFrame - getFrames() );
+	return false;
+}
 
 	return true;
 }
@@ -3916,19 +3919,18 @@ bool AudioEngine::testCheckAudioConsistency( const std::vector<std::shared_ptr<N
 									  static_cast<double>(nSampleFrames) );
 						if ( std::abs( ppNewNote->get_layer_selected( nn )->SamplePosition -
 									   fExpectedFrames ) > 1 ) {
-							ERRORLOG( QString( "[%4] glitch in audio render. Diff: %9\nPre: %1\nPost: %2\nwith passed frames: %3, nSampleFrames: %5, fExpectedFrames: %6, sample sampleRate: %7, driver sampleRate: %8\n" )
-									  .arg( ppOldNote->toQString( "", true ) )
-									  .arg( ppNewNote->toQString( "", true ) )
-									  .arg( fPassedFrames, 0, 'f' )
-									  .arg( sContext )
-									  .arg( nSampleFrames )
-									  .arg( fExpectedFrames, 0, 'f' )
-									  .arg( ppOldNote->getSample( nn )->get_sample_rate() )
-									  .arg( Hydrogen::get_instance()->getAudioOutput()->getSampleRate() )
-									  .arg( ppNewNote->get_layer_selected( nn )->SamplePosition -
-											fExpectedFrames, 0, 'g', 30 )
-									  );
-							bNoMismatch = false;
+							qDebug() << QString( "[testCheckAudioConsistency] [%4] glitch in audio render. Diff: %9\nPre: %1\nPost: %2\nwith passed frames: %3, nSampleFrames: %5, fExpectedFrames: %6, sample sampleRate: %7, driver sampleRate: %8\n" )
+								.arg( ppOldNote->toQString( "", true ) )
+								.arg( ppNewNote->toQString( "", true ) )
+								.arg( fPassedFrames, 0, 'f' )
+								.arg( sContext )
+								.arg( nSampleFrames )
+								.arg( fExpectedFrames, 0, 'f' )
+								.arg( ppOldNote->getSample( nn )->get_sample_rate() )
+								.arg( Hydrogen::get_instance()->getAudioOutput()->getSampleRate() )
+								.arg( ppNewNote->get_layer_selected( nn )->SamplePosition -
+									  fExpectedFrames, 0, 'g', 30 );
+						bNoMismatch = false;
 						}
 					}
 				} else {
@@ -3936,12 +3938,12 @@ bool AudioEngine::testCheckAudioConsistency( const std::vector<std::shared_ptr<N
 					// were properly applied.
 					if ( ppNewNote->get_position() - fPassedTicks !=
 						 ppOldNote->get_position() ) {
-							ERRORLOG( QString( "[%4] glitch in note queue.\n\nPre: %1 ;\n\nPost: %2 ; with passed ticks: %3\n" )
-									  .arg( ppOldNote->toQString( "", true ) )
-									  .arg( ppNewNote->toQString( "", true ) )
-									  .arg( fPassedTicks )
-									  .arg( sContext ) );
-							bNoMismatch = false;
+						qDebug() << QString( "[testCheckAudioConsistency] [%4] glitch in note queue.\n\nPre: %1 ;\n\nPost: %2 ; with passed ticks: %3\n" )
+							.arg( ppOldNote->toQString( "", true ) )
+							.arg( ppNewNote->toQString( "", true ) )
+							.arg( fPassedTicks )
+							.arg( sContext );
+						bNoMismatch = false;
 					}
 				}
 			}
@@ -3955,29 +3957,29 @@ bool AudioEngine::testCheckAudioConsistency( const std::vector<std::shared_ptr<N
 	if ( nNotesFound == 0 &&
 		 oldNotes.size() > 0 &&
 		 newNotes.size() > 0 ) {
-		ERRORLOG( QString( "[%1] bad test design. No notes played back." )
-				  .arg( sContext ) );
+		qDebug() << QString( "[testCheckAudioConsistency] [%1] bad test design. No notes played back." )
+			.arg( sContext );
 		if ( oldNotes.size() != 0 ) {
-			ERRORLOG( "old notes:" );
+			qDebug() << "old notes:";
 			for ( auto const& nnote : oldNotes ) {
-				ERRORLOG( nnote->toQString( "    ", true ) );
+				qDebug() << nnote->toQString( "    ", true );
 			}
 		}
 		if ( newNotes.size() != 0 ) {
-			ERRORLOG( "new notes:" );
+			qDebug() << "new notes:";
 			for ( auto const& nnote : newNotes ) {
-				ERRORLOG( nnote->toQString( "    ", true ) );
+				qDebug() << nnote->toQString( "    ", true );
 			}
 		}
-		ERRORLOG( QString( "curr tick: %1, curr frame: %2, nPassedFrames: %3, fPassedTicks: %4, fTickSize: %5" )
-				  .arg( getDoubleTick(), 0, 'f' )
-				  .arg( getFrames() )
-				  .arg( nPassedFrames )
-				  .arg( fPassedTicks, 0, 'f' )
-				  .arg( getTickSize(), 0, 'f' ) );
-		ERRORLOG( "notes in song:" );
+		qDebug() << QString( "[testCheckAudioConsistency] curr tick: %1, curr frame: %2, nPassedFrames: %3, fPassedTicks: %4, fTickSize: %5" )
+			.arg( getDoubleTick(), 0, 'f' )
+			.arg( getFrames() )
+			.arg( nPassedFrames )
+			.arg( fPassedTicks, 0, 'f' )
+			.arg( getTickSize(), 0, 'f' );
+		qDebug() << "[testCheckAudioConsistency] notes in song:";
 		for ( auto const& nnote : pSong->getAllNotes() ) {
-			ERRORLOG( nnote->toQString( "    ", true ) );
+			qDebug() << nnote->toQString( "    ", true );
 		}
 		
 		bNoMismatch = false;
@@ -4040,13 +4042,13 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 	pCoreActionController->toggleGridCell( nToggleColumn, nToggleRow );
 	lock( RIGHT_HERE );
 
-	QString sFirstContext = QString( "%1 : 1. toggling" ).arg( sContext );
+	QString sFirstContext = QString( "[testCheckConsistency] %1 : 1. toggling" ).arg( sContext );
 
 	// Check whether there is a change in song size
 	long nNewSongSize = pSong->lengthInTicks();
 	if ( nNewSongSize == nOldSongSize ) {
-		ERRORLOG( QString( "[%1] no change in song size" )
-				  .arg( sFirstContext ) );
+		qDebug() << QString( "[%1] no change in song size" )
+			.arg( sFirstContext );
 		return false;
 	}
 
@@ -4071,22 +4073,22 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 	m_fLastTickIntervalEnd = -1;
 	nLeadLag = computeTickInterval( &fTickStart, &fTickEnd, nBufferSize );
 	if ( std::abs( nLeadLag - nPrevLeadLag ) > 1 ) {
-		ERRORLOG( QString( "[%3] LeadLag should be constant since there should be change in tick size. old: %1, new: %2" )
-				  .arg( nPrevLeadLag ).arg( nLeadLag ).arg( sFirstContext ) );
+		qDebug() << QString( "[%3] LeadLag should be constant since there should be change in tick size. old: %1, new: %2" )
+			.arg( nPrevLeadLag ).arg( nLeadLag ).arg( sFirstContext );
 		return false;
 	}
 	if ( std::abs( fTickStart - m_fTickOffset - fPrevTickStart ) > 4e-3 ) {
-		ERRORLOG( QString( "[%4] Mismatch in the start of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
-				  .arg( fTickStart, 0, 'f' ).arg( fPrevTickStart, 0, 'f' )
-				  .arg( fPrevTickStart + m_fTickOffset, 0, 'f' )
-				  .arg( sFirstContext ) );
+		qDebug() << QString( "[%4] Mismatch in the start of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
+			.arg( fTickStart, 0, 'f' ).arg( fPrevTickStart, 0, 'f' )
+			.arg( fPrevTickStart + m_fTickOffset, 0, 'f' )
+			.arg( sFirstContext );
 		return false;
 	}
 	if ( std::abs( fTickEnd - m_fTickOffset - fPrevTickEnd ) > 4e-3 ) {
-		ERRORLOG( QString( "[%4] Mismatch in the end of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
-				  .arg( fTickEnd, 0, 'f' ).arg( fPrevTickEnd, 0, 'f' )
-				  .arg( fPrevTickEnd + m_fTickOffset, 0, 'f' )
-				  .arg( sFirstContext ) );
+		qDebug() << QString( "[%4] Mismatch in the end of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
+			.arg( fTickEnd, 0, 'f' ).arg( fPrevTickEnd, 0, 'f' )
+			.arg( fPrevTickEnd + m_fTickOffset, 0, 'f' )
+			.arg( sFirstContext );
 		return false;
 	}
 
@@ -4103,8 +4105,8 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 
 	// Check whether tempo and tick size have not changed.
 	if ( fPrevTempo != getBpm() || fPrevTickSize != getTickSize() ) {
-		ERRORLOG( QString( "[%1] tempo and ticksize are affected" )
-				  .arg( sFirstContext ) );
+		qDebug() << QString( "[%1] tempo and ticksize are affected" )
+			.arg( sFirstContext );
 		return false;
 	}
 
@@ -4121,7 +4123,7 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 	// Toggle the same grid cell again
 	//////
 
-	QString sSecondContext = QString( "%1 : 2. toggling" ).arg( sContext );
+	QString sSecondContext = QString( "[testCheckAudioConsistency] %1 : 2. toggling" ).arg( sContext );
 	
 	notes1.clear();
 	for ( const auto& ppNote : getSampler()->getPlayingNotesQueue() ) {
@@ -4148,8 +4150,8 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 	nOldSongSize = nNewSongSize;
 	nNewSongSize = pSong->lengthInTicks();
 	if ( nNewSongSize == nOldSongSize ) {
-		ERRORLOG( QString( "[%1] no change in song size" )
-				  .arg( sSecondContext ) );
+		qDebug() << QString( "[%1] no change in song size" )
+			.arg( sSecondContext );
 		return false;
 	}
 
@@ -4170,22 +4172,22 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 
 	nLeadLag = computeTickInterval( &fTickStart, &fTickEnd, nBufferSize );
 	if ( std::abs( nLeadLag - nPrevLeadLag ) > 1 ) {
-		ERRORLOG( QString( "[%3] LeadLag should be constant since there should be change in tick size. old: %1, new: %2" )
-				  .arg( nPrevLeadLag ).arg( nLeadLag ).arg( sSecondContext ) );
+		qDebug() << QString( "[%3] LeadLag should be constant since there should be change in tick size. old: %1, new: %2" )
+			.arg( nPrevLeadLag ).arg( nLeadLag ).arg( sSecondContext );
 		return false;
 	}
 	if ( std::abs( fTickStart - m_fTickOffset - fPrevTickStart ) > 4e-3 ) {
-		ERRORLOG( QString( "[%4] Mismatch in the start of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
-				  .arg( fTickStart, 0, 'f' ).arg( fPrevTickStart, 0, 'f' )
-				  .arg( fPrevTickStart + m_fTickOffset, 0, 'f' )
-				  .arg( sSecondContext ) );
+		qDebug() << QString( "[%4] Mismatch in the start of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
+			.arg( fTickStart, 0, 'f' ).arg( fPrevTickStart, 0, 'f' )
+			.arg( fPrevTickStart + m_fTickOffset, 0, 'f' )
+			.arg( sSecondContext );
 		return false;
 	}
 	if ( std::abs( fTickEnd - m_fTickOffset - fPrevTickEnd ) > 4e-3 ) {
-		ERRORLOG( QString( "[%4] Mismatch in the end of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
-				  .arg( fTickEnd, 0, 'f' ).arg( fPrevTickEnd, 0, 'f' )
-				  .arg( fPrevTickEnd + m_fTickOffset, 0, 'f' )
-				  .arg( sSecondContext )  );
+		qDebug() << QString( "[%4] Mismatch in the end of the tick interval handled by updateNoteQueue new: %1, old: %2, old+offset: %3" )
+			.arg( fTickEnd, 0, 'f' ).arg( fPrevTickEnd, 0, 'f' )
+			.arg( fPrevTickEnd + m_fTickOffset, 0, 'f' )
+			.arg( sSecondContext );
 		return false;
 	}
 
@@ -4202,8 +4204,8 @@ bool AudioEngine::testCheckConsistency( int nToggleColumn, int nToggleRow, const
 
 	// Check whether tempo and tick size have not changed.
 	if ( fPrevTempo != getBpm() || fPrevTickSize != getTickSize() ) {
-		ERRORLOG( QString( "[%1] tempo and ticksize are affected" )
-				  .arg( sSecondContext ) );
+		qDebug() << QString( "[%1] tempo and ticksize are affected" )
+			.arg( sSecondContext );
 		return false;
 	}
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -3449,7 +3449,7 @@ bool AudioEngine::testNoteEnqueuing() {
 
 	// Larger number to account for both small buffer sizes and long
 	// samples.
-	int nMaxCleaningCycles = 250;
+	int nMaxCleaningCycles = 500;
 	int nn = 0;
 
 	// Ensure the sampler is clean.

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -38,6 +38,7 @@
 #include "core/CoreActionController.h"
 #include "core/EventQueue.h"
 #include "core/Hydrogen.h"
+#include "core/AudioEngine/AudioEngine.h"
 #include "core/Basics/Song.h"
 #include "core/MidiAction.h"
 
@@ -450,6 +451,21 @@ void OscServer::PREVIOUS_BAR_Handler(lo_arg **argv,int i)
 
 	// Null song handling done in MidiActionManager.
 	pActionManager->handleAction( pAction );
+}
+
+void OscServer::BPM_Handler(lo_arg **argv,int i)
+{
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+
+	int nNewBpm = static_cast<int>( argv[0]->f );
+	nNewBpm = std::clamp( nNewBpm, MIN_BPM, MAX_BPM );
+
+	pHydrogen->getAudioEngine()->setNextBpm( nNewBpm );
+	pHydrogen->getSong()->setBpm( nNewBpm );
+
+	pHydrogen->setIsModified( true );
+	
+	H2Core::EventQueue::get_instance()->push_event( H2Core::EVENT_TEMPO_CHANGED, -1 );
 }
 
 void OscServer::BPM_INCR_Handler(lo_arg **argv,int i)
@@ -1146,6 +1162,7 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/PREVIOUS_BAR", "", PREVIOUS_BAR_Handler);
 	m_pServerThread->add_method("/Hydrogen/PREVIOUS_BAR", "f", PREVIOUS_BAR_Handler);
 	
+	m_pServerThread->add_method("/Hydrogen/BPM", "f", BPM_Handler);
 	m_pServerThread->add_method("/Hydrogen/BPM_DECR", "f", BPM_DECR_Handler);
 	m_pServerThread->add_method("/Hydrogen/BPM_INCR", "f", BPM_INCR_Handler);
 

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -378,6 +378,15 @@ class OscServer : public H2Core::Object<OscServer>
 		 * message.*/
 		static void PREVIOUS_BAR_Handler(lo_arg **argv, int i);
 		/**
+		 * Creates sets the current tempo of Hydrogen to the provided
+		 * value (first argument in @a argv).
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void BPM_Handler(lo_arg **argv, int i);
+		/**
 		 * Creates an Action of type @b BPM_INCR and passes its
 		 * references to MidiActionManager::handleAction().
 		 *


### PR DESCRIPTION
Feels like close to the finishing line for 1.2 :)

- test: print cause of failing AE tests in console

   the tests of the AudioEngine are located in the `AudioEngine` class in order to access private member variable without the need to create accessors for each of them. Whether or not a test succeeds is communicated by a return value. However, the console log in the CI only prints out the statement within the CPPUNIT ASSERT command which is the same for all AE tests. In order to determine the true reason for the failure one has to run the tests locally with the -V argument.

   To circumvent this, have more verbose results in the CI, and to catch a transient failure in the note enqueuing that seems to popup in the CI but which I can not reproduce locally, the AE test do print their errors directly using `qDebug()` instead of Hydrogens custom log queue. This way the cause of the problem should also appear in the console log of the CI.

- test: relax AE testNoteEnqueuing

   more interations will be done in the beginning of the test to ensure all notes in the Sampler are flushed

- OSC: add command to set tempo

   Previously, the tempo of Hydrogen could only be increased or decreased with OSC commands. Now, there is a command corresponding to the address `/Hydrogen/BPM` that sets the current tempo to the provided value.

   Implements https://github.com/hydrogen-music/hydrogen/issues/1195

- XSD: drop default values

   there were a number of default values for various parameters present in the XSD schema files. In principle, this is a nice idea. However, a number of them were not properly updated and are out-of-sync with the real default values assigned in the code. Also, there is no way - at least to my knowledge - to harness the default values of the XSD files and to use them as default values in the C++ code. To not cause confusion, I all default values were dropped.

   Implements https://github.com/hydrogen-music/hydrogen/issues/1197