### PR TITLE
OSC and MIDI action handling + couple of smaller fixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -122,6 +122,8 @@
 		- Add command /Hydrogen/VALIDATE_DRUMKIT
 		- Add command /Hydrogen/EXTRACT_DRUMKIT
 		- Add command /Hydrogen/BPM
+		- /Hydrogen/STRIP_SOLO_TOGGLE/X and /Hydrogen/STRIP_MUTE_TOGGLE/X
+		  can now be called without any argument too
 	* H2CLI
 		- Add `--upgrade` option to upgrade a drumkit
 		- Add `--check` option to validate a drumkit

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2123,7 +2123,7 @@ void AudioEngine::updatePlayingPatterns( int nColumn, long nTick ) {
 	}
 }
 
-void AudioEngine::toggleNextPattern( int nPatternNumber ) {
+void AudioEngine::toggleNextPatterns( int nPatternNumber ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	auto pPatternList = pSong->getPatternList();
@@ -2135,7 +2135,11 @@ void AudioEngine::toggleNextPattern( int nPatternNumber ) {
 	}
 }
 
-void AudioEngine::flushAndAddNextPattern( int nPatternNumber ) {
+void AudioEngine::clearNextPatterns() {
+	m_pNextPatterns->clear();
+}
+
+void AudioEngine::flushAndAddNextPatterns( int nPatternNumber ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	auto pPatternList = pSong->getPatternList();

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -453,18 +453,19 @@ public:
 	 * \param nTick Desired location in pattern mode.
 	 */
 	void updatePlayingPatterns( int nColumn, long nTick = 0 );
+	void clearNextPatterns();
 	/** 
 	 * Add pattern @a nPatternNumber to #m_pNextPatterns or deletes it
 	 * in case it is already present.
 	 */
-	void toggleNextPattern( int nPatternNumber );
+	void toggleNextPatterns( int nPatternNumber );
 	/**
 	 * Add pattern @a nPatternNumber to #m_pNextPatterns as well as
 	 * the whole content of #m_pPlayingPatterns. After the next call
 	 * to updatePlayingPatterns() only @a nPatternNumber will be left
 	 * playing.
 	 */
-	void flushAndAddNextPattern( int nPatternNumber );
+	void flushAndAddNextPatterns( int nPatternNumber );
 
 	/**
 	 * Updates the transport state and all notes in #m_songNoteQueue

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -229,8 +229,8 @@ bool CoreActionController::sendMasterVolumeFeedback() {
 		std::shared_ptr<Action> pFeedbackAction =
 			std::make_shared<Action>( "MASTER_VOLUME_ABSOLUTE" );
 		
-		pFeedbackAction->setParameter2( QString("%1")
-										.arg( fMasterVolume ) );
+		pFeedbackAction->setValue( QString("%1")
+								   .arg( fMasterVolume ) );
 		OscServer::get_instance()->handleAction( pFeedbackAction );
 	}
 #endif
@@ -256,7 +256,7 @@ bool CoreActionController::sendStripVolumeFeedback( int nStrip ) {
 				std::make_shared<Action>( "STRIP_VOLUME_ABSOLUTE" );
 		
 			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-			pFeedbackAction->setParameter2( QString("%1").arg( fStripVolume ) );
+			pFeedbackAction->setValue( QString("%1").arg( fStripVolume ) );
 			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
 #endif
@@ -330,7 +330,7 @@ bool CoreActionController::sendStripIsMutedFeedback( int nStrip ) {
 				std::make_shared<Action>( "STRIP_MUTE_TOGGLE" );
 		
 			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-			pFeedbackAction->setParameter2( QString("%1")
+			pFeedbackAction->setValue( QString("%1")
 											.arg( static_cast<int>(pInstr->is_muted()) ) );
 			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
@@ -358,8 +358,8 @@ bool CoreActionController::sendStripIsSoloedFeedback( int nStrip ) {
 				std::make_shared<Action>( "STRIP_SOLO_TOGGLE" );
 		
 			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-			pFeedbackAction->setParameter2( QString("%1")
-											.arg( static_cast<int>(pInstr->is_soloed()) ) );
+			pFeedbackAction->setValue( QString("%1")
+									   .arg( static_cast<int>(pInstr->is_soloed()) ) );
 			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
 #endif
@@ -385,8 +385,8 @@ bool CoreActionController::sendStripPanFeedback( int nStrip ) {
 				std::make_shared<Action>( "PAN_ABSOLUTE" );
 		
 			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-			pFeedbackAction->setParameter2( QString("%1")
-											.arg( pInstr->getPanWithRangeFrom0To1() ) );
+			pFeedbackAction->setValue( QString("%1")
+									   .arg( pInstr->getPanWithRangeFrom0To1() ) );
 			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
 #endif
@@ -412,8 +412,8 @@ bool CoreActionController::sendStripPanSymFeedback( int nStrip ) {
 				std::make_shared<Action>( "PAN_ABSOLUTE_SYM" );
 		
 			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-			pFeedbackAction->setParameter2( QString("%1")
-											.arg( pInstr->getPan() ) );
+			pFeedbackAction->setValue( QString("%1")
+									   .arg( pInstr->getPan() ) );
 			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
 #endif

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1469,7 +1469,7 @@ bool CoreActionController::removePattern( int nPatternNumber ) {
 	// _before_ updating the playing patterns.
 	for ( int ii = 0; ii < pNextPatterns->size(); ++ii ) {
 		if ( pNextPatterns->get( ii ) == pPattern ) {
-			pAudioEngine->toggleNextPattern( nPatternNumber );
+			pAudioEngine->toggleNextPatterns( nPatternNumber );
 		}
 	}
 	

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -55,304 +55,378 @@ CoreActionController::~CoreActionController() {
 	//nothing
 }
 
-bool CoreActionController::setMasterVolume( float masterVolumeValue )
+bool CoreActionController::setMasterVolume( float fMasterVolumeValue )
 {
-	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	auto pSong = Hydrogen::get_instance()->getSong();
 
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "no song set" );
 		return false;
 	}
 	
-	pHydrogen->getSong()->setVolume( masterVolumeValue );
+	pSong->setVolume( fMasterVolumeValue );
 	
-#ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "MASTER_VOLUME_ABSOLUTE" );
-	pFeedbackAction->setParameter2( QString("%1").arg( masterVolumeValue ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
-#endif
-	
-	MidiMap*	pMidiMap = MidiMap::get_instance();
-	
-	auto ccParamValues = pMidiMap->findCCValuesByActionType( QString("MASTER_VOLUME_ABSOLUTE"));
-	
-	handleOutgoingControlChanges( ccParamValues, (masterVolumeValue / 1.5) * 127 );
-
-	return true;
+	return sendMasterVolumeFeedback();
 }
 
 bool CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool bSelectStrip )
 {
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	auto pHydrogen = Hydrogen::get_instance();
+	
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
+	
+		pInstr->set_volume( fVolumeValue );
+	
+		if ( bSelectStrip ) {
+			pHydrogen->setSelectedInstrumentNumber( nStrip );
+		}
+	
+		pHydrogen->setIsModified( true );
 
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
+		return sendStripVolumeFeedback( nStrip );
 	}
 
-	if ( bSelectStrip ) {
-		pHydrogen->setSelectedInstrumentNumber( nStrip );
-	}
-	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
-
-	auto pInstr = pInstrList->get( nStrip );
-	pInstr->set_volume( fVolumeValue );
-	
-#ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "STRIP_VOLUME_ABSOLUTE" );
-	
-	pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-	pFeedbackAction->setParameter2( QString("%1").arg( fVolumeValue ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
-#endif
-
-	MidiMap*	pMidiMap = MidiMap::get_instance();
-	
-	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("STRIP_VOLUME_ABSOLUTE"), QString("%1").arg( nStrip ) );
-	
-	handleOutgoingControlChanges( ccParamValues, (fVolumeValue / 1.5) * 127 );
-	pHydrogen->setIsModified( true );
-
-	return true;
+	return false;
 }
 
 bool CoreActionController::setMetronomeIsActive( bool isActive )
 {
 	Preferences::get_instance()->m_bUseMetronome = isActive;
-	
-#ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "TOGGLE_METRONOME" );
-	
-	pFeedbackAction->setParameter1( QString("%1").arg( (int) isActive ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
-#endif
-	
-	MidiMap*	pMidiMap = MidiMap::get_instance();
-	
-	auto ccParamValues = pMidiMap->findCCValuesByActionType( QString("TOGGLE_METRONOME"));
-	
-	handleOutgoingControlChanges( ccParamValues, (int) isActive * 127 );
 
-	return true;
+	return sendMetronomeIsActiveFeedback();
 }
 
-bool CoreActionController::setMasterIsMuted( bool isMuted )
+bool CoreActionController::setMasterIsMuted( bool bIsMuted )
 {
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "no song set" );
 		return false;
 	}
 	
-	pHydrogen->getSong()->setIsMuted( isMuted );
+	pSong->setIsMuted( bIsMuted );
+	
 	pHydrogen->setIsModified( true );
+
+	return sendMasterIsMutedFeedback();
+}
+
+bool CoreActionController::toggleStripIsMuted( int nStrip )
+{
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr == nullptr ) {
+		return false;
+	}
+	
+	return setStripIsMuted( nStrip, !pInstr->is_muted() );
+}
+
+bool CoreActionController::setStripIsMuted( int nStrip, bool bIsMuted )
+{
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
+		pInstr->set_muted( bIsMuted );
+
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
+	
+		pHydrogen->setIsModified( true );
+
+		return sendStripIsMutedFeedback( nStrip );
+	}
+
+	return false;
+}
+
+bool CoreActionController::toggleStripIsSoloed( int nStrip )
+{
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr == nullptr ) {
+		return false;
+	}
+	
+	return setStripIsSoloed( nStrip, !pInstr->is_soloed() );
+}
+
+bool CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
+{
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
+	
+		pInstr->set_soloed( isSoloed );
+
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
+	
+		pHydrogen->setIsModified( true );
+
+		return sendStripIsSoloedFeedback( nStrip );
+	}
+
+	return false;
+}
+
+bool CoreActionController::setStripPan( int nStrip, float fValue, bool bSelectStrip )
+{
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
+	
+		pInstr->setPanWithRangeFrom0To1( fValue );
+		
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
+		
+		pHydrogen->setIsModified( true );
+		
+		if ( bSelectStrip ) {
+			pHydrogen->setSelectedInstrumentNumber( nStrip );
+		}
+
+		return sendStripPanFeedback( nStrip );
+	}
+
+	return false;
+}
+
+
+bool CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelectStrip )
+{
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
+	
+		pInstr->setPan( fValue );
+		
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
+		
+		pHydrogen->setIsModified( true );
+		
+		if ( bSelectStrip ) {
+			pHydrogen->setSelectedInstrumentNumber( nStrip );
+		}
+
+		return sendStripPanSymFeedback( nStrip );
+	}
+
+	return false;
+}
+
+bool CoreActionController::sendMasterVolumeFeedback() {
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+		
+	float fMasterVolume = pSong->getVolume();
 	
 #ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "MUTE_TOGGLE" );
+	if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+		
+		std::shared_ptr<Action> pFeedbackAction =
+			std::make_shared<Action>( "MASTER_VOLUME_ABSOLUTE" );
+		
+		pFeedbackAction->setParameter2( QString("%1")
+										.arg( fMasterVolume ) );
+		OscServer::get_instance()->handleAction( pFeedbackAction );
+	}
+#endif
 	
-	pFeedbackAction->setParameter1( QString("%1").arg( (int) isMuted ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
+	MidiMap* pMidiMap = MidiMap::get_instance();
+	
+	auto ccParamValues = pMidiMap->findCCValuesByActionType( QString("MASTER_VOLUME_ABSOLUTE"));
+	
+	return handleOutgoingControlChanges( ccParamValues, (fMasterVolume / 1.5) * 127 );
+}
+
+bool CoreActionController::sendStripVolumeFeedback( int nStrip ) {
+
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
+
+		float fStripVolume = pInstr->get_volume();
+		
+#ifdef H2CORE_HAVE_OSC
+		if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+		
+			std::shared_ptr<Action> pFeedbackAction =
+				std::make_shared<Action>( "STRIP_VOLUME_ABSOLUTE" );
+		
+			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
+			pFeedbackAction->setParameter2( QString("%1").arg( fStripVolume ) );
+			OscServer::get_instance()->handleAction( pFeedbackAction );
+		}
+#endif
+
+		MidiMap* pMidiMap = MidiMap::get_instance();
+	
+		auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("STRIP_VOLUME_ABSOLUTE"),
+																   QString("%1").arg( nStrip ) );
+	
+		return handleOutgoingControlChanges( ccParamValues, (fStripVolume / 1.5) * 127 );
+	}
+	
+	return false;
+}
+
+bool CoreActionController::sendMetronomeIsActiveFeedback() {
+	auto pPref = Preferences::get_instance();
+	
+#ifdef H2CORE_HAVE_OSC
+	if ( pPref->getOscFeedbackEnabled() ) {
+		std::shared_ptr<Action> pFeedbackAction =
+			std::make_shared<Action>( "TOGGLE_METRONOME" );
+		
+		pFeedbackAction->setParameter1( QString("%1")
+										.arg( static_cast<int>(pPref->m_bUseMetronome) ) );
+		OscServer::get_instance()->handleAction( pFeedbackAction );
+	}
+#endif
+	
+	MidiMap* pMidiMap = MidiMap::get_instance();
+	
+	auto ccParamValues = pMidiMap->findCCValuesByActionType( QString("TOGGLE_METRONOME"));
+	
+	return handleOutgoingControlChanges( ccParamValues,
+										 static_cast<int>(pPref->m_bUseMetronome) * 127 );
+}
+
+bool CoreActionController::sendMasterIsMutedFeedback() {
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "no song set" );
+		return false;
+	}
+	
+#ifdef H2CORE_HAVE_OSC
+	if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+		std::shared_ptr<Action> pFeedbackAction =
+			std::make_shared<Action>( "MUTE_TOGGLE" );
+		
+		pFeedbackAction->setParameter1( QString("%1")
+										.arg( static_cast<int>(pSong->getIsMuted()) ) );
+		OscServer::get_instance()->handleAction( pFeedbackAction );
+	}
 #endif
 
 	MidiMap*	pMidiMap = MidiMap::get_instance();
 	
 	auto ccParamValues = pMidiMap->findCCValuesByActionType( QString("MUTE_TOGGLE") );
 
-	handleOutgoingControlChanges( ccParamValues, (int) isMuted * 127 );
-
-	return true;
+	return handleOutgoingControlChanges( ccParamValues,
+										 static_cast<int>(pSong->getIsMuted()) * 127 );
 }
 
-bool CoreActionController::toggleStripIsMuted(int nStrip)
-{
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
-	}
+bool CoreActionController::sendStripIsMutedFeedback( int nStrip ) {
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
 	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
-	
-	if( pInstrList->is_valid_index( nStrip ))
-	{
-		auto pInstr = pInstrList->get( nStrip );
+#ifdef H2CORE_HAVE_OSC
+		if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+			std::shared_ptr<Action> pFeedbackAction =
+				std::make_shared<Action>( "STRIP_MUTE_TOGGLE" );
 		
-		if( pInstr ) {
-			setStripIsMuted( nStrip , !pInstr->is_muted() );
+			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
+			pFeedbackAction->setParameter2( QString("%1")
+											.arg( static_cast<int>(pInstr->is_muted()) ) );
+			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
-	}
-
-	return true;
-}
-
-bool CoreActionController::setStripIsMuted( int nStrip, bool isMuted )
-{
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
-	}
-	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
-
-	auto pInstr = pInstrList->get( nStrip );
-	pInstr->set_muted( isMuted );
-	
-#ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "STRIP_MUTE_TOGGLE" );
-	
-	pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-	pFeedbackAction->setParameter2( QString("%1").arg( (int) isMuted ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
 #endif
 
-	MidiMap*	pMidiMap = MidiMap::get_instance();
+		MidiMap* pMidiMap = MidiMap::get_instance();
 	
-	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("STRIP_MUTE_TOGGLE"), QString("%1").arg( nStrip ) );
+		auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("STRIP_MUTE_TOGGLE"),
+																   QString("%1").arg( nStrip ) );
 	
-	handleOutgoingControlChanges( ccParamValues, ((int) isMuted) * 127 );
-	pHydrogen->setIsModified( true );
-
-	return true;
-}
-
-bool CoreActionController::toggleStripIsSoloed( int nStrip )
-{
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
+		return handleOutgoingControlChanges( ccParamValues,
+											 static_cast<int>(pInstr->is_muted()) * 127 );
 	}
 	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
+	return false;
+}
+
+bool CoreActionController::sendStripIsSoloedFeedback( int nStrip ) {
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
 	
-	if( pInstrList->is_valid_index( nStrip ))
-	{
-		auto pInstr = pInstrList->get( nStrip );
-	
-		if( pInstr ) {
-			setStripIsSoloed( nStrip , !pInstr->is_soloed() );
+#ifdef H2CORE_HAVE_OSC
+		if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+			std::shared_ptr<Action> pFeedbackAction =
+				std::make_shared<Action>( "STRIP_SOLO_TOGGLE" );
+		
+			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
+			pFeedbackAction->setParameter2( QString("%1")
+											.arg( static_cast<int>(pInstr->is_soloed()) ) );
+			OscServer::get_instance()->handleAction( pFeedbackAction );
 		}
+#endif
+
+		MidiMap* pMidiMap = MidiMap::get_instance();
+		auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("STRIP_SOLO_TOGGLE"),
+																   QString("%1").arg( nStrip ) );
+	
+		return handleOutgoingControlChanges( ccParamValues,
+											 static_cast<int>(pInstr->is_soloed()) * 127 );
 	}
 
-	return true;
+	return false;
 }
 
-bool CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
-{
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
+bool CoreActionController::sendStripPanFeedback( int nStrip ) {
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
 
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
-	}
-	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
-	
-	auto pInstr = pInstrList->get( nStrip );
-	pInstr->set_soloed( isSoloed );
-	
 #ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "STRIP_SOLO_TOGGLE" );
-	
-	pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-	pFeedbackAction->setParameter2( QString("%1").arg( (int) isSoloed ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
+		if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+			std::shared_ptr<Action> pFeedbackAction =
+				std::make_shared<Action>( "PAN_ABSOLUTE" );
+		
+			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
+			pFeedbackAction->setParameter2( QString("%1")
+											.arg( pInstr->getPanWithRangeFrom0To1() ) );
+			OscServer::get_instance()->handleAction( pFeedbackAction );
+		}
 #endif
 	
-	MidiMap*	pMidiMap = MidiMap::get_instance();
-	
-	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("STRIP_SOLO_TOGGLE"), QString("%1").arg( nStrip ) );
-	
-	handleOutgoingControlChanges( ccParamValues, ((int) isSoloed) * 127 );
-	pHydrogen->setIsModified( true );
+		MidiMap* pMidiMap = MidiMap::get_instance();
+		auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE"),
+																   QString("%1").arg( nStrip ) );
 
-	return true;
+		return handleOutgoingControlChanges( ccParamValues,
+											 pInstr->getPanWithRangeFrom0To1() * 127 );
+	}
+
+	return false;
 }
 
-
-
-bool CoreActionController::setStripPan( int nStrip, float fValue, bool bSelectStrip )
-{
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
-	}
-	
-	if ( bSelectStrip ) {
-		pHydrogen->setSelectedInstrumentNumber( nStrip );
-	}
-	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
-
-	auto pInstr = pInstrList->get( nStrip );
-	pInstr->setPanWithRangeFrom0To1( fValue );
+bool CoreActionController::sendStripPanSymFeedback( int nStrip ) {
+	auto pInstr = getStrip( nStrip );
+	if ( pInstr != nullptr ) {
 
 #ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "PAN_ABSOLUTE" );
-	
-	pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-	pFeedbackAction->setParameter2( QString("%1").arg( fValue ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
+		if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
+			std::shared_ptr<Action> pFeedbackAction =
+				std::make_shared<Action>( "PAN_ABSOLUTE_SYM" );
+		
+			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
+			pFeedbackAction->setParameter2( QString("%1")
+											.arg( pInstr->getPan() ) );
+			OscServer::get_instance()->handleAction( pFeedbackAction );
+		}
 #endif
 	
-	MidiMap*	pMidiMap = MidiMap::get_instance();
-	
-	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE"), QString("%1").arg( nStrip ) );
+		MidiMap* pMidiMap = MidiMap::get_instance();
+		auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE_SYM"),
+																   QString("%1").arg( nStrip ) );
 
-	handleOutgoingControlChanges( ccParamValues, fValue * 127 );
-	pHydrogen->setIsModified( true );
-
-	return true;
-}
-
-bool CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelectStrip )
-{
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-
-	if ( pHydrogen->getSong() == nullptr ) {
-		ERRORLOG( "no song set" );
-		return false;
+		return handleOutgoingControlChanges( ccParamValues,
+											 pInstr->getPan() * 127 );
 	}
-	
-	if ( bSelectStrip ) {
-		pHydrogen->setSelectedInstrumentNumber( nStrip );
-	}
-	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	InstrumentList *pInstrList = pSong->getInstrumentList();
 
-	auto pInstr = pInstrList->get( nStrip );
-	pInstr->setPan( fValue );
-
-#ifdef H2CORE_HAVE_OSC
-	std::shared_ptr<Action> pFeedbackAction = std::make_shared<Action>( "PAN_ABSOLUTE_SYM" );
-	
-	pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-	pFeedbackAction->setParameter2( QString("%1").arg( fValue ) );
-	OscServer::get_instance()->handleAction( pFeedbackAction );
-#endif
-	
-	MidiMap*	pMidiMap = MidiMap::get_instance();
-	
-	auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE_SYM"), QString("%1").arg( nStrip ) );
-	handleOutgoingControlChanges( ccParamValues, pInstr->getPanWithRangeFrom0To1() * 127 );
-	pHydrogen->setIsModified( true );
-
-	return true;
+	return false;
 }
 
 bool CoreActionController::handleOutgoingControlChanges( std::vector<int> params, int nValue)
@@ -367,13 +441,28 @@ bool CoreActionController::handleOutgoingControlChanges( std::vector<int> params
 	}
 
 	for ( auto param : params ) {
-		if(	pMidiDriver != nullptr &&
-			pPref->m_bEnableMidiFeedback && param >= 0 ){
+		if ( pMidiDriver != nullptr &&
+			 pPref->m_bEnableMidiFeedback && param >= 0 ){
 			pMidiDriver->handleOutgoingControlChange( param, nValue, m_nDefaultMidiFeedbackChannel );
 		}
 	}
 
 	return true;
+}
+
+std::shared_ptr<Instrument> CoreActionController::getStrip( int nStrip ) const {
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "no song set" );
+		return nullptr;
+	}
+
+	auto pInstr = pSong->getInstrumentList()->get( nStrip );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Couldn't find instrument [%1]" ).arg( nStrip ) );
+	}
+
+	return pInstr;
 }
 
 bool CoreActionController::initExternalControlInterfaces()
@@ -383,50 +472,47 @@ bool CoreActionController::initExternalControlInterfaces()
 	 */
 	
 	//MASTER_VOLUME_ABSOLUTE
-	Hydrogen* pHydrogen = Hydrogen::get_instance();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "no song set" );
 		return false;
 	}
 	
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-
-	bool bIsModified = pSong->getIsModified();
-	
-	setMasterVolume( pSong->getVolume() );
+	sendMasterVolumeFeedback();
 	
 	//PER-INSTRUMENT/STRIP STATES
 	InstrumentList *pInstrList = pSong->getInstrumentList();
-	for(int i=0; i < pInstrList->size(); i++){
+	for ( int ii = 0; ii < pInstrList->size(); ii++){
+		auto pInstr = pInstrList->get( ii );
+		if ( pInstr != nullptr ) {
 		
 			//STRIP_VOLUME_ABSOLUTE
-			auto pInstr = pInstrList->get( i );
-			setStripVolume( i, pInstr->get_volume(), false );
+			sendStripVolumeFeedback( ii );
 
 			//PAN_ABSOLUTE
-			float fValue = pInstr->getPanWithRangeFrom0To1();
-			setStripPan( i, fValue, false );
+			sendStripPanFeedback( ii );
 			
 			//STRIP_MUTE_TOGGLE
-			setStripIsMuted( i, pInstr->is_muted() );
+			sendStripIsMutedFeedback( ii );
 			
 			//SOLO
-			if(pInstr->is_soloed()) {
-				setStripIsSoloed( i, pInstr->is_soloed() );
-			}
+			sendStripIsSoloedFeedback( ii );
+		}
 	}
 	
 	//TOGGLE_METRONOME
-	setMetronomeIsActive( Preferences::get_instance()->m_bUseMetronome );
+	sendMetronomeIsActiveFeedback();
 	
 	//MUTE_TOGGLE
-	setMasterIsMuted( Hydrogen::get_instance()->getSong()->getIsMuted() );
-
-	pHydrogen->setIsModified( bIsModified );
+	sendMasterIsMutedFeedback();
 	
 	return true;
 }
+
+//////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////
 
 bool CoreActionController::newSong( const QString& sSongPath ) {
 	

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -31,6 +31,7 @@
 namespace H2Core
 {
 	class Drumkit;
+	class Instrument;
 
 /** \ingroup docCore docAutomation */
 class CoreActionController : public H2Core::Object<CoreActionController> {
@@ -72,7 +73,6 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		bool toggleStripIsSoloed( int nStrip );
 		
 		bool initExternalControlInterfaces();
-	bool handleOutgoingControlChanges( std::vector<int> params, int nValue);
 	
 		// -----------------------------------------------------------
 		// Actions required for session management.
@@ -359,7 +359,21 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * @return bool true on success
 		 */
     	bool toggleGridCell( int nColumn, int nRow );
-	private:
+private:
+	bool sendMasterVolumeFeedback();
+	bool sendStripVolumeFeedback( int nStrip );
+	bool sendMetronomeIsActiveFeedback();
+	bool sendMasterIsMutedFeedback();
+	bool sendStripIsMutedFeedback( int nStrip );
+	bool sendStripIsSoloedFeedback( int nStrip );
+	bool sendStripPanFeedback( int nStrip );
+	bool sendStripPanSymFeedback( int nStrip );
+	
+	bool handleOutgoingControlChanges( std::vector<int> params, int nValue);
+	std::shared_ptr<Instrument> getStrip( int nStrip ) const;
+	
+	// -----------------------------------------------------------
+	// Actions required for session management.
 		
 		/**
 		 * Sets a #H2Core::Song to be used by Hydrogen.

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -70,10 +70,6 @@ enum EventType {
 	 * changed. `-1` indicates that multiple instruments were altered.
 	 */
 	EVENT_INSTRUMENT_PARAMETERS_CHANGED,
-	/** The instrument list of the current song was changed, e.g. by
-	 * adding or removing an instrument.
-	 */
-	EVENT_INSTRUMENT_LIST_CHANGED,
 	EVENT_MIDI_ACTIVITY,
 	EVENT_XRUN,
 	EVENT_NOTEON,

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -64,7 +64,16 @@ enum EventType {
 	 */
 	EVENT_SELECTED_PATTERN_CHANGED,
 	EVENT_SELECTED_INSTRUMENT_CHANGED,
-	EVENT_PARAMETERS_INSTRUMENT_CHANGED,
+	/** Some parameters of an instrument have been changed.
+	 *
+	 * Numbers `>=0` indicate the number of the instrument that has been
+	 * changed. `-1` indicates that multiple instruments were altered.
+	 */
+	EVENT_INSTRUMENT_PARAMETERS_CHANGED,
+	/** The instrument list of the current song was changed, e.g. by
+	 * adding or removing an instrument.
+	 */
+	EVENT_INSTRUMENT_LIST_CHANGED,
 	EVENT_MIDI_ACTIVITY,
 	EVENT_XRUN,
 	EVENT_NOTEON,

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -609,10 +609,10 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 }
 
 
-void Hydrogen::toggleNextPattern( int nPatternNumber ) {
+void Hydrogen::toggleNextPatterns( int nPatternNumber ) {
 	if ( __song != nullptr && getMode() == Song::Mode::Pattern ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
-		m_pAudioEngine->toggleNextPattern( nPatternNumber );
+		m_pAudioEngine->toggleNextPatterns( nPatternNumber );
 		m_pAudioEngine->unlock();
 
 	} else {
@@ -620,10 +620,10 @@ void Hydrogen::toggleNextPattern( int nPatternNumber ) {
 	}
 }
 
-bool Hydrogen::flushAndAddNextPattern( int nPatternNumber ) {
+bool Hydrogen::flushAndAddNextPatterns( int nPatternNumber ) {
 	if ( __song != nullptr && getMode() == Song::Mode::Pattern ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
-		m_pAudioEngine->flushAndAddNextPattern( nPatternNumber );
+		m_pAudioEngine->flushAndAddNextPatterns( nPatternNumber );
 		m_pAudioEngine->unlock();
 
 		return true;
@@ -1361,6 +1361,7 @@ void Hydrogen::setPatternMode( Song::PatternMode mode )
 			// the functions and activate the next patterns once the
 			// current ones are looped.
 			m_pAudioEngine->updatePlayingPatterns( m_pAudioEngine->getColumn() );
+			m_pAudioEngine->clearNextPatterns();
 		}
 
 		m_pAudioEngine->unlock();

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -620,15 +620,19 @@ void Hydrogen::toggleNextPattern( int nPatternNumber ) {
 	}
 }
 
-void Hydrogen::flushAndAddNextPattern( int nPatternNumber ) {
+bool Hydrogen::flushAndAddNextPattern( int nPatternNumber ) {
 	if ( __song != nullptr && getMode() == Song::Mode::Pattern ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
 		m_pAudioEngine->flushAndAddNextPattern( nPatternNumber );
 		m_pAudioEngine->unlock();
 
+		return true;
+
 	} else {
 		ERRORLOG( "can't set next pattern in song mode" );
 	}
+
+	return false;
 }
 
 void Hydrogen::restartDrivers()
@@ -1026,7 +1030,7 @@ void Hydrogen::setBcOffsetAdjust()
 	m_nStartOffset = pPreferences->m_startOffset;
 }
 
-void Hydrogen::handleBeatCounter()
+bool Hydrogen::handleBeatCounter()
 {
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
@@ -1060,7 +1064,7 @@ void Hydrogen::handleBeatCounter()
 	if( beatDiff > 3.001 * 1/m_ntaktoMeterCompute ) {
 		m_nEventCount = 1;
 		m_nBeatCount = 1;
-		return;
+		return false;
 	}
 	// Only accept differences big enough
 	if (m_nBeatCount == 1 || beatDiff > .001) {
@@ -1122,14 +1126,17 @@ void Hydrogen::handleBeatCounter()
 
 				m_nBeatCount = 1;
 				m_nEventCount = 1;
-				return;
+				return true;
 			}
 		}
 		else {
 			m_nBeatCount ++;
 		}
 	}
-	return;
+	else {
+		return false;
+	}
+	return true;
 }
 //~ m_nBeatCounter
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -965,11 +965,6 @@ void Hydrogen::setSelectedInstrumentNumber( int nInstrument )
 	EventQueue::get_instance()->push_event( EVENT_SELECTED_INSTRUMENT_CHANGED, -1 );
 }
 
-void Hydrogen::refreshInstrumentParameters( int nInstrument )
-{
-	EventQueue::get_instance()->push_event( EVENT_PARAMETERS_INSTRUMENT_CHANGED, -1 );
-}
-
 void Hydrogen::renameJackPorts( std::shared_ptr<Song> pSong )
 {
 #ifdef H2CORE_HAVE_JACK

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1665,7 +1665,7 @@ long Hydrogen::getTickForColumn( int nColumn ) const
 		}
 		totalTick += nPatternSize;
 	}
-	
+
 	return totalTick;
 }
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -340,9 +340,6 @@ void			previewSample( Sample *pSample );
 	void			setSelectedInstrumentNumber( int nInstrument );
 	std::shared_ptr<Instrument>		getSelectedInstrument() const;
 
-
-	void			refreshInstrumentParameters( int nInstrument );
-
 	/**
 	 * Calls audioEngine_renameJackPorts() if
 	 * Preferences::m_bJackTrackOuts is set to true.

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -107,7 +107,7 @@ public:
 	/** Wrapper around AudioEngine::toggleNextPattern().*/
 	void			toggleNextPattern( int nPatternNumber );
 	/** Wrapper around AudioEngine::flushAndAddNextPattern().*/
-	void			flushAndAddNextPattern( int nPatternNumber );
+	bool			flushAndAddNextPattern( int nPatternNumber );
 	
 		/**
 		 * Get the current song.
@@ -361,7 +361,7 @@ void			previewSample( Sample *pSample );
 	void			setNoteLength( float notelength);
 	float			getNoteLength();
 	int			getBcStatus();
-	void			handleBeatCounter();
+	bool			handleBeatCounter();
 	void			setBcOffsetAdjust();
 
 	/** Calling JackAudioDriver::releaseTimebaseMaster() directly from

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -104,10 +104,10 @@ public:
 	QString			m_LastMidiEvent;
 	int				m_nLastMidiEventParameter;
 
-	/** Wrapper around AudioEngine::toggleNextPattern().*/
-	void			toggleNextPattern( int nPatternNumber );
-	/** Wrapper around AudioEngine::flushAndAddNextPattern().*/
-	bool			flushAndAddNextPattern( int nPatternNumber );
+	/** Wrapper around AudioEngine::toggleNextPatterns().*/
+	void			toggleNextPatterns( int nPatternNumber );
+	/** Wrapper around AudioEngine::flushAndAddNextPatterns().*/
+	bool			flushAndAddNextPatterns( int nPatternNumber );
 	
 		/**
 		 * Get the current song.

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -518,7 +518,7 @@ void JackAudioDriver::updateTransportInfo()
 		pAudioEngine->setNextState( AudioEngine::State::Playing );
 		break;
 
-	case JackTransportStarting: 
+	case JackTransportStarting:
 		// Waiting for sync ready. If there are slow-sync clients,
 		// this can take more than one cycle.
 		pAudioEngine->setNextState( AudioEngine::State::Ready );

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -235,7 +235,11 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 	pHydrogen->m_LastMidiEvent = "NOTE";
 	pHydrogen->m_nLastMidiEventParameter = msg.m_nData1;
 
-	bool bActionSuccess = pMidiActionManager->handleActions( pMidiMap->getNoteActions( msg.m_nData1 ) );
+	auto actions = pMidiMap->getNoteActions( msg.m_nData1 );
+	for ( auto action : actions ) {
+		action->setValue( QString::number( msg.m_nData2 ) );
+	}
+	bool bActionSuccess = pMidiActionManager->handleActions( actions );
 
 	if ( bActionSuccess && pPref->m_bMidiDiscardNoteAfterAction ) {
 		return;

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -384,7 +384,7 @@ bool MidiActionManager::select_next_pattern( std::shared_ptr<Action> pAction, Hy
 		pHydrogen->setSelectedPatternNumber( row );
 	}
 	else if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
-		pHydrogen->toggleNextPattern( row );
+		pHydrogen->toggleNextPatterns( row );
 	}
 	return true;
 }
@@ -410,7 +410,7 @@ bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pActio
 		return select_next_pattern( pAction, pHydrogen );
 	}
 	
-	return pHydrogen->flushAndAddNextPattern( row );
+	return pHydrogen->flushAndAddNextPatterns( row );
 }
 
 bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -544,8 +544,11 @@ bool MidiActionManager::effect_level_absolute( std::shared_ptr<Action> pAction, 
 				pInstr->set_fx_level( 0 , fx_id );
 			}
 			
-			pHydrogen->setSelectedInstrumentNumber( nLine );			
-		} else {
+			pHydrogen->setSelectedInstrumentNumber( nLine );
+
+			EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+		}
+		else {
 			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
 			return false;
 		}
@@ -584,8 +587,10 @@ bool MidiActionManager::effect_level_relative( std::shared_ptr<Action> pAction, 
 				}
 			}
 			
-			pHydrogen->setSelectedInstrumentNumber( nLine );			
-		} else {
+			pHydrogen->setSelectedInstrumentNumber( nLine );
+			EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+		}
+		else {
 			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
 			return false;
 		}
@@ -676,7 +681,9 @@ bool MidiActionManager::strip_volume_absolute( std::shared_ptr<Action> pAction, 
 		}
 	
 		pHydrogen->setSelectedInstrumentNumber(nLine);
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 
@@ -719,7 +726,9 @@ bool MidiActionManager::strip_volume_relative( std::shared_ptr<Action> pAction, 
 		}
 	
 		pHydrogen->setSelectedInstrumentNumber(nLine);
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 
@@ -754,7 +763,9 @@ bool MidiActionManager::pan_absolute( std::shared_ptr<Action> pAction, Hydrogen*
 		pInstr->setPanWithRangeFrom0To1( (float) pan_param / 127.f );
 	
 		pHydrogen->setSelectedInstrumentNumber(nLine);
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 
@@ -789,7 +800,9 @@ bool MidiActionManager::pan_absolute_sym( std::shared_ptr<Action> pAction, Hydro
 		pInstr->setPan( (float) pan_param / 127.f );
 	
 		pHydrogen->setSelectedInstrumentNumber(nLine);
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 
@@ -832,7 +845,9 @@ bool MidiActionManager::pan_relative( std::shared_ptr<Action> pAction, Hydrogen*
 		}
 
 		pHydrogen->setSelectedInstrumentNumber(nLine);
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 
@@ -882,9 +897,9 @@ bool MidiActionManager::gain_level_absolute( std::shared_ptr<Action> pAction, Hy
 		}
 	
 		pHydrogen->setSelectedInstrumentNumber( nLine );
-	
-		pHydrogen->refreshInstrumentParameters( nLine );
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 	
@@ -933,9 +948,9 @@ bool MidiActionManager::pitch_level_absolute( std::shared_ptr<Action> pAction, H
 		}
 	
 		pHydrogen->setSelectedInstrumentNumber( nLine );
-	
-		pHydrogen->refreshInstrumentParameters( nLine );
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 
@@ -971,9 +986,9 @@ bool MidiActionManager::filter_cutoff_level_absolute( std::shared_ptr<Action> pA
 		}
 	
 		pHydrogen->setSelectedInstrumentNumber( nLine );
-	
-		pHydrogen->refreshInstrumentParameters( nLine );
-	} else {
+		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	}
+	else {
 		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
 	}
 	

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1071,8 +1071,10 @@ bool MidiActionManager::next_bar( std::shared_ptr<Action> , Hydrogen* pHydrogen 
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
+
+	int nNewColumn = std::max( 0, pHydrogen->getAudioEngine()->getColumn() ) + 1;
 	
-	pHydrogen->getCoreActionController()->locateToColumn( pHydrogen->getAudioEngine()->getColumn() +1 );
+	pHydrogen->getCoreActionController()->locateToColumn( nNewColumn );
 	return true;
 }
 

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1090,7 +1090,7 @@ bool MidiActionManager::previous_bar( std::shared_ptr<Action> , Hydrogen* pHydro
 	return true;
 }
 
-bool setSong( int nSongNumber, Hydrogen * pHydrogen ) {
+bool MidiActionManager::setSong( int nSongNumber, Hydrogen* pHydrogen ) {
 	int nActiveSongNumber = Playlist::get_instance()->getActiveSongNumber();
 	if( nSongNumber >= 0 && nSongNumber <= Playlist::get_instance()->size() - 1 ) {
 		if ( nActiveSongNumber != nSongNumber ) {

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -339,7 +339,7 @@ bool MidiActionManager::strip_solo_toggle( std::shared_ptr<Action> pAction, Hydr
 		return false;
 	}
 
-	return pHydrogen->getCoreActionController()->setStripIsMuted( nLine, !pInstr->is_soloed() );
+	return pHydrogen->getCoreActionController()->setStripIsSoloed( nLine, !pInstr->is_soloed() );
 }
 
 bool MidiActionManager::beatcounter( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -233,8 +233,7 @@ bool MidiActionManager::stop( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
 	}
 	
 	pHydrogen->sequencer_stop();
-	pHydrogen->getCoreActionController()->locateToColumn( 0 );
-	return true;
+	return pHydrogen->getCoreActionController()->locateToColumn( 0 );
 }
 
 bool MidiActionManager::play_stop_pause_toggle( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
@@ -274,8 +273,7 @@ bool MidiActionManager::mute( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
 		return false;
 	}
 	
-	pHydrogen->getCoreActionController()->setMasterIsMuted( true );
-	return true;
+	return pHydrogen->getCoreActionController()->setMasterIsMuted( true );
 }
 
 bool MidiActionManager::unmute( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
@@ -285,8 +283,7 @@ bool MidiActionManager::unmute( std::shared_ptr<Action> , Hydrogen* pHydrogen ) 
 		return false;
 	}
 	
-	pHydrogen->getCoreActionController()->setMasterIsMuted( false );
-	return true;
+	return pHydrogen->getCoreActionController()->setMasterIsMuted( false );
 }
 
 bool MidiActionManager::mute_toggle( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
@@ -296,69 +293,53 @@ bool MidiActionManager::mute_toggle( std::shared_ptr<Action> , Hydrogen* pHydrog
 		return false;
 	}
 	
-	pHydrogen->getCoreActionController()->setMasterIsMuted( !pHydrogen->getSong()->getIsMuted() );
-	return true;
+	return pHydrogen->getCoreActionController()->setMasterIsMuted( !pHydrogen->getSong()->getIsMuted() );
 }
 
 bool MidiActionManager::strip_mute_toggle( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 	
-	
 	bool ok;
-	bool bSucccess = true;
-	
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if ( pInstrList->is_valid_index( nLine ) ) {
-		auto pInstr = pInstrList->get( nLine );
-		
-		if ( pInstr ) {
-			pHydrogen->getCoreActionController()->setStripIsMuted( nLine, !pInstr->is_muted() );
-		} else {
-			bSucccess = false;
-		}
-	} else {
-		bSucccess = false;
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
 	}
 
-	return bSucccess;
+	return pHydrogen->getCoreActionController()->setStripIsMuted( nLine, !pInstr->is_muted() );
 }
 
 bool MidiActionManager::strip_solo_toggle( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 	
 	bool ok;
-	bool bSucccess = true;
-	
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
-
-	if ( pInstrList->is_valid_index( nLine ) ) {
-		auto pInstr = pInstrList->get( nLine );
-		
-		if ( pInstr ) {
-			pHydrogen->getCoreActionController()->setStripIsSoloed( nLine, !pInstr->is_soloed() );
-		} else {
-			bSucccess = false;
-		}
-	} else {
-		bSucccess = false;
-	}
 	
-	return bSucccess;
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
+	}
+
+	return pHydrogen->getCoreActionController()->setStripIsMuted( nLine, !pInstr->is_soloed() );
 }
 
 bool MidiActionManager::beatcounter( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
@@ -368,8 +349,7 @@ bool MidiActionManager::beatcounter( std::shared_ptr<Action> , Hydrogen* pHydrog
 		return false;
 	}
 	
-	pHydrogen->handleBeatCounter();
-	return true;
+	return pHydrogen->handleBeatCounter();
 }
 
 bool MidiActionManager::tap_tempo( std::shared_ptr<Action> , Hydrogen* pHydrogen ) {
@@ -384,18 +364,20 @@ bool MidiActionManager::tap_tempo( std::shared_ptr<Action> , Hydrogen* pHydrogen
 }
 
 bool MidiActionManager::select_next_pattern( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 	
 	bool ok;
 	int row = pAction->getParameter1().toInt(&ok,10);
-	if( row > pHydrogen->getSong()->getPatternList()->size() - 1 ||
+	if( row > pSong->getPatternList()->size() - 1 ||
 		row < 0 ) {
 		ERRORLOG( QString( "Provided value [%1] out of bound [0,%2]" ).arg( row )
-				  .arg( pHydrogen->getSong()->getPatternList()->size() - 1 ) );
+				  .arg( pSong->getPatternList()->size() - 1 ) );
 		return false;
 	}
 	if ( pHydrogen->getPatternMode() == Song::PatternMode::Selected ) {
@@ -408,31 +390,34 @@ bool MidiActionManager::select_next_pattern( std::shared_ptr<Action> pAction, Hy
 }
 
 bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 	
 	bool ok;
 	int row = pAction->getParameter1().toInt(&ok,10);
-	if( row > pHydrogen->getSong()->getPatternList()->size() -1 ||
+	if( row > pSong->getPatternList()->size() -1 ||
 		row < 0 ) {
 		ERRORLOG( QString( "Provided value [%1] out of bound [0,%2]" ).arg( row )
-				  .arg( pHydrogen->getSong()->getPatternList()->size() - 1 ) );
+				  .arg( pSong->getPatternList()->size() - 1 ) );
 		return false;
 	}
 	if ( pHydrogen->getPatternMode() == Song::PatternMode::Selected ) {
 		return select_next_pattern( pAction, pHydrogen );
 	}
 	
-	pHydrogen->flushAndAddNextPattern( row );
-	return true; 
+	return pHydrogen->flushAndAddNextPattern( row );
 }
 
 bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -442,10 +427,10 @@ bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pA
 		return true;
 	}
 	int row = pHydrogen->getSelectedPatternNumber() + pAction->getParameter1().toInt(&ok,10);
-	if( row > pHydrogen->getSong()->getPatternList()->size() - 1 ||
+	if( row > pSong->getPatternList()->size() - 1 ||
 		row < 0 ) {
 		ERRORLOG( QString( "Provided value [%1] out of bound [0,%2]" ).arg( row )
-				  .arg( pHydrogen->getSong()->getPatternList()->size() - 1 ) );
+				  .arg( pSong->getPatternList()->size() - 1 ) );
 		return false;
 	}
 	
@@ -499,18 +484,19 @@ bool MidiActionManager::select_and_play_pattern( std::shared_ptr<Action> pAction
 }
 
 bool MidiActionManager::select_instrument( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 	
 	bool ok;
 	int  nInstrumentNumber = pAction->getValue().toInt(&ok,10) ;
-	
 
-	if ( pHydrogen->getSong()->getInstrumentList()->size() < nInstrumentNumber ) {
-		nInstrumentNumber = pHydrogen->getSong()->getInstrumentList()->size() -1;
+	if ( pSong->getInstrumentList()->size() < nInstrumentNumber ) {
+		nInstrumentNumber = pSong->getInstrumentList()->size() -1;
 	} else if ( nInstrumentNumber < 0 ) {
 		nInstrumentNumber = 0;
 	}
@@ -520,8 +506,10 @@ bool MidiActionManager::select_instrument( std::shared_ptr<Action> pAction, Hydr
 }
 
 bool MidiActionManager::effect_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -531,38 +519,32 @@ bool MidiActionManager::effect_level_absolute( std::shared_ptr<Action> pAction, 
 	int fx_param = pAction->getValue().toInt(&ok,10);
 	int fx_id = pAction->getParameter2().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if ( pInstrList->is_valid_index( nLine) ) {
-		auto pInstr = pInstrList->get( nLine );
-		
-		if ( pInstr ) {
-			if( fx_param != 0 ) {
-				pInstr->set_fx_level(  ( (float) (fx_param / 127.0 ) ), fx_id );
-			} else {
-				pInstr->set_fx_level( 0 , fx_id );
-			}
-			
-			pHydrogen->setSelectedInstrumentNumber( nLine );
-
-			EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
-		}
-		else {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
-	} else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
 		return false;
 	}
+		
+	if( fx_param != 0 ) {
+		pInstr->set_fx_level( (float) (fx_param / 127.0 ), fx_id );
+	} else {
+		pInstr->set_fx_level( 0 , fx_id );
+	}
+			
+	pHydrogen->setSelectedInstrumentNumber( nLine );
+
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 
 	return true;
 }
 
 bool MidiActionManager::effect_level_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -572,52 +554,46 @@ bool MidiActionManager::effect_level_relative( std::shared_ptr<Action> pAction, 
 	int fx_param = pAction->getValue().toInt(&ok,10);
 	int fx_id = pAction->getParameter2().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if ( pInstrList->is_valid_index( nLine) ) {
-		auto pInstr = pInstrList->get( nLine );
-		
-		if ( pInstr ) {
-			if( fx_param != 0 ) {
-				if ( fx_param == 1 && pInstr->get_fx_level( fx_id ) <= 0.95 ) {
-					pInstr->set_fx_level( pInstr->get_fx_level( fx_id ) + 0.05, fx_id );
-				} else if ( pInstr->get_fx_level( fx_id ) >= 0.05 ) {
-					pInstr->set_fx_level( pInstr->get_fx_level( fx_id ) - 0.05, fx_id );
-				}
-			}
-			
-			pHydrogen->setSelectedInstrumentNumber( nLine );
-			EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
-		}
-		else {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
-	} else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
 		return false;
 	}
+	if ( fx_param != 0 ) {
+		if ( fx_param == 1 && pInstr->get_fx_level( fx_id ) <= 0.95 ) {
+			pInstr->set_fx_level( pInstr->get_fx_level( fx_id ) + 0.05, fx_id );
+		}
+		else if ( pInstr->get_fx_level( fx_id ) >= 0.05 ) {
+			pInstr->set_fx_level( pInstr->get_fx_level( fx_id ) - 0.05, fx_id );
+		}
+	}
+			
+	pHydrogen->setSelectedInstrumentNumber( nLine );
+
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+
 	return true;
 }
 
 //sets the volume of a master output to a given level (percentage)
 bool MidiActionManager::master_volume_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 
 	bool ok;
-	int vol_param = pAction->getValue().toInt(&ok,10);
+	int nVolume = pAction->getValue().toInt(&ok,10);
 
-	std::shared_ptr<Song> song = pHydrogen->getSong();
-
-	if( vol_param != 0 ){
-		song->setVolume( 1.5* ( (float) (vol_param / 127.0 ) ));
+	if ( nVolume != 0 ) {
+		pSong->setVolume( 1.5* ( (float) (nVolume / 127.0 ) ));
 	} else {
-		song->setVolume( 0 );
+		pSong->setVolume( 0 );
 	}
 
 	return true;
@@ -634,7 +610,7 @@ bool MidiActionManager::master_volume_relative( std::shared_ptr<Action> pAction,
 	}
 
 	bool ok;
-	int nVolume = pAction->getParameter2().toInt(&ok,10);
+	int nVolume = pAction->getValue().toInt(&ok,10);
 
 	if ( nVolume != 0 ) {
 		if ( nVolume == 1 && pSong->getVolume() < 1.5 ) {
@@ -651,39 +627,34 @@ bool MidiActionManager::master_volume_relative( std::shared_ptr<Action> pAction,
 
 //sets the volume of a mixer strip to a given level (percentage)
 bool MidiActionManager::strip_volume_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
 
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
-	int vol_param = pAction->getValue().toInt(&ok,10);
+	int nVolume = pAction->getValue().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if ( pInstrList->is_valid_index( nLine ) ) {
-		auto pInstr = pInstrList->get( nLine );
-	
-		if ( pInstr == nullptr) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
-	
-		if( vol_param != 0 ) {
-			pInstr->set_volume( 1.5* ( (float) (vol_param / 127.0 ) ));
-		} else {
-			pInstr->set_volume( 0 );
-		}
-	
-		pHydrogen->setSelectedInstrumentNumber(nLine);
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
 	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	
+	if ( nVolume != 0 ) {
+		pInstr->set_volume( 1.5* ( (float) (nVolume / 127.0 ) ));
+	} else {
+		pInstr->set_volume( 0 );
 	}
+	
+	pHydrogen->setSelectedInstrumentNumber(nLine);
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 
 	return true;
 }
@@ -700,7 +671,7 @@ bool MidiActionManager::strip_volume_relative( std::shared_ptr<Action> pAction, 
 
 	bool ok;
 	int nLine = pAction->getParameter1().toInt(&ok,10);
-	int nVolume = pAction->getParameter2().toInt(&ok,10);
+	int nVolume = pAction->getValue().toInt(&ok,10);
 
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 
@@ -731,8 +702,10 @@ bool MidiActionManager::strip_volume_relative( std::shared_ptr<Action> pAction, 
 
 // sets the absolute panning of a given mixer channel
 bool MidiActionManager::pan_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -741,35 +714,29 @@ bool MidiActionManager::pan_absolute( std::shared_ptr<Action> pAction, Hydrogen*
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int pan_param = pAction->getValue().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
-	
-	if( pInstrList->is_valid_index( nLine ) ) {
-		pHydrogen->setSelectedInstrumentNumber( nLine );
-	
-		auto pInstr = pInstrList->get( nLine );
-	
-		if( pInstr == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
 
-		pInstr->setPanWithRangeFrom0To1( (float) pan_param / 127.f );
+	auto pInstr = pInstrList->get( nLine );
+	if( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
+	}
 	
-		pHydrogen->setSelectedInstrumentNumber(nLine);
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
-	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
-	}
+	pInstr->setPanWithRangeFrom0To1( (float) pan_param / 127.f );
+	
+	pHydrogen->setSelectedInstrumentNumber(nLine);
+
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 
 	return true;
 }
 
 // sets the absolute panning of a given mixer channel
 bool MidiActionManager::pan_absolute_sym( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -778,27 +745,18 @@ bool MidiActionManager::pan_absolute_sym( std::shared_ptr<Action> pAction, Hydro
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int pan_param = pAction->getValue().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if( pInstrList->is_valid_index( nLine ) ) {
-		pHydrogen->setSelectedInstrumentNumber( nLine );
-	
-		auto pInstr = pInstrList->get( nLine );
-	
-		if( pInstr == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
+	}
 
-		pInstr->setPan( (float) pan_param / 127.f );
+	pInstr->setPan( (float) pan_param / 127.f );
 	
-		pHydrogen->setSelectedInstrumentNumber(nLine);
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
-	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
-	}
+	pHydrogen->setSelectedInstrumentNumber(nLine);
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 
 	return true;
 }
@@ -807,8 +765,10 @@ bool MidiActionManager::pan_absolute_sym( std::shared_ptr<Action> pAction, Hydro
 // changes the panning of a given mixer channel
 // this is useful if the panning is set by a rotary control knob
 bool MidiActionManager::pan_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -817,40 +777,34 @@ bool MidiActionManager::pan_relative( std::shared_ptr<Action> pAction, Hydrogen*
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int pan_param = pAction->getValue().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if( pInstrList->is_valid_index( nLine ) ) {	
-		pHydrogen->setSelectedInstrumentNumber( nLine );
-
-		auto pInstr = pInstrList->get( nLine );
-
-		if( pInstr == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
+	auto pInstr = pInstrList->get( nLine );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
+	}
 	
-		float fPan = pInstr->getPan();
+	float fPan = pInstr->getPan();
 
-		if( pan_param == 1 && fPan < 1.f ) {
-			pInstr->setPan( fPan + 0.1 );
-		} else if( pan_param != 1 && fPan > -1.f ) {
-			pInstr->setPan( fPan - 0.1 );
-		}
+	if ( pan_param == 1 && fPan < 1.f ) {
+		pInstr->setPan( fPan + 0.1 );
+	}
+	else if ( pan_param != 1 && fPan > -1.f ) {
+		pInstr->setPan( fPan - 0.1 );
+	}
 
-		pHydrogen->setSelectedInstrumentNumber(nLine);
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
-	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
-	}
+	pHydrogen->setSelectedInstrumentNumber(nLine);
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 
 	return true;
 }
 
 bool MidiActionManager::gain_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -861,48 +815,43 @@ bool MidiActionManager::gain_level_absolute( std::shared_ptr<Action> pAction, Hy
 	int component_id = pAction->getParameter2().toInt(&ok,10);
 	int layer_id = pAction->getParameter3().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	
-	if( pInstrList->is_valid_index( nLine ) )
-	{
-		auto pInstr = pInstrList->get( nLine );
-		if( pInstr == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
-	
-		auto pComponent =  pInstr->get_component( component_id );
-		if( pComponent == nullptr) {
-			ERRORLOG( QString( "Unable to retrieve component (Par. 2) [%1]" ).arg( component_id ) );
-			return false;
-		}
-	
-		auto pLayer = pComponent->get_layer( layer_id );
-		if( pLayer == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve layer (Par. 3) [%1]" ).arg( layer_id ) );
-			return false;
-		}
-	
-		if( gain_param != 0 ) {
-			pLayer->set_gain( 5.0* ( (float) (gain_param / 127.0 ) ) );
-		} else {
-			pLayer->set_gain( 0 );
-		}
-	
-		pHydrogen->setSelectedInstrumentNumber( nLine );
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	auto pInstr = pInstrList->get( nLine );
+	if( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
 	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	
+	auto pComponent =  pInstr->get_component( component_id );
+	if( pComponent == nullptr) {
+		ERRORLOG( QString( "Unable to retrieve component (Par. 2) [%1]" ).arg( component_id ) );
+		return false;
 	}
+	
+	auto pLayer = pComponent->get_layer( layer_id );
+	if( pLayer == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve layer (Par. 3) [%1]" ).arg( layer_id ) );
+		return false;
+	}
+	
+	if ( gain_param != 0 ) {
+		pLayer->set_gain( 5.0* ( (float) (gain_param / 127.0 ) ) );
+	} else {
+		pLayer->set_gain( 0 );
+	}
+	
+	pHydrogen->setSelectedInstrumentNumber( nLine );
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 	
 	return true;
 }
 
 bool MidiActionManager::pitch_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -913,47 +862,43 @@ bool MidiActionManager::pitch_level_absolute( std::shared_ptr<Action> pAction, H
 	int component_id = pAction->getParameter2().toInt(&ok,10);
 	int layer_id = pAction->getParameter3().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 
-	if( pInstrList->is_valid_index( nLine ) ) {
-		auto pInstr = pInstrList->get( nLine );
-		if( pInstr == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
-	
-		auto pComponent =  pInstr->get_component( component_id );
-		if( pComponent == nullptr) {
-			ERRORLOG( QString( "Unable to retrieve component (Par. 2) [%1]" ).arg( component_id ) );
-			return false;
-		}
-	
-		auto pLayer = pComponent->get_layer( layer_id );
-		if( pLayer == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve layer (Par. 3) [%1]" ).arg( layer_id ) );
-			return false;
-		}
-	
-		if( pitch_param != 0 ){
-			pLayer->set_pitch( 49* ( (float) (pitch_param / 127.0 ) ) -24.5 );
-		} else {
-			pLayer->set_pitch( -24.5 );
-		}
-	
-		pHydrogen->setSelectedInstrumentNumber( nLine );
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	auto pInstr = pInstrList->get( nLine );
+	if( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
 	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	
+	auto pComponent =  pInstr->get_component( component_id );
+	if( pComponent == nullptr) {
+		ERRORLOG( QString( "Unable to retrieve component (Par. 2) [%1]" ).arg( component_id ) );
+		return false;
 	}
+	
+	auto pLayer = pComponent->get_layer( layer_id );
+	if( pLayer == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve layer (Par. 3) [%1]" ).arg( layer_id ) );
+		return false;
+	}
+	
+	if( pitch_param != 0 ){
+		pLayer->set_pitch( 49* ( (float) (pitch_param / 127.0 ) ) -24.5 );
+	} else {
+		pLayer->set_pitch( -24.5 );
+	}
+	
+	pHydrogen->setSelectedInstrumentNumber( nLine );
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 
 	return true;
 }
 
 bool MidiActionManager::filter_cutoff_level_absolute( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {
+	auto pSong = pHydrogen->getSong();
+	
 	// Preventive measure to avoid bad things.
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
@@ -962,29 +907,23 @@ bool MidiActionManager::filter_cutoff_level_absolute( std::shared_ptr<Action> pA
 	int nLine = pAction->getParameter1().toInt(&ok,10);
 	int filter_cutoff_param = pAction->getValue().toInt(&ok,10);
 
-	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 
-	if( pInstrList->is_valid_index( nLine ) ) {
-		auto pInstr = pInstrList->get( nLine );
-		if( pInstr == nullptr ) {
-			ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
-			return false;
-		}
-	
-		pInstr->set_filter_active( true );
-		if( filter_cutoff_param != 0 ) {
-			pInstr->set_filter_cutoff( ( (float) (filter_cutoff_param / 127.0 ) ) );
-		} else {
-			pInstr->set_filter_cutoff( 0 );
-		}
-	
-		pHydrogen->setSelectedInstrumentNumber( nLine );
-		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
+	auto pInstr = pInstrList->get( nLine );
+	if( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument (Par. 1) [%1]" ).arg( nLine ) );
+		return false;
 	}
-	else {
-		ERRORLOG( QString( "Invalid line parameter (Par. 1) [%1]" ).arg( nLine ) );
+	
+	pInstr->set_filter_active( true );
+	if( filter_cutoff_param != 0 ) {
+		pInstr->set_filter_cutoff( ( (float) (filter_cutoff_param / 127.0 ) ) );
+	} else {
+		pInstr->set_filter_cutoff( 0 );
 	}
+	
+	pHydrogen->setSelectedInstrumentNumber( nLine );
+	EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nLine );
 	
 	return true;
 }

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1100,10 +1100,14 @@ bool setSong( int nSongNumber, Hydrogen * pHydrogen ) {
 		// Preventive measure to avoid bad things.
 		if ( pHydrogen->getSong() == nullptr ) {
 			___ERRORLOG( "No song set yet" );
-		} else {
+		}
+		else if ( Playlist::get_instance()->size() == 0 ) {
+			___ERRORLOG( QString( "No songs added to the current playlist yet" ) );
+		}
+		else {
 			___ERRORLOG( QString( "Provided song number [%1] out of bound [0,%2]" )
 						 .arg( nSongNumber )
-						 .arg( pHydrogen->getSong()->getPatternList()->size() - 1 ) );
+						 .arg( Playlist::get_instance()->size() - 1 ) );
 		}
 		return false;
 	}

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -172,6 +172,8 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 
 		int m_nLastBpmChangeCCParameter;
 
+	bool setSong( int nSongNumber, H2Core::Hydrogen* pHydrogen );
+
 	public:
 
 		/**

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -270,7 +270,7 @@ int OscServer::generic_handler(const char *	path,
 						 .arg( nStrip ) );
 				std::shared_ptr<Action> pAction = std::make_shared<Action>("PAN_RELATIVE");
 				pAction->setParameter1( QString::number( nStrip ) );
-				pAction->setParameter2( QString::number( argv[0]->f, 'f', 0 ) );
+				pAction->setValue( QString::number( argv[0]->f, 'f', 0 ) );
 				MidiActionManager::get_instance()->handleAction( pAction );
 				bMessageProcessed = true;
 			}
@@ -602,7 +602,7 @@ void OscServer::MASTER_VOLUME_RELATIVE_Handler(lo_arg **argv,int i)
 {
 	INFOLOG( "processing message" );
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("MASTER_VOLUME_RELATIVE");
-	pAction->setParameter2( QString::number( argv[0]->f, 'f', 0 ));
+	pAction->setValue( QString::number( argv[0]->f, 'f', 0 ));
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
 	// Null song handling done in MidiActionManager.
@@ -624,7 +624,7 @@ void OscServer::STRIP_VOLUME_RELATIVE_Handler(QString param1, QString param2)
 	INFOLOG( "processing message" );
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("STRIP_VOLUME_RELATIVE");
 	pAction->setParameter1( param1 );
-	pAction->setParameter2( param2 );
+	pAction->setValue( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
 	// Null song handling done in MidiActionManager.
@@ -658,7 +658,7 @@ void OscServer::FILTER_CUTOFF_LEVEL_ABSOLUTE_Handler(QString param1, QString par
 	INFOLOG( "processing message" );
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("FILTER_CUTOFF_LEVEL_ABSOLUTE");
 	pAction->setParameter1( param1 );
-	pAction->setParameter2( param2 );
+	pAction->setValue( param2 );
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();
 
 	// Null song handling done in MidiActionManager.
@@ -731,7 +731,7 @@ void OscServer::SELECT_INSTRUMENT_Handler(lo_arg **argv,int i)
 {
 	INFOLOG( "processing message" );
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("SELECT_INSTRUMENT");
-	pAction->setParameter2(  QString::number( argv[0]->f, 'f', 0 ) );
+	pAction->setValue( QString::number( argv[0]->f, 'f', 0 ) );
 
 	MidiActionManager* pActionManager = MidiActionManager::get_instance();	
 
@@ -1081,10 +1081,10 @@ void OscServer::handleAction( std::shared_ptr<Action> pAction )
 	
 	if( pAction->getType() == "MASTER_VOLUME_ABSOLUTE"){
 		bool ok;
-		float param2 = pAction->getParameter2().toFloat(&ok);
+		float fValue = pAction->getValue().toFloat(&ok);
 			
 		lo_message reply = lo_message_new();
-		lo_message_add_float(reply, param2);
+		lo_message_add_float( reply, fValue );
 
 		broadcastMessage("/Hydrogen/MASTER_VOLUME_ABSOLUTE", reply);
 		
@@ -1093,10 +1093,10 @@ void OscServer::handleAction( std::shared_ptr<Action> pAction )
 	
 	if( pAction->getType() == "STRIP_VOLUME_ABSOLUTE"){
 		bool ok;
-		float param2 = pAction->getParameter2().toFloat(&ok);
+		float fValue = pAction->getValue().toFloat(&ok);
 
 		lo_message reply = lo_message_new();
-		lo_message_add_float(reply, param2);
+		lo_message_add_float( reply, fValue );
 
 		QByteArray ba = QString("/Hydrogen/STRIP_VOLUME_ABSOLUTE/%1").arg(pAction->getParameter1()).toLatin1();
 		const char *c_str2 = ba.data();
@@ -1132,10 +1132,10 @@ void OscServer::handleAction( std::shared_ptr<Action> pAction )
 	
 	if( pAction->getType() == "STRIP_MUTE_TOGGLE"){
 		bool ok;
-		float param2 = pAction->getParameter2().toFloat(&ok);
+		float fValue = pAction->getValue().toFloat(&ok);
 
 		lo_message reply = lo_message_new();
-		lo_message_add_float(reply, param2);
+		lo_message_add_float( reply, fValue );
 
 		QByteArray ba = QString("/Hydrogen/STRIP_MUTE_TOGGLE/%1").arg(pAction->getParameter1()).toLatin1();
 		const char *c_str2 = ba.data();
@@ -1147,10 +1147,10 @@ void OscServer::handleAction( std::shared_ptr<Action> pAction )
 	
 	if( pAction->getType() == "STRIP_SOLO_TOGGLE"){
 		bool ok;
-		float param2 = pAction->getParameter2().toFloat(&ok);
+		float fValue = pAction->getValue().toFloat(&ok);
 
 		lo_message reply = lo_message_new();
-		lo_message_add_float(reply, param2);
+		lo_message_add_float( reply, fValue );
 
 		QByteArray ba = QString("/Hydrogen/STRIP_SOLO_TOGGLE/%1").arg(pAction->getParameter1()).toLatin1();
 		const char *c_str2 = ba.data();
@@ -1162,10 +1162,10 @@ void OscServer::handleAction( std::shared_ptr<Action> pAction )
 	
 	if( pAction->getType() == "PAN_ABSOLUTE"){
 		bool ok;
-		float param2 = pAction->getParameter2().toFloat(&ok);
+		float fValue = pAction->getValue().toFloat(&ok);
 
 		lo_message reply = lo_message_new();
-		lo_message_add_float(reply, param2);
+		lo_message_add_float( reply, fValue );
 
 		QByteArray ba = QString("/Hydrogen/PAN_ABSOLUTE/%1").arg(pAction->getParameter1()).toLatin1();
 		const char *c_str2 = ba.data();
@@ -1177,10 +1177,10 @@ void OscServer::handleAction( std::shared_ptr<Action> pAction )
 
 	if( pAction->getType() == "PAN_ABSOLUTE_SYM"){
 		bool ok;
-		float param2 = pAction->getParameter2().toFloat(&ok);
+		float fValue = pAction->getValue().toFloat(&ok);
 
 		lo_message reply = lo_message_new();
-		lo_message_add_float(reply, param2);
+		lo_message_add_float( reply, fValue );
 
 		QByteArray ba = QString("/Hydrogen/PAN_ABSOLUTE_SYM/%1").arg(pAction->getParameter1()).toLatin1();
 		const char *c_str2 = ba.data();

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -553,11 +553,12 @@ void OscServer::BPM_Handler(lo_arg **argv,int i)
 	INFOLOG( "processing message" );
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 
-	int nNewBpm = static_cast<int>( argv[0]->f );
-	nNewBpm = std::clamp( nNewBpm, MIN_BPM, MAX_BPM );
+	float fNewBpm = argv[0]->f;
+	fNewBpm = std::clamp( fNewBpm, static_cast<float>(MIN_BPM),
+						  static_cast<float>(MAX_BPM) );
 
-	pHydrogen->getAudioEngine()->setNextBpm( nNewBpm );
-	pHydrogen->getSong()->setBpm( nNewBpm );
+	pHydrogen->getAudioEngine()->setNextBpm( fNewBpm );
+	pHydrogen->getSong()->setBpm( fNewBpm );
 
 	pHydrogen->setIsModified( true );
 	

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -303,7 +303,7 @@ int OscServer::generic_handler(const char *	path,
 	QRegExp rxStripMute( "/Hydrogen/STRIP_MUTE_TOGGLE/(\\d+)" );
 	pos = rxStripMute.indexIn( oscPath );
 	if ( pos > -1 ) {
-		if( argc == 1 ){
+		if( argc <= 1 ){
 			int nStrip = rxStripMute.cap(1).toInt() - 1;
 			if ( nStrip > -1 && nStrip < nNumberOfStrips ) {
 				INFOLOG( QString( "processing message as toggling mute of strip [%1]" )
@@ -322,7 +322,7 @@ int OscServer::generic_handler(const char *	path,
 	QRegExp rxStripSolo( "/Hydrogen/STRIP_SOLO_TOGGLE/(\\d+)" );
 	pos = rxStripSolo.indexIn( oscPath );
 	if ( pos > -1 ) {
-		if ( argc == 1 ) {
+		if ( argc <= 1 ) {
 			int nStrip = rxStripSolo.cap(1).toInt() - 1;
 			if ( nStrip > -1 && nStrip < nNumberOfStrips ) {
 				INFOLOG( QString( "processing message as toggling solo of strip [%1]" )

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -819,6 +819,8 @@ class OscServer : public H2Core::Object<OscServer>
 		 * handled and the server should try other methods */
 		static int  generic_handler(const char *path, const char *types, lo_arg ** argv,
 								int argc, lo_message data, void *user_data);
+	static int incomingMessageLogging(const char *path, const char *types, lo_arg ** argv,
+								int argc, lo_message data, void *user_data);
 
 	private:
 		/**

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -34,7 +34,7 @@ class EventListener
 		virtual void songModifiedEvent() {}
 		virtual void selectedPatternChangedEvent() {}
 		virtual void selectedInstrumentChangedEvent() {}
-		virtual void parametersInstrumentChangedEvent() {}
+	virtual void instrumentParametersChangedEvent( int nInstrumentNumber ) { UNUSED( nInstrumentNumber ); }
 		virtual void midiActivityEvent() {}
 		virtual void noteOnEvent( int nInstrument ) { UNUSED( nInstrument ); }
 		virtual void XRunEvent() {}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -745,8 +745,8 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->selectedInstrumentChangedEvent();
 				break;
 
-			case EVENT_PARAMETERS_INSTRUMENT_CHANGED:
-				pListener->parametersInstrumentChangedEvent();
+			case EVENT_INSTRUMENT_PARAMETERS_CHANGED:
+				pListener->instrumentParametersChangedEvent( event.value );
 				break;
 
 			case EVENT_MIDI_ACTIVITY:

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -171,48 +171,6 @@ signals:
 		 * millisecond to pop all Events from the EventQueue
 		 * and invoke the corresponding functions.
 		 *
-		 * Depending on the H2Core::EventType, the following members
-		 * of EventListener will be called:
-		 * - H2Core::EVENT_STATE -> 
-		     EventListener::stateChangedEvent()
-		 * - H2Core::EVENT_PATTERN_CHANGED -> 
-		     EventListener::patternChangedEvent()
-		 * - H2Core::EVENT_PATTERN_MODIFIED -> 
-		     EventListener::patternModifiedEvent()
-		 * - H2Core::EVENT_SONG_MODIFIED -> 
-		     EventListener::songModifiedEvent()
-		 * - H2Core::EVENT_SELECTED_PATTERN_CHANGED -> 
-		     EventListener::selectedPatternChangedEvent()
-		 * - H2Core::EVENT_SELECTED_INSTRUMENT_CHANGED -> 
-		     EventListener::selectedInstrumentChangedEvent()
-		 * - H2Core::EVENT_PARAMETERS_INSTRUMENT_CHANGED -> 
-		     EventListener::parametersInstrumentChangedEvent()
-		 * - H2Core::EVENT_MIDI_ACTIVITY -> 
-		     EventListener::midiActivityEvent()
-		 * - H2Core::EVENT_NOTEON -> 
-		     EventListener::noteOnEvent()
-		 * - H2Core::EVENT_ERROR -> 
-		     EventListener::errorEvent()
-		 * - H2Core::EVENT_XRUN -> 
-		     EventListener::XRunEvent()
-		 * - H2Core::EVENT_METRONOME -> 
-		     EventListener::metronomeEvent()
-		 * - H2Core::EVENT_PROGRESS -> 
-		     EventListener::progressEvent()
-		 * - H2Core::EVENT_JACK_SESSION -> 
-		     EventListener::jacksessionEvent()
-		 * - H2Core::EVENT_PLAYLIST_LOADSONG -> 
-		     EventListener::playlistLoadSongEvent()
-		 * - H2Core::EVENT_UNDO_REDO -> 
-		     EventListener::undoRedoActionEvent()
-		 * - H2Core::EVENT_TEMPO_CHANGED -> 
-		     EventListener::tempoChangedEvent()
-		 * - H2Core::EVENT_UPDATE_PREFERENCES -> 
-		     EventListener::updatePreferencesEvent()
-		 * - H2Core::EVENT_UPDATE_SONG -> 
-		     EventListener::updateSongEvent()
-		 * - H2Core::EVENT_NONE -> nothing
-		 *
 		 * In addition, all MIDI notes in
 		 * H2Core::EventQueue::m_addMidiNoteVector will converted into
 		 * actions via SE_addNoteAction() and deleted from the

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -683,29 +683,6 @@ void InstrumentEditor::instrumentParametersChangedEvent( int nInstrumentNumber )
 		m_pCutoffRotary->setValue( m_pInstrument->get_filter_cutoff() );
 		m_pResonanceRotary->setValue( m_pInstrument->get_filter_resonance() );
 		//~ filter
-
-		// pitch offset
-		char tmp[7];
-		sprintf( tmp, "%#.2f", m_pInstrument->get_pitch_offset() );
-		if ( m_pPitchLCD->text() != tmp ) {
-			m_pPitchLCD->setText( tmp );
-		
-			/* fCoarsePitch is the closest integer to pitch_offset (represents the pitch shift interval in half steps)
-			   while it is an integer number, it's defined float to be used in next lines */
-			float fCoarsePitch = round( m_pInstrument->get_pitch_offset() );
-
-			//fFinePitch represents the fine adjustment (between -0.5 and +0.5) if pitch_offset has decimal part
-			float fFinePitch = m_pInstrument->get_pitch_offset() - fCoarsePitch;
-
-			m_pPitchCoarseRotary->setValue( fCoarsePitch );
-			m_pPitchFineRotary->setValue( fFinePitch );
-		}
-		// instr gain
-		if ( m_pInstrumentGain->getValue() != m_pInstrument->get_gain() ) {
-			sprintf( tmp, "%#.2f", m_pInstrument->get_gain() );
-			m_pInstrumentGainLCD->setText( tmp );
-			m_pInstrumentGain->setValue( m_pInstrument->get_gain() );
-		}
 	}
 	else {
 		m_pNameLbl->setText( QString( "NULL Instrument..." ) );
@@ -799,7 +776,7 @@ void InstrumentEditor::rotaryChanged( WidgetWithInput *ref)
 			}
 		}
 		else if ( pRotary == m_pLayerPitchFineRotary ) {
-			m_pLayerPitchFineLCD->setText( QString( "%1" ).arg( fVal ) );
+			m_pLayerPitchFineLCD->setText( QString( "%1" ).arg( fVal, 0, 'f', 0 ) );
 			auto pCompo = m_pInstrument->get_component(m_nSelectedComponent);
 			if( pCompo ) {
 				auto pLayer = pCompo->get_layer( m_nSelectedLayer );
@@ -1211,7 +1188,8 @@ void InstrumentEditor::selectLayer( int nLayer )
 			m_pLayerPitchFineRotary->setValue( fFinePitch * 100 );
 
 			m_pLayerPitchCoarseLCD->setText( QString( "%1" ).arg( (int) fCoarsePitch ) );
-			m_pLayerPitchFineLCD->setText( QString( "%1" ).arg( fFinePitch * 100 ) );
+			m_pLayerPitchFineLCD->setText( QString( "%1" )
+										   .arg( fFinePitch * 100, 0, 'f', 0 ) );
 
 			m_pRemoveLayerBtn->setIsActive( true );
 			m_pSampleEditorBtn->setIsActive( true );

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -67,6 +67,7 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 		// implements EventListener interface
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void updateSongEvent( int ) override;
+	virtual void instrumentParametersChangedEvent( int ) override;
 		//~ implements EventListener interface
 		void update();
 		static int findFreeDrumkitComponentId( int startingPoint = 0 );

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -72,11 +72,6 @@ InstrumentEditorPanel::~InstrumentEditorPanel()
 	INFOLOG( "DESTROY" );
 }
 
-void InstrumentEditorPanel::parametersInstrumentChangedEvent()
-{
-	drumkitLoadedEvent();
-}
-
 void InstrumentEditorPanel::drumkitLoadedEvent() {
 	std::vector<H2Core::DrumkitComponent*>* pComponentList = H2Core::Hydrogen::get_instance()->getSong()->getComponents();
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
@@ -45,7 +45,6 @@ class InstrumentEditorPanel : public QWidget, private H2Core::Object<InstrumentE
 		explicit InstrumentEditorPanel(const InstrumentEditorPanel&) = delete;
 		InstrumentEditorPanel& operator=( const InstrumentEditorPanel& rhs ) = delete;
 
-		virtual void parametersInstrumentChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
 	virtual void updateSongEvent( int ) override;
 		

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -40,7 +40,6 @@ using namespace H2Core;
 #include "InstrumentEditor/InstrumentEditorPanel.h"
 #include "DrumPatternEditor.h"
 #include "../HydrogenApp.h"
-#include "../Mixer/Mixer.h"
 #include "../Widgets/Button.h"
 #include "../Skin.h"
 
@@ -299,9 +298,16 @@ void InstrumentLine::muteClicked()
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
+	
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	auto pInstr = pInstrList->get( m_nInstrumentNumber );
 	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument [%1]" )
+				  .arg( m_nInstrumentNumber ) );
 		return;
 	}
 	
