### PR TITLE
Fix various typos (user facing and non-user facing)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -239,7 +239,7 @@
 	* LADI support
 	* maximum number of bars is now configurable
 	* added czech translation
-	* fixed serveral export song failures
+	* fixed several export song failures
 	* added ogg, flac, aiff export support
 	* added some new commandline parameter for no_gui version
 	* added rubberband-cli support

--- a/linux/debian/changelog
+++ b/linux/debian/changelog
@@ -42,7 +42,7 @@ hydrogen (1.0.0) unstable; urgency=low
   * LADI support
   * maximum number of bars is now configurable
   * added czech translation
-  * fixed serveral export song failures
+  * fixed several export song failures
   * added ogg, flac, aiff export support
   * added some new commandline parameter for no_gui version
   * added rubberband-cli support

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -650,7 +650,7 @@ void AudioEngine::updateBpmAndTickSize() {
 		// it too in order to prevent inconsistencies in the transport
 		// and audio rendering when switching off the Timeline during
 		// playback, relocating, switching it on again, alter song
-		// size or sample rate, and switchting it off again. I know,
+		// size or sample rate, and switching it off again. I know,
 		// quite an edge case but still.
 		// If we deal with a single speed for the whole song, the frames
 		// since the beginning of the song are tempo-dependent and have to
@@ -1578,7 +1578,7 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 		___ERRORLOG( QString( "Failed to lock audioEngine in allowed %1 ms, missed buffer" ).arg( fSlackTime ) );
 
 		if ( dynamic_cast<DiskWriterDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
-			return 2;	// inform the caller that we could not aquire the lock
+			return 2;	// inform the caller that we could not acquire the lock
 		}
 
 		return 0;

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -215,7 +215,7 @@ public:
 	/**
 	 * Mutex unlocking of the AudioEngine.
 	 *
-	 * Unlocks the AudioEngine to allow other threads acces, and leaves #__locker untouched.
+	 * Unlocks the AudioEngine to allow other threads access, and leaves #__locker untouched.
 	 */
 	void			unlock();
 
@@ -239,14 +239,14 @@ public:
 	 * \param nframes Buffersize.
 	 * \param arg Unused.
 	 * \return
-	 * - __2__ : Failed to aquire the audio engine lock, no processing took place.
+	 * - __2__ : Failed to acquire the audio engine lock, no processing took place.
 	 * - __1__ : kill the audio driver thread.
 	 * - __0__ : else
 	 */
 	static int                      audioEngine_process( uint32_t nframes, void *arg );
 
 	/**
-	 * Calcuates the number of frames that make up a tick.
+	 * Calculates the number of frames that make up a tick.
 	 */
 	static float	computeTickSize( const int nSampleRate, const float fBpm, const int nResolution);
 	/**
@@ -738,9 +738,9 @@ private:
 	/** Helper function */
 	bool testCheckTransportPosition( const QString& sContext ) const;
 	/**
-	 * Takes two instances of Sampler::m_playingNotesQueue and checkes
+	 * Takes two instances of Sampler::m_playingNotesQueue and checks
 	 * whether matching notes have exactly @a nPassedFrames difference
-	 * in thei SelectedLayerInfo::SamplePosition.
+	 * in their SelectedLayerInfo::SamplePosition.
 	 */
 	bool testCheckAudioConsistency( const std::vector<std::shared_ptr<Note>> oldNotes,
 									const std::vector<std::shared_ptr<Note>> newNotes,
@@ -855,7 +855,7 @@ private:
 	 * The current transport position thus corresponds
 	 * to #m_fTick = lookahead + #m_nPatternStartTick +
 	 * #m_nPatternTickPosition. (The lookahead is both speed and
-	 * sample reate dependent).
+	 * sample rate dependent).
 	 */
 	long				m_nPatternStartTick;
 
@@ -865,7 +865,7 @@ private:
 	 * The current transport position thus corresponds
 	 * to #m_fTick = lookahead + #m_nPatternStartTick +
 	 * #m_nPatternTickPosition. (The lookahead is both speed and
-	 * sample reate dependent).
+	 * sample rate dependent).
 	 */
 	long				m_nPatternTickPosition;
 

