### PR TITLE
Undo/redo improvements for pattern size widget

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1741,6 +1741,17 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 		// special processing for key press
 		QKeyEvent *k = (QKeyEvent *)e;
 
+		if ( k->matches( QKeySequence::StandardKey::Undo ) ) {
+			k->accept();
+			action_undo();
+			return true;
+		} else if ( k->matches( QKeySequence::StandardKey::Redo ) ) {
+			k->accept();
+			action_redo();
+			return true;
+		}
+
+
 		// qDebug( "Got key press for instrument '%c'", k->ascii() );
 		switch (k->key()) {
 		case Qt::Key_Space:

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -124,12 +124,14 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	m_pLCDSpinBoxNumerator->move( 36, 0 );
 	connect( m_pLCDSpinBoxNumerator, &LCDSpinBox::slashKeyPressed, this, &PatternEditorPanel::switchPatternSizeFocus );
 	connect( m_pLCDSpinBoxNumerator, SIGNAL( valueChanged( double ) ), this, SLOT( patternSizeChanged( double ) ) );
+	m_pLCDSpinBoxNumerator->setKeyboardTracking( false );
 	
 	m_pLCDSpinBoxDenominator = new LCDSpinBox( m_pSizeResol, QSize( 48, 20 ), LCDSpinBox::Type::Int, 1, 192 );
 	m_pLCDSpinBoxDenominator->setKind( LCDSpinBox::Kind::PatternSizeDenominator );
 	m_pLCDSpinBoxDenominator->move( 106, 0 );
 	connect( m_pLCDSpinBoxDenominator, &LCDSpinBox::slashKeyPressed, this, &PatternEditorPanel::switchPatternSizeFocus );
 	connect( m_pLCDSpinBoxDenominator, SIGNAL( valueChanged( double ) ), this, SLOT( patternSizeChanged( double ) ) );
+	m_pLCDSpinBoxDenominator->setKeyboardTracking( false );
 			
 	QLabel* label1 = new ClickableLabel( m_pSizeResol, QSize( 4, 13 ), "/", ClickableLabel::Color::Dark );
 	label1->resize( QSize( 20, 17 ) );

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -122,7 +122,14 @@ void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 
 void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 	double fOldValue = value();
-	
+
+	// Pass Undo/Redo commands up to the parent
+	if ( ev->matches( QKeySequence::StandardKey::Undo )
+		 || ev->matches( QKeySequence::StandardKey::Redo ) ) {
+		ev->ignore();
+		return;
+	}
+
 	if ( m_kind == Kind::PatternSizeDenominator &&
 		 ( ev->key() == Qt::Key_Up || ev->key() == Qt::Key_Down ||
 		   ev->key() == Qt::Key_PageUp || ev->key() == Qt::Key_PageDown ) ) {


### PR DESCRIPTION
I came across a couple of infelicities in changing pattern size.

The first is that (in macOS at least) changing pattern size by *typing* in the pattern size LCD Spinbox, the keyboard input focus is somehow left somewhere that using Ctrl-Z (or Command-Z) doesn't get propagated to the system menu option as a regular shortcut. The regular key events are unaffected and propagated, so I'm not sure where it's missed, but handling this explicitly seems reasonable, so adding this to the main form's handling solves that particular issue.

Secondly, it's possible to type in the spinbox and get a `valueChanged` event for a value that's already the same pattern size (eg. by pressing `Return`) which can lead to redundant undo actions in the undo history. So, I've made the action check the new pattern size against the existing one and avoiding inserting that undo action.

At the same time, I changed the macro text on the pattern change undo action to reflect the user-visible action better.

However, there's still one annoying problem that I'm not sure exactly what the right answer to is. The scenario:

  * Pattern length is 8, with many notes entered.
  * User decides to change pattern length to 16
  * User clicks in the Numerator box
  * User types "1"
     * Hydrogen immediately sets the pattern length to 1 and deletes every note after the first quarter-note
  * User types "6"
     * Hydrogen sets the pattern length to 16, but most of the notes are gone, with very little clue as to why
  * User is confused and sad

(Reader, *I* was that user.)

I think that, when entering a value using the keyboard rather than the spin arrows, the pattern size shouldn't be changed until the user hits `Return`. Setting via the spin arrows should probably continue to change the size immediately.

~~However, `QSpinBox` doesn't seem to provide a way to differentiate between `valueChanged` events caused by the keyboard or the spin arrows. This seems absolutely fine for `QSpinBox`'s intended use in dialog boxes, where changing the value isn't expected to change anything on its own, and things don't change until the user Accepts the dialog.~~

~~I'll continue looking to see if there's a sensible way around this using whatever is provided by `QSpinBox`. @oddtime , @theGreatWhiteShark  any thoughts on the usability issue?~~

Found it. Just need to turn of keyboardTracking. Hurrah.