@@ -315,7 +321,25 @@ void InstrumentLine::muteClicked()
 
 void InstrumentLine::soloClicked()
 {
-	HydrogenApp::get_instance()->getMixer()->soloClicked( m_nInstrumentNumber );
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	std::shared_ptr<Song> pSong = pHydrogen->getSong();
+	if ( pSong == nullptr ) {
+		ERRORLOG( "No song set yet" );
+		return;
+	}
+	
+	InstrumentList *pInstrList = pSong->getInstrumentList();
+	auto pInstr = pInstrList->get( m_nInstrumentNumber );
+	if ( pInstr == nullptr ) {
+		ERRORLOG( QString( "Unable to retrieve instrument [%1]" )
+				  .arg( m_nInstrumentNumber ) );
+		return;
+	}
+	
+	pHydrogen->setSelectedInstrumentNumber( m_nInstrumentNumber );
+
+	CoreActionController* pCoreActionController = pHydrogen->getCoreActionController();
+	pCoreActionController->setStripIsSoloed( m_nInstrumentNumber, !pInstr->is_soloed() );
 }
 
 void InstrumentLine::sampleWarningClicked()

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -301,6 +301,10 @@ void InstrumentLine::muteClicked()
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	InstrumentList *pInstrList = pSong->getInstrumentList();
 	auto pInstr = pInstrList->get( m_nInstrumentNumber );
