### PR TITLE
MainForm: fix recent song opening (#1580)

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -981,17 +981,24 @@ void MainForm::action_file_openDemo() {
 	openSongWithDialog( sWindowTitle, Filesystem::demos_dir(), true );
 }
 
-void MainForm::openSongWithDialog( const QString& sWindowTitle, const QString& sPath, bool bIsDemo ) {
+bool MainForm::prepareSongOpening() {
+	
 	auto pHydrogen = Hydrogen::get_instance();
 	if ( pHydrogen->getAudioEngine()->getState() ==
 		 H2Core::AudioEngine::State::Playing ) {
 		pHydrogen->sequencer_stop();
 	}
 
-	bool bProceed = handleUnsavedChanges();
-	if( !bProceed ) {
+	return handleUnsavedChanges();
+}
+
+void MainForm::openSongWithDialog( const QString& sWindowTitle, const QString& sPath, bool bIsDemo ) {
+	// Check for unsaved changes.
+	if ( ! prepareSongOpening() ) {
 		return;
 	}
+	
+	auto pHydrogen = Hydrogen::get_instance();
 
 	QFileDialog fd(this);
 	fd.setFileMode( QFileDialog::ExistingFile );
@@ -1014,8 +1021,6 @@ void MainForm::openSongWithDialog( const QString& sWindowTitle, const QString& s
 			pHydrogen->getSong()->setFilename( "" );
 		}
 	}
-
-	HydrogenApp::get_instance()->getInstrumentRack()->getSoundLibraryPanel()->update_background_color();
 }
 
 void MainForm::showPreferencesDialog()
@@ -1547,6 +1552,11 @@ void MainForm::updateRecentUsedSongList()
 
 void MainForm::action_file_open_recent(QAction *pAction)
 {
+	// Check for unsaved changes.
+	if ( ! prepareSongOpening() ) {
+		return;
+	}
+	
 	HydrogenApp::get_instance()->openSong( pAction->text() );
 }
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -317,6 +317,7 @@ public slots:
 		QMenu* m_pInfoMenu;
 
 	void openSongWithDialog( const QString& sWindowTitle, const QString& sPath, bool bIsDemo );
+	bool prepareSongOpening();
 
 	/** Since the filename of the current song does change whenever
 		the users uses "Save As" multiple autosave files would be


### PR DESCRIPTION
When opening a recent song Hydrogen does now stop the engine as well as ask whether to discard unsaved modifications the same way it does when open a song or a demo.

Fixes #1580 