--- a/src/core/AudioEngine/TransportInfo.h
+++ b/src/core/AudioEngine/TransportInfo.h
@@ -92,7 +92,7 @@ private:
 	 * #m_nFrames, and #m_fTickSize.
 	 *
 	 * Note that the smallest unit for positioning a #Note is a frame
-	 * due to the humanization capatibilities.
+	 * due to the humanization capabilities.
 	 *
 	 * Float is, unfortunately, not enough. When the engine is running
 	 * for a long time the high precision digits after decimal point

--- a/src/core/Basics/Adsr.cpp
+++ b/src/core/Basics/Adsr.cpp
@@ -110,8 +110,8 @@ ADSR::~ADSR() { }
  *
  * These parameters allow suitable curves for attack, decay and release to be formed.
  *
- * Because some parameters will take on trivial valuesbdepending on use, its desitable to inline this to allow
- * constant propagation to remove redundant operations.
+ * Because some parameters will take on trivial values depending on use, it's desirable to inline this
+ * to allow constant propagation to remove redundant operations.
  *
  * The exponential loop isn't naturally vectorisable since there is a loop carried dependency for the
  * exponential variable. However, we can manually unroll the loop and replace the single Q with multiple

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -294,7 +294,7 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 	 * @a sTargetDir.
 	 *
 	 * \param sDrumkitPath Tar-compressed drumkit with .h2drumkit
-	 * extention
+	 * extension
 	 * \param sTargetDir Folder to extract the drumkit to. If the
 	 * folder is not present yet, it will be created. If left empty,
 	 * the drumkit will be installed to the users drumkit data folder.

--- a/src/core/EventQueue.cpp
+++ b/src/core/EventQueue.cpp
@@ -66,7 +66,7 @@ void EventQueue::push_event( const EventType type, const int nValue )
 //	INFOLOG( QString( "[pushEvent] %1 : %2 %3" ).arg( nIndex ).arg( ev.type ).arg( ev.value ) );
 
 	/* If the event queue is full, log an error. We could drop the old event, or the new event we're trying to
-	   place. It's preferrable to drop the oldest event in the queue, on the basis that many
+	   place. It's preferable to drop the oldest event in the queue, on the basis that many
 	   change-of-state-events are probably no longer relevant or redundant based on newer events in the queue,
 	   so we keep the new event. However, since the new event has overwritten the oldest event in the queue,
 	   we also adjust the read pointer, otherwise pop_event would return this newest event on the next call,

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -269,7 +269,7 @@ namespace H2Core
 		static QString drumkit_file( const QString& dk_path );
 
 		/**
-		 * Returns filename and extention of the expected drumkit file.
+		 * Returns filename and extension of the expected drumkit file.
 		 */
 		static QString drumkit_xml();
 
@@ -318,7 +318,7 @@ namespace H2Core
 		 * event informing the GUI to show a read-only warning.)
 		 *
 		 * \param sSongPath Absolute path to an .h2song file.
-		 * \param bCheckExistance Whether the existance of the file is
+		 * \param bCheckExistance Whether the existence of the file is
 		 * checked (should be true for opening and false for creating
 		 * a new song)
 		 * \return true - if valid.

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -838,7 +838,7 @@ void Hydrogen::onTapTempoAccelEvent()
 
 	// We multiply by a factor of two in order to allow for tempi
 	// smaller than the minimum one enter the calculation of the