+	if ( pInstr == nullptr ) {
+		return;
+	}
+	
 	pHydrogen->setSelectedInstrumentNumber( m_nInstrumentNumber );
 
 	CoreActionController* pCoreActionController = pHydrogen->getCoreActionController();
@@ -1005,4 +1009,48 @@ void PatternEditorInstrumentList::mouseMoveEvent(QMouseEvent *event)
 
 	// propago l'evento
 	QWidget::mouseMoveEvent(event);
+}
+
+
+void PatternEditorInstrumentList::instrumentParametersChangedEvent( int nInstrumentNumber ) {
+	auto pInstrumentList = Hydrogen::get_instance()->getSong()->getInstrumentList();
+
+	if ( nInstrumentNumber == -1 ) {
+		// Update all lines.
+		for ( int ii = 0; ii < MAX_INSTRUMENTS; ++ii ) {
+			auto pInstrumentLine = m_pInstrumentLine[ ii ];
+			if ( pInstrumentLine != nullptr ) {
+				auto pInstrument = pInstrumentList->get( ii );
+				if ( pInstrument == nullptr ) {
+					ERRORLOG( QString( "Instrument [%1] associated to InstrumentLine [%1] not found" )
+							  .arg( ii ) );
+					return;
+				}
+				
+				pInstrumentLine->setName( pInstrument->get_name() );
+				pInstrumentLine->setMuted( pInstrument->is_muted() );
+				pInstrumentLine->setSoloed( pInstrument->is_soloed() );
+			}
+		}
+	}
+	else {
+		// Update a specific line
+		auto pInstrument = pInstrumentList->get( nInstrumentNumber );
+		if ( pInstrument == nullptr ) {
+			ERRORLOG( QString( "Instrument [%1] not found" )
+					  .arg( nInstrumentNumber ) );
+			return;
+		}
+	
+		auto pInstrumentLine = m_pInstrumentLine[ nInstrumentNumber ];
+		if ( pInstrumentLine == nullptr ) {
+			ERRORLOG( QString( "No InstrumentLine for instrument [%1] created yet" )
+					  .arg( nInstrumentNumber ) );
+			return;
+		}
+
+		pInstrumentLine->setName( pInstrument->get_name() );
+		pInstrumentLine->setMuted( pInstrument->is_muted() );
+		pInstrumentLine->setSoloed( pInstrument->is_soloed() );
+	}
 }

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -57,6 +57,8 @@ class InstrumentLine : public PixmapWidget
 	public:
 		explicit InstrumentLine(QWidget* pParent);
 
