### PR TITLE
Fix note deletion in PatternEdtior and memory leakage (#1520)

### DIFF
--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -355,7 +355,7 @@ void DrumPatternEditor::mouseDragUpdateEvent( QMouseEvent *ev )
 }
 
 void DrumPatternEditor::addOrDeleteNoteAction(	int nColumn,
-												int nInstrumentID,
+												int nInstrumentRow,
 												int nSelectedPatternNumber,
 												int oldLength,
 												float oldVelocity,
@@ -389,10 +389,9 @@ void DrumPatternEditor::addOrDeleteNoteAction(	int nColumn,
 
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 
-	auto pSelectedInstrument = pSong->getInstrumentList()->get( nInstrumentID );
+	auto pSelectedInstrument = pSong->getInstrumentList()->get( nInstrumentRow );
 
 	m_pAudioEngine->lock( RIGHT_HERE );	// lock the audio engine
-
 
 	if ( isDelete ) {
 
@@ -403,7 +402,7 @@ void DrumPatternEditor::addOrDeleteNoteAction(	int nColumn,
 			Note *pNote = it->second;
 			assert( pNote );
 			if ( ( isNoteOff && pNote->get_note_off() )
-				 || ( pNote->get_instrument()->get_id() == nInstrumentID
+				 || ( pNote->get_instrument()->get_id() == pSelectedInstrument->get_id()
 					  && pNote->get_key() == oldNoteKeyVal 
 					  && pNote->get_octave() == oldOctaveKeyVal
 					  && pNote->get_velocity() == oldVelocity

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -547,6 +547,7 @@ void PatternEditor::deselectAndOverwriteNotes( std::vector< H2Core::Note *> &sel
 			} else if ( pSelectedNote->match( pNote ) && pNote->get_position() == pSelectedNote->get_position() ) {
 				// Something else occupying the same position (which may or may not be an exact duplicate)
 				it = pNotes->erase( it );
+				delete pNote;
 			} else {
 				// Any other note
 				++it;


### PR DESCRIPTION
- fixing a recently introduced bug in the lookup of the note to be deleted using the instrument ID
- fix memory leakage #1520