-	// average. Else the minumum one could not be reached via tap
+	// average. Else the minimum one could not be reached via tap
 	// tempo and it is clambed anyway.
 	if ( fInterval < 60000.0 * 2 / static_cast<float>(MIN_BPM) ) {
 		setTapTempo( fInterval );

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -572,7 +572,7 @@ private:
 
 	/**
 	 * Onset of the recorded last in addRealtimeNote(). It is used to
-	 * determine the custom lenght of the note in case the note on
+	 * determine the custom length of the note in case the note on
 	 * event is followed by a note off event.
 	 */
 	int				m_nLastRecordedMIDINoteTick;

--- a/src/core/IO/AudioOutput.h
+++ b/src/core/IO/AudioOutput.h
@@ -56,7 +56,7 @@ public:
 	{
 		return getBufferSize();
 	}
-	/** Get the number of XRuns that occured since the audio driver
+	/** Get the number of XRuns that occurred since the audio driver
 	 *	has started.
 	 */
 	virtual int getXRuns() const { return 0; }

--- a/src/core/IO/CoreAudioDriver.cpp
+++ b/src/core/IO/CoreAudioDriver.cpp
@@ -117,7 +117,7 @@ QString CoreAudioDriver::deviceName( AudioDeviceID deviceID )
 	};
 	err = AudioObjectGetPropertyData( deviceID, &propertyAddress, 0, NULL, &size, &deviceNameRef );
 	if ( err != noErr ) {
-		ERRORLOG( QString( "Coudn't get name for device %1" ).arg( deviceID ) );
+		ERRORLOG( QString( "Couldn't get name for device %1" ).arg( deviceID ) );
 		return QString();
 	}
 	UInt32 nBufferSize = CFStringGetMaximumSizeForEncoding( CFStringGetLength( deviceNameRef ), kCFStringEncodingUTF8 );

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -205,7 +205,7 @@ void* diskWriterDriver_thread( void* param )
 
 			int ret = pDriver->m_processCallback( nUsedBuffer, nullptr );
 			
-			// In case the DiskWriter couldn't aquire the lock of the AudioEngine.
+			// In case the DiskWriter couldn't acquire the lock of the AudioEngine.
 			while( ret != 0 ) {
 				ret = pDriver->m_processCallback( nUsedBuffer, nullptr );
 			}

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -78,7 +78,7 @@ class InstrumentComponent;
  * etc. Of all these information Hydrogen does only use the provided
  * tempo (and overrides all internal ones). Therefore, unlike many
  * other application, it does _not_ respond to changes in measure
