### PR TITLE
Fix off-by-one error on empty pattern group vector

### DIFF
--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -3081,7 +3081,7 @@ void SongEditorPositionRuler::updatePosition()
 	auto pPatternGroupVector = m_pHydrogen->getSong()->getPatternGroupVector();
 	m_nColumn = std::max( m_pAudioEngine->getColumn(), 0 );
 
-	if ( pPatternGroupVector->size() >= m_nColumn &&
+	if ( pPatternGroupVector->size() > m_nColumn &&
 		 pPatternGroupVector->at( m_nColumn )->size() > 0 ) {
 		int nLength = pPatternGroupVector->at( m_nColumn )->longest_pattern_length();
 		fTick += (float)m_pAudioEngine->getPatternTickPosition() / (float)nLength;


### PR DESCRIPTION
This caused a crash on opening a song with an empty pattern vector, and previously worked due to an underflow in comparison which was removed as a side effect of b3f93f3e3991bc1fba0649b5b3199f7549a10e58