### PR TITLE
Note: fix note construction from tmp file

### DIFF
--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -72,7 +72,6 @@ Note::Note( std::shared_ptr<Instrument> instrument, int position, float velocity
 		__instrument_id = __instrument->get_id();
 
 		for ( const auto& pCompo : *__instrument->get_components() ) {
-
 			std::shared_ptr<SelectedLayerInfo> sampleInfo = std::make_shared<SelectedLayerInfo>();
 			sampleInfo->SelectedLayer = -1;
 			sampleInfo->SamplePosition = 0;
@@ -472,16 +471,26 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2midi_msg: %3\n" ).arg( sPrefix ).arg( s ).arg( __midi_msg ) )
 			.append( QString( "%1%2note_off: %3\n" ).arg( sPrefix ).arg( s ).arg( __note_off ) )
 			.append( QString( "%1%2just_recorded: %3\n" ).arg( sPrefix ).arg( s ).arg( __just_recorded ) )
-			.append( QString( "%1%2probability: %3\n" ).arg( sPrefix ).arg( s ).arg( __probability ) )
-			.append( QString( "%1" ).arg( __instrument->toQString( sPrefix + s, bShort ) ) );
+			.append( QString( "%1%2probability: %3\n" ).arg( sPrefix ).arg( s ).arg( __probability ) );
+		if ( __instrument != nullptr ) {		
+			sOutput.append( QString( "%1" ).arg( __instrument->toQString( sPrefix + s, bShort ) ) );
+		} else {
+			sOutput.append( QString( "%1%2instrument: nullptr\n" ).arg( sPrefix ).arg( s ) );
+		}
 		sOutput.append( QString( "%1%2layers_selected:\n" )
 						.arg( sPrefix ).arg( s ) );
 		for ( auto ll : __layers_selected ) {
-			sOutput.append( QString( "%1%2[component: %3, selected layer: %4, sample position: %5]\n" )
-							.arg( sPrefix ).arg( s + s )
-							.arg( ll.first )
-							.arg( ll.second->SelectedLayer )
-							.arg( ll.second->SamplePosition ) );
+			if ( ll.second != nullptr ) {
+				sOutput.append( QString( "%1%2[component: %3, selected layer: %4, sample position: %5]\n" )
+								.arg( sPrefix ).arg( s + s )
+								.arg( ll.first )
+								.arg( ll.second->SelectedLayer )
+								.arg( ll.second->SamplePosition ) );
+			} else {
+				sOutput.append( QString( "%1%2[component: %3, selected layer info: nullptr]\n" )
+								.arg( sPrefix ).arg( s + s )
+								.arg( ll.first ) );
+			}
 		}
 	} else {
 
@@ -518,14 +527,23 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", midi_msg: %1" ).arg( __midi_msg ) )
 			.append( QString( ", note_off: %1" ).arg( __note_off ) )
 			.append( QString( ", just_recorded: %1" ).arg( __just_recorded ) )
-			.append( QString( ", probability: %1" ).arg( __probability ) )
-			.append( QString( ", instrument: %1" ).arg( __instrument->get_name() ) )
-			.append( QString( ", layers_selected: " ) );
+			.append( QString( ", probability: %1" ).arg( __probability ) );
+		if ( __instrument != nullptr ) {
+			sOutput.append( QString( ", instrument: %1" ).arg( __instrument->get_name() ) );
+		} else {
+			sOutput.append( QString( ", instrument: nullptr" ) );
+		}
+		sOutput.append( QString( ", layers_selected: " ) );
 		for ( auto ll : __layers_selected ) {
-			sOutput.append( QString( "[component: %1, selected layer: %2, sample position: %3] " )
-							.arg( ll.first )
-							.arg( ll.second->SelectedLayer )
-							.arg( ll.second->SamplePosition ) );
+			if ( ll.second != nullptr ) {
+				sOutput.append( QString( "[component: %1, selected layer: %2, sample position: %3] " )
+								.arg( ll.first )
+								.arg( ll.second->SelectedLayer )
+								.arg( ll.second->SamplePosition ) );
+			} else {
+				sOutput.append( QString( "[component: %1, selected layer info: nullptr]" )
+								.arg( ll.first ) );
+			}
 		}
 	}
 	return sOutput;

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -157,8 +157,18 @@ void Note::map_instrument( InstrumentList* instruments )
 	if( !instr ) {
 		ERRORLOG( QString( "Instrument with ID: '%1' not found. Using empty instrument." ).arg( __instrument_id ) );
 		__instrument = std::make_shared<Instrument>();
-	} else {
+	}
+	else {
 		__instrument = instr;
+		__adsr = instr->copy_adsr();
+
+		for ( const auto& ppCompo : *instr->get_components() ) {
+			std::shared_ptr<SelectedLayerInfo> sampleInfo = std::make_shared<SelectedLayerInfo>();
+			sampleInfo->SelectedLayer = -1;
+			sampleInfo->SamplePosition = 0;
+
+			__layers_selected[ ppCompo->get_drumkit_componentID() ] = sampleInfo;
+		}
 	}
 }
 


### PR DESCRIPTION
when duplicating a pattern, the duplicated one is written to a temp file and discarded. The pattern actually showing up in the GUI was constructed using the temp file. During this construction the `__instrument` member of the associated notes is assigned in `Note::map_instrument()` instead of being provided to the constructor itself. However, the function forgets to properly initialized both the `__adsr` and `__layers_selected` of the note causing it to fail playback in the current session.

Fixes #1587 