### PR TITLE
Follow XDG dirs spec #643

### DIFF
--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -442,6 +442,11 @@ namespace H2Core
 		static bool check_permissions( const QString& path, const int perms, bool silent );
 
 		/**
+		 * Update the data, config and cache paths with QStandardPaths if old
+		 * folder doesn't exist (e.g. ~/.hydrogen/).
+		 */
+		static void update_usr_paths();
+		/**
 		 * Path to the system files set in Filesystem::bootstrap().
 		 *
 		 * If Q_OSMACX is set, it will be a concatenation of
@@ -466,6 +471,7 @@ namespace H2Core
 		 */
 		static QString __sys_data_path;     ///< the path to the system files
 		static QString __usr_data_path;     ///< the path to the user files
+		static QString __usr_cache_path;    ///< the path to the cache files
 		static QString __usr_cfg_path;      ///< the path to the user config file
 		static QString __usr_log_path;      ///< the path to the log file
 		static QStringList __ladspa_paths;  ///< paths to laspa plugins


### PR DESCRIPTION
Fix #643. Uses QStandardPaths to get cache, data and config XDG folders.
The config file go to `$XDG_CONFIG_HOME/hydrogen/hydrogen.conf`
The cache folder go to `$XDG_CACHE_HOME/hydrogen/`
And all the data subfolders (drumkits, plugins, playlists, etc.) go to
`$XDG_DATA_HOME/hydrogen/` along with the `hydrogen.log` file.

If old folder (`~/.hydrogen/`) is found, use that instead of the XDG paths.

The `__usr_*_paths` are setted outside a function, so QStandardPaths isn't
avaliable to get the XDG paths. Also no APPNAME is avaliable until
`setApplicationName()` is called after the `Filesystem::check_usr_paths()`
is used. To avoid this, `update_usr_paths()` is added at the begining of
`check_usr_paths()` to update the correct values from QStandardPaths.

Need test on Windows and Mac.