### PR TITLE
Fix repology link in README Packaging Status section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ More details in the [INSTALL.md](INSTALL.md) file.
 <details>
   <summary>Expand to see the status of Hydrogen in the package ecosystem</summary>
   
-  [![Packaging status](https://repology.org/badge/vertical-allrepos/hydrogen.svg?header=Hydrogen)](https://repology.org/project/hydrogen/versions)
+  [![Packaging status](https://repology.org/badge/vertical-allrepos/hydrogen-drum-machine.svg?header=Hydrogen)](https://repology.org/project/hydrogen-drum-machine/versions)
 
 </details>
 


### PR DESCRIPTION
The repology hydrogen package was disambiguated from 'hydrogen' to 'hydrogen-drum-machine'. This commit reflects that change and correctly displays the badge.