+	int getNumber() const;
+	
 		void setName(const QString& sName);
 		void setSelected(bool isSelected);
 		void setNumber(int nIndex);
@@ -120,6 +122,10 @@ public slots:
 	bool m_bEntered;
 };
 
+inline int InstrumentLine::getNumber() const {
+	return m_nInstrumentNumber;
+}
+
 
 /** \ingroup docGUI*/
 class PatternEditorInstrumentList :  public QWidget,
@@ -142,6 +148,7 @@ class PatternEditorInstrumentList :  public QWidget,
 	virtual void selectedInstrumentChangedEvent() override;
 	virtual void updateSongEvent( int nEvent ) override;
 	virtual void drumkitLoadedEvent() override;
+	virtual void instrumentParametersChangedEvent( int ) override;
 	
 	void repaintInstrumentLines();
 	public slots:

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -149,7 +149,7 @@ SongEditor::~SongEditor()
 int SongEditor::yScrollTarget( QScrollArea *pScrollArea, int *pnPatternInView )
 {
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
-	int nScroll = pScrollArea->verticalScrollBar()->value();
+	const int nScroll = pScrollArea->verticalScrollBar()->value();
 	int nHeight = pScrollArea->height();
 
 	auto pPlayingPatterns = m_pAudioEngine->getPlayingPatterns();
@@ -174,6 +174,12 @@ int SongEditor::yScrollTarget( QScrollArea *pScrollArea, int *pnPatternInView )
 	std::vector<int> playingRows;
 	for ( Pattern *pPattern : currentPatterns ) {
 		playingRows.push_back( pSongPatterns->index( pPattern ) );
+	}
+
+	// Occasionally the detection of playing patterns glitches at the
+	// transition to empty columns.
+	if ( playingRows.size() == 0 ) {
+		return nScroll;
 	}
 
 	// Check if there are any currently playing patterns which are entirely visible.

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1488,7 +1488,7 @@ void SongEditorPatternList::mousePressEvent( QMouseEvent *ev )
 		   ev->pos().x() < 15 ) &&
 		 m_pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
 		
