### PR TITLE
Fix object lifetime issues

### DIFF
--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -138,7 +138,9 @@ ExportSongDialog::ExportSongDialog(QWidget* parent)
 
 ExportSongDialog::~ExportSongDialog()
 {
-	HydrogenApp::get_instance()->removeEventListener( this );
+	if ( auto pH2App = HydrogenApp::get_instance() ) {
+		pH2App->removeEventListener( this );
+	}
 }
 
 QString ExportSongDialog::createDefaultFilename()

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -209,17 +209,17 @@ HydrogenApp::~HydrogenApp()
 
 	delete SoundLibraryDatabase::get_instance();
 
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-	if (pHydrogen) {
-		// Hydrogen calls removeSong on from its destructor, so here we just delete the objects:
-		delete pHydrogen;
-	}
-
 	#ifdef H2CORE_HAVE_LADSPA
 	for (uint nFX = 0; nFX < MAX_FX; nFX++) {
 		delete m_pLadspaFXProperties[nFX];
 	}
 	#endif
+
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	if (pHydrogen) {
+		// Hydrogen calls removeSong on from its destructor, so here we just delete the objects:
+		delete pHydrogen;
+	}
 
 	m_pInstance = nullptr;
 

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -221,18 +221,9 @@ HydrogenApp::~HydrogenApp()
 	}
 	#endif
 
+	m_pInstance = nullptr;
+
 }
-
-
-
-/// Return an HydrogenApp m_pInstance
-HydrogenApp* HydrogenApp::get_instance() {
-	if (m_pInstance == nullptr) {
-		std::cerr << "Error! HydrogenApp::get_instance (m_pInstance = NULL)" << std::endl;
-	}
-	return m_pInstance;
-}
-
 
 
 

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -260,6 +260,11 @@ private slots:
 };
 
 
+/// Return an HydrogenApp m_pInstance
+inline HydrogenApp* HydrogenApp::get_instance() {
+	return m_pInstance;
+}
+
 inline Mixer* HydrogenApp::getMixer()
 {
 	return m_pMixer;	

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -906,8 +906,24 @@ void PatternEditorPanel::zoomOutBtnClicked()
 	Preferences::get_instance()->setPatternEditorGridHeight( m_pDrumPatternEditor->getGridHeight() );
 }
 
+void PatternEditorPanel::updatePatternInfo() {
+	Hydrogen *pHydrogen = Hydrogen::get_instance();
+	std::shared_ptr<Song> pSong = pHydrogen->getSong();
+
+	m_pPattern = nullptr;
+	m_nSelectedPatternNumber = pHydrogen->getSelectedPatternNumber();
+
+	if ( pSong != nullptr ) {
+		PatternList *pPatternList = pSong->getPatternList();
+		if ( ( m_nSelectedPatternNumber != -1 ) && ( m_nSelectedPatternNumber < pPatternList->size() ) ) {
+			m_pPattern = pPatternList->get( m_nSelectedPatternNumber );
+		}
+	}
+}
 
 void PatternEditorPanel::updateEditors( bool bPatternOnly ) {
+
+	updatePatternInfo();
 
 	// Changes of pattern may leave the cursor out of bounds.
 	setCursorPosition( getCursorPosition() );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -107,6 +107,8 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 
 		void selectInstrumentNotes( int nInstrument );
 
+		void updatePatternInfo();
+
 		void updateEditors( bool bPatternOnly = false );
 
 	void patternSizeChangedAction( int nLength, double fDenominator,

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -137,7 +137,9 @@ SoundLibraryPanel::SoundLibraryPanel( QWidget *pParent, bool bInItsOwnDialog )
 
 SoundLibraryPanel::~SoundLibraryPanel()
 {
-	HydrogenApp::get_instance()->removeEventListener( this );
+	if ( auto pH2App = HydrogenApp::get_instance() ) {
+		pH2App->removeEventListener( this );
+	}
 
 	for (uint i = 0; i < __system_drumkit_info_list.size(); ++i ) {
 		delete __system_drumkit_info_list[i];


### PR DESCRIPTION
Some reordering of object destruction and dependencies to avoid memory issues. Some show up as crashes, some show up with `-fsanitize=address`.