### PR TITLE
Tweak JACK master button & use current Preferences in dialog

### DIFF
--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -290,13 +290,12 @@ void JackAudioDriver::relocateUsingBBT()
 		 m_JackTransportPos.beats_per_minute > MAX_BPM ||
 		 m_JackTransportPos.ticks_per_beat < 1 ) {
 		ERRORLOG( QString( "Unsupported to BBT content. beat_type: %1, bar: %2, beat: %3, beats_per_bar: %4, beats_per_minute: %5, ticks_per_beat: %6" )
-				  .arg( m_JackTransportPos.beat_type < 1 )
-				  .arg( m_JackTransportPos.bar < 1 )
-				  .arg( m_JackTransportPos.beat < 1 )
-				  .arg( m_JackTransportPos.beats_per_bar < 1 )
-				  .arg( m_JackTransportPos.beats_per_minute < MIN_BPM )
-				  .arg( m_JackTransportPos.beats_per_minute > MAX_BPM )
-				  .arg( m_JackTransportPos.ticks_per_beat < 1 ) );
+				  .arg( m_JackTransportPos.beat_type )
+				  .arg( m_JackTransportPos.bar )
+				  .arg( m_JackTransportPos.beat )
+				  .arg( m_JackTransportPos.beats_per_bar )
+				  .arg( m_JackTransportPos.beats_per_minute )
+				  .arg( m_JackTransportPos.ticks_per_beat ) );
 		return;
 	}
 
@@ -1033,7 +1032,10 @@ void JackAudioDriver::initTimebaseMaster()
 						     JackTimebaseCallback, this);
 		if ( nReturnValue != 0 ){
 			pPreferences->m_bJackMasterMode = Preferences::NO_JACK_TIME_MASTER;
-		} else {
+			WARNINGLOG( QString( "Hydrogen was not able to register itself as Timebase Master: [%1]" )
+						.arg( nReturnValue ) );
+		}
+		else {
 			m_nTimebaseTracking = 2;
 			m_timebaseState = Timebase::Master;
 			EventQueue::get_instance()->push_event( EVENT_JACK_TIMEBASE_STATE_CHANGED,

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -315,7 +315,8 @@ CommonStrings::CommonStrings(){
 	m_sAudioDriverErrorHint = tr( "Please use the Preferences to select a different one." );
 	m_sAudioDriverNotPresent = tr( "No audio driver set!" );
 
-	m_sJackMasterTooltip = tr("JACK Timebase master on/off");
+	m_sJackTBMMasterTooltip = tr("Register Hydrogen as JACK Timebase master");
+	m_sJackTBMSlaveTooltip = tr("Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.");
 	m_sJackMasterDisabledTooltip = tr( "JACK timebase support is disabled in the Preferences" );
 	
 	/*: Title of the window displayed when using the MIDI learning

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -127,7 +127,8 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getAudioDriverErrorHint() const { return m_sAudioDriverErrorHint; }
 	const QString& getAudioDriverNotPresent() const { return m_sAudioDriverNotPresent; }
 	
-	const QString& getJackMasterTooltip() const { return m_sJackMasterTooltip; }
+	const QString& getJackTBMMasterTooltip() const { return m_sJackTBMMasterTooltip; }
+	const QString& getJackTBMSlaveTooltip() const { return m_sJackTBMSlaveTooltip; }
 	const QString& getJackMasterDisabledTooltip() const { return m_sJackMasterDisabledTooltip; }
 	
 	const QString& getMidiSenseWindowTitle() const { return m_sMidiSenseWindowTitle; }
@@ -254,7 +255,8 @@ private:
 	QString m_sAudioDriverErrorHint;
 	QString m_sAudioDriverNotPresent;
 
-	QString m_sJackMasterTooltip;
+	QString m_sJackTBMMasterTooltip;
+	QString m_sJackTBMSlaveTooltip;
 	QString m_sJackMasterDisabledTooltip;
 	
 	QString m_sMidiSenseWindowTitle;

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -147,7 +147,6 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	connect( this, &PreferencesDialog::rejected, this, &PreferencesDialog::onRejected );
 
 	Preferences *pPref = Preferences::get_instance();
-	pPref->loadPreferences( false );	// reload user's preferences
 	
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	auto pHydrogen = Hydrogen::get_instance();


### PR DESCRIPTION
the button is now both properly initialized and updated in case the TBM support is toggled in the PreferencesDialog or the J. Transport button is pressed.

In addition, it got an additional state:
- unchecked: no TBM
- checked (regular background): Hydrogen is the current TBM
- checked (red background): Another application is the current TBM and Hydrogen attempts to respond to the provided BBT and tempo information. In case the button is clicked in this state, Hydrogen will register itself as TBM

---

Upon opening the PreferencesDialog did reload the local preferences of the user from file and used it to overwrite the current instance of the Preferences. This was done since the beginning of the versioning history.

I am not quite sure what is the purpose of this line but it overwrites all local changes to the Preferences that have not been saved yet (by regulary quitting Hydrogen). As a number of Buttons and options in the GUI alter settings in the Preferences this resets them to their previous state without updating them. The users changes are overwritten and the GUI and the core get slightly out of sync. I removed this line because it seem to have no purpose anymore.