### PR TITLE
Shotlist: fix slot handling

### DIFF
--- a/src/gui/src/ShotList.h
+++ b/src/gui/src/ShotList.h
@@ -46,6 +46,7 @@
 ///
 /** \ingroup docGUI*/
 class ShotList : public QObject {
+	Q_OBJECT
 
 	/// Find a widget which inherits the named class
 	static QWidget *findWidgetInheriting( QObject *pObject, QString &sName );


### PR DESCRIPTION
due to a missing `Q_OBJECT` macro the `Shotlist::nextShot()` slot was not successfully registered and only the first shot could be taken.