### PR TITLE
Remove unnecessary iteration and shared_ptr uses

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1772,8 +1772,11 @@ void AudioEngine::processAudio( uint32_t nFrames ) {
 		if ( val_R > m_fMasterPeak_R ) {
 			m_fMasterPeak_R = val_R;
 		}
+	}
 
-		for ( auto pComponent : *pSong->getComponents() ) {
+	for ( auto component : *pSong->getComponents() ) {
+		DrumkitComponent *pComponent = component.get();
+		for ( unsigned i = 0; i < nFrames; ++i ) {
 			float compo_val_L = pComponent->get_out_L(i);
 			float compo_val_R = pComponent->get_out_R(i);
 


### PR DESCRIPTION
Profiling with `sample` on macOS didn't show this prominently, but a
large amount of CPU time in the audio engine was used in ProcessAudio
to update per-component peak amplitude values.

This was due to:
  - expensive iterators over vector of components called for each
    and every output sample
  - shared pointers to component and sample accessed implicitly
    every access

Solved by splitting the component peak calculation and transposing
the loop nest so the expensive iterator is the outer loop, and
caching the component pointer rather than using the shared_ptr
inside the inner loop.

Checking with `tests/tests -b` shows this improves performance for
the simplest case by about 45% on Apple Silicon, and by about 25%
on RPi4 and on x86_64.