### PR TITLE
Shotlist: trigger shots using core event

### DIFF
--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -172,7 +172,8 @@ enum EventType {
 	EVENT_SONG_SIZE_CHANGED,
 	EVENT_DRIVER_CHANGED,
 	EVENT_PLAYBACK_TRACK_CHANGED,
-	EVENT_SOUND_LIBRARY_CHANGED
+	EVENT_SOUND_LIBRARY_CHANGED,
+	EVENT_NEXT_SHOT
 };
 
 /** Basic building block for the communication between the core of

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -64,6 +64,7 @@ class EventListener
 	virtual void driverChangedEvent(){}
 	virtual void playbackTrackChangedEvent(){}
 	virtual void soundLibraryChangedEvent(){}
+	virtual void nextShotEvent(){}
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -849,6 +849,10 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->soundLibraryChangedEvent();
 				break;
 
+			case EVENT_NEXT_SHOT:
+				pListener->nextShotEvent();
+				break;
+
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}

--- a/src/gui/src/ShotList.h
+++ b/src/gui/src/ShotList.h
@@ -25,6 +25,7 @@
 
 #include <QtGui>
 #include <QtWidgets>
+#include "EventListener.h"
 
 /// Shot List
 ///
@@ -45,7 +46,7 @@
 /// application to allow a lot of flexibility in how screenshots are set up in shot lists.
 ///
 /** \ingroup docGUI*/
-class ShotList : public QObject {
+class ShotList : public QObject, public EventListener {
 	Q_OBJECT
 
 	/// Find a widget which inherits the named class
@@ -93,12 +94,12 @@ private:
 	void shoot( QString s );
 
 public:
-	ShotList( QStringList shots ) {
-		m_shots = shots;
-	}
+	ShotList( QStringList shots );
 	ShotList( QString sShotsFilename );
+	~ShotList();
 
 	void shoot();
+	void nextShotEvent() override;
 
 public slots:
 	void nextShot( void );


### PR DESCRIPTION
A number of GUI slots have been changed in v1.2 to just be wrappers around public methods of `CoreActionController`. While this reduces redundancy as well as complexity of the GUI by a margin it also means that triggering the slot for activating e.g. song mode does not put the GUI in song mode right away. The core will be set to song mode but GUI will be informed and subsequently updated using an event in `EventQueue` asynchronously.

This is a problem when using the Shotlist as it just processes one line after another and does not wait for the GUI to be synced with the core again.

To fix it, the next shot is now triggered using an event of the `EventQueue` too. Since queued events are processed sequentially this slows down the pace of shotlist processing to match GUI updating.

Processing a `Shotlist` becomes a lot slower using this patch but I think this is not relevant since it is just invoked by a developer like once a year.