### PR TITLE
Fix audio driver selection and creation (#1514)

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -382,10 +382,8 @@ float AudioEngine::getElapsedTime() const {
 	
 	const auto pHydrogen = Hydrogen::get_instance();
 	const auto pDriver = pHydrogen->getAudioOutput();
-	assert( pDriver );
 	
-	if ( pDriver->getSampleRate() == 0 ) {
-		ERRORLOG( "Not properly initialized yet" );
+	if ( pDriver == nullptr || pDriver->getSampleRate() == 0 ) {
 		return 0;
 	}
 
@@ -1157,8 +1155,10 @@ AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 	}
 		
 	setupLadspaFX();
-	
-	handleDriverChange();
+
+	if ( pSong != nullptr ) {
+		handleDriverChange();
+	}
 
 	EventQueue::get_instance()->push_event( EVENT_DRIVER_CHANGED, 0 );
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1194,16 +1194,12 @@ void AudioEngine::startAudioDrivers()
 #endif
 
 	if ( sAudioDriver != "Auto" ) {
-		drivers.removeAll( sAudioDriver );
-		drivers.prepend( sAudioDriver );
+		drivers.clear();
+		drivers << sAudioDriver;
 	}
 	AudioOutput* pAudioDriver;
 	for ( QString sDriver : drivers ) {
 		if ( ( pAudioDriver = createAudioDriver( sDriver ) ) != nullptr ) {
-			if ( sDriver != sAudioDriver && sAudioDriver != "Auto" ) {
-				ERRORLOG( QString( "Couldn't start preferred driver [%1], falling back to [%2]" )
-						  .arg( sAudioDriver ).arg( sDriver ) );
-			}
 			break;
 		}
 	}
@@ -1211,6 +1207,8 @@ void AudioEngine::startAudioDrivers()
 	// If the audio driver could not be created, we resort to the
 	// NullDriver.
 	if ( m_pAudioDriver == nullptr ) {
+		ERRORLOG( QString( "Couldn't start audio driver [%1], falling back to NullDriver" )
+				  .arg( sAudioDriver ) );
 		createAudioDriver( "NullDriver" );
 	}
 
@@ -3486,7 +3484,7 @@ bool AudioEngine::testNoteEnqueuing() {
 		// }
 		
 		if ( nn > nMaxCleaningCycles ) {
-			qDebug() << "[testNoteEnqueuing] Sampler is in weird state";
+			qDebug() << "[testNoteEnqueuing] [song mode] Sampler is in weird state";
 			return false;
 		}
 	}

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -296,12 +296,25 @@ public:
 	 */
 	void			startAudioDrivers();
 	/**
-	 * Assign an INITIATED audio driver.*/
-	void			setAudioDrivers( AudioOutput* pAudioDriver );
-	/**
 	 * Stops all audio and MIDI drivers.
 	 */
 	void			stopAudioDrivers();
+	AudioOutput*	getAudioDriver() const;
+	/**
+	 * Create an audio driver using audioEngine_process() as its argument
+	 * based on the provided choice and calling their _init()_ function to
+	 * trigger their initialization.
+	 *
+	 * For a listing of all possible choices, please see
+	 * Preferences::m_sAudioDriver.
+	 *
+	 * \param sDriver String specifying which audio driver should be
+	 * created.
+	 * \return Pointer to the freshly created audio driver. If the
+	 * creation resulted in a NullDriver, the corresponding object will be
+	 * deleted and a null pointer returned instead.
+	 */
+	AudioOutput*	createAudioDriver( const QString& sDriver );
 					
 	void			restartAudioDrivers();
 					
@@ -314,10 +327,6 @@ public:
 	 * \param pSong Song for which per-track output ports should be generated.
 	 */
 	void			renameJackPorts(std::shared_ptr<Song> pSong);
-	
- 
-	void			setAudioDriver( AudioOutput* pAudioDriver );
-	AudioOutput*	getAudioDriver() const;
 
 	/* retrieve the midi (input) driver */
 	MidiInput*		getMidiDriver() const;
@@ -612,22 +621,7 @@ private:
 	void			clearNoteQueue();
 	/** Clear all audio buffers.
 	 */
-	void			clearAudioBuffers( uint32_t nFrames );	
-	/**
-	 * Create an audio driver using audioEngine_process() as its argument
-	 * based on the provided choice and calling their _init()_ function to
-	 * trigger their initialization.
-	 *
-	 * For a listing of all possible choices, please see
-	 * Preferences::m_sAudioDriver.
-	 *
-	 * \param sDriver String specifying which audio driver should be
-	 * created.
-	 * \return Pointer to the freshly created audio driver. If the
-	 * creation resulted in a NullDriver, the corresponding object will be
-	 * deleted and a null pointer returned instead.
-	 */
-	AudioOutput*	createDriver( const QString& sDriver );
+	void			clearAudioBuffers( uint32_t nFrames );
 	/**
 	 * Takes all notes from the current patterns, from the MIDI queue
 	 * #m_midiNoteQueue, and those triggered by the metronome and pushes

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -636,15 +636,13 @@ void Hydrogen::restartDrivers()
 	m_pAudioEngine->restartAudioDrivers();
 }
 
-bool Hydrogen::startExportSession(int sampleRate, int sampleDepth )
+bool Hydrogen::startExportSession( int nSampleRate, int nSampleDepth )
 {
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
 	if ( pAudioEngine->getState() == AudioEngine::State::Playing ) {
 		sequencer_stop();
 	}
-	
-	unsigned nSamplerate = (unsigned) sampleRate;
 
 	std::shared_ptr<Song> pSong = getSong();
 	
@@ -660,17 +658,24 @@ bool Hydrogen::startExportSession(int sampleRate, int sampleDepth )
 	 * Stop the current driver and fire up the DiskWriter.
 	 */
 	pAudioEngine->stopAudioDrivers();
+	
+	AudioOutput* pDriver =
+		pAudioEngine->createAudioDriver( "DiskWriterDriver" );
 
-	DiskWriterDriver* pNewDriver = new DiskWriterDriver( AudioEngine::audioEngine_process, nSamplerate, sampleDepth );
-	int nRes = pNewDriver->init( Preferences::get_instance()->m_nBufferSize );
-	if ( nRes != 0 ) {
-		ERRORLOG( "Unable to initialize disk writer driver." );
+	DiskWriterDriver* pDiskWriterDriver = dynamic_cast<DiskWriterDriver*>( pDriver );
+	if ( pDriver == nullptr || pDiskWriterDriver == nullptr ) {
+		ERRORLOG( "Unable to start up DiskWriterDriver" );
+
+		if ( pDriver != nullptr ) {
+			delete pDriver;
+		}
 		return false;
 	}
-	m_bExportSessionIsActive = true;
 	
-	pAudioEngine->setAudioDriver( pNewDriver );
-	pAudioEngine->setupLadspaFX();
+	pDiskWriterDriver->setSampleRate( static_cast<unsigned>(nSampleRate) );
+	pDiskWriterDriver->setSampleDepth( nSampleDepth );
+
+	m_bExportSessionIsActive = true;
 
 	return true;
 }

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -722,9 +722,7 @@ void Hydrogen::stopExportSession()
 /// Used to display audio driver info
 AudioOutput* Hydrogen::getAudioOutput() const
 {
-	AudioEngine* pAudioEngine = m_pAudioEngine;
-
-	return pAudioEngine->getAudioDriver();
+	return m_pAudioEngine->getAudioDriver();
 }
 
 /// Used to display midi driver info

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -295,12 +295,12 @@ void* diskWriterDriver_thread( void* param )
 
 
 
-DiskWriterDriver::DiskWriterDriver( audioProcessCallback processCallback, unsigned nSamplerate, int nSampleDepth )
+DiskWriterDriver::DiskWriterDriver( audioProcessCallback processCallback )
 		: AudioOutput()
-		, m_nSampleRate( nSamplerate )
-		, m_nSampleDepth ( nSampleDepth )
+		, m_nSampleRate( 4800 )
+		, m_nSampleDepth( 32 )
 		, m_processCallback( processCallback )
-		, m_nBufferSize( 0 )
+		, m_nBufferSize( 1024 )
 		, m_pOut_L( nullptr )
 		, m_pOut_R( nullptr ) {
 }

--- a/src/core/IO/DiskWriterDriver.h
+++ b/src/core/IO/DiskWriterDriver.h
@@ -51,7 +51,7 @@ class DiskWriterDriver : public Object<DiskWriterDriver>, public AudioOutput
 		float*					m_pOut_L;
 		float*					m_pOut_R;
 
-		DiskWriterDriver( audioProcessCallback processCallback, unsigned nSamplerate, int nSampleDepth );
+		DiskWriterDriver( audioProcessCallback processCallback );
 		~DiskWriterDriver();
 
 		virtual int init( unsigned nBufferSize ) override;
@@ -66,6 +66,12 @@ class DiskWriterDriver : public Object<DiskWriterDriver>, public AudioOutput
 		}
 
 		virtual unsigned getSampleRate() override;
+	void setSampleRate( unsigned nNewRate ) {
+		m_nSampleRate = nNewRate;
+	}
+	void setSampleDepth( int nNewDepth ) {
+		m_nSampleDepth = nNewDepth;
+	}
 		
 		virtual float* getOut_L() override {
 			return m_pOut_L;

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -57,18 +57,21 @@ namespace H2Core {
 int JackAudioDriver::jackDriverSampleRate( jack_nframes_t nframes, void* param ){
 	// Used for logging.
 	Base * __object = ( Base * )param;
-	QString msg = QString("Jack SampleRate changed: the sample rate is now %1/sec").arg( QString::number( static_cast<int>(nframes) ) );
 	// The __INFOLOG macro uses the Base *__object and not the
 	// Object instance as INFOLOG does. It will call
 	// __object->logger()->log( H2Core::Logger::Info, ..., msg )
 	// (see object.h).
-	__INFOLOG( msg );
+	__INFOLOG( QString("New JACK sample rate: [%1]/sec")
+			   .arg( QString::number( static_cast<int>(nframes) ) ) );
 	JackAudioDriver::jackServerSampleRate = nframes;
 	return 0;
 }
 
-int JackAudioDriver::jackDriverBufferSize( jack_nframes_t nframes, void* arg ){
+int JackAudioDriver::jackDriverBufferSize( jack_nframes_t nframes, void* param ){
 	// This function does _NOT_ have to be realtime safe.
+	Base * __object = ( Base * )param;
+	__INFOLOG( QString("new JACK buffer size: [%1]")
+			   .arg( QString::number( static_cast<int>(nframes) ) ) );
 	JackAudioDriver::jackServerBufferSize = nframes;
 	return 0;
 }
@@ -217,7 +220,6 @@ void JackAudioDriver::disconnect()
 	m_pClient = nullptr;
 	
 	if ( pOldClient != nullptr ) {
-		INFOLOG( "calling jack_client_close" );
 		int nReturnCode = jack_client_close( pOldClient );
 		if ( nReturnCode != 0 ) {
 			ERRORLOG( "Error in jack_client_close" );
@@ -230,7 +232,6 @@ void JackAudioDriver::disconnect()
 void JackAudioDriver::deactivate()
 {
 	if ( m_pClient != nullptr ) {
-		INFOLOG( "calling jack_deactivate" );
 		int nReturnCode = jack_deactivate( m_pClient );
 		if ( nReturnCode != 0 ) {
 			ERRORLOG( "Error in jack_deactivate" );
@@ -412,9 +413,9 @@ bool JackAudioDriver::compareAdjacentBBT() const
 	
 	if ( m_JackTransportPos.beats_per_minute !=
 		 m_previousJackTransportPos.beats_per_minute ) {
-		INFOLOG( QString( "Change in tempo from [%1] to [%2]" )
-				 .arg( m_previousJackTransportPos.beats_per_minute )
-				 .arg( m_JackTransportPos.beats_per_minute ) );
+		// DEBUGLOG( QString( "Change in tempo from [%1] to [%2]" )
+		// 		  .arg( m_previousJackTransportPos.beats_per_minute )
+		// 		  .arg( m_JackTransportPos.beats_per_minute ) );
 		return false;
 	}
 
@@ -439,11 +440,11 @@ bool JackAudioDriver::compareAdjacentBBT() const
 			if ( m_JackTransportPos.bar !=
 				m_previousJackTransportPos.bar + 1 ||
 				m_JackTransportPos.beat != 1 ) {
-				INFOLOG( QString( "Change in position from bar:beat [%1]:[%2] to [%3]:[%4]*" )
-						 .arg( m_previousJackTransportPos.bar )
-						 .arg( m_previousJackTransportPos.beat )
-						 .arg( m_JackTransportPos.bar )
-						 .arg( m_JackTransportPos.beat ) );
+				// DEBUGLOG( QString( "Change in position from bar:beat [%1]:[%2] to [%3]:[%4]*" )
+				// 		  .arg( m_previousJackTransportPos.bar )
+				// 		  .arg( m_previousJackTransportPos.beat )
+				// 		  .arg( m_JackTransportPos.bar )
+				// 		  .arg( m_JackTransportPos.beat ) );
 				return false;
 			}
 		} else {
@@ -451,11 +452,11 @@ bool JackAudioDriver::compareAdjacentBBT() const
 				m_previousJackTransportPos.bar ||
 				m_JackTransportPos.beat !=
 				m_previousJackTransportPos.beat + 1 ) {
-				INFOLOG( QString( "Change in position from bar:beat [%1]:[%2] to [%3]:[%4]**" )
-						 .arg( m_previousJackTransportPos.bar )
-						 .arg( m_previousJackTransportPos.beat )
-						 .arg( m_JackTransportPos.bar )
-						 .arg( m_JackTransportPos.beat ) );
+				// DEBUGLOG( QString( "Change in position from bar:beat [%1]:[%2] to [%3]:[%4]**" )
+				// 		  .arg( m_previousJackTransportPos.bar )
+				// 		  .arg( m_previousJackTransportPos.beat )
+				// 		  .arg( m_JackTransportPos.bar )
+				// 		  .arg( m_JackTransportPos.beat ) );
 				return false;
 			}
 		}
@@ -463,11 +464,11 @@ bool JackAudioDriver::compareAdjacentBBT() const
 				m_previousJackTransportPos.bar ||
 				m_JackTransportPos.beat !=
 				m_previousJackTransportPos.beat ) {
-		INFOLOG( QString( "Change in position from bar:beat [%1]:[%2] to [%3]:[%4]***" )
-				 .arg( m_previousJackTransportPos.bar )
-				 .arg( m_previousJackTransportPos.beat )
-				 .arg( m_JackTransportPos.bar )
-				 .arg( m_JackTransportPos.beat ) );
+		// DEBUGLOG( QString( "Change in position from bar:beat [%1]:[%2] to [%3]:[%4]***" )
+		// 		  .arg( m_previousJackTransportPos.bar )
+		// 		  .arg( m_previousJackTransportPos.beat )
+		// 		  .arg( m_JackTransportPos.bar )
+		// 		  .arg( m_JackTransportPos.beat ) );
 		return false;
 	}
 
@@ -476,10 +477,10 @@ bool JackAudioDriver::compareAdjacentBBT() const
 			  m_JackTransportPos.ticks_per_beat - nNewTick ) > 1 &&
 		 abs( m_JackTransportPos.tick +
 			  m_JackTransportPos.ticks_per_beat - nNewTick ) > 1 ) {
-		INFOLOG( QString( "Change in position from tick [%1] to [%2] instead of [%3]" )
-				 .arg( m_previousJackTransportPos.tick )
-				 .arg( m_JackTransportPos.tick )
-				 .arg( nNewTick ));
+		// DEBUGLOG( QString( "Change in position from tick [%1] to [%2] instead of [%3]" )
+		// 		  .arg( m_previousJackTransportPos.tick )
+		// 		  .arg( m_JackTransportPos.tick )
+		// 		  .arg( nNewTick ));
 		return false;
 	}
 		
@@ -804,7 +805,7 @@ int JackAudioDriver::init( unsigned bufferSize )
 	/* tell JACK server to update us if the buffer size
 	   (frames per process cycle) changes.
 	*/
-	jack_set_buffer_size_callback( m_pClient, jackDriverBufferSize, nullptr );
+	jack_set_buffer_size_callback( m_pClient, jackDriverBufferSize, this );
 
 	/* display an XRun event in the GUI.*/
 	jack_set_xrun_callback( m_pClient, jackXRunCallback, nullptr );

--- a/src/core/IO/PortAudioDriver.cpp
+++ b/src/core/IO/PortAudioDriver.cpp
@@ -286,7 +286,8 @@ unsigned PortAudioDriver::getSampleRate()
 int PortAudioDriver::getLatency()
 {
 	const PaStreamInfo *pStreamInfo = Pa_GetStreamInfo( m_pStream );
-	return (int)( pStreamInfo->outputLatency * getSampleRate() );
+	return std::max( static_cast<int>( pStreamInfo->outputLatency * getSampleRate() ),
+					 0 );
 }
 
 float* PortAudioDriver::getOut_L()

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -310,6 +310,10 @@ CommonStrings::CommonStrings(){
 	/*: Displayed when hovering over the button in the
 	PatternEditorPanel to activate the PianoRollEditor.*/
 	m_sShowPianoRollEditorTooltip = tr( "Show piano roll editor" );
+	
+	m_sAudioDriverStartError = tr( "Unable to start audio driver!" );
+	m_sAudioDriverErrorHint = tr( "Please use the Preferences to select a different one." );
+	m_sAudioDriverNotPresent = tr( "No audio driver set!" );
 
 	m_sJackMasterTooltip = tr("JACK Timebase master on/off");
 	m_sJackMasterDisabledTooltip = tr( "JACK timebase support is disabled in the Preferences" );

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -123,6 +123,10 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getShowPianoRollEditorTooltip() const { return m_sShowPianoRollEditorTooltip; }
 	const QString& getPatternSizeDisabledTooltip() const { return m_sPatternSizeDisabledTooltip; }
 	
+	const QString& getAudioDriverStartError() const { return m_sAudioDriverStartError; }
+	const QString& getAudioDriverErrorHint() const { return m_sAudioDriverErrorHint; }
+	const QString& getAudioDriverNotPresent() const { return m_sAudioDriverNotPresent; }
+	
 	const QString& getJackMasterTooltip() const { return m_sJackMasterTooltip; }
 	const QString& getJackMasterDisabledTooltip() const { return m_sJackMasterDisabledTooltip; }
 	
@@ -237,6 +241,10 @@ private:
 	
 	QString m_sShowDrumkitEditorTooltip;
 	QString m_sShowPianoRollEditorTooltip;
+	
+	QString m_sAudioDriverStartError;
+	QString m_sAudioDriverErrorHint;
+	QString m_sAudioDriverNotPresent;
 
 	QString m_sJackMasterTooltip;
 	QString m_sJackMasterDisabledTooltip;

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -214,8 +214,9 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 	if ( pHydrogen->getAudioOutput() == nullptr ||
 		 dynamic_cast<NullDriver*>(pHydrogen->getAudioOutput()) != nullptr ) {
 		QMessageBox::warning( this, "Hydrogen",
-							   QString( "%1\n%2" )
+							   QString( "%1 [%2]\n%3" )
 							  .arg( pCommonStrings->getAudioDriverStartError() )
+							  .arg( pPref->m_sAudioDriver )
 							  .arg( pCommonStrings->getAudioDriverErrorHint() ) );
 	}
 }

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -89,6 +89,7 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 	, m_sPreviousAutoSaveFilename( "" )
 {
 	auto pPref = H2Core::Preferences::get_instance();
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
 	
 	setObjectName( "MainForm" );
 	setMinimumSize( QSize( 1000, 500 ) );
@@ -109,7 +110,7 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 	// will be loaded by the NSM client singleton itself and not
 	// by the MainForm. The latter will just access the already
 	// loaded Song.
-	if ( ! H2Core::Hydrogen::get_instance()->isUnderSessionManagement() ){
+	if ( ! pHydrogen->isUnderSessionManagement() ){
 		std::shared_ptr<H2Core::Song>pSong = nullptr;
 
 		if ( sSongFilename.isEmpty() ) {
@@ -191,7 +192,7 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 	// ~ playlist display timer
 
 	//beatcouter
-	Hydrogen::get_instance()->setBcOffsetAdjust();
+	pHydrogen->setBcOffsetAdjust();
 
 	m_pUndoView = new QUndoView(h2app->m_pUndoStack);
 	m_pUndoView->setWindowTitle(tr("Undo history"));
@@ -203,6 +204,19 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 		if( !loadlist ){
 			_ERRORLOG ( "Error loading the playlist" );
 		}
+	}
+
+	// Must be done _after_ the creation of the HydrogenApp instance.
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	
+	// Check whether the audio driver could be loaded based on the
+	// content of the config file
+	if ( pHydrogen->getAudioOutput() == nullptr ||
+		 dynamic_cast<NullDriver*>(pHydrogen->getAudioOutput()) != nullptr ) {
+		QMessageBox::warning( this, "Hydrogen",
+							   QString( "%1\n%2" )
+							  .arg( pCommonStrings->getAudioDriverStartError() )
+							  .arg( pCommonStrings->getAudioDriverErrorHint() ) );
 	}
 }
 
@@ -1703,6 +1717,10 @@ void MainForm::initKeyInstMap()
 
 bool MainForm::eventFilter( QObject *o, QEvent *e )
 {
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pHydrogenApp = HydrogenApp::get_instance();
+	
 	if ( e->type() == QEvent::FileOpen ) {
 		// Mac OS always opens files (including via double click in Finder) via a FileOpenEvent.
 		QFileOpenEvent *fe = dynamic_cast<QFileOpenEvent*>(e);
@@ -1711,14 +1729,14 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 
 		if ( sFileName.endsWith( H2Core::Filesystem::songs_ext ) ) {
 			if ( handleUnsavedChanges() ) {
-				HydrogenApp::get_instance()->openSong( sFileName );
+				pHydrogenApp->openSong( sFileName );
 			}
 
 		} else if ( sFileName.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
 			H2Core::Drumkit::install( sFileName );
 
 		} else if ( sFileName.endsWith( H2Core::Filesystem::playlist_ext ) ) {
-			bool loadlist = HydrogenApp::get_instance()->getPlayListDialog()->loadListByFileName( sFileName );
+			bool loadlist = pHydrogenApp->getPlayListDialog()->loadListByFileName( sFileName );
 			if ( loadlist ) {
 				H2Core::Playlist::get_instance()->setNextSongByNumber( 0 );
 			}
@@ -1730,10 +1748,19 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 		QKeyEvent *k = (QKeyEvent *)e;
 
 		// qDebug( "Got key press for instrument '%c'", k->ascii() );
-		//int songnumber = 0;
-		Hydrogen* pHydrogen = Hydrogen::get_instance();
 		switch (k->key()) {
 		case Qt::Key_Space:
+
+			// Hint that something is wrong in case there is no proper audio
+			// driver set.
+			if ( pHydrogen->getAudioOutput() == nullptr ||
+				 dynamic_cast<NullDriver*>(pHydrogen->getAudioOutput()) != nullptr ) {
+				QMessageBox::warning( this, "Hydrogen",
+									  QString( "%1\n%2" )
+									  .arg( pCommonStrings->getAudioDriverNotPresent() )
+									  .arg( pCommonStrings->getAudioDriverErrorHint() ) );
+				return true;
+			}
 
 			switch ( k->modifiers() ) {
 			case Qt::NoModifier:

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -643,6 +643,19 @@ void PlayerControl::recBtnClicked() {
 
 /// Start audio engine
 void PlayerControl::playBtnClicked() {
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+
+	// Hint that something is wrong in case there is no proper audio
+	// driver set.
+	if ( m_pHydrogen->getAudioOutput() == nullptr ||
+		 dynamic_cast<NullDriver*>(m_pHydrogen->getAudioOutput()) != nullptr ) {
+		QMessageBox::warning( this, "Hydrogen",
+							   QString( "%1\n%2" )
+							  .arg( pCommonStrings->getAudioDriverNotPresent() )
+							  .arg( pCommonStrings->getAudioDriverErrorHint() ) );
+		return;
+	}
+	
 	if ( ! m_pPlayBtn->isChecked() ) {
 		m_pHydrogen->sequencer_play();
 		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Playing."), 5000);
@@ -656,12 +669,24 @@ void PlayerControl::playBtnClicked() {
 /// Stop audio engine
 void PlayerControl::stopBtnClicked()
 {
-	auto pHydrogen = Hydrogen::get_instance();
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+
+	// Hint that something is wrong in case there is no proper audio
+	// driver set.
+	if ( m_pHydrogen->getAudioOutput() == nullptr ||
+		 dynamic_cast<NullDriver*>(m_pHydrogen->getAudioOutput()) != nullptr ) {
+		QMessageBox::warning( this, "Hydrogen",
+							   QString( "%1\n%2" )
+							  .arg( pCommonStrings->getAudioDriverNotPresent() )
+							  .arg( pCommonStrings->getAudioDriverErrorHint() ) );
+		return;
+	}
+	
 	if ( ! m_pPlayBtn->isDown() ) {
 		m_pPlayBtn->setChecked(false);
 	}
-	pHydrogen->sequencer_stop();
-	pHydrogen->getCoreActionController()->locateToColumn( 0 );
+	m_pHydrogen->sequencer_stop();
+	m_pHydrogen->getCoreActionController()->locateToColumn( 0 );
 	(HydrogenApp::get_instance())->setStatusBarMessage(tr("Stopped."), 5000);
 }
 

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -781,7 +781,9 @@ void PreferencesDialog::on_okBtn_clicked()
 	if ( pHydrogen->getAudioOutput() == nullptr ||
 		 dynamic_cast<NullDriver*>(pHydrogen->getAudioOutput()) != nullptr ) {
 		int nRes = QMessageBox::warning( this, "Hydrogen",
-										 tr( "No audio driver set.\nAre you sure you want to proceed?" ),
+										 QString( "%1\n" )
+										 .arg( pCommonStrings->getAudioDriverNotPresent() )
+										 .append( tr( "Are you sure you want to proceed?" ) ),
 										 pCommonStrings->getButtonOk(),
 										 pCommonStrings->getButtonCancel(),
 										 nullptr, 1 );
@@ -1442,10 +1444,14 @@ void PreferencesDialog::sampleRateComboBoxEditTextChanged( const QString&  )
 
 void PreferencesDialog::on_restartDriverBtn_clicked()
 {
+	QApplication::setOverrideCursor( Qt::WaitCursor );
+	
 	updateDriverPreferences();
 	Preferences *pPref = Preferences::get_instance();
 	auto pHydrogen = Hydrogen::get_instance();
 	pHydrogen->restartDrivers();
+	
+	QApplication::restoreOverrideCursor();
 
 	if ( pHydrogen->getAudioOutput() == nullptr ||
 		 dynamic_cast<NullDriver*>(pHydrogen->getAudioOutput()) != nullptr ) {

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -930,33 +930,29 @@ void PreferencesDialog::updateDriverInfo()
 	auto pAudioDriver = Hydrogen::get_instance()->getAudioOutput();
 
 	// Reset info text
-	driverInfoLbl->setText("");
+	updateDriverInfoLabel();
 
 	if ( driverComboBox->currentText() == "Auto" ) {
 
-		driverInfoLbl->setText( tr("Automatic driver selection")
-								.append( "<br><br>" ));
-
 		if ( dynamic_cast<H2Core::JackAudioDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoJack();
-		} else if ( dynamic_cast<H2Core::AlsaAudioDriver*>(pAudioDriver) != nullptr ) {
+		}
+		else if ( dynamic_cast<H2Core::AlsaAudioDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoAlsa();
-		} else if ( dynamic_cast<H2Core::PortAudioDriver*>(pAudioDriver) != nullptr ) {
+		}
+		else if ( dynamic_cast<H2Core::PortAudioDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoPortAudio();
-		} else if ( dynamic_cast<H2Core::CoreAudioDriver*>(pAudioDriver) != nullptr ) {
+		}
+		else if ( dynamic_cast<H2Core::CoreAudioDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoCoreAudio();
-		} else if ( dynamic_cast<H2Core::PulseAudioDriver*>(pAudioDriver) != nullptr ) {
+		}
+		else if ( dynamic_cast<H2Core::PulseAudioDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoPulseAudio();
-		} else if ( dynamic_cast<H2Core::OssDriver*>(pAudioDriver) != nullptr ) {
+		}
+		else if ( dynamic_cast<H2Core::OssDriver*>(pAudioDriver) != nullptr ) {
 			setDriverInfoOss();
-		} else {
-			QString sInfo = driverInfoLbl->text();
-		
-			// Display the selected driver as well.
-			sInfo.append( "<b>" )
-				.append( tr( "Error starting audio driver" ) )
-				.append( "</b> " );
-			driverInfoLbl->setText( sInfo );
+		}
+		else {
 		
 			m_pAudioDeviceTxt->setDriver( "Null" );
 			m_pAudioDeviceTxt->setIsActive( false );
@@ -1012,23 +1008,113 @@ void PreferencesDialog::updateDriverInfo()
 	bufferSizeSpinBox->setValue( pPref->m_nBufferSize );
 }
 
+void PreferencesDialog::updateDriverInfoLabel() {
+
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	auto pAudioDriver = Hydrogen::get_instance()->getAudioOutput();
+	QString sInfo;
+
+	if ( driverComboBox->currentText() == "Auto" ) {
+		sInfo.append( tr("Automatic driver selection") )
+			.append( "<br><br>" );
+	}
+	
+	if ( dynamic_cast<H2Core::JackAudioDriver*>(pAudioDriver) != nullptr ) {		
+		sInfo.append( "<b>" )
+			.append( tr( "JACK Audio Connection Kit Driver" ) )
+			.append( "</b><br>" )
+			.append( tr( "Low latency audio driver" ) );
+#ifndef H2CORE_HAVE_JACK
+		sInfo.append( "<br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getPreferencesNotCompiled() )
+			.append( "</font></b>" );
+#endif
+	}
+	else if ( dynamic_cast<H2Core::AlsaAudioDriver*>(pAudioDriver) != nullptr ) {
+		sInfo.append( "<b>" ).append( tr( "ALSA Driver" ) )
+			.append( "</b><br>" );
+#ifndef H2CORE_HAVE_ALSA
+		sInfo.append( "<br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getPreferencesNotCompiled() )
+			.append( "</font></b>" );
+#else
+		auto pAlsaDriver =
+			dynamic_cast<H2Core::AlsaAudioDriver*>(Hydrogen::get_instance()->getAudioOutput());
+		if ( pAlsaDriver != nullptr ) {
+			sInfo.append( "<br>" ).append( tr( "Currently connected to device: " ) )
+				.append( "<b>" ).append( pAlsaDriver->m_sAlsaAudioDevice )
+				.append( "</b>" );
+		} else {
+			ERRORLOG( "ALSA driver selected in PreferencesDialog but no ALSA driver running?" );
+		}
+#endif
+	}
+	else if ( dynamic_cast<H2Core::PortAudioDriver*>(pAudioDriver) != nullptr ) {
+		sInfo.append( "<b>" ).append( tr( "PortAudio Driver" ) )
+			.append( "</b><br>" );
+#ifndef H2CORE_HAVE_PORTAUDIO
+		sInfo.append( "<br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getPreferencesNotCompiled() )
+			.append( "</font></b>" );
+#endif
+	}
+	else if ( dynamic_cast<H2Core::CoreAudioDriver*>(pAudioDriver) != nullptr ) {	
+		sInfo.append( "<b>" ).append( tr( "CoreAudio Driver" ) )
+			.append( "</b><br>" );
+#ifndef H2CORE_HAVE_COREAUDIO
+		sInfo.append( "<br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getPreferencesNotCompiled() )
+			.append( "</font></b>" );
+#endif
+	}
+	else if ( dynamic_cast<H2Core::PulseAudioDriver*>(pAudioDriver) != nullptr ) {		
+		sInfo.append( "<b>" ).append( tr( "PulseAudio Driver" ) )
+			.append( "</b><br>" );
+#ifndef H2CORE_HAVE_PULSEAUDIO
+		sInfo.append( "<br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getPreferencesNotCompiled() )
+			.append( "</font></b>" );
+#endif
+	}
+	else if ( dynamic_cast<H2Core::OssDriver*>(pAudioDriver) != nullptr ) {
+		sInfo.append( "<b>" ).append( tr( "Open Sound System" ) )
+			.append( "</b><br>" )
+			.append( tr( "Simple audio driver [/dev/dsp]" ) );
+#ifndef H2CORE_HAVE_OSS
+		sInfo.append( "<br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getPreferencesNotCompiled() )
+			.append( "</font></b>" );
+#endif
+	}
+	else {
+		
+		if ( driverComboBox->currentText() == "Auto" ) {
+		
+			// Display the selected driver as well.
+			sInfo.append( "<b>" )
+				.append( tr( "Error starting audio driver" ) )
+				.append( "</b><br><br>" );
+		}
+		
+		// Display the selected driver as well.
+		sInfo.append( "NullDriver" )
+			.append( "<br><br><b><font color=" )
+			.append( m_sColorRed ).append( ">")
+			.append( pCommonStrings->getAudioDriverNotPresent() )
+			.append( "</font></b>" );
+	}
+	
+	driverInfoLbl->setText( sInfo );
+}
+
 void PreferencesDialog::setDriverInfoOss() {
 	auto pPref = H2Core::Preferences::get_instance();
-	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
-	QString sInfo = driverInfoLbl->text();
-		
-	sInfo.append( "<b>" ).append( tr( "Open Sound System" ) )
-		.append( "</b><br>" )
-		.append( tr( "Simple audio driver [/dev/dsp]" ) );
-#ifndef H2CORE_HAVE_OSS
-	sInfo.append( "<br><b><font color=" )
-		.append( m_sColorRed ).append( ">")
-		.append( pCommonStrings->getPreferencesNotCompiled() )
-		.append( "</font></b>" );
-
-#endif
-	driverInfoLbl->setText( sInfo );
 	
 	m_pAudioDeviceTxt->setDriver( "OSS" );
 	m_pAudioDeviceTxt->setIsActive(true);
@@ -1054,29 +1140,6 @@ void PreferencesDialog::setDriverInfoOss() {
 
 void PreferencesDialog::setDriverInfoAlsa() {
 	auto pPref = H2Core::Preferences::get_instance();
-	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
-	QString sInfo = driverInfoLbl->text();
-		
-	sInfo.append( "<b>" ).append( tr( "ALSA Driver" ) )
-		.append( "</b><br>" );
-#ifndef H2CORE_HAVE_ALSA
-	sInfo.append( "<br><b><font color=" )
-		.append( m_sColorRed ).append( ">")
-		.append( pCommonStrings->getPreferencesNotCompiled() )
-		.append( "</font></b>" );
-#else
-	auto pAlsaDriver =
-		dynamic_cast<H2Core::AlsaAudioDriver*>(Hydrogen::get_instance()->getAudioOutput());
-	if ( pAlsaDriver != nullptr ) {
-		sInfo.append( "<br>" ).append( tr( "Currently connected to device: " ) )
-			.append( "<b>" ).append( pAlsaDriver->m_sAlsaAudioDevice )
-			.append( "</b>" );
-	} else {
-		ERRORLOG( "ALSA driver selected in PreferencesDialog but no ALSA driver running?" );
-	}
-#endif
-	driverInfoLbl->setText( sInfo );
 
 	m_pAudioDeviceTxt->setDriver( "ALSA" );
 	m_pAudioDeviceTxt->setIsActive(true);
@@ -1103,20 +1166,6 @@ void PreferencesDialog::setDriverInfoAlsa() {
 void PreferencesDialog::setDriverInfoJack() {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	
-	QString sInfo = driverInfoLbl->text();
-		
-	sInfo.append( "<b>" )
-		.append( tr( "JACK Audio Connection Kit Driver" ) )
-		.append( "</b><br>" )
-		.append( tr( "Low latency audio driver" ) );
-#ifndef H2CORE_HAVE_JACK
-	sInfo.append( "<br><b><font color=" )
-		.append( m_sColorRed ).append( ">")
-		.append( pCommonStrings->getPreferencesNotCompiled() )
-		.append( "</font></b>" );
-#endif
-	driverInfoLbl->setText( sInfo );
-
 	m_pAudioDeviceTxt->setDriver( "JACK" );
 	m_pAudioDeviceTxt->setIsActive(false);
 	m_pAudioDeviceTxt->lineEdit()->setText( "" );
@@ -1147,19 +1196,6 @@ void PreferencesDialog::setDriverInfoJack() {
 
 void PreferencesDialog::setDriverInfoCoreAudio() {
 	auto pPref = H2Core::Preferences::get_instance();
-	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
-	QString sInfo = driverInfoLbl->text();
-		
-	sInfo.append( "<b>" ).append( tr( "CoreAudio Driver" ) )
-		.append( "</b><br>" );
-#ifndef H2CORE_HAVE_COREAUDIO
-	sInfo.append( "<br><b><font color=" )
-		.append( m_sColorRed ).append( ">")
-		.append( pCommonStrings->getPreferencesNotCompiled() )
-		.append( "</font></b>" );
-#endif
-	driverInfoLbl->setText( sInfo );
 
 	m_pAudioDeviceTxt->setDriver( "CoreAudio" );
 	m_pAudioDeviceTxt->setIsActive( true );
@@ -1185,19 +1221,6 @@ void PreferencesDialog::setDriverInfoCoreAudio() {
 
 void PreferencesDialog::setDriverInfoPortAudio() {
 	auto pPref = H2Core::Preferences::get_instance();
-	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
-	QString sInfo = driverInfoLbl->text();
-		
-	sInfo.append( "<b>" ).append( tr( "PortAudio Driver" ) )
-		.append( "</b><br>" );
-#ifndef H2CORE_HAVE_PORTAUDIO
-	sInfo.append( "<br><b><font color=" )
-		.append( m_sColorRed ).append( ">")
-		.append( pCommonStrings->getPreferencesNotCompiled() )
-		.append( "</font></b>" );
-#endif
-	driverInfoLbl->setText( sInfo );
 
 	m_pAudioDeviceTxt->setDriver( "PortAudio" );
 	m_pAudioDeviceTxt->setIsActive( true );
@@ -1223,19 +1246,6 @@ void PreferencesDialog::setDriverInfoPortAudio() {
 }
 
 void PreferencesDialog::setDriverInfoPulseAudio() {
-	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
-	QString sInfo = driverInfoLbl->text();
-		
-	sInfo.append( "<b>" ).append( tr( "PulseAudio Driver" ) )
-		.append( "</b><br>" );
-#ifndef H2CORE_HAVE_PULSEAUDIO
-	sInfo.append( "<br><b><font color=" )
-		.append( m_sColorRed ).append( ">")
-		.append( pCommonStrings->getPreferencesNotCompiled() )
-		.append( "</font></b>" );
-#endif
-	driverInfoLbl->setText( sInfo );
 	
 	m_pAudioDeviceTxt->setDriver( "PulseAudio" );
 	m_pAudioDeviceTxt->setIsActive(false);

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.h
@@ -149,6 +149,7 @@ class PreferencesDialog :  public QDialog, private Ui_PreferencesDialog_UI,  pub
 private:
 
 	void updateDriverInfo();
+	void updateDriverInfoLabel();
 	void setDriverInfoOss();
 	void setDriverInfoAlsa();
 	void setDriverInfoJack();


### PR DESCRIPTION
In the previous behavior a different driver was started by Hydrogen unbeknownst to the user in case the selected one was unable to start. Now, it resorts to `NullDriver` in case the driver picked by the user could not be started. The Fallback can still be used via the "Auto" driver. By letting the audio driver selection fail temporarily the whole selection process becomes more clear.

This required some addition popup dialogs to inform the user about what is going on:
- The Preferences dialog will prompt an error popup when not able to restart the selected driver
- The Preferences dialog will prompt a warning dialog in case the OK button was clicked while `NullDriver` is present in the `AudioEngine`.
- During startup a dialog informs the user in case the selected driver couldn't be started and hints to set a different one in the preferences.
- When clicking Play or Stop in the PlayerControl or <kbd>Space</kbd> a dialog informs the user that no driver is present and hints to set a different one in the preferences.

Additional changes:
- `AudioEngine::setAudioDriver` was merged into `AudioEngine::createAudioDriver` in order for the driver assignment to properly fail in case the call to its `connect` routine did not succeed.
- `JackAudioDriver` does now print the buffer size received from the server in the log
- `PortAudioDriver` got 0 as a lower bound for its latency (since I got some artifacts (invalid values) at certain configurations)
- Previously, the info printed in the right column of the Audio tab in the PreferencesDialog was based solely on the selection of the driver in the corresponding combo box. This had two flaws
   - Whenever the selected driver could not be loaded and the NullDriver was used instead, the user was not informed
   - The info was printed the moment another driver was selected in the combo box. Now, the info does represent the driver running in the audio engine. It thus requires a restart of the driver in order to driver info to update. This is a nice hint that a restart of the driver is required.

Fixes #1514 