-		m_pHydrogen->toggleNextPattern( nRow );
+		m_pHydrogen->toggleNextPatterns( nRow );
 	}
 	else {
 		if ( ! ( m_pHydrogen->isPatternEditorLocked() &&
@@ -1529,7 +1529,7 @@ void SongEditorPatternList::mousePressEvent( QMouseEvent *ev )
 ///
 void SongEditorPatternList::togglePattern( int row ) {
 
-	m_pHydrogen->toggleNextPattern( row );
+	m_pHydrogen->toggleNextPatterns( row );
 	createBackground();
 	update();
 }

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1482,13 +1482,13 @@ void SongEditorPatternList::mousePressEvent( QMouseEvent *ev )
 		return;
 	}
 
-	if ( (ev->button() == Qt::MiddleButton)
-		 || (ev->modifiers() == Qt::ControlModifier && ev->button() == Qt::RightButton)
-		 || (ev->modifiers() == Qt::ControlModifier && ev->button() == Qt::LeftButton)
-		 || ev->pos().x() < 15 ){
-		if ( m_pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
-			m_pHydrogen->toggleNextPattern( nRow );
-		}
+	if ( ( ev->button() == Qt::MiddleButton ||
+		   ( ev->modifiers() == Qt::ControlModifier && ev->button() == Qt::RightButton ) ||
+		   ( ev->modifiers() == Qt::ControlModifier && ev->button() == Qt::LeftButton ) ||
+		   ev->pos().x() < 15 ) &&
+		 m_pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
+		
+		m_pHydrogen->toggleNextPattern( nRow );
 	}
 	else {
 		if ( ! ( m_pHydrogen->isPatternEditorLocked() &&


### PR DESCRIPTION
This patch ensure all parameter changes done using MIDI and OSC commands are immediately represented in the GUI. In addition, it aligns the handling of both OSC and MIDI commands. Things went out of sync at some point with OSC handlers storing most numerical values in `Action::m_sParameter2` while MIDI handler did so in `Action::m_sValue`. As a result either the MIDI or the OSC command was working. I tested all commands and fixed those broken.

I also made the OSC message logging more verbose so one can see just from the logs what is going on.

Additional fixes:
- toggling mute or solo of a strip using OSC command can now be done without argument too.
- provide velocity of a MIDI NOTE ON event as `Action::m_sValue`. Previously, the velocity was just ignored
- fix segfault in SongEditor when passing empty columns
- allow float point precision when adjusting tempo using `BPM` OSC command
- fix relocation glitches occurring when using the JACK driver
- properly display layer pitch when altering its value using OSC
- fix solo button in the instrument lines of the pattern editor when starting up Hydrogen with hidden mixer
- make whole range of pattern list elements clickable in selected pattern mode
- remove stacked pattern indicators when switching to selected pattern mode 
