### PR TITLE
Fix ADSR release/mute groups (#1573) and default DK selection on export

### DIFF
--- a/src/core/Basics/Adsr.cpp
+++ b/src/core/Basics/Adsr.cpp
@@ -249,8 +249,8 @@ bool ADSR::applyADSR( float *pLeft, float *pRight, int nFrames, int nReleaseFram
 	if ( __state == RELEASE ) {
 
 		int nReleaseFrames = nFrames - n;
-		if ( nReleaseFrames * fStep > __decay ) {
-			nReleaseFrames = ceil( __decay / fStep );
+		if ( nReleaseFrames * fStep > __release ) {
+			nReleaseFrames = ceil( __release / fStep );
 		}
 
 		m_fQ = applyExponential( fDecayExponent, -fDecayYOffset, 0.0, __release_value,
@@ -258,6 +258,7 @@ bool ADSR::applyADSR( float *pLeft, float *pRight, int nFrames, int nReleaseFram
 
 		n += nReleaseFrames;
 		__ticks += nReleaseFrames * fStep;
+		
 		if ( __ticks >= __release ) {
 			__state = IDLE;
 		}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1225,9 +1225,11 @@ void MainForm::functionDeleteInstrument(int instrument)
 }
 
 
-void MainForm::action_instruments_exportLibrary()
-{
-	SoundLibraryExportDialog exportDialog( this, QString(), H2Core::Hydrogen::get_instance()->getCurrentDrumkitLookup() );
+void MainForm::action_instruments_exportLibrary() {
+
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	SoundLibraryExportDialog exportDialog( this, pHydrogen->getCurrentDrumkitName(),
+										   pHydrogen->getCurrentDrumkitLookup() );
 	exportDialog.exec();
 }
 


### PR DESCRIPTION
- fix release in `ADSR::applyADSR()`
- use the currently loaded drumkit as the default selection when Drumkit > Export ing it via the main menu. Previously, the drumkit combo box was initialized empty.