### PR TITLE
Tweak MIDI and OSC pattern selection

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2132,18 +2132,27 @@ void AudioEngine::flushAndAddNextPatterns( int nPatternNumber ) {
 	auto pPatternList = pSong->getPatternList();
 
 	m_pNextPatterns->clear();
+	bool bAlreadyPlaying = false;
 	
-	for ( int ii = 0; ii < m_pPlayingPatterns->size(); ++ii ) {
-		m_pNextPatterns->add( m_pPlayingPatterns->get( ii ) );
-	}
-	
-	// Appending the requested pattern.
 	// Note: we will not perform a bound check on the provided pattern
 	// number. This way the user can use the SELECT_ONLY_NEXT_PATTERN
 	// MIDI or OSC command to flush all playing patterns.
-	auto pPattern = pPatternList->get( nPatternNumber );
-	if ( pPattern != nullptr ) {
-		m_pNextPatterns->add( pPattern );
+	auto pRequestedPattern = pPatternList->get( nPatternNumber );
+	
+	for ( int ii = 0; ii < m_pPlayingPatterns->size(); ++ii ) {
+
+		auto pPlayingPattern = m_pPlayingPatterns->get( ii );
+		if ( pPlayingPattern != pRequestedPattern ) {
+			m_pNextPatterns->add( pPlayingPattern );
+		}
+		else if ( pRequestedPattern != nullptr ) {
+			bAlreadyPlaying = true;
+		}
+	}
+	
+	// Appending the requested pattern.
+	if ( ! bAlreadyPlaying && pRequestedPattern != nullptr ) {
+		m_pNextPatterns->add( pRequestedPattern );
 	}
 }
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2110,7 +2110,7 @@ void AudioEngine::updatePlayingPatterns( int nColumn, long nTick ) {
 	}
 }
 
