### PR TITLE
Various fixes

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -387,7 +387,7 @@ float AudioEngine::getElapsedTime() const {
 		return 0;
 	}
 
-	return getFrames() / static_cast<float>(pDriver->getSampleRate());
+	return ( getFrames() - m_nFrameOffset )/ static_cast<float>(pDriver->getSampleRate());
 }
 
 void AudioEngine::locate( const double fTick, bool bWithJackBroadcast ) {

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1889,6 +1889,8 @@ void AudioEngine::updateSongSize() {
 		return;
 	}
 
+	bool bEndOfSongReached = false;
+
 	double fNewSongSizeInTicks = static_cast<double>( pSong->lengthInTicks() );
 
 	// WARNINGLOG( QString( "[Before] frame: %1, bpm: %2, tickSize: %3, column: %4, tick: %5, mod(tick): %6, pTickPos: %7, pStartPos: %8, m_fLastTickIntervalEnd: %9, m_fSongSizeInTicks: %10" )
@@ -1910,7 +1912,6 @@ void AudioEngine::updateSongSize() {
 	double fRepetitions =
 		std::floor( getDoubleTick() / m_fSongSizeInTicks );
 
-	//
 	m_fSongSizeInTicks = fNewSongSizeInTicks;
 
 	// Expected behavior:
@@ -1932,8 +1933,7 @@ void AudioEngine::updateSongSize() {
 	long nNewPatternStartTick = pHydrogen->getTickForColumn( getColumn() );
 
 	if ( nNewPatternStartTick == -1 ) {
-		ERRORLOG( QString( "Something went wrong. No tick found for column [%1]" )
-				  .arg( getColumn() ) );
+		bEndOfSongReached = true;
 	}
 	
 	if ( nNewPatternStartTick != m_nPatternStartTick ) {
@@ -1987,8 +1987,12 @@ void AudioEngine::updateSongSize() {
 	// consistent.
 	updateTransportPosition( getDoubleTick() );
 
-	if ( m_nColumn == -1 ) {
+	if ( m_nColumn == -1 ||
+		 ( bEndOfSongReached &&
+		   pSong->getLoopMode() != Song::LoopMode::Enabled ) ) {
 		stop();
+		stopPlayback();
+		locate( 0 );
 	}
 
 	// WARNINGLOG( QString( "[After] frame: %1, bpm: %2, tickSize: %3, column: %4, tick: %5, pTickPos: %6, pStartPos: %7, m_fLastTickIntervalEnd: %8" )

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -346,7 +346,7 @@ void AudioEngine::reset( bool bWithJackBroadcast ) {
 	clearNoteQueue();
 	
 #ifdef H2CORE_HAVE_JACK
-	if ( pHydrogen->haveJackTransport() && bWithJackBroadcast ) {
+	if ( pHydrogen->hasJackTransport() && bWithJackBroadcast ) {
 		// Tell all other JACK clients to relocate as well. This has
 		// to be called after updateFrames().
 		static_cast<JackAudioDriver*>( m_pAudioDriver )->locateTransport( 0 );
@@ -406,7 +406,7 @@ void AudioEngine::locate( const double fTick, bool bWithJackBroadcast ) {
 	// transport is rolling again. That's why we relocate internally
 	// too - as we do not have to be afraid for transport to get out
 	// of sync as it is not rolling.
-	if ( pHydrogen->haveJackTransport() && bWithJackBroadcast &&
+	if ( pHydrogen->hasJackTransport() && bWithJackBroadcast &&
 		 m_state == State::Playing ) {
 		nNewFrame = computeFrameFromTick( fTick, &m_fTickMismatch );
 	} else {
@@ -414,7 +414,7 @@ void AudioEngine::locate( const double fTick, bool bWithJackBroadcast ) {
 		nNewFrame = computeFrameFromTick( fTick, &m_fTickMismatch );
 	}
 
-	if ( pHydrogen->haveJackTransport() && bWithJackBroadcast ) {
+	if ( pHydrogen->hasJackTransport() && bWithJackBroadcast ) {
 		static_cast<JackAudioDriver*>( m_pAudioDriver )->locateTransport( nNewFrame );
 		return;
 	}
@@ -1024,7 +1024,7 @@ void AudioEngine::clearAudioBuffers( uint32_t nFrames )
 	}
 	
 #ifdef H2CORE_HAVE_JACK
-	if ( Hydrogen::get_instance()->haveJackAudioDriver() ) {
+	if ( Hydrogen::get_instance()->hasJackAudioDriver() ) {
 		JackAudioDriver* pJackAudioDriver = static_cast<JackAudioDriver*>(m_pAudioDriver);
 	
 		if( pJackAudioDriver ) {
@@ -1153,7 +1153,7 @@ AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 		return nullptr;
 	}
 
-	if ( pSong != nullptr && pHydrogen->haveJackAudioDriver() ) {
+	if ( pSong != nullptr && pHydrogen->hasJackAudioDriver() ) {
 		pHydrogen->renameJackPorts( pSong );
 	}
 		
@@ -1600,7 +1600,7 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	// Sync transport with server (in case the current audio driver is
 	// designed that way)
 #ifdef H2CORE_HAVE_JACK
-	if ( Hydrogen::get_instance()->haveJackTransport() ) {
+	if ( Hydrogen::get_instance()->hasJackTransport() ) {
 		// Compares the current transport state, speed in bpm, and
 		// transport position with a query request to the JACK
 		// server. It will only overwrite the transport state, if
@@ -2590,7 +2590,7 @@ void AudioEngine::play() {
 	assert( m_pAudioDriver );
 
 #ifdef H2CORE_HAVE_JACK
-	if ( Hydrogen::get_instance()->haveJackTransport() ) {
+	if ( Hydrogen::get_instance()->hasJackTransport() ) {
 		// Tell all other JACK clients to start as well and wait for
 		// the JACK server to give the signal.
 		static_cast<JackAudioDriver*>( m_pAudioDriver )->startTransport();
@@ -2609,7 +2609,7 @@ void AudioEngine::stop() {
 	assert( m_pAudioDriver );
 	
 #ifdef H2CORE_HAVE_JACK
-	if ( Hydrogen::get_instance()->haveJackTransport() ) {
+	if ( Hydrogen::get_instance()->hasJackTransport() ) {
 		// Tell all other JACK clients to stop as well and wait for
 		// the JACK server to give the signal.
 		static_cast<JackAudioDriver*>( m_pAudioDriver )->stopTransport();

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -647,19 +647,7 @@ private:
 	int				updateNoteQueue( unsigned nFrames );
 	void 			processAudio( uint32_t nFrames );
 	long long 		computeTickInterval( double* fTickStart, double* fTickEnd, unsigned nFrames );
-	
-	/** Increments #m_fElapsedTime at the end of a process cycle.
-	 *
-	 * At the end of H2Core::audioEngine_process() this function will
-	 * be used to add the time passed during the last process cycle to
-	 * #m_fElapsedTime.
-	 *
-	 * \param bufferSize Number of frames process during a cycle of
-	 * the audio engine.
-	 * \param sampleRate Temporal resolution used by the sound card in
-	 * frames per second.
-	 */
-	void			updateElapsedTime( unsigned bufferSize, unsigned sampleRate );
+    
 	void			updateBpmAndTickSize();
 	
 	void			setPatternTickPosition( long nTick );

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -747,7 +747,7 @@ bool CoreActionController::deleteTag( int nPosition ) {
 bool CoreActionController::activateJackTransport( bool bActivate ) {
 	
 #ifdef H2CORE_HAVE_JACK
-	if ( !Hydrogen::get_instance()->haveJackAudioDriver() ) {
+	if ( !Hydrogen::get_instance()->hasJackAudioDriver() ) {
 		ERRORLOG( "Unable to (de)activate Jack transport. Please select the Jack driver first." );
 		return false;
 	}
@@ -773,7 +773,7 @@ bool CoreActionController::activateJackTimebaseMaster( bool bActivate ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	
 #ifdef H2CORE_HAVE_JACK
-	if ( !pHydrogen->haveJackAudioDriver() ) {
+	if ( !pHydrogen->hasJackAudioDriver() ) {
 		ERRORLOG( "Unable to (de)activate Jack timebase master. Please select the Jack driver first." );
 		return false;
 	}

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -978,7 +978,7 @@ void Hydrogen::renameJackPorts( std::shared_ptr<Song> pSong )
 	}
 	
 	if( Preferences::get_instance()->m_bJackTrackOuts == true ){
-		if ( haveJackAudioDriver() && pSong != nullptr ) {
+		if ( hasJackAudioDriver() && pSong != nullptr ) {
 
 			// When restarting the audio driver after loading a new song under
 			// Non session management all ports have to be registered _prior_
@@ -1143,7 +1143,7 @@ void Hydrogen::offJackMaster()
 #ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
-	if ( haveJackTransport() ) {
+	if ( hasJackTransport() ) {
 		static_cast< JackAudioDriver* >( pAudioEngine->getAudioDriver() )->releaseTimebaseMaster();
 	}
 #endif
@@ -1154,7 +1154,7 @@ void Hydrogen::onJackMaster()
 #ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
-	if ( haveJackTransport() ) {
+	if ( hasJackTransport() ) {
 		static_cast< JackAudioDriver* >( pAudioEngine->getAudioDriver() )->initTimebaseMaster();
 	}
 #endif
@@ -1197,7 +1197,7 @@ void Hydrogen::__panic()
 	m_pAudioEngine->getSampler()->stopPlayingNotes();
 }
 
-bool Hydrogen::haveJackAudioDriver() const {
+bool Hydrogen::hasJackAudioDriver() const {
 #ifdef H2CORE_HAVE_JACK
 	if ( m_pAudioEngine->getAudioDriver() != nullptr ) {
 		if ( dynamic_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver()) != nullptr ) {
@@ -1210,7 +1210,7 @@ bool Hydrogen::haveJackAudioDriver() const {
 #endif	
 }
 
-bool Hydrogen::haveJackTransport() const {
+bool Hydrogen::hasJackTransport() const {
 #ifdef H2CORE_HAVE_JACK
 	if ( m_pAudioEngine->getAudioDriver() != nullptr ) {
 		if ( dynamic_cast<JackAudioDriver*>(m_pAudioEngine->getAudioDriver()) != nullptr &&
@@ -1244,7 +1244,7 @@ float Hydrogen::getMasterBpm() const {
 JackAudioDriver::Timebase Hydrogen::getJackTimebaseState() const {
 #ifdef H2CORE_HAVE_JACK
 	AudioEngine* pAudioEngine = m_pAudioEngine;
-	if ( haveJackTransport() ) {
+	if ( hasJackTransport() ) {
 		return static_cast<JackAudioDriver*>(pAudioEngine->getAudioDriver())->getTimebaseState();
 	} 
 	return JackAudioDriver::Timebase::None;

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -423,13 +423,13 @@ void			previewSample( Sample *pSample );
 	 * \return Whether JackAudioDriver is used as current audio
 	 * driver.
 	 */
-	bool			haveJackAudioDriver() const;
+	bool			hasJackAudioDriver() const;
 	/**
 	 * \return Whether JackAudioDriver is used as current audio driver
 	 * and JACK transport was activated via the GUI
 	 * (#H2Core::Preferences::m_bJackTransportMode).
 	 */
-	bool			haveJackTransport() const;
+	bool			hasJackTransport() const;
         float			getMasterBpm() const;
 
 	/**
@@ -451,7 +451,7 @@ void			previewSample( Sample *pSample );
 	Tempo getTempoSource() const;
 	
 	/**
-	 * \return Whether we haveJackTransport() and there is an external
+	 * \return Whether we hasJackTransport() and there is an external
 	 * JACK timebase master broadcasting us tempo information and
 	 * making use disregard Hydrogen's Timeline information (see
 	 * #H2Core::JackAudioDriver::m_timebaseState).

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1796,7 +1796,7 @@ void  DrumPatternEditor::functionDropInstrumentUndoAction( int nTargetInstrument
 		}
 	}
 
-	if ( pHydrogen->haveJackAudioDriver() ) {
+	if ( pHydrogen->hasJackAudioDriver() ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
 		pHydrogen->renameJackPorts( pHydrogen->getSong() );
 		m_pAudioEngine->unlock();
@@ -1965,7 +1965,7 @@ void DrumPatternEditor::functionAddEmptyInstrumentUndo()
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	pHydrogen->removeInstrument( pHydrogen->getSong()->getInstrumentList()->size() -1 );
 
-	if ( pHydrogen->haveJackAudioDriver() ) {
+	if ( pHydrogen->hasJackAudioDriver() ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
 		pHydrogen->renameJackPorts( pHydrogen->getSong() );
 		m_pAudioEngine->unlock();

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -2005,6 +2005,8 @@ void DrumPatternEditor::functionAddEmptyInstrumentRedo()
 
 	pHydrogen->setSelectedInstrumentNumber( pList->size() - 1 );
 
+	updateEditor();
+
 }
 ///~undo / redo actions from pattern editor instrument list
 ///==========================================================

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -646,7 +646,7 @@ void InstrumentLine::functionRenameInstrument()
 	if ( bIsOkPressed  ) {
 		pSelectedInstrument->set_name( sNewName );
 
-		if ( pHydrogen->haveJackAudioDriver() ) {
+		if ( pHydrogen->hasJackAudioDriver() ) {
 			pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
 			pHydrogen->renameJackPorts( pHydrogen->getSong() );
 			pHydrogen->getAudioEngine()->unlock();

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -395,10 +395,10 @@ PlayerControl::PlayerControl(QWidget *parent)
 									  false, QSize(),
 									  tr("JACK transport on/off"),
 									  false, true );
-	if ( ! m_pHydrogen->haveJackAudioDriver() ) {
+	if ( ! m_pHydrogen->hasJackAudioDriver() ) {
 		m_pJackTransportBtn->hide();
 	}
-	if ( m_pHydrogen->haveJackTransport() ) {
+	if ( m_pHydrogen->hasJackTransport() ) {
 		m_pJackTransportBtn->setChecked( true );
 	} else {
 		m_pJackTransportBtn->setChecked( false );
@@ -417,12 +417,12 @@ PlayerControl::PlayerControl(QWidget *parent)
 								   QSize(), pCommonStrings->getJackTBMMasterTooltip(),
 								   false, true );
 	
-	if ( ! m_pHydrogen->haveJackAudioDriver() ) {
+	if ( ! m_pHydrogen->hasJackAudioDriver() ) {
 		m_pJackMasterBtn->hide();
 	}
 			
 	if ( pPref->m_bJackTimebaseEnabled ) {
-		if ( m_pHydrogen->haveJackTransport() ) {
+		if ( m_pHydrogen->hasJackTransport() ) {
 			if ( m_pHydrogen->getJackTimebaseState() ==
 				 JackAudioDriver::Timebase::Master ) {
 				m_pJackMasterBtn->setChecked( true );
@@ -886,7 +886,7 @@ void PlayerControl::bctDownButtonClicked()
 
 void PlayerControl::jackTransportBtnClicked()
 {
-	if ( !m_pHydrogen->haveJackAudioDriver() ) {
+	if ( !m_pHydrogen->hasJackAudioDriver() ) {
 		QMessageBox::warning( this, "Hydrogen", tr( "JACK-transport will work only with JACK driver." ) );
 		return;
 	}
@@ -907,7 +907,7 @@ void PlayerControl::jackTransportBtnClicked()
 void PlayerControl::jackMasterBtnClicked()
 {
 #ifdef H2CORE_HAVE_JACK
-	if ( !m_pHydrogen->haveJackTransport() ) {
+	if ( !m_pHydrogen->hasJackTransport() ) {
 		QMessageBox::warning( this, "Hydrogen", tr( "JACK transport will work only with JACK driver." ) );
 		return;
 	}
@@ -1143,7 +1143,7 @@ void PlayerControl::tempoChangedEvent( int nValue )
 }
 
 void PlayerControl::driverChangedEvent() {
-	if ( m_pHydrogen->haveJackAudioDriver() ) {
+	if ( m_pHydrogen->hasJackAudioDriver() ) {
 		m_pJackTransportBtn->show();
 		m_pJackMasterBtn->show();
 
@@ -1246,7 +1246,7 @@ void PlayerControl::onPreferencesChanged( H2Core::Preferences::Changes changes )
 		auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
 		if ( pPref->m_bJackTimebaseEnabled ) {
-			if ( Hydrogen::get_instance()->haveJackTransport() ) {
+			if ( Hydrogen::get_instance()->hasJackTransport() ) {
 				m_pJackMasterBtn->setIsActive( true );
 				jackTimebaseStateChangedEvent();
 			}

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -154,12 +154,12 @@ int SongEditor::yScrollTarget( QScrollArea *pScrollArea, int *pnPatternInView )
 
 	auto pPlayingPatterns = m_pAudioEngine->getPlayingPatterns();
 
-	m_pAudioEngine->lock( RIGHT_HERE );
-
 	// If no patterns are playing, no scrolling needed either.
 	if ( pPlayingPatterns->size() == 0 ) {
 		return nScroll;
 	}
+
+	m_pAudioEngine->lock( RIGHT_HERE );
 
 	PatternList *pSongPatterns = pHydrogen->getSong()->getPatternList();
 


### PR DESCRIPTION
- renaming `Hydrogen::haveJackTransport` and `Hydrogen::haveJackAudioDriver` into `hasJackTransport` and `hasJackAudioDriver`
- whenever tempo was changed without the `Timeline` activated or song size was altered, the elapsed time shown in the `PlayerControl` did glitch. This was fixed by taking `AudioEngine::m_nFrameOffset` into account.
- fix deadlock occuring in case the playhead passes a column without any patterns activated
- the editor was not properly updated when adding a new instrument via main menu and its background did not cover the new size.
- when creating a song with a couple of empty columns followed by one last pattern and toggling that last one while the playhead is in the empty ones, transport was wrapped regardless of whether loop mode was activated or not. Now, it only gets wrapped with loop mode activated. Else, the song is stopped and the playhead moves to the beginning of the song.