### PR TITLE
Minimize updated areas of editors for playhead movement

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -27,6 +27,7 @@
 #include "../HydrogenApp.h"
 #include "../EventListener.h"
 #include "../UndoActions.h"
+#include "../Skin.h"
 
 #include <core/Globals.h>
 #include <core/Basics/Song.h>
@@ -883,8 +884,27 @@ void PatternEditor::stackedModeActivationEvent( int nValue )
 }
 
 void PatternEditor::updatePosition( float fTick ) {
+	if ( m_nTick == (int)fTick ) {
+		return;
+	}
+
+	float fDiff = m_fGridWidth * (fTick - m_nTick);
+
 	m_nTick = fTick;
-	update();
+
+	int nOffset = Skin::getPlayheadShaftOffset();
+	int nX = static_cast<int>(static_cast<float>(PatternEditor::nMargin) +
+							  static_cast<float>(m_nTick) *
+							  m_fGridWidth );
+
+	QRect updateRect( nX -2, 0, 4 + Skin::nPlayheadWidth, height() );
+	update( updateRect );
+	if ( fDiff > 1.0 || fDiff < -1.0 ) {
+		// New cursor is far enough away from the old one that the single update rect won't cover both. So
+		// update at the old location as well.
+		updateRect.translate( -fDiff, 0 );
+		update( updateRect );
+	}
 }
 
 void PatternEditor::storeNoteProperties( const Note* pNote ) {

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -122,13 +122,24 @@ void PatternEditorRuler::updatePosition( bool bForce ) {
 	int nTick = pAudioEngine->getPatternTickPosition();
 
 	if ( nTick != m_nTick || bForce ) {
+		int nDiff = m_fGridWidth * (nTick - m_nTick);
 		m_nTick = nTick;
-		update();
+		int nX = static_cast<int>( static_cast<float>(PatternEditor::nMargin) + 1 +
+								   m_nTick * static_cast<float>(m_fGridWidth) -
+								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		QRect updateRect( nX -2, 0, 4 + Skin::nPlayheadWidth, height() );
+		update( updateRect );
+		if ( nDiff > 1 || nDiff < -1 ) {
+			// New cursor is far enough away from the old one that the single update rect won't cover both. So
+			// update at the old location as well.
+			updateRect.translate( -nDiff, 0 );
+			update( updateRect );
+		}
 
 		if ( ! bIsSelectedPatternPlaying ) {
 			nTick = -1;
 		}
-		
+
 		auto pPatternEditorPanel = HydrogenApp::get_instance()->getPatternEditorPanel();
 		if ( pPatternEditorPanel != nullptr ) {
 			pPatternEditorPanel->getDrumPatternEditor()->updatePosition( nTick );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -974,9 +974,24 @@ void SongEditor::updateWidget() {
 	m_previousMousePosition = m_currentMousePosition;
 }
 
+
 void SongEditor::updatePosition( float fTick ) {
-	m_fTick = fTick;
-	update();
+	if ( fTick != m_fTick ) {
+		float fDiff = static_cast<float>(m_nGridWidth) * (fTick - m_fTick);
+		m_fTick = fTick;
+		int nX = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
+								   m_fTick * static_cast<float>(m_nGridWidth) -
+								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nOffset = Skin::getPlayheadShaftOffset();
+		QRect updateRect( nX + nOffset -2, 0, 4, height() );
+		update( updateRect );
+		if ( fDiff > 1.0 || fDiff < -1.0 ) {
+			// New cursor is far enough away from the old one that the single update rect won't cover both. So
+			// update at the old location as well.
+			updateRect.translate( -fDiff, 0 );
+			update( updateRect );
+		}
+	}
 }
 
 void SongEditor::paintEvent( QPaintEvent *ev )
@@ -3125,10 +3140,22 @@ void SongEditorPositionRuler::updatePosition()
 	m_pAudioEngine->unlock();
 
 	if ( fTick != m_fTick ) {
+		float fDiff = static_cast<float>(m_nGridWidth) * (fTick - m_fTick);
 
 		m_fTick = fTick;
-	
-		update();
+		int nX = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
+								   m_fTick * static_cast<float>(m_nGridWidth) -
+								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+
+		QRect updateRect( nX -2, 0, 4 + Skin::nPlayheadWidth, height() );
+		update( updateRect );
+		if ( fDiff > 1.0 || fDiff < -1.0 ) {
+			// New cursor is far enough away from the old one that the single update rect won't cover both. So
+			// update at the old location as well.
+			updateRect.translate( -fDiff, 0 );
+			update( updateRect );
+		}
+
 		auto pSongEditorPanel = HydrogenApp::get_instance()->getSongEditorPanel();
 		if ( pSongEditorPanel != nullptr ) {
 			pSongEditorPanel->getSongEditor()->updatePosition( fTick );


### PR DESCRIPTION
While playing, the song editor and pattern editors will update
periodically to show the progress of the playhead across the song
or pattern. The backgrounds are cached as pixmaps so this is a lot
faster than redrawing the whole song or pattern, but blitting the pixmap can
still take significant amounts of time when large areas of screen space
are taken up by these widgets (particularly on, say, a Raspberry
Pi attached to a 2560x1440 display). It's unclear if Qt is using
any hardware acceleration for this, but I've seen large amounts of
CPU time used in Linux and macOS profiling.

This change modifies the timer-driven updates to call update() on
only the minimal area necessary to correctly keep the widget fresh,
and erase the old playhead and render the new one.

There's an annoying amount of code duplication here, as there's 
no common ancestor class to fold the song editor geometry into.
That feels ripe for a refactor.

On the RPi4, running one of my tunes with a full screen display on the
2560x1440 display, this reduces the CPU time taken for 1000 seconds worth of
play time by quite a bit:

 |          | master time | new time | diff | %          |
 |----------|-------------|----------|------|------------|
 | hydrogen | 453         | 368      | -85  | -18.8%     |
 | Xorg     | 83          | 15       | -68  | -81.9%     |
 | Total    | 536         | 383      | -153 | -28.5%     |

(So, overall that's going from 53% of a CPU core to 38% of a CPU core)