### PR TITLE
JACK: relocate when transport is stopped

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -146,6 +146,8 @@
 		  of the song after transport was loop at least once
 		- deactivating loop mode result stopping transport at the end of
 		  the song even if transport was already looped at least once
+		- relocation of the playhead use JACK is now also support in case
+		  transport is not rolling
 
 2021-12-05 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.1.1

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -439,6 +439,12 @@ void AudioEngine::locateToFrame( const long long nFrame ) {
 	double fNewTick = computeTickFromFrame( nFrame );
 	
 	updateTransportPosition( fNewTick );
+
+	// While the locate function is wrapped by a caller in the
+	// CoreActionController - which takes care of queuing the
+	// relocation event - this function is only meant to be used in
+	// very specific circumstances and is not that nicely wrapped.
+	EventQueue::get_instance()->push_event( EVENT_RELOCATION, 0 );
 }
 
 void AudioEngine::incrementTransportPosition( uint32_t nFrames ) {

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -160,8 +160,8 @@ enum EventType {
 	/** Locks the PatternEditor on the pattern currently played back.*/
 	EVENT_PATTERN_EDITOR_LOCKED,
 	/** Triggered in case there is a relocation of the transport
-	 * position due to an user interaction or an incoming MIDI/OSC
-	 * command. 
+	 * position due to an user interaction or an incoming
+	 * MIDI/OSC/JACK command.
 	 */
 	EVENT_RELOCATION,
 	EVENT_SONG_SIZE_CHANGED,

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -513,7 +513,7 @@ void JackAudioDriver::updateTransportInfo()
 	switch ( m_JackTransportState ) {
 	case JackTransportStopped: // Transport is halted
 		pAudioEngine->setNextState( AudioEngine::State::Ready );
-		return;
+		break;
 		
 	case JackTransportRolling: // Transport is playing
 		pAudioEngine->setNextState( AudioEngine::State::Playing );


### PR DESCRIPTION
Due to limitations of a previous implementation the JACK driver did only process the incoming transport information in case transport was rolling within Hydrogen. The playhead would only be updated when starting transport and Hydrogen appeared to be out of sync with other JACK clients (see #1597).

Fortunately, with the new transport implementation of the audio engine I do not see any reason right now to still discard the transport information instead of performing a playhead update like all the other JACK clients do.

Addresses #1597 