-void AudioEngine::toggleNextPatterns( int nPatternNumber ) {
+void AudioEngine::toggleNextPattern( int nPatternNumber ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	auto pPatternList = pSong->getPatternList();
@@ -2126,7 +2126,7 @@ void AudioEngine::clearNextPatterns() {
 	m_pNextPatterns->clear();
 }
 
-void AudioEngine::flushAndAddNextPatterns( int nPatternNumber ) {
+void AudioEngine::flushAndAddNextPattern( int nPatternNumber ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	auto pPatternList = pSong->getPatternList();

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -458,14 +458,14 @@ public:
 	 * Add pattern @a nPatternNumber to #m_pNextPatterns or deletes it
 	 * in case it is already present.
 	 */
-	void toggleNextPatterns( int nPatternNumber );
+	void toggleNextPattern( int nPatternNumber );
 	/**
 	 * Add pattern @a nPatternNumber to #m_pNextPatterns as well as
 	 * the whole content of #m_pPlayingPatterns. After the next call
 	 * to updatePlayingPatterns() only @a nPatternNumber will be left
 	 * playing.
 	 */
-	void flushAndAddNextPatterns( int nPatternNumber );
+	void flushAndAddNextPattern( int nPatternNumber );
 
 	/**
 	 * Updates the transport state and all notes in #m_songNoteQueue

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1499,7 +1499,7 @@ bool CoreActionController::removePattern( int nPatternNumber ) {
 	// _before_ updating the playing patterns.
 	for ( int ii = 0; ii < pNextPatterns->size(); ++ii ) {
 		if ( pNextPatterns->get( ii ) == pPattern ) {
-			pAudioEngine->toggleNextPatterns( nPatternNumber );
+			pAudioEngine->toggleNextPattern( nPatternNumber );
 		}
 	}
 	

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -55,6 +55,12 @@ enum EventType {
 	 * A pattern was added, deleted, or modified.
 	 */
 	EVENT_PATTERN_MODIFIED,
+	/**
+	 * Used in stacked pattern mode to indicate that a either
+	 * AudioEngine::m_pNextPatterns or AudioEngine::m_pPlayingPatterns
+	 * changed.
+	 */
+	EVENT_STACKED_PATTERNS_CHANGED,
 	/** Another pattern was selected via MIDI or the GUI without
 	 * affecting the audio transport. While the selection in the
 	 * former case already happens in the GUI, this event will be used

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -618,6 +618,7 @@ void Hydrogen::toggleNextPattern( int nPatternNumber ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
 		m_pAudioEngine->toggleNextPattern( nPatternNumber );
 		m_pAudioEngine->unlock();
+		EventQueue::get_instance()->push_event( EVENT_STACKED_PATTERNS_CHANGED, 0 );
 
 	} else {
 		ERRORLOG( "can't set next pattern in song mode" );
@@ -629,6 +630,7 @@ bool Hydrogen::flushAndAddNextPattern( int nPatternNumber ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
 		m_pAudioEngine->flushAndAddNextPattern( nPatternNumber );
 		m_pAudioEngine->unlock();
+		EventQueue::get_instance()->push_event( EVENT_STACKED_PATTERNS_CHANGED, 0 );
 
 		return true;
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -613,10 +613,10 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 }
 
 
-void Hydrogen::toggleNextPatterns( int nPatternNumber ) {
+void Hydrogen::toggleNextPattern( int nPatternNumber ) {
 	if ( __song != nullptr && getMode() == Song::Mode::Pattern ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
-		m_pAudioEngine->toggleNextPatterns( nPatternNumber );
+		m_pAudioEngine->toggleNextPattern( nPatternNumber );
 		m_pAudioEngine->unlock();
 
 	} else {
@@ -624,10 +624,10 @@ void Hydrogen::toggleNextPatterns( int nPatternNumber ) {
 	}
 }
 
-bool Hydrogen::flushAndAddNextPatterns( int nPatternNumber ) {
+bool Hydrogen::flushAndAddNextPattern( int nPatternNumber ) {
 	if ( __song != nullptr && getMode() == Song::Mode::Pattern ) {
 		m_pAudioEngine->lock( RIGHT_HERE );
-		m_pAudioEngine->flushAndAddNextPatterns( nPatternNumber );
+		m_pAudioEngine->flushAndAddNextPattern( nPatternNumber );
 		m_pAudioEngine->unlock();
 
 		return true;

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -109,10 +109,10 @@ public:
 	QString			m_LastMidiEvent;
 	int				m_nLastMidiEventParameter;
 
-	/** Wrapper around AudioEngine::toggleNextPatterns().*/
-	void			toggleNextPatterns( int nPatternNumber );
-	/** Wrapper around AudioEngine::flushAndAddNextPatterns().*/
-	bool			flushAndAddNextPatterns( int nPatternNumber );
+	/** Wrapper around AudioEngine::toggleNextPattern().*/
+	void			toggleNextPattern( int nPatternNumber );
+	/** Wrapper around AudioEngine::flushAndAddNextPattern().*/
+	bool			flushAndAddNextPattern( int nPatternNumber );
 	
 		/**
 		 * Get the current song.

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -399,17 +399,27 @@ bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pActio
 	}
 	
 	bool ok;
-	int row = pAction->getParameter1().toInt(&ok,10);
-	if( row > pSong->getPatternList()->size() -1 ||
-		row < 0 ) {
-		INFOLOG( QString( "Provided pattern number [%1] out of bound [0,%2]. All patterns will be deselected." ).arg( row )
-				  .arg( pSong->getPatternList()->size() - 1 ) );
+	int nRow = pAction->getParameter1().toInt(&ok,10);
+	if ( nRow > pSong->getPatternList()->size() -1 ||
+		nRow < 0 ) {
+		if ( pHydrogen->getPatternMode() == Song::PatternMode::Selected ) {
+			ERRORLOG( QString( "Provided pattern number [%1] out of bound [0,%2]." )
+					  .arg( nRow )
+					  .arg( pSong->getPatternList()->size() - 1 ) );
+			return false;
+		}
+		else {
+			INFOLOG( QString( "Provided pattern number [%1] out of bound [0,%2]. All patterns will be deselected." )
+					 .arg( nRow )
+					 .arg( pSong->getPatternList()->size() - 1 ) );
+		}
 	}
+	
 	if ( pHydrogen->getPatternMode() == Song::PatternMode::Selected ) {
 		return select_next_pattern( pAction, pHydrogen );
 	}
 	
-	return pHydrogen->flushAndAddNextPattern( row );
+	return pHydrogen->flushAndAddNextPattern( nRow );
 }
 
 bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -402,9 +402,8 @@ bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pActio
 	int row = pAction->getParameter1().toInt(&ok,10);
 	if( row > pSong->getPatternList()->size() -1 ||
 		row < 0 ) {
-		ERRORLOG( QString( "Provided value [%1] out of bound [0,%2]" ).arg( row )
+		INFOLOG( QString( "Provided pattern number [%1] out of bound [0,%2]. All patterns will be deselected." ).arg( row )
 				  .arg( pSong->getPatternList()->size() - 1 ) );
-		return false;
 	}
 	if ( pHydrogen->getPatternMode() == Song::PatternMode::Selected ) {
 		return select_next_pattern( pAction, pHydrogen );

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -384,7 +384,7 @@ bool MidiActionManager::select_next_pattern( std::shared_ptr<Action> pAction, Hy
 		pHydrogen->setSelectedPatternNumber( row );
 	}
 	else if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
-		pHydrogen->toggleNextPatterns( row );
+		pHydrogen->toggleNextPattern( row );
 	}
 	return true;
 }
@@ -409,7 +409,7 @@ bool MidiActionManager::select_only_next_pattern( std::shared_ptr<Action> pActio
 		return select_next_pattern( pAction, pHydrogen );
 	}
 	
-	return pHydrogen->flushAndAddNextPatterns( row );
+	return pHydrogen->flushAndAddNextPattern( row );
 }
 
 bool MidiActionManager::select_next_pattern_relative( std::shared_ptr<Action> pAction, Hydrogen* pHydrogen ) {

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -643,6 +643,17 @@ void OscServer::SELECT_NEXT_PATTERN_Handler(lo_arg **argv,int i)
 	pActionManager->handleAction( pAction );
 }
 
+void OscServer::SELECT_ONLY_NEXT_PATTERN_Handler(lo_arg **argv,int i)
+{
+	INFOLOG( "processing message" );
+	std::shared_ptr<Action> pAction = std::make_shared<Action>("SELECT_ONLY_NEXT_PATTERN");
+	pAction->setParameter1(  QString::number( argv[0]->f, 'f', 0 ) );
+	MidiActionManager* pActionManager = MidiActionManager::get_instance();
+
+	// Null song handling done in MidiActionManager.
+	pActionManager->handleAction( pAction );
+}
+
 void OscServer::SELECT_AND_PLAY_PATTERN_Handler(lo_arg **argv,int i)
 {
 	INFOLOG( "processing message" );
@@ -1279,6 +1290,7 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/MASTER_VOLUME_RELATIVE", "f", MASTER_VOLUME_RELATIVE_Handler);
 	
 	m_pServerThread->add_method("/Hydrogen/SELECT_NEXT_PATTERN", "f", SELECT_NEXT_PATTERN_Handler);
+	m_pServerThread->add_method("/Hydrogen/SELECT_ONLY_NEXT_PATTERN", "f", SELECT_ONLY_NEXT_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/SELECT_AND_PLAY_PATTERN", "f", SELECT_AND_PLAY_PATTERN_Handler);
 	
 	m_pServerThread->add_method("/Hydrogen/BEATCOUNTER", "", BEATCOUNTER_Handler);

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -164,6 +164,7 @@ class OscServer : public H2Core::Object<OscServer>
 		 * - MASTER_VOLUME_RELATIVE_Handler()
 		 * - STRIP_VOLUME_RELATIVE_Handler()
 		 * - SELECT_NEXT_PATTERN_Handler()
+		 * - SELECT_ONLY_NEXT_PATTERN_Handler()
 		 * - SELECT_AND_PLAY_PATTERN_Handler() 
 		 * - PLAYLIST_SONG_Handler()
 		 * - SELECT_INSTRUMENT_Handler()
@@ -463,6 +464,18 @@ class OscServer : public H2Core::Object<OscServer>
 		 * \param i Unused number of arguments passed by the OSC
 		 * message.*/
 		static void SELECT_NEXT_PATTERN_Handler(lo_arg **argv, int i);
+		/**
+		 * Creates an Action of type @b SELECT_ONLY_NEXT_PATTERN and
+		 * passes its references to MidiActionManager::handleAction().
+		 *
+		 * The first argument in @a argv will be used to set
+		 * Action::parameter1.
+		 *
+		 * \param argv Pointer to a vector of arguments passed
+		 * by the OSC message.
+		 * \param i Unused number of arguments passed by the OSC
+		 * message.*/
+		static void SELECT_ONLY_NEXT_PATTERN_Handler(lo_arg **argv, int i);
 		/**
 		 * Creates an Action of type @b SELECT_AND_PLAY_PATTERN and
 		 * passes its references to MidiActionManager::handleAction().

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -65,6 +65,7 @@ class EventListener
 	virtual void playbackTrackChangedEvent(){}
 	virtual void soundLibraryChangedEvent(){}
 	virtual void nextShotEvent(){}
+	virtual void stackedPatternsChangedEvent(){}
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -852,6 +852,10 @@ void HydrogenApp::onEventQueueTimer()
 			case EVENT_NEXT_SHOT:
 				pListener->nextShotEvent();
 				break;
+				
+			case EVENT_STACKED_PATTERNS_CHANGED:
+				pListener->stackedPatternsChangedEvent();
+				break;
 
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1460,6 +1460,11 @@ void SongEditorPatternList::selectedPatternChangedEvent() {
 	update();
 }
 
+void SongEditorPatternList::stackedPatternsChangedEvent() {
+	createBackground();
+	update();
+}
+
 /// Single click, select the next pattern
 void SongEditorPatternList::mousePressEvent( QMouseEvent *ev )
 {

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1487,7 +1487,7 @@ void SongEditorPatternList::mousePressEvent( QMouseEvent *ev )
 		   ev->pos().x() < 15 ) &&
 		 m_pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
 		
-		m_pHydrogen->toggleNextPatterns( nRow );
+		m_pHydrogen->toggleNextPattern( nRow );
 	}
 	else {
 		if ( ! ( m_pHydrogen->isPatternEditorLocked() &&
@@ -1528,7 +1528,7 @@ void SongEditorPatternList::mousePressEvent( QMouseEvent *ev )
 ///
 void SongEditorPatternList::togglePattern( int row ) {
 
-	m_pHydrogen->toggleNextPatterns( row );
+	m_pHydrogen->toggleNextPattern( row );
 	createBackground();
 	update();
 }

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -281,6 +281,7 @@ class SongEditorPatternList :  public QWidget
 	virtual void songModeActivationEvent() override;
 	virtual void stackedModeActivationEvent( int nValue ) override;
 	virtual void selectedPatternChangedEvent() override;
+	virtual void stackedPatternsChangedEvent() override;
 
 	public slots:
 		void patternPopup_edit();


### PR DESCRIPTION
MIDI action `SELECT_ONLY_NEXT_PATTERN` was introduced into the OSC API as well and fixed. Previously, it produced glitches in case the selected pattern was already playing. In addition, it is now possible to stop all patterns in stacked pattern mode by providing a pattern number outside range of available patterns.

`EVENT_STACKED_PATTERNS_CHANGED` was introduced to give immediate visual feedback in case the playing or queued patterns were altered using MIDI or OSC event.