### PR TITLE
Use ladish instead of lash for jack session management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,7 @@ ENDIF()
 FIND_HELPER(PORTAUDIO portaudio-2.0 portaudio.h portaudio)
 FIND_HELPER(PORTMIDI portmidi portmidi.h portmidi)
 FIND_HELPER(PULSEAUDIO libpulse pulse/pulseaudio.h pulse)
-FIND_HELPER(LASH lash-1.0 lash/lash.h lash)
+FIND_HELPER(LASH liblash lash-1.0/lash/lash.h lash)
 FIND_HELPER(LRDF lrdf lrdf.h lrdf)
 
 FIND_HELPER(RUBBERBAND rubberband rubberband/RubberBandStretcher.h rubberband)

--- a/src/core/Lash/LashClient.cpp
+++ b/src/core/Lash/LashClient.cpp
@@ -30,7 +30,7 @@
 
 #if defined(H2CORE_HAVE_LASH) || _DOXYGEN_
 
-#include <lash/lash.h>
+include <lash-1.0/lash/lash.h>
 #include <core/Preferences/Preferences.h>
 #include <core/H2Exception.h>
 

--- a/src/core/Lash/LashClient.h
+++ b/src/core/Lash/LashClient.h
@@ -27,7 +27,7 @@
 #ifndef LASH_CLIENT
 #define LASH_CLIENT
 
-#include <lash/lash.h>
+include <lash-1.0/lash/lash.h>
 
 #include <string>
 #include <cassert>

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -73,7 +73,7 @@
 #endif
 
 #ifdef H2CORE_HAVE_LASH
-#include <lash/lash.h>
+include <lash-1.0/lash/lash.h>
 #include <core/Lash/LashClient.h>
 #endif
 


### PR DESCRIPTION
Hydrogen still can make use of the lash library for Jack session management: unfortunately the library is basically unmaintained (no commits on devel git since July 2009).
However there is Nedko Arnaudov's ladish (LADI Session Handler) library, a rewrite of lash featuring:
 * Save and restore sets of JACK (audio and MIDI) enabled applications.
 * Provide JACK clients with virtual hardware ports, so projects can be transfered (or backups restored) between computers running
   different hardware and backups. 
 * Don't require session handling library to be used.
 * Flow canvas based GUI. Positions of elements on the canvas are saved/restored.
 * Allow clients to use external storage to save their state. This includes storing internal state to non-filesystem place like memory
   of a hardware synth. This also includes storing client internal state (client project data) in a way that is not directly bound to ladish project.
The library is already used by projects from kxstudio, as Carla or Cadence.
It's also completely compatible with lash: to use it only thing needed should be replacing the library name and the header file path in the hydrogen sources (a mere 4 line change). This PR does exactly this and was locally built & tested.
While transitioning to NSM it could be useful do this change.