### PR TITLE
Fix minor JACK relocation bug and playhead glitches 

### DIFF
--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -354,6 +354,7 @@ public:
 
 	int				getColumn() const;
 	long long		getFrameOffset() const;
+	void			setFrameOffset( long long nFrameOffset );
 	double  		getTickOffset() const;
 
 	const PatternList*	getNextPatterns() const;
@@ -1094,6 +1095,9 @@ inline float AudioEngine::getNextBpm() const {
 }
 inline long long AudioEngine::getFrameOffset() const {
 	return m_nFrameOffset;
+}
+inline void AudioEngine::setFrameOffset( long long nFrameOffset ) {
+	m_nFrameOffset = nFrameOffset;
 }
 inline double AudioEngine::getTickOffset() const {
 	return m_fTickOffset;

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -307,7 +307,7 @@ void JackAudioDriver::relocateUsingBBT()
 	if ( pSong == nullptr ) {
 		// Expected behavior if Hydrogen is exited while playback is
 		// still running.
-		DEBUGLOG( "No song set." );
+		// DEBUGLOG( "No song set." );
 		return;
 	}
 
@@ -532,7 +532,7 @@ void JackAudioDriver::updateTransportInfo()
 	if ( pHydrogen->getSong() == nullptr ) {
 		// Expected behavior if Hydrogen is exited while playback is
 		// still running.
-		DEBUGLOG( "No song set." );
+		// DEBUGLOG( "No song set." );
 		return;
 	}
 
@@ -571,15 +571,20 @@ void JackAudioDriver::updateTransportInfo()
 	// timeline) or by a different JACK client.
 	if ( pAudioEngine->getFrames() - pAudioEngine->getFrameOffset() !=
 		 m_JackTransportPos.frame ) {
-		// INFOLOG( QString( "[relocation detected] frames: %1, offset: %2, Jack frames: %3" )
+		
+		// DEBUGLOG( QString( "[relocation detected] frames: %1, offset: %2, Jack frames: %3" )
 		// 		 .arg( pAudioEngine->getFrames() )
 		// 		 .arg( pAudioEngine->getFrameOffset() )
 		// 		 .arg( m_JackTransportPos.frame ) );
+		
 		// Reset playback to the beginning of the pattern if Hydrogen
 		// is in pattern mode.
 		if ( pHydrogen->getMode() == Song::Mode::Pattern ) {
 			pAudioEngine->locateToFrame( 0 );
-		} else {
+			pAudioEngine->setFrameOffset( pAudioEngine->getFrames() -
+										  m_JackTransportPos.frame );
+		}
+		else {
 			if ( !bTimebaseEnabled || m_timebaseState != Timebase::Slave ) {
 				pAudioEngine->locateToFrame( m_JackTransportPos.frame );
 			} else {
@@ -1090,7 +1095,7 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 	if ( pSong == nullptr ) {
-		DEBUGLOG( "No song set." );
+		// DEBUGLOG( "No song set." );
 		return;
 	}
 

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -3084,6 +3084,12 @@ void SongEditorPositionRuler::updatePosition()
 	if ( m_pHydrogen->getMode() == Song::Mode::Pattern ) {
 		fTick = -1;
 	}
+	else if ( fTick < 0 ) {
+		// As some variables of the audio engine are initialized as or
+		// reset to -1 we ensure this does not affect the position of
+		// the playhead in the SongEditor.
+		fTick = 0;
+	}
 
 	m_pAudioEngine->unlock();
 


### PR DESCRIPTION
- in case playback is in pattern mode and an external application triggered a relocation, the frame offset of the audio engine was not properly resetted.
- As some variables of the audio engine are initialized as or reset to -1 we ensure this does not affect the position of the playhead in the SongEditor. Else it will be rendered within the left margin of the SE