### PR TITLE
HydrogenApp: fix relative song loading

### DIFF
--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -365,13 +365,18 @@ void HydrogenApp::closeFXProperties()
 #endif
 }
 
-bool HydrogenApp::openSong( QString sFilename) {
+bool HydrogenApp::openSong( QString sFilename ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 
 	// Check whether there is an autosave file next to it
 	// containing newer content.
 	QFileInfo fileInfo( sFilename );
+
+	// Ensure the path to the file is not relative.
+	if ( fileInfo.isRelative() ) {
+		sFilename = fileInfo.absoluteFilePath();
+	}
 
 	// In case the user did open a hidden file, the baseName()
 	// will be an empty string.

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -85,7 +85,7 @@ class HydrogenApp :  public QObject, public EventListener,  public H2Core::Objec
 		virtual ~HydrogenApp();
 
 		/** 
-		 * \param sFilename Absolute path used to load the next Song.
+		 * \param sFilename Absolute or relative path used to load the next #H2Core::Song.
 		 * \return bool true on success
 		 */
 		static bool openSong( QString sFilename );


### PR DESCRIPTION
There was a regression allowing to load song only using absolute paths. This is fixed now and they can be loaded using relative paths again.