### PR TITLE
Fix playhead glitches

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -401,27 +401,16 @@ void AudioEngine::locate( const double fTick, bool bWithJackBroadcast ) {
 #ifdef H2CORE_HAVE_JACK
 	// In case Hydrogen is using the JACK server to sync transport, it
 	// has to be up to the server to relocate to a different
-	// position. However, if the transport is not rolling, the JACK
-	// server won't broadcast the new position we asked for until the
-	// transport is rolling again. That's why we relocate internally
-	// too - as we do not have to be afraid for transport to get out
-	// of sync as it is not rolling.
-	if ( pHydrogen->hasJackTransport() && bWithJackBroadcast &&
-		 m_state == State::Playing ) {
-		nNewFrame = computeFrameFromTick( fTick, &m_fTickMismatch );
-	} else {
-		reset( false );
-		nNewFrame = computeFrameFromTick( fTick, &m_fTickMismatch );
-	}
-
+	// position.
 	if ( pHydrogen->hasJackTransport() && bWithJackBroadcast ) {
+		nNewFrame = computeFrameFromTick( fTick, &m_fTickMismatch );
 		static_cast<JackAudioDriver*>( m_pAudioDriver )->locateTransport( nNewFrame );
 		return;
 	}
-#else
+#endif
+
 	reset( false );
 	nNewFrame = computeFrameFromTick( fTick, &m_fTickMismatch );
-#endif
 	
 	setFrames( nNewFrame );
 	updateTransportPosition( fTick );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -3079,7 +3079,7 @@ void SongEditorPositionRuler::updatePosition()
 	m_pAudioEngine->lock( RIGHT_HERE );
 
 	auto pPatternGroupVector = m_pHydrogen->getSong()->getPatternGroupVector();
-	m_nColumn = m_pAudioEngine->getColumn();
+	m_nColumn = std::max( m_pAudioEngine->getColumn(), 0 );
 
 	if ( pPatternGroupVector->size() >= m_nColumn &&
 		 pPatternGroupVector->at( m_nColumn )->size() > 0 ) {


### PR DESCRIPTION
`AudioEngine::locate()` was not fully adopted to the changes done in https://github.com/hydrogen-music/hydrogen/pull/1603. This could cause small glitches of the playhead which moved to the beginning of the song for a fraction of a second if transport was relocated in JACK transport mode with playback not rolling.

In case transport was reset and `AudioEngine::m_nColumn` was set to -1 the second instead of the first tempo marker was highlighted as the current one.