### PR TITLE
GMRockKit: comply with GM

### DIFF
--- a/data/drumkits/GMRockKit/drumkit.xml
+++ b/data/drumkits/GMRockKit/drumkit.xml
@@ -1060,7 +1060,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>57</midiOutNote>
+   <midiOutNote>55</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
    <isHihat>-1</isHihat>
@@ -1200,7 +1200,7 @@ p, li { white-space: pre-wrap; }
    <Release>1000</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>81</midiOutNote>
+   <midiOutNote>53</midiOutNote>
    <isStopNote>false</isStopNote>
    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
    <isHihat>-1</isHihat>


### PR DESCRIPTION
Two MIDI note mappings of instruments in the GMRockKit were changed to better match the General MIDI standard.
- Splash: 57 (Crash Cymbal 2) -> 55 (Splash cymbal)
- Bell: 81 (Open Triangle) -> 53 (Ride Bell)

addresses #1576 