### PR TITLE
Fix MIDI action problems

### DIFF
--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -348,7 +348,7 @@ bool CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelec
 	
 	MidiMap*	pMidiMap = MidiMap::get_instance();
 	
-	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE"), QString("%1").arg( nStrip ) );
+	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE_SYM"), QString("%1").arg( nStrip ) );
 	handleOutgoingControlChanges( ccParamValues, pInstr->getPanWithRangeFrom0To1() * 127 );
 	pHydrogen->setIsModified( true );
 

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -53,10 +53,9 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 {
 		EventQueue::get_instance()->push_event( EVENT_MIDI_ACTIVITY, -1 );
 
-		INFOLOG( "[start of handleMidiMessage]" );
-		INFOLOG( QString("[handleMidiMessage] channel: %1").arg(msg.m_nChannel) );
-		INFOLOG( QString("[handleMidiMessage] val1: %1").arg( msg.m_nData1 ) );
-		INFOLOG( QString("[handleMidiMessage] val2: %1").arg( msg.m_nData2 ) );
+		INFOLOG( QString( "[start of handleMidiMessage] channel: %1, val1: %2, val2: %3" )
+				 .arg( msg.m_nChannel ).arg( msg.m_nData1 )
+				 .arg( msg.m_nData2 ) );
 
 		// midi channel filter for all messages
 		bool bIsChannelValid = true;

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -155,6 +155,7 @@ MidiActionManager::MidiActionManager() {
 	m_actionMap.insert(std::make_pair("SELECT_AND_PLAY_PATTERN", std::make_pair( &MidiActionManager::select_and_play_pattern, 1 ) ));
 	m_actionMap.insert(std::make_pair("PAN_RELATIVE", std::make_pair( &MidiActionManager::pan_relative, 1 ) ));
 	m_actionMap.insert(std::make_pair("PAN_ABSOLUTE", std::make_pair( &MidiActionManager::pan_absolute, 1 ) ));
+	m_actionMap.insert(std::make_pair("PAN_ABSOLUTE_SYM", std::make_pair( &MidiActionManager::pan_absolute_sym, 1 ) ));
 	m_actionMap.insert(std::make_pair("FILTER_CUTOFF_LEVEL_ABSOLUTE", std::make_pair( &MidiActionManager::filter_cutoff_level_absolute, 1 ) ));
 	m_actionMap.insert(std::make_pair("BEATCOUNTER", std::make_pair( &MidiActionManager::beatcounter, 0 ) ));
 	m_actionMap.insert(std::make_pair("TAP_TEMPO", std::make_pair( &MidiActionManager::tap_tempo, 0 ) ));
@@ -759,6 +760,42 @@ bool MidiActionManager::pan_absolute( std::shared_ptr<Action> pAction, Hydrogen*
 
 	return true;
 }
+
+// sets the absolute panning of a given mixer channel
+bool MidiActionManager::pan_absolute_sym( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	// Preventive measure to avoid bad things.
+	if ( pHydrogen->getSong() == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return false;
+	}
+
+	bool ok;
+	int nLine = pAction->getParameter1().toInt(&ok,10);
+	int pan_param = pAction->getValue().toInt(&ok,10);
+
+	std::shared_ptr<Song> pSong = pHydrogen->getSong();
+	InstrumentList *pInstrList = pSong->getInstrumentList();
+	
+	if( pInstrList->is_valid_index( nLine ) ) {
+		pHydrogen->setSelectedInstrumentNumber( nLine );
+	
+		auto pInstr = pInstrList->get( nLine );
+	
+		if( pInstr == nullptr ) {
+			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+			return false;
+		}
+
+		pInstr->setPan( (float) pan_param / 127.f );
+	
+		pHydrogen->setSelectedInstrumentNumber(nLine);
+	} else {
+		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	}
+
+	return true;
+}
+
 
 // changes the panning of a given mixer channel
 // this is useful if the panning is set by a rotary control knob

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -134,7 +134,7 @@ MidiActionManager::MidiActionManager() {
 	m_actionMap.insert(std::make_pair("MUTE_TOGGLE", std::make_pair( &MidiActionManager::mute_toggle, 0 ) ));
 	m_actionMap.insert(std::make_pair("STRIP_MUTE_TOGGLE", std::make_pair( &MidiActionManager::strip_mute_toggle, 1 ) ));
 	m_actionMap.insert(std::make_pair("STRIP_SOLO_TOGGLE", std::make_pair( &MidiActionManager::strip_solo_toggle, 1 ) ));	
-	m_actionMap.insert(std::make_pair("_NEXT_BAR", std::make_pair( &MidiActionManager::next_bar, 0 ) ));
+	m_actionMap.insert(std::make_pair(">>_NEXT_BAR", std::make_pair( &MidiActionManager::next_bar, 0 ) ));
 	m_actionMap.insert(std::make_pair("<<_PREVIOUS_BAR", std::make_pair( &MidiActionManager::previous_bar, 0 ) ));
 	m_actionMap.insert(std::make_pair("BPM_INCR", std::make_pair( &MidiActionManager::bpm_increase, 1 ) ));
 	m_actionMap.insert(std::make_pair("BPM_DECR", std::make_pair( &MidiActionManager::bpm_decrease, 1 ) ));

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -154,6 +154,7 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 		bool select_and_play_pattern(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool pan_relative(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool pan_absolute(std::shared_ptr<Action> , H2Core::Hydrogen * );
+	bool pan_absolute_sym(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool filter_cutoff_level_absolute(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool beatcounter(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool tap_tempo(std::shared_ptr<Action> , H2Core::Hydrogen * );

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -217,7 +217,10 @@ int OscServer::generic_handler(const char *	path,
 		if( argc == 1 ){
 			int nStrip = rxStripPanRel.cap(1).toInt() - 1;
 			if ( nStrip > -1 && nStrip < nNumberOfStrips ) {
-				PAN_RELATIVE_Handler( QString::number( nStrip ) , QString::number( argv[0]->f, 'f', 0 ) );
+				std::shared_ptr<Action> pAction = std::make_shared<Action>("PAN_RELATIVE");
+				pAction->setParameter1( QString::number( nStrip ) );
+				pAction->setParameter2( QString::number( argv[0]->f, 'f', 0 ) );
+				MidiActionManager::get_instance()->handleAction( pAction );
 			}
 		}
 	}
@@ -543,39 +546,6 @@ void OscServer::SELECT_AND_PLAY_PATTERN_Handler(lo_arg **argv,int i)
 {
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("SELECT_AND_PLAY_PATTERN");
 	pAction->setParameter1(  QString::number( argv[0]->f, 'f', 0 ) );
-	MidiActionManager* pActionManager = MidiActionManager::get_instance();
-
-	// Null song handling done in MidiActionManager.
-	pActionManager->handleAction( pAction );
-}
-
-void OscServer::PAN_ABSOLUTE_Handler(QString param1, QString param2)
-{
-	std::shared_ptr<Action> pAction = std::make_shared<Action>("PAN_ABSOLUTE");
-	pAction->setParameter1( param1 );
-	pAction->setParameter2( param2 );
-	MidiActionManager* pActionManager = MidiActionManager::get_instance();
-
-	// Null song handling done in MidiActionManager.
-	pActionManager->handleAction( pAction );
-}
-
-void OscServer::PAN_ABSOLUTE_SYM_Handler(QString param1, QString param2)
-{
-	std::shared_ptr<Action> pAction = std::make_shared<Action>("PAN_ABSOLUTE_SYM");
-	pAction->setParameter1( param1 );
-	pAction->setParameter2( param2 );
-	MidiActionManager* pActionManager = MidiActionManager::get_instance();
-
-	// Null song handling done in MidiActionManager.
-	pActionManager->handleAction( pAction );
-}
-
-void OscServer::PAN_RELATIVE_Handler(QString param1, QString param2)
-{
-	std::shared_ptr<Action> pAction = std::make_shared<Action>("PAN_RELATIVE");
-	pAction->setParameter1( param1 );
-	pAction->setParameter2( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
 	// Null song handling done in MidiActionManager.

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -237,6 +237,8 @@ class OscServer : public H2Core::Object<OscServer>
 		 * - \e /Hydrogen/STRIP_VOLUME_ABSOLUTE/[x]
 		 * - \e /Hydrogen/STRIP_VOLUME_RELATIVE/[x]
 		 * - \e /Hydrogen/PAN_ABSOLUTE/[x]
+		 * - \e /Hydrogen/PAN_ABSOLUTE_SYM/[x]
+		 * - \e /Hydrogen/PAN_RELATIVE/[x]
 		 * - \e /Hydrogen/STRIP_MUTE_TOGGLE/[x]
 		 * - \e /Hydrogen/STRIP_SOLO_TOGGLE/[x]
 		 *
@@ -473,33 +475,6 @@ class OscServer : public H2Core::Object<OscServer>
 		 * \param i Unused number of arguments passed by the OSC
 		 * message.*/
 		static void SELECT_AND_PLAY_PATTERN_Handler(lo_arg **argv, int i);
-		/**
-		 * Creates an Action of type @b PAN_RELATIVE and
-		 * passes its references to MidiActionManager::handleAction().
-		 *
-		 * \param param1 Sets Action::parameter1 of the newly created
-		 * Action.
-		 * \param param2 Sets Action::parameter2 of the newly created
-		 * Action.*/
-		static void PAN_RELATIVE_Handler(QString param1, QString param2);
-		/**
-		 * Creates an Action of type @b PAN_ABSOLUTE and
-		 * passes its references to MidiActionManager::handleAction().
-		 *
-		 * \param param1 Sets Action::parameter1 of the newly created
-		 * Action.
-		 * \param param2 Sets Action::parameter2 of the newly created
-		 * Action.*/
-		static void PAN_ABSOLUTE_Handler(QString param1, QString param2);
-		/**
-		 * Creates an Action of type @b PAN_ABSOLUTE_SYM and
-		 * passes its references to MidiActionManager::handleAction().
-		 *
-		 * \param param1 Sets Action::parameter1 of the newly created
-		 * Action.
-		 * \param param2 Sets Action::parameter2 of the newly created
-		 * Action.*/
-		static void PAN_ABSOLUTE_SYM_Handler(QString param1, QString param2);
 		/**
 		 * Creates an Action of type @b FILTER_CUTOFF_LEVEL_ABSOLUTE
 		 * and passes its references to
@@ -822,6 +797,7 @@ class OscServer : public H2Core::Object<OscServer>
 		 * (if only a single argument is present.)
 		 * - \e /Hydrogen/STRIP_VOLUME_ABSOLUTE/[x]
 		 * - \e /Hydrogen/PAN_ABSOLUTE/[x]
+		 * - \e /Hydrogen/PAN_ABSOLUTE_SYM/[x]
 		 * - \e /Hydrogen/PAN_RELATIVE/[x]
 		 * - \e /Hydrogen/FILTER_CUTOFF_LEVEL_ABSOLUTE/[x]
 		 * - \e /Hydrogen/STRIP_MUTE_TOGGLE/[x]

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -119,9 +119,9 @@ MixerLine::MixerLine(QWidget* parent, int nInstr)
 	uint y = 0;
 	for ( uint i = 0; i < MAX_FX; i++ ) {
 		m_pFxRotary[i] = new Rotary( this, Rotary::Type::Small, tr( "FX %1 send" ).arg( i + 1 ), false );
-		pAction = std::make_shared<Action>(QString( "EFFECT%1_LEVEL_ABSOLUTE" ).arg( QString::number( i + 1 ) ) );
+		pAction = std::make_shared<Action>( "EFFECT_LEVEL_ABSOLUTE" );
 		pAction->setParameter1( QString::number( nInstr ) );
-		pAction->setParameter2( QString::number(i+1) );
+		pAction->setParameter2( QString::number( i ) );
 		m_pFxRotary[i]->setAction( pAction );
 		if ( (i % 2) == 0 ) {
 			m_pFxRotary[i]->move( 9, 63 + (20 * y) );

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -110,7 +110,7 @@ MixerLine::MixerLine(QWidget* parent, int nInstr)
 	m_pPanRotary = new Rotary( this, Rotary::Type::Center, tr( "Pan" ), false, -1.0, 1.0 );
 	m_pPanRotary->move( 6, 32 );
 	connect( m_pPanRotary, SIGNAL( valueChanged( WidgetWithInput* ) ), this, SLOT( panChanged( WidgetWithInput* ) ) );
-	pAction = std::make_shared<Action>("PAN_ABSOLUTE_SYM");
+	pAction = std::make_shared<Action>("PAN_ABSOLUTE");
 	pAction->setParameter1( QString::number(nInstr ));
 	pAction->setValue( QString::number( 0 ));
 	m_pPanRotary->setAction(pAction);

--- a/src/gui/src/Widgets/MidiSenseWidget.cpp
+++ b/src/gui/src/Widgets/MidiSenseWidget.cpp
@@ -104,6 +104,8 @@ void MidiSenseWidget::updateMidi(){
 			std::shared_ptr<Action> pAction = std::make_shared<Action>( m_pAction->getType() );
 
 			pAction->setParameter1( m_pAction->getParameter1() );
+			pAction->setParameter2( m_pAction->getParameter2() );
+			pAction->setParameter3( m_pAction->getParameter3() );
 
 			if( m_sLastMidiEvent.left(2) == "CC" ){
 				pMidiMap->registerCCEvent( m_LastMidiEventParameter , pAction );


### PR DESCRIPTION
- fix absolute pan handling

  the symmetric counterpart of MidiActionManager::pan_absolute was not implemented although the action binding of the pan  rotaries in the Mixer tried to access it.

  also, the pan action handlers of the OscServer were dead code.
- more concise MIDI in logging
- MidiSenseWidget: fix action handling
    
    during assignment only the first parameter of the associated action was used while both the second and third were discarded
- fix EFFECT_LEVEL_ABSOLUTE MIDI action
- fix next bar MIDI action handling