- * (since these would have to be mapped to the lenght of the current
+ * (since these would have to be mapped to the length of the current
  * pattern). Every client can be registered as timebase master by
  * supplying a callback (for Hydrogen this would be
  * JackTimebaseCallback()) but there can be at most one timebase

--- a/src/core/Lilipond/Lilypond.cpp
+++ b/src/core/Lilipond/Lilypond.cpp
@@ -30,7 +30,7 @@
  * It contains the notation style (states the position of notes), and for this
  * it follows the "Guide to Standardized Drumset Notation" by Norman Weinberg.
  *
- * Note that the GM-kit uses two unconventionnal instruments: "Stick" and
+ * Note that the GM-kit uses two unconventional instruments: "Stick" and
  * "Hand Clap", so for those I did what I could and used the recommended
  * triangle notehead to distinguish them for drum and cymbal notation.
  */

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -167,7 +167,7 @@ MidiActionManager::MidiActionManager() {
 	m_actionMap.insert(std::make_pair("UNDO_ACTION", std::make_pair( &MidiActionManager::undo_action, 0 ) ));
 	m_actionMap.insert(std::make_pair("REDO_ACTION", std::make_pair( &MidiActionManager::redo_action, 0 ) ));
 	/*
-	  the m_actionList holds all Action identfiers which hydrogen is able to interpret.
+	  the m_actionList holds all Action identifiers which hydrogen is able to interpret.
 	*/
 	m_actionList <<"";
 	for ( const auto& ppAction : m_actionMap ) {

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -106,7 +106,7 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 		static MidiActionManager *__instance;
 
 		/**
-		 * Holds the names of all Action identfiers which Hydrogen is
+		 * Holds the names of all Action identifiers which Hydrogen is
 		 * able to interpret.
 		 */
 	QStringList m_actionList;
@@ -178,7 +178,7 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 		 * Handles multiple actions at once and calls handleAction()
 		 * on them.
 		 *
-		 * \return true - in case all actions were successul, false - otherwise.
+		 * \return true - in case all actions were successful, false - otherwise.
 		 */
 	bool handleActions( std::vector<std::shared_ptr<Action>> );
 		/**

--- a/src/core/Timeline.h
+++ b/src/core/Timeline.h
@@ -49,7 +49,7 @@ namespace H2Core
  * holding the current Song::m_fBpm (the tempo set via the BPM
  * widget). This special first marker can only be "removed" by the
  * user by adding a TempoMarker to the first column. In addition, it's
- * tempo get's updated when toggling the Timeline. This, it does not
+ * tempo gets updated when toggling the Timeline. This, it does not
  * immediately respond to changes of the song tempo (using the BPM
  * widget or MIDI/OSC commands). The special tempo marker is prepended
  * in the getAllTempoMarkers() functions.
@@ -129,7 +129,7 @@ public:
 	 * Returns the tempo of the Song at a given column.
 	 *
 	 * There does not have to be a TempoMarker present at @a nColumn
-	 * as the function takes all preceeding ones into account as well.
+	 * as the function takes all preceding ones into account as well.
 	 *
 	 * @param nColumn Position of the Timeline to query for a 
 	 *   tempo marker.

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -52,7 +52,7 @@ CommonStrings::CommonStrings(){
 	  is designed to hold three characters.*/
 	m_sTimelineBigButton = tr( "Timeline" );
 	/*: Text displayed on the button to enable the LADSPA effect strips. Its size
-	  is designed to hold eigth characters.*/
+	  is designed to hold eight characters.*/
 	m_sFXButton = tr( "FX" );
 	/*: Text displayed on the button to show the instrument peaks. Its size
 	  is designed to hold four characters.*/
@@ -262,7 +262,7 @@ CommonStrings::CommonStrings(){
 	 characters but not that flexible.*/
 	m_sTimeMilliSecondsLabel = tr( "1/1000" );
 	/*: Text displayed in the Master Mixer Strip as a heading for the
-	  humanization rotaries. Designed to hold eigth characters but not
+	  humanization rotaries. Designed to hold eight characters but not
 	  that flexible.*/
 	m_sHumanizeLabel = tr( "Humanize" );
 	/*: Text displayed in the Master Mixer Strip as a heading for the

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -89,7 +89,7 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm )
 	m_pEventQueueTimer->start( QUEUE_TIMER_PERIOD );
 
 	// Wait for m_nPreferenceUpdateTimeout milliseconds of no update
-	// signal before propagating the update. Else importing/reseting a
+	// signal before propagating the update. Else importing/resetting a
 	// theme will slow down the GUI significantly.
 	m_pPreferencesUpdateTimer = new QTimer( this );
 	m_pPreferencesUpdateTimer->setSingleShot( true );
@@ -416,7 +416,7 @@ bool HydrogenApp::openSong( QString sFilename) {
 	if ( ! sRecoverFilename.isEmpty() ) {
 		QMessageBox msgBox;
 		// Not commonized in CommmonStrings as it is required before
-		// HydrogenApp was instanciated.
+		// HydrogenApp was instantiated.
 		msgBox.setText( tr( "There are unsaved changes." ) );
 		msgBox.setInformativeText( tr( "Do you want to recover them?" ) );
 		msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Discard );
@@ -433,7 +433,7 @@ bool HydrogenApp::openSong( QString sFilename) {
 	if ( ! pCoreActionController->openSong( sFilename, sRecoverFilename ) ) {
 		QMessageBox msgBox;
 		// Not commonized in CommmonStrings as it is required before
-		// HydrogenApp was instanciated.
+		// HydrogenApp was instantiated.
 		msgBox.setText( tr( "Error loading song." ) );
 		msgBox.setWindowTitle( "Hydrogen" );
 		msgBox.setIcon( QMessageBox::Warning );
@@ -450,7 +450,7 @@ bool HydrogenApp::openSong( std::shared_ptr<Song> pSong ) {
 	if ( ! pCoreActionController->openSong( pSong ) ) {
 		QMessageBox msgBox;
 		// Not commonized in CommmonStrings as it is required before
-		// HydrogenApp was instanciated.
+		// HydrogenApp was instantiated.
 		msgBox.setText( tr( "Error loading song." ) );
 		msgBox.setWindowTitle( "Hydrogen" );
 		msgBox.setIcon( QMessageBox::Warning );
@@ -493,7 +493,7 @@ bool HydrogenApp::recoverEmptySong() {
 	if ( ! sRecoverFilename.isEmpty() ) {
 		QMessageBox msgBox;
 		// Not commonized in CommmonStrings as it is required before
-		// HydrogenApp was instanciated.
+		// HydrogenApp was instantiated.
 		msgBox.setText( tr( "There are unsaved changes." ) );
 		msgBox.setInformativeText( tr( "Do you want to recover them?" ) );
 		msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Discard );
@@ -514,7 +514,7 @@ bool HydrogenApp::recoverEmptySong() {
 	if ( ! pCoreActionController->openSong( sFilename, sRecoverFilename ) ) {
 		QMessageBox msgBox;
 		// Not commonized in CommmonStrings as it is required before
-		// HydrogenApp was instanciated.
+		// HydrogenApp was instantiated.
 		msgBox.setText( tr( "Error loading song." ) );
 		msgBox.setWindowTitle( "Hydrogen" );
 		msgBox.setIcon( QMessageBox::Warning );

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -160,7 +160,7 @@ public:
 	static constexpr int nMargin = 20;
 
 	/** Caches the AudioEngine::m_nPatternTickPosition in the member
-		variable #m_nTick and triggeres an update(). */
+		variable #m_nTick and triggers an update(). */
 	void updatePosition( float fTick );
 	void editNoteLengthAction( int nColumn,
 							   int nRealColumn,

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -2041,7 +2041,7 @@ void PreferencesDialog::resetTheme() {
 	updateAppearanceTab( m_pCurrentTheme );
 	HydrogenApp::get_instance()->changePreferences( H2Core::Preferences::Changes::AppearanceTab );
 
-	HydrogenApp::get_instance()->setStatusBarMessage( tr( "Theme reseted" ), 10000 );
+	HydrogenApp::get_instance()->setStatusBarMessage( tr( "Theme reset" ), 10000 );
 }
 
 

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -520,7 +520,7 @@ public:
 				clearSelection();
 				updateWidgetGroup();
 			} else if ( ev->button() == Qt::RightButton && m_pSelectionGroup->m_selectedElements.empty() ) {
-				// Right-clicking with an emply selection will first attempt to select anything at the click
+				// Right-clicking with an empty selection will first attempt to select anything at the click
 				// position before passing the click through to the client.
 				QRect r = QRect( ev->pos(), ev->pos() );
 				std::vector<Elem> elems = m_pWidget->elementsIntersecting( r );

--- a/src/gui/src/Widgets/LED.cpp
+++ b/src/gui/src/Widgets/LED.cpp
@@ -35,7 +35,7 @@ LED::LED( QWidget *pParent, QSize size )
 	setFixedSize( size );
 
 	// Since the load function does not report success, we will check
-	// for the existance of the background image separately.
+	// for the existence of the background image separately.
 	QString sPath;
 	float fAspectRatio = static_cast<float>( size.width() ) / static_cast<float>( size.height() );
 	if ( fAspectRatio < 1 ) {
@@ -87,7 +87,7 @@ MetronomeLED::MetronomeLED( QWidget *pParent, QSize size )
 	HydrogenApp::get_instance()->addEventListener( this );
 	
 	// Since the load function does not report success, we will check
-	// for the existance of the background image separately.
+	// for the existence of the background image separately.
 	QString sPath( Skin::getSvgImagePath() + "/led_22_7.svg" );
 	QFile file( sPath );
 	if ( file.exists() ) {

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -66,7 +66,7 @@ Rotary::Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSt
 	updateTooltip();
 
 	// Since the load function does not report success, we will check
-	// for the existance of the knob image separately.
+	// for the existence of the knob image separately.
 	QString sKnobPath( Skin::getSvgImagePath() + "/rotary.svg" ); 
 	QFile knobFile( sKnobPath );
 	if ( knobFile.exists() ) {

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -37,7 +37,7 @@
  *
  * The widgets can be set by click-drag, wheel event, and by
  * keyboard. For the latter the widget has to be clicked first, in
- * order for it to aquire focus. The derived class must indicate the
+ * order for it to acquire focus. The derived class must indicate the
  * presence of the focus in its paintEvent() using the
  * H2Core::ColorTheme::m_highlightColor.
  *

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -50,7 +50,7 @@ void TransportTest::tearDown() {
 	// The tests in here tend to produce a very large number of log
 	// messages and a couple of them may tend to be printed _after_
 	// the results of the overall test runnner. This is quite
-	// unpleasent as the overall result is only shown after
+	// unpleasant as the overall result is only shown after
 	// scrolling. As the TestRunner itself does not seem to support
 	// fixtures, we flush the logger in here.
 	H2Core::Logger::get_instance()->flush();


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts,*.po -L ake,ba,nax,nnumber,ontop,pevent,pevents,ro,sur`