### PR TITLE
[PATCH] Follow XDG Base Directory spec on Linux

### DIFF
--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -447,6 +447,12 @@ namespace H2Core
 		static bool check_permissions( const QString& path, const int perms, bool silent );
 
 		/**
+		 * Update the data, config and cache paths with QStandardPaths if old
+		 * folder doesn't exist (e.g. ~/.hydrogen/).
+		 */
+		static void update_usr_paths();
+
+		/**
 		 * Path to the system files set in Filesystem::bootstrap().
 		 *
 		 * If Q_OSMACX is set, it will be a concatenation of
@@ -471,6 +477,7 @@ namespace H2Core
 		 */
 		static QString __sys_data_path;     ///< the path to the system files
 		static QString __usr_data_path;     ///< the path to the user files
+		static QString __usr_cache_path;    ///< the path to the cache files
 		static QString __usr_cfg_path;      ///< the path to the user config file
 		static QString __usr_log_path;      ///< the path to the log file
 		static QStringList __ladspa_paths;  ///< paths to laspa plugins


### PR DESCRIPTION
Fix #643. Uses QStandardPaths to get cache, data and config XDG folders **only on Linux**. If old folder (e.g. `~/.hydrogen/`) is found, use that instead of the XDG paths. If no folder is found, create the XDG dirs.

According to https://doc.qt.io/qt-5/qstandardpaths.html this should be the default paths returned by QStandardPaths (Follow the ENV paths configured by the user):

| QStandardPaths | Linux  Path|
|-------------------|------------|
| AppConfigLocation |  ~/.config/hydrogen |
| AppLocalDataLocation | ~/.local/share/hydrogen |
| CacheLocation |  ~/.cache/hydrogen |

The `__usr_*_paths` are setted outside a function, so QStandardPaths isn't avaliable to get the XDG paths. Also no APPNAME is avaliable until setApplicationName() is called after the `Filesystem::check_usr_paths()` is used. To avoid this `update_usr_paths()` is added at the begining of `check_usr_paths()` to update the correct values from QStandardPaths.