### PR TITLE
Buttons: click instead of press

### DIFF
--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -75,15 +75,26 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pShowInstrumentBtn = new Button( m_pInstrumentPropTop, QSize( 141, 22 ), Button::Type::Toggle, "",
 									   pCommonStrings->getGeneralButton(), false, QSize(),
 									   tr( "Show instrument properties" ) );
-	connect( m_pShowInstrumentBtn, SIGNAL( pressed() ), this, SLOT( showInstrument() ) );
 	m_pShowInstrumentBtn->move( 4, 4 );
-	m_pShowInstrumentBtn->setChecked( true );
+	
+	connect( m_pShowInstrumentBtn, &QPushButton::clicked,
+			 [=]() { m_pInstrumentProp->show();
+				 m_pLayerProp->hide();
+			 });
+	connect( m_pShowInstrumentBtn, &QPushButton::clicked,
+			 this, &InstrumentEditor::tabButtonClicked );
 
 	m_pShowLayersBtn = new Button( m_pInstrumentPropTop, QSize( 140, 22 ), Button::Type::Toggle, "",
 								   pCommonStrings->getLayersButton(), false, QSize(),
 								   tr( "Show layers properties" ) );
-	connect( m_pShowLayersBtn, SIGNAL( pressed() ), this, SLOT( showLayers() ) );
 	m_pShowLayersBtn->move( 145, 4 );
+	
+	connect( m_pShowLayersBtn, &QPushButton::clicked,
+			 [=]() { m_pInstrumentProp->hide();
+				 m_pLayerProp->show();
+			 });
+	connect( m_pShowLayersBtn, &QPushButton::clicked,
+			 this, &InstrumentEditor::tabButtonClicked );
 
 
 	// Instrument properties
@@ -172,7 +183,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pFilterBypassBtn = new Button( m_pInstrumentProp, QSize( 36, 15 ), Button::Type::Toggle,
 									 "", pCommonStrings->getBypassButton(), true,
 									 QSize( 0, 0 ), "", false, true );
-	connect( m_pFilterBypassBtn, SIGNAL( pressed() ),
+	connect( m_pFilterBypassBtn, SIGNAL( clicked() ),
 			 this, SLOT( filterActiveBtnClicked() ) );
 	m_pFilterBypassBtn->move( 67, 169 );
 
@@ -333,7 +344,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 										Button::Type::Push, "dropdown.svg", "",
 										false, QSize( 12, 12 ) );
 	m_buttonDropDownCompo->move( 263, 8 );
