### PR TITLE
data/drumkits: change license GPL -> CC-BY-SA

### DIFF
--- a/data/drumkits/GMRockKit/drumkit.xml
+++ b/data/drumkits/GMRockKit/drumkit.xml
@@ -7,7 +7,7 @@
 p, li { white-space: pre-wrap; }
 &lt;/style>&lt;/head>&lt;body style=" font-family:'Lucida Grande'; font-size:10pt; font-weight:400; font-style:normal;">
 &lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">A Sampled 5pc Pearl DX Series Drumkit.&lt;/p>&lt;/body>&lt;/html></info>
- <license>GPL</license>
+<license>CC-BY-SA</license>
  <image></image>
  <imageLicense>undefined license</imageLicense>
  <componentList>

--- a/data/drumkits/TR808EmulationKit/drumkit.xml
+++ b/data/drumkits/TR808EmulationKit/drumkit.xml
@@ -7,7 +7,7 @@
 p, li { white-space: pre-wrap; }
 &lt;/style>&lt;/head>&lt;body style=" font-family:'Lucida Grande'; font-size:10pt; font-weight:400; font-style:normal;">
 &lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">This drum kit contains 16 original sounds that were synthesized from scratch (using only basic synth waves, like sine, noise etc.). It simulates the sounds of the legendary Roland TR-808 Rhythm Composer. More kits from ArtemioLabs: http://artemiolabs.com/downloads/audio/hydrogen/&lt;/p>&lt;/body>&lt;/html></info>
- <license>GPL</license>
+ <license>CC-BY-SA</license>
  <image></image>
  <imageLicense>undefined license</imageLicense>
  <componentList>


### PR DESCRIPTION
The current license of the drumkits is GPL. However, this license is more suitable to code than to creative output. How about changing it to CC-BY-SA? This is somewhat the GPL of the cultural and artistic world.