-	connect( m_buttonDropDownCompo, SIGNAL( pressed() ),
+	connect( m_buttonDropDownCompo, SIGNAL( clicked() ),
 			 this, SLOT( onDropDownCompoClicked() ) );
 
 	// Layer preview
@@ -374,11 +385,11 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pSampleEditorBtn->setObjectName( "SampleEditorButton" );
 	m_pSampleEditorBtn->move( 191, 304 );
 
-	connect( m_pLoadLayerBtn, SIGNAL( pressed() ),
+	connect( m_pLoadLayerBtn, SIGNAL( clicked() ),
 			 this, SLOT( loadLayerBtnClicked() ) );
-	connect( m_pRemoveLayerBtn, SIGNAL( pressed() ),
+	connect( m_pRemoveLayerBtn, SIGNAL( clicked() ),
 			 this, SLOT( removeLayerButtonClicked() ) );
-	connect( m_pSampleEditorBtn, SIGNAL( pressed() ),
+	connect( m_pSampleEditorBtn, SIGNAL( clicked() ),
 			 this, SLOT( showSampleEditor() ) );
 	// Layer gain
 	m_pLayerGainLCD = new LCDDisplay( m_pLayerProp, QSize( 36, 16 ) );
@@ -473,6 +484,10 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	update();
 	//~component handling
 
+	m_pLayerProp->hide();
+	m_pShowLayersBtn->setChecked( false );
+	m_pInstrumentProp->show();
+	m_pShowInstrumentBtn->setChecked( true );
 
 	selectLayer( m_nSelectedLayer );
 
@@ -761,7 +776,7 @@ void InstrumentEditor::rotaryChanged( WidgetWithInput *ref)
 void InstrumentEditor::filterActiveBtnClicked()
 {
 	if ( m_pInstrument ) {
-		m_pInstrument->set_filter_active( m_pFilterBypassBtn->isChecked() );
+		m_pInstrument->set_filter_active( ! m_pFilterBypassBtn->isChecked() );
 	}
 }
 
@@ -791,34 +806,19 @@ void InstrumentEditor::waveDisplayDoubleClicked( QWidget* pRef )
 	}
 }
 
-void InstrumentEditor::showLayers()
+void InstrumentEditor::tabButtonClicked()
 {
-	if ( m_pShowLayersBtn->isDown() && m_pShowLayersBtn->isChecked() ) {
-		m_pShowLayersBtn->setChecked( true );
-		m_pShowLayersBtn->setDown( false );
-		return;
-	}
-	m_pShowInstrumentBtn->setChecked( false );
-	m_pLayerProp->show();
-	m_pInstrumentProp->hide();
-
-	m_pShowLayersBtn->show();
-	m_pShowInstrumentBtn->show();
-}
-
-void InstrumentEditor::showInstrument()
-{
-	if ( m_pShowInstrumentBtn->isDown() && m_pShowInstrumentBtn->isChecked() ) {
+	if ( m_pInstrumentProp->isVisible() ) {
+		m_pShowLayersBtn->setChecked( false );
 		m_pShowInstrumentBtn->setChecked( true );
-		m_pShowInstrumentBtn->setDown( false );
-		return;
 	}
-	m_pShowLayersBtn->setChecked( false );
-	m_pInstrumentProp->show();
-	m_pLayerProp->hide();
-
-	m_pShowLayersBtn->show();
-	m_pShowInstrumentBtn->show();
+	else if ( m_pLayerProp->isVisible() ) {
+		m_pShowLayersBtn->setChecked( true );
+		m_pShowInstrumentBtn->setChecked( false );
+	}
+	else {
+		ERRORLOG( "Neither the instrument nor the layer editor is visible" );
+	}
 }
 
 void InstrumentEditor::showSampleEditor()

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -73,8 +73,6 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 
 
 	public slots:
-		void showLayers();
-		void showInstrument();
 		void showSampleEditor();
 		void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
@@ -101,6 +99,8 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 		void sampleSelectionChanged( int );
 
 		void waveDisplayDoubleClicked( QWidget *pRef );
+
+	void tabButtonClicked();
 
 	private:
 		std::shared_ptr<H2Core::Instrument> m_pInstrument;

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -51,12 +51,21 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 
 	// instrument editor button
 	m_pShowInstrumentEditorBtn = new Button( pTabButtonsPanel, QSize( 145, 24 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getInstrumentButton(), false, QSize(), tr( "Show Instrument editor" ) );
-	connect( m_pShowInstrumentEditorBtn, SIGNAL( pressed() ), this, SLOT( on_showInstrumentEditorBtnClicked() ) );
+	connect( m_pShowInstrumentEditorBtn, &QPushButton::clicked,
+			 [=]() { m_pSoundLibraryPanel->hide();
+				 InstrumentEditorPanel::get_instance()->show();
+			 });
+	connect( m_pShowInstrumentEditorBtn, &QPushButton::clicked,
+			 this, &InstrumentRack::tabButtonClicked );
 
 	// show sound library button
 	m_pShowSoundLibraryBtn = new Button( pTabButtonsPanel,QSize( 145, 24 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSoundLibraryButton(), false, QSize(), tr( "Show sound library" ) );
-	connect( m_pShowSoundLibraryBtn, SIGNAL( pressed() ), this, SLOT( on_showSoundLibraryBtnClicked() ) );
-
+	connect( m_pShowSoundLibraryBtn, &QPushButton::clicked,
+			 [=]() { m_pSoundLibraryPanel->show();
+				 InstrumentEditorPanel::get_instance()->hide();
+			 });
+	connect( m_pShowSoundLibraryBtn, &QPushButton::clicked,
+			 this, &InstrumentRack::tabButtonClicked );
 
 	QHBoxLayout *pTabHBox = new QHBoxLayout();
 	pTabHBox->setSpacing( 0 );
@@ -86,7 +95,10 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 	
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &InstrumentRack::onPreferencesChanged );
 	
-	on_showInstrumentEditorBtnClicked();	// show the instrument editor as default
+	InstrumentEditorPanel::get_instance()->show();
+	m_pSoundLibraryPanel->hide();
+	m_pShowInstrumentEditorBtn->setChecked( true );
+	m_pShowSoundLibraryBtn->setChecked( false );
 }
 
 
@@ -96,37 +108,18 @@ InstrumentRack::~InstrumentRack()
 	INFOLOG( "DESTROY" );
 }
 
-void InstrumentRack::on_showSoundLibraryBtnClicked()
-{
-	if ( m_pShowSoundLibraryBtn->isChecked() && m_pShowSoundLibraryBtn->isDown() ) {
-		
+void InstrumentRack::tabButtonClicked() {
+	if ( m_pSoundLibraryPanel->isVisible() ) {
 		m_pShowSoundLibraryBtn->setChecked( true );
-		m_pShowSoundLibraryBtn->setDown( false );
-		return;
+		m_pShowInstrumentEditorBtn->setChecked( false );
 	}
-	
-	m_pShowInstrumentEditorBtn->setChecked( false );
-
-	m_pSoundLibraryPanel->show();
-	InstrumentEditorPanel::get_instance()->hide();
-}
-
-void InstrumentRack::on_showInstrumentEditorBtnClicked()
-{
-	if ( m_pShowInstrumentEditorBtn->isChecked() && m_pShowInstrumentEditorBtn->isDown() ) {
-		
-		m_pShowInstrumentEditorBtn->setChecked( true );
-		m_pShowInstrumentEditorBtn->setDown( false );
-		return;
-	} else if ( ! m_pShowInstrumentEditorBtn->isChecked() &&
-				! m_pShowInstrumentEditorBtn->isDown() ) {
+	else if ( InstrumentEditorPanel::get_instance()->isVisible() ) {
+		m_pShowSoundLibraryBtn->setChecked( false );
 		m_pShowInstrumentEditorBtn->setChecked( true );
 	}
-
-	m_pShowSoundLibraryBtn->setChecked( false );
-
-	InstrumentEditorPanel::get_instance()->show();
-	m_pSoundLibraryPanel->hide();
+	else {
+		ERRORLOG( "Neither the sound library panel nor the instrument editor panel are visible" );
+	}
 }
 
 void InstrumentRack::onPreferencesChanged(  H2Core::Preferences::Changes changes ) {

--- a/src/gui/src/InstrumentRack.h
+++ b/src/gui/src/InstrumentRack.h
@@ -46,9 +46,10 @@ class InstrumentRack : public QWidget, protected WidgetWithScalableFont<5, 6, 7>
 		SoundLibraryPanel* getSoundLibraryPanel() {	return m_pSoundLibraryPanel;	}
 
 	public slots:
-		void on_showSoundLibraryBtnClicked();
-		void on_showInstrumentEditorBtnClicked();
 		void onPreferencesChanged( H2Core::Preferences::Changes changes );
+
+private slots:
+	void tabButtonClicked();
 
 	private:
 		/// button for showing the Sound Library

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -118,13 +118,13 @@ Mixer::Mixer( QWidget* pParent )
 	
 	m_pOpenMixerSettingsBtn = new Button( m_pMasterLine, QSize( 17, 17 ), Button::Type::Push, "cog.svg", "", false, QSize( 13, 13 ), tr( "Mixer Settings" ) );
 	m_pOpenMixerSettingsBtn->move( 96, 6 );
-	connect( m_pOpenMixerSettingsBtn, SIGNAL( pressed() ), this, SLOT( openMixerSettingsDialog() ) );
+	connect( m_pOpenMixerSettingsBtn, SIGNAL( clicked() ), this, SLOT( openMixerSettingsDialog() ) );
 
 
 	m_pShowFXPanelBtn = new Button( m_pMasterLine, QSize( 49, 15 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getFXButton(), false, QSize(), tr( "Show FX panel" ) );
 	m_pShowFXPanelBtn->move( 63, 243 );
 	m_pShowFXPanelBtn->setChecked(false);
-	connect( m_pShowFXPanelBtn, SIGNAL( pressed() ), this, SLOT( showFXPanelClicked() ));
+	connect( m_pShowFXPanelBtn, SIGNAL( clicked() ), this, SLOT( showFXPanelClicked() ));
 	m_pShowFXPanelBtn->setChecked( Preferences::get_instance()->isFXTabVisible() );
 
 #ifndef H2CORE_HAVE_LADSPA
@@ -134,7 +134,7 @@ Mixer::Mixer( QWidget* pParent )
 	m_pShowPeaksBtn = new Button( m_pMasterLine, QSize( 49, 15 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getPeakButton(), false, QSize(), tr( "Show instrument peaks" ) );
 	m_pShowPeaksBtn->move( 63, 259 );
 	m_pShowPeaksBtn->setChecked( (Preferences::get_instance())->showInstrumentPeaks() );
-	connect( m_pShowPeaksBtn, SIGNAL( pressed() ), this, SLOT( showPeaksBtnClicked() ));
+	connect( m_pShowPeaksBtn, SIGNAL( clicked() ), this, SLOT( showPeaksBtnClicked() ));
 //~ Master frame
 
 
@@ -755,7 +755,7 @@ void Mixer::resizeEvent ( QResizeEvent *ev )
 
 void Mixer::showFXPanelClicked()
 {
-	if ( ! m_pShowFXPanelBtn->isChecked() ) {
+	if ( m_pShowFXPanelBtn->isChecked() ) {
 		m_pFXFrame->show();
 		Preferences::get_instance()->setFXTabVisible( true );
 	} else {
@@ -770,7 +770,7 @@ void Mixer::showPeaksBtnClicked()
 {
 	Preferences *pPref = Preferences::get_instance();
 
-	if ( ! m_pShowPeaksBtn->isChecked() ) {
+	if ( m_pShowPeaksBtn->isChecked() ) {
 		pPref->setInstrumentPeaks( true );
 		( HydrogenApp::get_instance() )->setStatusBarMessage( tr( "Show instrument peaks = On"), 2000 );
 	} else {

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -75,7 +75,7 @@ MixerLine::MixerLine(QWidget* parent, int nInstr)
 	m_pPlaySampleBtn = new Button( this, QSize( 20, 15 ), Button::Type::Push, "play.svg", "", false, QSize( 7, 7 ), tr( "Play sample" ) );
 	m_pPlaySampleBtn->move( 6, 1 );
 	m_pPlaySampleBtn->setObjectName( "PlaySampleButton" );
-	connect(m_pPlaySampleBtn, SIGNAL( pressed() ), this, SLOT( playSampleBtnClicked() ) );
+	connect(m_pPlaySampleBtn, SIGNAL( clicked() ), this, SLOT( playSampleBtnClicked() ) );
 
 	// Trigger sample LED
 	m_pTriggerSampleLED = new LED( this, QSize( 5, 13 ) );
@@ -92,7 +92,7 @@ MixerLine::MixerLine(QWidget* parent, int nInstr)
 	m_pMuteBtn = new Button( this, QSize( 22, 15 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSmallMuteButton(), true, QSize(), tr( "Mute" ) );
 	m_pMuteBtn->move( 5, 16 );
 	m_pMuteBtn->setObjectName( "MixerMuteButton" );
-	connect(m_pMuteBtn, SIGNAL( pressed() ), this, SLOT( muteBtnClicked() ));
+	connect(m_pMuteBtn, SIGNAL( clicked() ), this, SLOT( muteBtnClicked() ));
 	pAction = std::make_shared<Action>("STRIP_MUTE_TOGGLE");
 	pAction->setParameter1( QString::number(nInstr ));
 	m_pMuteBtn->setAction(pAction);
@@ -101,7 +101,7 @@ MixerLine::MixerLine(QWidget* parent, int nInstr)
 	m_pSoloBtn = new Button( this, QSize( 22, 15 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSmallSoloButton(), false, QSize(), tr( "Solo" ) );
 	m_pSoloBtn->move( 28, 16 );
 	m_pSoloBtn->setObjectName( "MixerSoloButton" );
-	connect(m_pSoloBtn, SIGNAL( pressed() ), this, SLOT( soloBtnClicked() ));
+	connect(m_pSoloBtn, SIGNAL( clicked() ), this, SLOT( soloBtnClicked() ));
 	pAction = std::make_shared<Action>("STRIP_SOLO_TOGGLE");
 	pAction->setParameter1( QString::number(nInstr ));
 	m_pSoloBtn->setAction(pAction);
@@ -404,12 +404,12 @@ ComponentMixerLine::ComponentMixerLine(QWidget* parent, int CompoID)
 	// Mute button
 	m_pMuteBtn = new Button( this, QSize( 22, 15 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSmallMuteButton(), true, QSize(), tr( "Mute" ) );
 	m_pMuteBtn->move( 5, 16 );
-	connect(m_pMuteBtn, SIGNAL( pressed() ), this, SLOT( muteBtnClicked() ));
+	connect(m_pMuteBtn, SIGNAL( clicked() ), this, SLOT( muteBtnClicked() ));
 
 	// Solo button
 	m_pSoloBtn = new Button( this, QSize( 22, 15 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getSmallSoloButton(), false, QSize(), tr( "Solo" ) );
 	m_pSoloBtn->move( 28, 16 );
-	connect(m_pSoloBtn, SIGNAL( pressed() ), this, SLOT( soloBtnClicked() ));
+	connect(m_pSoloBtn, SIGNAL( clicked() ), this, SLOT( soloBtnClicked() ));
 
 	Preferences *pPref = Preferences::get_instance();
 
@@ -629,7 +629,7 @@ MasterMixerLine::MasterMixerLine(QWidget* parent)
 	// Mute btn
 	m_pMuteBtn = new Button( this, QSize( 42, 17 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getBigMuteButton(), true );
 	m_pMuteBtn->move( 20, 31 );
-	connect( m_pMuteBtn, SIGNAL( pressed() ), this, SLOT( muteClicked() ) );
+	connect( m_pMuteBtn, SIGNAL( clicked() ), this, SLOT( muteClicked() ) );
 	pAction = std::make_shared<Action>("MUTE_TOGGLE");
 	m_pMuteBtn->setAction( pAction );
 
@@ -652,7 +652,7 @@ MasterMixerLine::~MasterMixerLine()
 
 void MasterMixerLine::muteClicked()
 {
-	Hydrogen::get_instance()->getCoreActionController()->setMasterIsMuted( ! m_pMuteBtn->isChecked() );
+	Hydrogen::get_instance()->getCoreActionController()->setMasterIsMuted( m_pMuteBtn->isChecked() );
 }
 
 void MasterMixerLine::faderChanged( WidgetWithInput *pRef )
@@ -885,13 +885,13 @@ LadspaFXMixerLine::LadspaFXMixerLine(QWidget* parent)
 	// active button
 	m_pBypassBtn = new Button( this, QSize( 34, 14 ), Button::Type::Toggle, "", HydrogenApp::get_instance()->getCommonStrings()->getBypassButton(), true, QSize(), tr( "FX bypass") );
 	m_pBypassBtn->move( 52, 25 );
-	connect( m_pBypassBtn, SIGNAL( pressed() ), this, SLOT( bypassBtnClicked() ) );
+	connect( m_pBypassBtn, SIGNAL( clicked() ), this, SLOT( bypassBtnClicked() ) );
 	
 
 	// edit button
 	m_pEditBtn = new Button( this, QSize( 34, 14 ), Button::Type::Push, "", HydrogenApp::get_instance()->getCommonStrings()->getEditButton(), false, QSize(), tr( "Edit FX parameters") );
 	m_pEditBtn->move( 86, 25 );
-	connect( m_pEditBtn, SIGNAL( pressed() ), this, SLOT( editBtnClicked() ) );
+	connect( m_pEditBtn, SIGNAL( clicked() ), this, SLOT( editBtnClicked() ) );
 
 	// instrument name widget
 	m_pNameLCD = new LCDDisplay( this, QSize( 108, 15 ) );

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -82,7 +82,7 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 	m_pMuteBtn->move( 145, 0 );
 	m_pMuteBtn->setChecked(false);
 	m_pMuteBtn->setObjectName( "MuteButton" );
-	connect(m_pMuteBtn, SIGNAL( pressed() ), this, SLOT( muteClicked() ));
+	connect(m_pMuteBtn, SIGNAL( clicked() ), this, SLOT( muteClicked() ));
 
 	/*: Text displayed on the button for soloing an instrument. Its
 	  size is designed for a single character.*/
@@ -94,7 +94,7 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 	m_pSoloBtn->move( 163, 0 );
 	m_pSoloBtn->setChecked(false);
 	m_pSoloBtn->setObjectName( "SoloButton" );
-	connect(m_pSoloBtn, SIGNAL( pressed() ), this, SLOT(soloClicked()));
+	connect(m_pSoloBtn, SIGNAL( clicked() ), this, SLOT(soloClicked()));
 
 	m_pSampleWarning = new Button( this, QSize( 15, 13 ), Button::Type::Icon,
 								   "warning.svg", "", false, QSize(),
@@ -102,7 +102,7 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 								   true );
 	m_pSampleWarning->move( 128, 5 );
 	m_pSampleWarning->hide();
-	connect(m_pSampleWarning, SIGNAL( pressed() ), this, SLOT( sampleWarningClicked() ));
+	connect(m_pSampleWarning, SIGNAL( clicked() ), this, SLOT( sampleWarningClicked() ));
 
 
 	// Popup menu

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -185,7 +185,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 								  "speaker.svg", "", false, QSize( 15, 13 ),
 								  tr( "Hear new notes" ), false, true );
 	m_pHearNotesBtn->move( 42, 1 );
-	connect( m_pHearNotesBtn, SIGNAL( pressed() ), this, SLOT( hearNotesBtnClick() ) );
+	connect( m_pHearNotesBtn, SIGNAL( clicked() ), this, SLOT( hearNotesBtnClick() ) );
 	m_pHearNotesBtn->setChecked( pPref->getHearNewNotes() );
 	m_pHearNotesBtn->setObjectName( "HearNotesBtn" );
 	m_pHearNotesLbl = new ClickableLabel( m_pRec, QSize( 36, 13 ), HydrogenApp::get_instance()->getCommonStrings()->getHearNotesLabel(), ClickableLabel::Color::Dark );
@@ -202,7 +202,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	m_pQuantizeEventsBtn->move( 111, 1 );
 	m_pQuantizeEventsBtn->setChecked( pPref->getQuantizeEvents() );
 	m_pQuantizeEventsBtn->setObjectName( "QuantizeEventsBtn" );
-	connect( m_pQuantizeEventsBtn, SIGNAL( pressed() ), this, SLOT( quantizeEventsBtnClick() ) );
+	connect( m_pQuantizeEventsBtn, SIGNAL( clicked() ), this, SLOT( quantizeEventsBtnClick() ) );
 	m_pQuantizeEventsLbl = new ClickableLabel( m_pRec, QSize( 44, 13 ), HydrogenApp::get_instance()->getCommonStrings()->getQuantizeEventsLabel(), ClickableLabel::Color::Dark );
 	m_pQuantizeEventsLbl->setAlignment( Qt::AlignRight );
 	m_pQuantizeEventsLbl->move( 64, 4 );
@@ -211,7 +211,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	__show_drum_btn = new Button( m_pRec, QSize( 25, 18 ), Button::Type::Push, "drum.svg", "", false, QSize( 17, 13 ), HydrogenApp::get_instance()->getCommonStrings()->getShowPianoRollEditorTooltip() );
 	__show_drum_btn->move( 178, 1 );
 	__show_drum_btn->setObjectName( "ShowDrumBtn" );
-	connect( __show_drum_btn, SIGNAL( pressed() ), this, SLOT( showDrumEditorBtnClick() ) );
+	connect( __show_drum_btn, SIGNAL( clicked() ), this, SLOT( showDrumEditorBtnClick() ) );
 	// Since the button to activate the piano roll is shown
 	// initially, both buttons get the same tooltip. Actually only the
 	// last one does need a tooltip since it will be shown regardless
@@ -222,19 +222,19 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	__show_piano_btn->move( 178, 1 );
 	__show_piano_btn->setObjectName( "ShowDrumBtn" );
 	__show_piano_btn->hide();
-	connect( __show_piano_btn, SIGNAL( pressed() ), this, SLOT( showDrumEditorBtnClick() ) );
+	connect( __show_piano_btn, SIGNAL( clicked() ), this, SLOT( showDrumEditorBtnClick() ) );
 	m_pShowPianoLbl = new ClickableLabel( m_pRec, QSize( 40, 13 ), HydrogenApp::get_instance()->getCommonStrings()->getShowPianoLabel(), ClickableLabel::Color::Dark );
 	m_pShowPianoLbl->setAlignment( Qt::AlignRight );
 	m_pShowPianoLbl->move( 135, 4 );
 
 	// zoom-in btn
 	Button *zoom_in_btn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Push, "plus.svg", "", false, QSize( 9, 9 ), tr( "Zoom in" ) );
-	connect( zoom_in_btn, SIGNAL( pressed() ), this, SLOT( zoomInBtnClicked() ) );
+	connect( zoom_in_btn, SIGNAL( clicked() ), this, SLOT( zoomInBtnClicked() ) );
 
 
 	// zoom-out btn
 	Button *zoom_out_btn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Push, "minus.svg", "", false, QSize( 9, 9 ), tr( "Zoom out" ) );
-	connect( zoom_out_btn, SIGNAL( pressed() ), this, SLOT( zoomOutBtnClicked() ) );
+	connect( zoom_out_btn, SIGNAL( clicked() ), this, SLOT( zoomOutBtnClicked() ) );
 // End Editor TOP
 
 
@@ -731,9 +731,9 @@ void PatternEditorPanel::selectedPatternChangedEvent()
 void PatternEditorPanel::hearNotesBtnClick()
 {
 	Preferences *pref = ( Preferences::get_instance() );
-	pref->setHearNewNotes( ! m_pHearNotesBtn->isChecked() );
+	pref->setHearNewNotes( m_pHearNotesBtn->isChecked() );
 
-	if ( ! m_pHearNotesBtn->isChecked() ) {
+	if ( m_pHearNotesBtn->isChecked() ) {
 		( HydrogenApp::get_instance() )->setStatusBarMessage( tr( "Hear new notes = On" ), 2000 );
 	} else {
 		( HydrogenApp::get_instance() )->setStatusBarMessage( tr( "Hear new notes = Off" ), 2000 );
@@ -743,9 +743,9 @@ void PatternEditorPanel::hearNotesBtnClick()
 void PatternEditorPanel::quantizeEventsBtnClick()
 {
 	Preferences *pref = ( Preferences::get_instance() );
-	pref->setQuantizeEvents( ! m_pQuantizeEventsBtn->isChecked() );
+	pref->setQuantizeEvents( m_pQuantizeEventsBtn->isChecked() );
 
-	if ( ! m_pQuantizeEventsBtn->isChecked() ) {
+	if ( m_pQuantizeEventsBtn->isChecked() ) {
 		( HydrogenApp::get_instance() )->setStatusBarMessage( tr( "Quantize incoming keyboard/midi events = On" ),	2000 );
 	} else {
 		( HydrogenApp::get_instance() )->setStatusBarMessage( tr( "Quantize incoming keyboard/midi events = Off" ), 2000 );

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -107,7 +107,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pRwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push,
 							"rewind.svg", "", false, QSize( 13, 13 ), tr("Rewind") );
 	m_pRwdBtn->move( 166, 15 );
-	connect(m_pRwdBtn, SIGNAL( pressed() ), this, SLOT( rewindBtnClicked() ));
+	connect(m_pRwdBtn, SIGNAL( clicked() ), this, SLOT( rewindBtnClicked() ));
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("<<_PREVIOUS_BAR");
 	m_pRwdBtn->setAction( pAction );
 
@@ -117,7 +117,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pRecBtn->move( 193, 15 );
 	m_pRecBtn->setChecked(false);
 	m_pRecBtn->setHidden(false);
-	connect(m_pRecBtn, SIGNAL( pressed() ), this, SLOT( recBtnClicked() ));
+	connect(m_pRecBtn, SIGNAL( clicked() ), this, SLOT( recBtnClicked() ));
 	pAction = std::make_shared<Action>("RECORD_READY");
 	m_pRecBtn->setAction( pAction );
 
@@ -126,7 +126,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 							 "play_pause.svg", "", false, QSize( 30, 21 ), tr("Play/ Pause") );
 	m_pPlayBtn->move( 220, 15 );
 	m_pPlayBtn->setChecked(false);
-	connect(m_pPlayBtn, SIGNAL( pressed() ), this, SLOT( playBtnClicked() ));
+	connect(m_pPlayBtn, SIGNAL( clicked() ), this, SLOT( playBtnClicked() ));
 	pAction = std::make_shared<Action>("PLAY/PAUSE_TOGGLE");
 	m_pPlayBtn->setAction( pAction );
 
@@ -134,7 +134,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pStopBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push,
 							 "stop.svg", "", false, QSize( 11, 11 ), tr("Stop") );
 	m_pStopBtn->move( 252, 15 );
-	connect(m_pStopBtn, SIGNAL( pressed() ), this, SLOT( stopBtnClicked() ));
+	connect(m_pStopBtn, SIGNAL( clicked() ), this, SLOT( stopBtnClicked() ));
 	pAction = std::make_shared<Action>("STOP");
 	m_pStopBtn->setAction( pAction );
 
@@ -142,7 +142,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pFfwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push,
 							 "fast_forward.svg", "", false, QSize( 13, 13 ), tr("Fast Forward") );
 	m_pFfwdBtn->move( 279, 15 );
-	connect(m_pFfwdBtn, SIGNAL( pressed() ), this, SLOT( fastForwardBtnClicked() ));
+	connect(m_pFfwdBtn, SIGNAL( clicked() ), this, SLOT( fastForwardBtnClicked() ));
 	pAction = std::make_shared<Action>(">>_NEXT_BAR");
 	m_pFfwdBtn->setAction( pAction );
 
@@ -171,7 +171,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 									false, true );
 	m_pPatternModeBtn->move( 190, 3 );
 	m_pPatternModeBtn->setChecked(true);
-	connect(m_pPatternModeBtn, &QPushButton::pressed,
+	connect(m_pPatternModeBtn, &QPushButton::clicked,
 			[=]() { Hydrogen::get_instance()->getCoreActionController()->
 					activateSongMode( false );
 			});
@@ -189,7 +189,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 								 false, QSize(), tr("Song Mode"),
 								 false, true );
 	m_pSongModeBtn->move( 263, 3 );
-	connect(m_pSongModeBtn, &QPushButton::pressed,
+	connect(m_pSongModeBtn, &QPushButton::clicked,
 			[=]() { Hydrogen::get_instance()->getCoreActionController()->
 					activateSongMode( true );
 			});
@@ -244,7 +244,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	}
 	updateBeatCounterToolTip();
 		
-	connect(m_pBCOnOffBtn, SIGNAL( pressed() ), this, SLOT( bcOnOffBtnClicked() ));
+	connect(m_pBCOnOffBtn, SIGNAL( clicked() ), this, SLOT( bcOnOffBtnClicked() ));
 	pAction = std::make_shared<Action>("BEATCOUNTER");
 	m_pBCOnOffBtn->setAction( pAction );
 //~  BC on off
@@ -285,25 +285,25 @@ PlayerControl::PlayerControl(QWidget *parent)
 							  Button::Type::Push, "plus.svg", "", false,
 							  QSize( 8, 8 ), "", false, true );
 	m_pBCTUpBtn->move( 2, 3 );
-	connect( m_pBCTUpBtn, SIGNAL( pressed() ), this, SLOT( bctUpButtonClicked() ) );
+	connect( m_pBCTUpBtn, SIGNAL( clicked() ), this, SLOT( bctUpButtonClicked() ) );
 
 	m_pBCTDownBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
 								Button::Type::Push, "minus.svg", "", false,
 								QSize( 8, 8 ), "", false, true );
 	m_pBCTDownBtn->move( 2, 14 );
-	connect( m_pBCTDownBtn, SIGNAL( pressed() ), this, SLOT( bctDownButtonClicked() ) );
+	connect( m_pBCTDownBtn, SIGNAL( clicked() ), this, SLOT( bctDownButtonClicked() ) );
 
 	m_pBCBUpBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
 							  Button::Type::Push, "plus.svg", "", false,
 							  QSize( 8, 8 ), "", false, true );
 	m_pBCBUpBtn->move( 64, 3 );
-	connect( m_pBCBUpBtn, SIGNAL( pressed() ), this, SLOT( bcbUpButtonClicked() ) );
+	connect( m_pBCBUpBtn, SIGNAL( clicked() ), this, SLOT( bcbUpButtonClicked() ) );
 
 	m_pBCBDownBtn = new Button( m_pControlsBCPanel, QSize( 19, 12 ),
 								Button::Type::Push, "minus.svg", "", false,
 								QSize( 8, 8 ), "", false, true );
 	m_pBCBDownBtn->move( 64, 14 );
-	connect( m_pBCBDownBtn, SIGNAL( pressed() ), this, SLOT( bcbDownButtonClicked() ) );
+	connect( m_pBCBDownBtn, SIGNAL( clicked() ), this, SLOT( bcbDownButtonClicked() ) );
 
 	m_pBCSetPlayBtn = new Button( m_pControlsBCPanel, QSize( 19, 15 ),
 								  Button::Type::Push, "",
@@ -312,7 +312,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 								  tr("Set BPM / Set BPM and play"),
 								  false, true );
 	m_pBCSetPlayBtn->move( 64, 25 );
-	connect(m_pBCSetPlayBtn, SIGNAL( pressed() ), this, SLOT( bcSetPlayBtnClicked() ));
+	connect(m_pBCSetPlayBtn, SIGNAL( clicked() ), this, SLOT( bcSetPlayBtnClicked() ));
 //~ beatcounter
 
 
@@ -354,7 +354,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	m_pRubberBPMChange->move( 131, 0 );
 	m_pRubberBPMChange->setChecked( pPref->getRubberBandBatchMode());
-	connect( m_pRubberBPMChange, SIGNAL( pressed() ), this, SLOT( rubberbandButtonToggle() ) );
+	connect( m_pRubberBPMChange, SIGNAL( clicked() ), this, SLOT( rubberbandButtonToggle() ) );
 	QString program = pPref->m_rubberBandCLIexecutable;
 	//test the path. if test fails, no button
 	if ( QFile( program ).exists() == false) {
@@ -370,7 +370,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 								  tr("Switch metronome on/off"),
 								  false, true );
 	m_pMetronomeBtn->move( 6, 2 );
-	connect( m_pMetronomeBtn, SIGNAL( pressed() ), this, SLOT( metronomeButtonClicked() ) );
+	connect( m_pMetronomeBtn, SIGNAL( clicked() ), this, SLOT( metronomeButtonClicked() ) );
 	pAction = std::make_shared<Action>("TOGGLE_METRONOME");
 	m_pMetronomeBtn->setAction( pAction );
 	m_pMetronomeBtn->setChecked( pPref->m_bUseMetronome );
@@ -481,13 +481,13 @@ PlayerControl::PlayerControl(QWidget *parent)
 								  "", pCommonStrings->getMixerButton(), false, QSize(),
 								  tr( "Show mixer" ) );
 	m_pShowMixerBtn->move( 0, 0 );
-	connect(m_pShowMixerBtn, SIGNAL( pressed() ), this, SLOT( showMixerButtonClicked() ));
+	connect(m_pShowMixerBtn, SIGNAL( clicked() ), this, SLOT( showMixerButtonClicked() ));
 
 	m_pShowInstrumentRackBtn = new Button( pLcdBackGround, QSize( 168, 23 ), Button::Type::Toggle,
 										   "", pCommonStrings->getInstrumentRackButton(), false, QSize(),
 										   tr( "Show Instrument Rack" ) );
 	m_pShowInstrumentRackBtn->move( 88, 0 );
-	connect( m_pShowInstrumentRackBtn, SIGNAL( pressed() ),
+	connect( m_pShowInstrumentRackBtn, SIGNAL( clicked() ),
 			 this, SLOT( showInstrumentRackButtonClicked() ) );
 
 	m_pStatusLabel = new LCDDisplay(pLcdBackGround, QSize( 255, 18 ) );
@@ -642,7 +642,7 @@ void PlayerControl::updatePlayerControl()
 /// Toggle record mode
 void PlayerControl::recBtnClicked() {
 	if ( m_pHydrogen->getAudioEngine()->getState() != H2Core::AudioEngine::State::Playing ) {
-		if ( ! m_pRecBtn->isChecked() ) {
+		if ( m_pRecBtn->isChecked() ) {
 			Preferences::get_instance()->setRecordEvents(true);
 			(HydrogenApp::get_instance())->setScrollStatusBarMessage(tr("Record midi events = On" ), 2000 );
 		}
@@ -668,7 +668,7 @@ void PlayerControl::playBtnClicked() {
 		return;
 	}
 	
-	if ( ! m_pPlayBtn->isChecked() ) {
+	if ( m_pPlayBtn->isChecked() ) {
 		m_pHydrogen->sequencer_play();
 		(HydrogenApp::get_instance())->setStatusBarMessage(tr("Playing."), 5000);
 	}
@@ -780,7 +780,7 @@ void PlayerControl::bpmChanged( double fNewBpmValue ) {
 void PlayerControl::bcOnOffBtnClicked()
 {
 	Preferences *pPref = Preferences::get_instance();
-	if ( ! m_pBCOnOffBtn->isChecked() ) {
+	if ( m_pBCOnOffBtn->isChecked() ) {
 		pPref->m_bbc = Preferences::BC_ON;
 		(HydrogenApp::get_instance())->setStatusBarMessage(tr(" BC Panel on"), 5000);
 		m_pControlsBCPanel->show();
@@ -811,7 +811,7 @@ void PlayerControl::rubberbandButtonToggle()
 {
 	Preferences *pPref = Preferences::get_instance();
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
-	if ( ! m_pRubberBPMChange->isChecked() ) {
+	if ( m_pRubberBPMChange->isChecked() ) {
 		// Recalculate all samples ones just to be safe since the
 		// recalculation is just triggered if there is a tempo change
 		// in the audio engine.
@@ -962,7 +962,7 @@ void PlayerControl::metronomeButtonClicked()
 	Hydrogen*	pHydrogen = Hydrogen::get_instance();
 	CoreActionController* pController = pHydrogen->getCoreActionController();
 	
-	pController->setMetronomeIsActive( ! m_pMetronomeBtn->isChecked() );
+	pController->setMetronomeIsActive( m_pMetronomeBtn->isChecked() );
 }
 
 void PlayerControl::showMixerButtonClicked()

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -116,7 +116,7 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 	// Rewind button
 	m_pRwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "rewind.svg", "", false, QSize( 13, 13 ), tr("Rewind") );
 	m_pRwdBtn->move( 4, 4 );
-	connect(m_pRwdBtn, SIGNAL( pressed() ), this, SLOT( rewindBtnClicked() ));
+	connect(m_pRwdBtn, SIGNAL( clicked() ), this, SLOT( rewindBtnClicked() ));
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAYLIST_PREV_SONG");
 	m_pRwdBtn->setAction( pAction );
 
@@ -124,21 +124,21 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 	m_pPlayBtn = new Button( pControlsPanel, QSize( 30, 21 ), Button::Type::Toggle, "play.svg", "", false, QSize( 13, 13 ), tr("Play/ Pause/ Load selected song") );
 	m_pPlayBtn->move( 31, 4 );
 	m_pPlayBtn->setChecked(false);
-	connect(m_pPlayBtn, SIGNAL( pressed() ), this, SLOT( nodePlayBTN() ));
+	connect(m_pPlayBtn, SIGNAL( clicked() ), this, SLOT( nodePlayBTN() ));
 	pAction = std::make_shared<Action>("PLAY/PAUSE_TOGGLE");
 	m_pPlayBtn->setAction( pAction );
 
 	// Stop button
 	m_pStopBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "stop.svg", "", false, QSize( 11, 11 ), tr("Stop") );
 	m_pStopBtn->move( 63, 4 );
-	connect(m_pStopBtn, SIGNAL( pressed() ), this, SLOT( nodeStopBTN() ));
+	connect(m_pStopBtn, SIGNAL( clicked() ), this, SLOT( nodeStopBTN() ));
 	pAction = std::make_shared<Action>("STOP");
 	m_pStopBtn->setAction( pAction );
 
 	// Fast forward button
 	m_pFfwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "fast_forward.svg", "", false, QSize( 13, 13 ), tr("Fast Forward") );
 	m_pFfwdBtn->move( 90, 4 );
-	connect(m_pFfwdBtn, SIGNAL( pressed() ), this, SLOT( ffWDBtnClicked() ));
+	connect(m_pFfwdBtn, SIGNAL( clicked() ), this, SLOT( ffWDBtnClicked() ));
 	pAction = std::make_shared<Action>("PLAYLIST_NEXT_SONG");
 	m_pFfwdBtn->setAction( pAction );
 
@@ -188,12 +188,12 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 
 	// zoom-in btn
 	Button *pUpBtn = new Button( nullptr, QSize( 16, 16 ), Button::Type::Push, "up.svg", "", false, QSize( 9, 9 ), tr( "sort" ) );
-	connect(pUpBtn, SIGNAL( pressed() ), this, SLOT(o_upBClicked()) );
+	connect(pUpBtn, SIGNAL( clicked() ), this, SLOT(o_upBClicked()) );
 	pSideBarLayout->addWidget(pUpBtn);
 
 	// zoom-in btn
 	Button *pDownBtn = new Button( nullptr, QSize( 16, 16 ), Button::Type::Push, "down.svg", "", false, QSize( 9, 9 ), tr( "sort" ) );
-	connect(pDownBtn, SIGNAL( pressed() ), this, SLOT(o_downBClicked()));
+	connect(pDownBtn, SIGNAL( clicked() ), this, SLOT(o_downBClicked()));
 	pSideBarLayout->addWidget(pDownBtn);
 
 	//restore the playlist
@@ -747,7 +747,7 @@ void PlaylistDialog::nodePlayBTN()
 	Hydrogen *		pHydrogen = Hydrogen::get_instance();
 	HydrogenApp *	pH2App = HydrogenApp::get_instance();
 
-	if ( ! m_pPlayBtn->isChecked() ) {
+	if ( m_pPlayBtn->isChecked() ) {
 		QTreeWidgetItem* m_pPlaylistItem = m_pPlaylistTree->currentItem();
 		if ( m_pPlaylistItem == nullptr ){
 			QMessageBox::information ( this, "Hydrogen", tr ( "No valid song selected!" ) );
@@ -771,8 +771,8 @@ void PlaylistDialog::nodePlayBTN()
 		}
 
 		pHydrogen->sequencer_play();
-	}else
-	{
+	}
+	else {
 		pHydrogen->sequencer_stop();
 		pH2App->setStatusBarMessage(tr("Pause."), 5000);
 	}

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -80,7 +80,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 								 pCommonStrings->getTimelineEnabled() );
 	m_pTimelineBtn->move( 94, 4 );
 	m_pTimelineBtn->setObjectName( "TimelineBtn" );
-	connect( m_pTimelineBtn, SIGNAL( pressed() ), this, SLOT( timelineBtnPressed() ) );
+	connect( m_pTimelineBtn, SIGNAL( clicked() ), this, SLOT( timelineBtnClicked() ) );
 	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Slave ) {
 		m_pTimelineBtn->setToolTip( pCommonStrings->getTimelineDisabledTimebaseSlave() );
 		m_pTimelineBtn->setIsActive( false );
@@ -95,36 +95,36 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	// clear sequence button
 	m_pClearPatternSeqBtn = new Button( pBackPanel,	QSize( 61, 21 ), Button::Type::Push, "", pCommonStrings->getClearButton(), false, QSize(), tr("Clear pattern sequence") );
 	m_pClearPatternSeqBtn->move( 2, 25 );
-	connect( m_pClearPatternSeqBtn, SIGNAL( pressed() ), this, SLOT( clearSequence() ) );
+	connect( m_pClearPatternSeqBtn, SIGNAL( clicked() ), this, SLOT( clearSequence() ) );
 
 	// new pattern button
 	Button *newPatBtn = new Button( pBackPanel,	QSize( 25, 21 ), Button::Type::Push, "plus.svg", "", false, QSize( 15, 15 ), tr("Create new pattern") );
 	newPatBtn->move( 64, 25 );
-	connect( newPatBtn, SIGNAL( pressed() ), this, SLOT( newPatBtnClicked() ) );
+	connect( newPatBtn, SIGNAL( clicked() ), this, SLOT( newPatBtnClicked() ) );
 
 	// down button
 	m_pDownBtn = new Button( pBackPanel, QSize( 25, 10 ), Button::Type::Push,
 							 "down.svg", "", false, QSize( 7, 7 ),
 							 tr("Move the selected pattern down"), false, true, "2" );
 	m_pDownBtn->move( 90, 36 );
-	connect( m_pDownBtn, SIGNAL( pressed() ), this, SLOT( downBtnClicked() ) );
+	connect( m_pDownBtn, SIGNAL( clicked() ), this, SLOT( downBtnClicked() ) );
 
 	// up button
 	m_pUpBtn = new Button( pBackPanel, QSize( 25, 10 ), Button::Type::Push,
 						   "up.svg", "", false, QSize( 7, 7 ),
 						   tr("Move the selected pattern up"), false, true, "2" );
 	m_pUpBtn->move( 90, 25 );
-	connect( m_pUpBtn, SIGNAL( pressed() ), this, SLOT( upBtnClicked() ) );
+	connect( m_pUpBtn, SIGNAL( clicked() ), this, SLOT( upBtnClicked() ) );
 
 	// Two buttons sharing the same position and either of them is
 	// shown unpressed.
 	m_pSelectionModeBtn = new Button( pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "select.svg", "", false, QSize( 17, 16 ), tr( "Select mode" ) );
 	m_pSelectionModeBtn->move( 116, 25 );
-	connect( m_pSelectionModeBtn, SIGNAL( pressed() ), this, SLOT( selectionModeBtnPressed() ) );
+	connect( m_pSelectionModeBtn, SIGNAL( clicked() ), this, SLOT( selectionModeBtnClicked() ) );
 
 	m_pDrawModeBtn = new Button( pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "draw.svg", "", false, QSize( 17, 16 ), tr( "Draw mode") );
 	m_pDrawModeBtn->move( 116, 25 );
-	connect( m_pDrawModeBtn, SIGNAL( pressed() ), this, SLOT( drawModeBtnPressed() ) );
+	connect( m_pDrawModeBtn, SIGNAL( clicked() ), this, SLOT( drawModeBtnClicked() ) );
 
 	if ( pHydrogen->getActionMode() == H2Core::Song::ActionMode::selectMode ) {
 		m_pDrawModeBtn->hide();
@@ -133,14 +133,14 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	}
 
 	// Two buttons sharing the same position and either of them is
-	// shown unpressed.
+	// shown unpressed
 	m_pPatternEditorLockedBtn = new Button( pBackPanel, QSize( 25, 21 ),
 											Button::Type::Toggle, "lock_closed.svg",
 											"", false, QSize( 21, 17 ),
 											pCommonStrings->getPatternEditorLocked(),
 											false, true );
 	m_pPatternEditorLockedBtn->move( 142, 25 );
-	connect( m_pPatternEditorLockedBtn, &Button::pressed,
+	connect( m_pPatternEditorLockedBtn, &QPushButton::clicked,
 			 [=](){Hydrogen::get_instance()->setIsPatternEditorLocked( false ); } );
 
 	m_pPatternEditorUnlockedBtn = new Button( pBackPanel, QSize( 25, 21 ),
@@ -150,7 +150,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 											  pCommonStrings->getPatternEditorLocked(),
 											  false, true );
 	m_pPatternEditorUnlockedBtn->move( 142, 25 );
-	connect( m_pPatternEditorUnlockedBtn, &Button::pressed,
+	connect( m_pPatternEditorUnlockedBtn, &QPushButton::clicked,
 			 [=](){Hydrogen::get_instance()->setIsPatternEditorLocked( true ); } );
 
 	if ( pHydrogen->isPatternEditorLocked() ) {
@@ -175,7 +175,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 										 tr( "single pattern mode"),
 										 false, true );
 	m_pPlaySelectedSingleBtn->move( 168, 25 );
-	connect( m_pPlaySelectedSingleBtn, &Button::pressed, [=]() {
+	connect( m_pPlaySelectedSingleBtn, &QPushButton::clicked, [=]() {
 		Hydrogen::get_instance()->setPatternMode( Song::PatternMode::Stacked );
 	});
 
@@ -187,7 +187,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 										   false, true );
 	m_pPlaySelectedMultipleBtn->move( 168, 25 );
 	m_pPlaySelectedMultipleBtn->hide();
-	connect( m_pPlaySelectedMultipleBtn, &Button::pressed, [=]() {
+	connect( m_pPlaySelectedMultipleBtn, &QPushButton::clicked, [=]() {
 		Hydrogen::get_instance()->setPatternMode( Song::PatternMode::Selected );
 	});
 
@@ -210,18 +210,18 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	// zoom-in btn
 	Button* pZoomInBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Push, "plus.svg", "", false, QSize( 9, 9 ) );
-	connect( pZoomInBtn, SIGNAL( pressed() ), this, SLOT( zoomOutBtnPressed() ) );
+	connect( pZoomInBtn, SIGNAL( clicked() ), this, SLOT( zoomOutBtnClicked() ) );
 
 
 
 	// zoom-out btn
 	Button* pZoomOutBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Push, "minus.svg", "", false, QSize( 9, 9 ) );
-	connect( pZoomOutBtn, SIGNAL( pressed() ), this, SLOT( zoomInBtnPressed() ) );
+	connect( pZoomOutBtn, SIGNAL( clicked() ), this, SLOT( zoomInBtnClicked() ) );
 
 	// view playback track toggle button
 	m_pViewPlaybackBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Toggle, "", pCommonStrings->getPlaybackTrackButton(), false, QSize(), tr( "View playback track" ) );
 	m_pViewPlaybackBtn->setObjectName( "ViewPlaybackBtn" );
-	connect( m_pViewPlaybackBtn, SIGNAL( pressed() ), this, SLOT( viewPlaybackTrackBtnPressed() ) );
+	connect( m_pViewPlaybackBtn, SIGNAL( clicked() ), this, SLOT( viewPlaybackTrackBtnClicked() ) );
 	m_pViewPlaybackBtn->setChecked( pPref->getShowPlaybackTrack() );
 	
 	// Playback Fader
@@ -255,12 +255,12 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	m_pEditPlaybackBtn = new Button( pBackPanel, QSize( 34, 17 ), Button::Type::Push, "", pCommonStrings->getEditButton(), false, QSize(), tr( "Choose playback track") );
 	m_pEditPlaybackBtn->move( 123, 4 );
 	m_pEditPlaybackBtn->hide();
-	connect( m_pEditPlaybackBtn, SIGNAL( pressed() ), this, SLOT( editPlaybackTrackBtnPressed() ) );
+	connect( m_pEditPlaybackBtn, SIGNAL( clicked() ), this, SLOT( editPlaybackTrackBtnClicked() ) );
 	m_pEditPlaybackBtn->setChecked( false );
 
 	// timeline view toggle button
 	m_pViewTimelineBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Toggle, "", pCommonStrings->getTimelineButton(), false, QSize(), tr( "View timeline" ) );
-	connect( m_pViewTimelineBtn, SIGNAL( pressed() ), this, SLOT( viewTimelineBtnPressed() ) );
+	connect( m_pViewTimelineBtn, SIGNAL( clicked() ), this, SLOT( viewTimelineBtnClicked() ) );
 	m_pViewTimelineBtn->setChecked( ! pPref->getShowPlaybackTrack() );
 	
 	
@@ -809,19 +809,19 @@ void SongEditorPanel::actionModeChangeEvent( int ) {
 	}
 }
 
-void SongEditorPanel::selectionModeBtnPressed()
+void SongEditorPanel::selectionModeBtnClicked()
 {
 	Hydrogen::get_instance()->setActionMode( H2Core::Song::ActionMode::drawMode );
 }
 
-void SongEditorPanel::drawModeBtnPressed()
+void SongEditorPanel::drawModeBtnClicked()
 {
 	Hydrogen::get_instance()->setActionMode( H2Core::Song::ActionMode::selectMode );
 }
 
 
-void SongEditorPanel::timelineBtnPressed() {
-	setTimelineActive( ! m_pTimelineBtn->isChecked() );
+void SongEditorPanel::timelineBtnClicked() {
+	setTimelineActive( m_pTimelineBtn->isChecked() );
 	Hydrogen::get_instance()->setIsModified( true );
 }
 
@@ -860,25 +860,25 @@ void SongEditorPanel::showPlaybackTrack()
 	updatePlaybackTrackIfNecessary();
 }
 
-void SongEditorPanel::viewTimelineBtnPressed()
+void SongEditorPanel::viewTimelineBtnClicked()
 {
-	if ( ! m_pViewTimelineBtn->isChecked() ){
+	if ( m_pViewTimelineBtn->isChecked() ){
 		showTimeline();
 	} else {
 		showPlaybackTrack();
 	}
 }
 
-void SongEditorPanel::viewPlaybackTrackBtnPressed()
+void SongEditorPanel::viewPlaybackTrackBtnClicked()
 {
-	if ( ! m_pViewPlaybackBtn->isChecked() ){
+	if ( m_pViewPlaybackBtn->isChecked() ){
 		showPlaybackTrack();
 	} else {
 		showTimeline();
 	}
 }
 
-void SongEditorPanel::editPlaybackTrackBtnPressed()
+void SongEditorPanel::editPlaybackTrackBtnClicked()
 {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
@@ -950,7 +950,7 @@ void SongEditorPanel::stackedModeActivationEvent( int )
 	}
 }
 
-void SongEditorPanel::zoomInBtnPressed()
+void SongEditorPanel::zoomInBtnClicked()
 {
 	unsigned width = m_pSongEditor->getGridWidth();
 	--width;
@@ -965,7 +965,7 @@ void SongEditorPanel::zoomInBtnPressed()
 }
 
 
-void SongEditorPanel::zoomOutBtnPressed()
+void SongEditorPanel::zoomOutBtnClicked()
 {
 	unsigned width = m_pSongEditor->getGridWidth();
 	++width;

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -109,9 +109,9 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 	virtual void stateChangedEvent( H2Core::AudioEngine::State ) override;
 
 	public slots:
-		void showHideTimeline( bool bPressed ) {
-			m_pTimelineBtn->setChecked( bPressed );
-			timelineBtnPressed();
+		void showHideTimeline( bool bClicked ) {
+			m_pTimelineBtn->setChecked( bClicked );
+			timelineBtnClicked();
 		}
 
 	private slots:
@@ -126,15 +126,15 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		void updatePlaybackFaderPeaks();
 		void updatePlayHeadPosition();
 
-		void selectionModeBtnPressed();
-		void drawModeBtnPressed();
-		void timelineBtnPressed();
-		void viewTimelineBtnPressed();
-		void viewPlaybackTrackBtnPressed();
-		void editPlaybackTrackBtnPressed();
+		void selectionModeBtnClicked();
+		void drawModeBtnClicked();
+		void timelineBtnClicked();
+		void viewTimelineBtnClicked();
+		void viewPlaybackTrackBtnClicked();
+		void editPlaybackTrackBtnClicked();
 
-		void zoomInBtnPressed();
-		void zoomOutBtnPressed();
+		void zoomInBtnClicked();
+		void zoomOutBtnClicked();
 		
 		void faderChanged( WidgetWithInput* pRef );
 


### PR DESCRIPTION
As a legacy from the previous implementation on the `Button` widget many of them still used the `pressed()` signal for interaction instead of `clicked()` - which is the default one in Qt.

In this PR I ported all buttons to use `clicked()` instead. This means, play button etc. are not triggering their associated function upon pressing done the mouse button but, instead, on releasing it. This has the following benefits
- the UX of our custom buttons is consistent with the one of all other buttons used in dialogs etc.
- as we now base our `Button` widget on `QPushButton` it was possible to get the button and the associated core state out of sync. E.g. pressing the Sound Library button while the Instrument Editor is shown hides the latter and shows the former. But if the user - while still holding down the mouse button - moves the mouse pointer outside of the boundaries of the button and releases there, the QPushButton never gets clicked as this is Qts way of cancelling the clicking. Now, the InstrumentEditor button is still checked while the Sound Library is shown.