### PR TITLE
Update NSM support

### DIFF
--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -565,7 +565,7 @@ public:
 	QString toQString( const QString& sPrefix, bool bShort = true ) const override;
 
 	/** Is allowed to call setSong().*/
-	friend void Hydrogen::setSong( std::shared_ptr<Song> pSong );
+	friend void Hydrogen::setSong( std::shared_ptr<Song> pSong, bool bRelinking );
 	/** Is allowed to call removeSong().*/
 	friend void Hydrogen::removeSong();
 	/** Is allowed to use locate() to directly set the position in

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -88,7 +88,7 @@ Drumkit::~Drumkit()
 std::shared_ptr<Drumkit> Drumkit::load( const QString& sDrumkitPath, bool bUpgrade, bool bSilent )
 {
 	if ( ! Filesystem::drumkit_valid( sDrumkitPath ) ) {
-		ERRORLOG( QString( "[%1] is not valid drumkit" ).arg( sDrumkitPath ) );
+		ERRORLOG( QString( "[%1] is not valid drumkit folder" ).arg( sDrumkitPath ) );
 		return nullptr;
 	}
 
@@ -273,7 +273,7 @@ QString Drumkit::loadNameFrom( const QString& sDrumkitDir, bool bSilent ) {
 bool Drumkit::loadDoc( const QString& sDrumkitDir, XMLDoc* pDoc, bool bSilent ) {
 
 	if ( ! Filesystem::drumkit_valid( sDrumkitDir ) ) {
-		ERRORLOG( QString( "[%1] is not valid drumkit" ).arg( sDrumkitDir ) );
+		ERRORLOG( QString( "[%1] is not valid drumkit folder" ).arg( sDrumkitDir ) );
 		return false;
 	}
 
@@ -572,7 +572,7 @@ std::vector<std::shared_ptr<InstrumentList::Content>> Drumkit::summarizeContent(
 bool Drumkit::remove( const QString& sDrumkitDir )
 {
 	if( ! Filesystem::drumkit_valid( sDrumkitDir ) ) {
-		ERRORLOG( QString( "%1 is not valid drumkit" ).arg( sDrumkitDir ) );
+		ERRORLOG( QString( "%1 is not valid drumkit folder" ).arg( sDrumkitDir ) );
 		return false;
 	}
 	

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -380,7 +380,6 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 	pInstrument->set_drumkit_path( sInstrumentDrumkitPath );
 	pInstrument->__drumkit_name = sInstrumentDrumkitName;
 
-	
 	pInstrument->set_volume( pNode->read_float( "volume", 1.0f,
 											   true, true, bSilent ) );
 	pInstrument->set_muted( pNode->read_bool( "isMuted", false,
@@ -455,14 +454,14 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 	License instrumentLicense;
 	if ( license == License() ) {
 		// No/empty license supplied. We will use the license stored
-		// in the drumkit.xml file found at
-		// sInstrumentDrumkitPath. But since loading it from file is a
-		// rather expensive action, we will query it from the Drumkit
-		// database. If, for some reasons, the drumkit is not present
-		// yet, the License will be loaded directly.
+		// in the drumkit.xml file found in __drumkit_name. But since
+		// loading it from file is a rather expensive action, we will
+		// query it from the Drumkit database. If, for some reasons,
+		// the drumkit is not present yet, the License will be loaded
+		// directly.
 		auto pSoundLibraryDatabase = Hydrogen::get_instance()->getSoundLibraryDatabase();
 		if ( pSoundLibraryDatabase != nullptr ) {
-			auto pDrumkit = pSoundLibraryDatabase->getDrumkit( sInstrumentDrumkitPath );
+			auto pDrumkit = pSoundLibraryDatabase->getDrumkit( pInstrument->get_drumkit_path() );
 			if ( pDrumkit != nullptr ) {
 				instrumentLicense = pDrumkit->get_license();
 			}
@@ -471,10 +470,10 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 		if ( instrumentLicense == License() ) {
 			if ( ! bSilent ) {
 				WARNINGLOG( QString( "No license could be retrieved from drumkit [%1] in database. Loading directly." )
-							.arg( sInstrumentDrumkitPath ) );
+							.arg( pInstrument->get_drumkit_path() ) );
 			}
 			
-			instrumentLicense = Drumkit::loadLicenseFrom( sInstrumentDrumkitPath );
+			instrumentLicense = Drumkit::loadLicenseFrom( pInstrument->get_drumkit_path() );
 		}
 	} else {
 		instrumentLicense = license;
@@ -484,15 +483,16 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 		// current format
 		XMLNode componentNode = pNode->firstChildElement( "instrumentComponent" );
 		while ( ! componentNode.isNull() ) {
-			pInstrument->get_components()->push_back(
-			    InstrumentComponent::load_from( &componentNode, sInstrumentDrumkitPath,
-												instrumentLicense, bSilent ) );
+			pInstrument->get_components()->
+				push_back( InstrumentComponent::load_from( &componentNode,
+														   pInstrument->get_drumkit_path(),
+														   instrumentLicense, bSilent ) );
 			componentNode = componentNode.nextSiblingElement( "instrumentComponent" );
 		}
 	}
 	else {
 		// back compatibility code
-		auto pCompo = Legacy::loadInstrumentComponent( pNode, sInstrumentDrumkitPath,
+		auto pCompo = Legacy::loadInstrumentComponent( pNode, pInstrument->get_drumkit_path(),
 													   instrumentLicense, bSilent );
 		if ( pCompo == nullptr ) {
 			ERRORLOG( "Unable to load component. Aborting." );
@@ -528,7 +528,9 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 			}
 
 			if ( pLayer->get_sample() != nullptr ) {
-				bSampleFound = true;
+				if ( ! bSampleFound ) {
+					bSampleFound = true;
+				}
 			} else {
 				pInstrument->set_missing_samples( true );
 			}
@@ -653,6 +655,11 @@ std::shared_ptr<InstrumentComponent> Instrument::get_component( int DrumkitCompo
 	}
 
 	return nullptr;
+}
+
+QString Instrument::get_drumkit_path() const
+{
+	return Filesystem::ensure_session_compatibility( __drumkit_path );
 }
 
 QString Instrument::toQString( const QString& sPrefix, bool bShort ) const {

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -282,7 +282,7 @@ class Instrument : public H2Core::Object<Instrument>
 		///< set the path of the related drumkit
 		void set_drumkit_path( const QString& sPath );
 		///< get the path of the related drumkits
-		const QString& get_drumkit_path() const;
+		QString get_drumkit_path() const;
 		///< set the name of the related drumkit
 		void set_drumkit_name( const QString& sName );
 		///< get the name of the related drumkits
@@ -666,11 +666,6 @@ inline int Instrument::get_higher_cc() const
 inline void Instrument::set_drumkit_path( const QString& sPath )
 {
 	__drumkit_path = sPath;
-}
-
-inline const QString& Instrument::get_drumkit_path() const
-{
-	return __drumkit_path;
 }
 
 inline void Instrument::set_drumkit_name( const QString& sName )

--- a/src/core/Basics/InstrumentLayer.cpp
+++ b/src/core/Basics/InstrumentLayer.cpp
@@ -174,7 +174,7 @@ void InstrumentLayer::save_to( XMLNode* node, bool bFull )
 	if ( bFull ) {
 		sFilename = Filesystem::prepare_sample_path( pSample->get_filepath() );
 	} else {
-		sFilename = get_sample()->get_filename();
+		sFilename = pSample->get_filename();
 	}
 	
 	layer_node.write_string( "filename", sFilename );

--- a/src/core/Basics/InstrumentLayer.cpp
+++ b/src/core/Basics/InstrumentLayer.cpp
@@ -93,6 +93,7 @@ std::shared_ptr<InstrumentLayer> InstrumentLayer::load_from( XMLNode* pNode, con
 	if ( ! Filesystem::file_exists( sFilename, true ) && ! sDrumkitPath.isEmpty() &&
 		 ! sFilename.startsWith( "/" ) ) {
 
+#ifdef H2CORE_HAVE_OSC
 		if ( pHydrogen->isUnderSessionManagement() ) {
 			// If we use the NSM support and the sample files to save
 			// are corresponding to the drumkit linked/located in the
@@ -121,6 +122,10 @@ std::shared_ptr<InstrumentLayer> InstrumentLayer::load_from( XMLNode* pNode, con
 			sFilename = sDrumkitPath + "/" + sFilename;
 			sAbsoluteFilename = sFilename;
 		}
+#else
+		sFilename = sDrumkitPath + "/" + sFilename;
+		sAbsoluteFilename = sFilename;
+#endif
 	}
 
 	std::shared_ptr<Sample> pSample = nullptr;

--- a/src/core/Basics/InstrumentLayer.cpp
+++ b/src/core/Basics/InstrumentLayer.cpp
@@ -26,6 +26,8 @@
 #include <core/Helpers/Xml.h>
 #include <core/Basics/Sample.h>
 #include <core/License.h>
+#include <core/Hydrogen.h>
+#include <core/NsmClient.h>
 #include <core/Preferences/Preferences.h>
 
 namespace H2Core
@@ -83,14 +85,46 @@ void InstrumentLayer::unload_sample()
 
 std::shared_ptr<InstrumentLayer> InstrumentLayer::load_from( XMLNode* pNode, const QString& sDrumkitPath, const License& drumkitLicense, bool bSilent )
 {
+	auto pHydrogen = Hydrogen::get_instance();
+	
 	QString sFilename = pNode->read_string( "filename", "", false, false, bSilent );
+	QString sAbsoluteFilename = sFilename;
+
 	if ( ! Filesystem::file_exists( sFilename, true ) && ! sDrumkitPath.isEmpty() &&
 		 ! sFilename.startsWith( "/" ) ) {
-		sFilename = sDrumkitPath + "/" + sFilename;
+
+		if ( pHydrogen->isUnderSessionManagement() ) {
+			// If we use the NSM support and the sample files to save
+			// are corresponding to the drumkit linked/located in the
+			// session folder, we have to ensure the relative paths
+			// are loaded. This is vital in order to support
+			// renaming, duplicating, and porting sessions.
+
+			// QFileInfo::isRelative() can not be used in here as
+			// samples within drumkits within the user or system
+			// drumkit folder are stored relatively as well (by saving
+			// just the filename).
+			if ( sFilename.left( 2 ) == "./" ||
+				 sFilename.left( 2 ) == ".\\" ) {
+				// Removing the leading "." of the relative path in
+				// sFilename while still using the associated folder
+				// separator.
+				sAbsoluteFilename = NsmClient::get_instance()->getSessionFolderPath() +
+					sFilename.right( sFilename.size() - 1 );
+			}
+			else {
+				sFilename = sDrumkitPath + "/" + sFilename;
+				sAbsoluteFilename = sFilename;
+			}
+		}
+		else {
+			sFilename = sDrumkitPath + "/" + sFilename;
+			sAbsoluteFilename = sFilename;
+		}
 	}
 
 	std::shared_ptr<Sample> pSample = nullptr;
-	if ( Filesystem::file_exists( sFilename, true ) ) {
+	if ( Filesystem::file_exists( sAbsoluteFilename, true ) ) {
 		pSample = std::make_shared<Sample>( sFilename, drumkitLicense );
 
 		// If 'ismodified' is not present, InstrumentLayer was stored as
@@ -162,6 +196,7 @@ std::shared_ptr<InstrumentLayer> InstrumentLayer::load_from( XMLNode* pNode, con
 
 void InstrumentLayer::save_to( XMLNode* node, bool bFull )
 {
+	auto pHydrogen = Hydrogen::get_instance();
 	auto pSample = get_sample();
 	if ( pSample == nullptr ) {
 		ERRORLOG( "No sample associated with layer. Skipping it" );
@@ -172,8 +207,25 @@ void InstrumentLayer::save_to( XMLNode* node, bool bFull )
 
 	QString sFilename;
 	if ( bFull ) {
-		sFilename = Filesystem::prepare_sample_path( pSample->get_filepath() );
-	} else {
+
+		if ( pHydrogen->isUnderSessionManagement() ) {
+			// If we use the NSM support and the sample files to save
+			// are corresponding to the drumkit linked/located in the
+			// session folder, we have to ensure the relative paths
+			// are written out. This is vital in order to support
+			// renaming, duplicating, and porting sessions.
+			if ( pSample->get_raw_filepath().left( 1 ) == '.' ) {
+				sFilename = pSample->get_raw_filepath();
+			}
+			else {
+				sFilename = Filesystem::prepare_sample_path( pSample->get_filepath() );
+			}
+		}
+		else {
+			sFilename = Filesystem::prepare_sample_path( pSample->get_filepath() );
+		}
+	}
+	else {
 		sFilename = pSample->get_filename();
 	}
 	

--- a/src/core/Basics/Sample.cpp
+++ b/src/core/Basics/Sample.cpp
@@ -121,10 +121,15 @@ Sample::~Sample()
 void Sample::set_filename( const QString& filename )
 {
 	QFileInfo Filename = QFileInfo( filename );
-	QFileInfo Dest = QFileInfo( __filepath );
+	QFileInfo Dest = QFileInfo( get_filepath() );
 	__filepath = QDir(Dest.absolutePath()).filePath( Filename.fileName() );
 }
 
+
+QString Sample::get_filepath() const
+{
+	return Filesystem::ensure_session_compatibility( __filepath );
+}
 
 std::shared_ptr<Sample> Sample::load( const QString& sFilepath, const License& license )
 {
@@ -152,9 +157,9 @@ bool Sample::load( float fBpm )
 	SF_INFO sound_info = {0};
 
 	// Opens file in read-only mode.
-	SNDFILE* file = sf_open( __filepath.toLocal8Bit(), SFM_READ, &sound_info );
+	SNDFILE* file = sf_open( get_filepath().toLocal8Bit(), SFM_READ, &sound_info );
 	if ( !file ) {
-		ERRORLOG( QString( "[Sample::load] Error loading file %1" ).arg( __filepath ) );
+		ERRORLOG( QString( "[Sample::load] Error loading file %1" ).arg( get_filepath() ) );
 		return false;
 	}
 	
@@ -181,12 +186,12 @@ bool Sample::load( float fBpm )
 	// encoding (e.g. 16 bit PCM).
 	sf_count_t count = sf_read_float( file, buffer, sound_info.frames * sound_info.channels );
 	if( count==0 ){
-		WARNINGLOG( QString( "%1 is an empty sample" ).arg( __filepath ) );
+		WARNINGLOG( QString( "%1 is an empty sample" ).arg( get_filepath() ) );
 	}
 	
 	// Deallocate the handler.
 	if ( sf_close( file ) != 0 ){
-		WARNINGLOG( QString( "Unable to close sample file %1" ).arg( __filepath ) );
+		WARNINGLOG( QString( "Unable to close sample file %1" ).arg( get_filepath() ) );
 	}
 	
 	// Flush the current content of the left and right channel and

--- a/src/core/Basics/Sample.h
+++ b/src/core/Basics/Sample.h
@@ -212,6 +212,8 @@ class Sample : public H2Core::Object<Sample>
 		const QString get_filename() const;
 		/** \param filename Filename part of #__filepath*/
 		void set_filename( const QString& filename );
+		/** \param filename sets #__filepath*/
+		void set_filepath( const QString& sFilepath );
 		/**
 		 * #__frames setter
 		 * \param value the new value for #__frames
@@ -349,6 +351,11 @@ inline void Sample::unload()
 inline bool Sample::is_empty() const
 {
 	return ( __data_l == 0 && __data_r == 0 );
+}
+
+inline void Sample::set_filepath( const QString& sFilepath )
+{
+	__filepath = sFilepath;
 }
 
 inline const QString Sample::get_filepath() const

--- a/src/core/Basics/Sample.h
+++ b/src/core/Basics/Sample.h
@@ -206,8 +206,9 @@ class Sample : public H2Core::Object<Sample>
 
 		/** \return true if both data channels are null pointers */
 		bool is_empty() const;
+		QString get_filepath() const;
 		/** \return #__filepath */
-		const QString get_filepath() const;
+		const QString get_raw_filepath() const;
 		/** \return Filename part of #__filepath */
 		const QString get_filename() const;
 		/** \param filename Filename part of #__filepath*/
@@ -353,14 +354,14 @@ inline bool Sample::is_empty() const
 	return ( __data_l == 0 && __data_r == 0 );
 }
 
+inline const QString Sample::get_raw_filepath() const
+{
+	return __filepath;
+}
+
 inline void Sample::set_filepath( const QString& sFilepath )
 {
 	__filepath = sFilepath;
-}
-
-inline const QString Sample::get_filepath() const
-{
-	return __filepath;
 }
 
 inline const QString Sample::get_filename() const

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -424,12 +424,14 @@ std::shared_ptr<Song> Song::loadFrom( XMLNode* pRootNode, bool bSilent )
 
 		sLastLoadedDrumkitPath = sMostCommonDrumkit;
 	}
+	pSong->setLastLoadedDrumkitPath( sLastLoadedDrumkitPath );
 	
 	if ( sLastLoadedDrumkitName.isEmpty() ) {
-		sLastLoadedDrumkitName = Drumkit::loadNameFrom( sLastLoadedDrumkitPath,
-														bSilent );
+		// Use the getter in here to support relative paths as well.
+		sLastLoadedDrumkitName =
+			Drumkit::loadNameFrom( pSong->getLastLoadedDrumkitPath(),
+								   bSilent );
 	}
-	pSong->setLastLoadedDrumkitPath( sLastLoadedDrumkitPath );
 	pSong->setLastLoadedDrumkitName( sLastLoadedDrumkitName );
 
 	// Pattern list
@@ -1421,6 +1423,11 @@ QString Song::makeComponentNameUnique( const QString& sName ) const {
 		}
 	}
 	return sName;
+}
+
+QString Song::getLastLoadedDrumkitPath() const
+{
+	return Filesystem::ensure_session_compatibility( m_sLastLoadedDrumkitPath );
 }
  
 QString Song::toQString( const QString& sPrefix, bool bShort ) const {

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1197,6 +1197,8 @@ void Song::setPanLawKNorm( float fKNorm ) {
 }
 
 void Song::setDrumkit( std::shared_ptr<Drumkit> pDrumkit, bool bConditional ) {
+	auto pHydrogen = Hydrogen::get_instance();
+
 	assert ( pDrumkit );
 	if ( pDrumkit == nullptr ) {
 		ERRORLOG( "Invalid drumkit supplied" );
@@ -1285,7 +1287,7 @@ void Song::setDrumkit( std::shared_ptr<Drumkit> pDrumkit, bool bConditional ) {
 
 	// Load samples of all instruments.
 	m_pInstrumentList->load_samples(
-		Hydrogen::get_instance()->getAudioEngine()->getBpm() );
+		pHydrogen->getAudioEngine()->getBpm() );
 
 }
 

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -284,7 +284,7 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 
 	const QString& getLastLoadedDrumkitName() const;
 	void setLastLoadedDrumkitName( const QString& sName );
-	const QString& getLastLoadedDrumkitPath() const;
+	QString getLastLoadedDrumkitPath() const;
 	void setLastLoadedDrumkitPath( const QString& sPath );
 	
 		/** Formatted string version for debugging purposes.
@@ -730,10 +730,6 @@ inline const QString& Song::getLastLoadedDrumkitName() const
 inline void Song::setLastLoadedDrumkitName( const QString& sName )
 {
 	m_sLastLoadedDrumkitName = sName;
-}
-inline const QString& Song::getLastLoadedDrumkitPath() const
-{
-	return m_sLastLoadedDrumkitPath;
 }
 inline void Song::setLastLoadedDrumkitPath( const QString& sPath )
 {

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -537,7 +537,10 @@ bool CoreActionController::newSong( const QString& sSongPath ) {
 
 	if ( pHydrogen->isUnderSessionManagement() ) {
 		pHydrogen->restartDrivers();
-	}		
+		// The drumkit of the new song will linked into the session
+		// folder during the next song save.
+		pHydrogen->setSessionDrumkitNeedsRelinking( true );
+	}
 
 	pSong->setFilename( sSongPath );
 
@@ -585,7 +588,7 @@ bool CoreActionController::openSong( const QString& sSongPath, const QString& sR
 	return setSong( pSong );
 }
 
-bool CoreActionController::openSong( std::shared_ptr<Song> pSong ) {
+bool CoreActionController::openSong( std::shared_ptr<Song> pSong, bool bRelinking ) {
 	
 	auto pHydrogen = Hydrogen::get_instance();
  
@@ -600,15 +603,15 @@ bool CoreActionController::openSong( std::shared_ptr<Song> pSong ) {
 		return false;
 	}
 
-	return setSong( pSong );
+	return setSong( pSong, bRelinking );
 }
 
-bool CoreActionController::setSong( std::shared_ptr<Song> pSong ) {
+bool CoreActionController::setSong( std::shared_ptr<Song> pSong, bool bRelinking ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
 
 	// Update the Song.
-	pHydrogen->setSong( pSong );
+	pHydrogen->setSong( pSong, bRelinking );
 		
 	if ( pHydrogen->isUnderSessionManagement() ) {
 		pHydrogen->restartDrivers();
@@ -619,9 +622,7 @@ bool CoreActionController::setSong( std::shared_ptr<Song> pSong ) {
 		// empty songs - created and set when hitting "New Song" in
 		// the main menu - aren't listed either.
 		insertRecentFile( pSong->getFilename() );
-		if ( ! pHydrogen->isUnderSessionManagement() ) {
-			Preferences::get_instance()->setLastSongFilename( pSong->getFilename() );
-		}
+		Preferences::get_instance()->setLastSongFilename( pSong->getFilename() );
 	}
 		
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
@@ -648,6 +649,28 @@ bool CoreActionController::saveSong() {
 		ERRORLOG( "Unable to save song. Empty filename!" );
 		return false;
 	}
+
+#ifdef H2CORE_HAVE_OSC
+	if ( pHydrogen->isUnderSessionManagement() &&
+		 pHydrogen->getSessionDrumkitNeedsRelinking() &&
+		 ! pHydrogen->getSessionIsExported() ) {
+
+		NsmClient::linkDrumkit( pSong );
+
+		// Properly set in NsmClient::linkDrumkit()
+		QString sSessionDrumkitPath = pSong->getLastLoadedDrumkitPath();
+
+		auto drumkitDatabase = pHydrogen->getSoundLibraryDatabase()->getDrumkitDatabase();
+		if ( drumkitDatabase.find( sSessionDrumkitPath ) != drumkitDatabase.end() ) {
+			// In case the session folder is already present in the
+			// SoundLibraryDatabase, we have to update it (takes a
+			// while) to ensure it's clean and all kits are valid. If
+			// it's not present, we can skip it because loading is
+			// done lazily.
+			pHydrogen->getSoundLibraryDatabase()->updateDrumkit( sSessionDrumkitPath );
+		}
+	}
+#endif
 	
 	// Actual saving
 	bool bSaved = pSong->save( sSongPath );
@@ -656,13 +679,6 @@ bool CoreActionController::saveSong() {
 				  .arg( sSongPath ) );
 		return false;
 	}
-
-#ifdef H2CORE_HAVE_OSC
-	if ( pHydrogen->isUnderSessionManagement() &&
-		 pHydrogen->getSessionDrumkitNeedsRelinking() ) {
-		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, true );
-	}
-#endif
 	
 	// Update the status bar.
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
@@ -1010,9 +1026,7 @@ bool CoreActionController::setDrumkit( std::shared_ptr<Drumkit> pDrumkit, bool b
 			// Create a symbolic link in the session folder when under session
 			// management.
 			if ( pHydrogen->isUnderSessionManagement() ) {
-#ifdef H2CORE_HAVE_OSC
 				pHydrogen->setSessionDrumkitNeedsRelinking( true );
-#endif
 			}
 
 			EventQueue::get_instance()->push_event( EVENT_DRUMKIT_LOADED, 0 );

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -656,6 +656,13 @@ bool CoreActionController::saveSong() {
 				  .arg( sSongPath ) );
 		return false;
 	}
+
+#ifdef H2CORE_HAVE_OSC
+	if ( pHydrogen->isUnderSessionManagement() &&
+		 pHydrogen->getSessionDrumkitNeedsRelinking() ) {
+		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, true );
+	}
+#endif
 	
 	// Update the status bar.
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
@@ -1004,7 +1011,7 @@ bool CoreActionController::setDrumkit( std::shared_ptr<Drumkit> pDrumkit, bool b
 			// management.
 			if ( pHydrogen->isUnderSessionManagement() ) {
 #ifdef H2CORE_HAVE_OSC
-				NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, false );
+				pHydrogen->setSessionDrumkitNeedsRelinking( true );
 #endif
 			}
 

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -121,9 +121,14 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * the current #H2Core::Song. All unsaved changes will be lost!
 		 *
 		 * \param pSong New Song.
+		 * \param bRelinking Whether the drumkit last loaded should be
+		 * relinked when under session management. This flag is used
+		 * to distinguish between the regular load of a song file
+		 * within a session and its replacement by another song (which
+		 * requires an update of the linked drumkit).
 		 * \return true on success
 		 */
-		bool openSong( std::shared_ptr<Song> pSong );
+		bool openSong( std::shared_ptr<Song> pSong, bool bRelinking = true );
 		/**
 		 * Saves the current #H2Core::Song.
 		 *
@@ -394,9 +399,14 @@ private:
 		 * current #H2Core::Song. All unsaved changes will be lost!
 		 *
 		 * \param pSong Pointer to the #H2Core::Song to set.
+		 * \param bRelinking Whether the drumkit last loaded should be
+		 * relinked when under session management. This flag is used
+		 * to distinguish between the regular load of a song file
+		 * within a session and its replacement by another song (which
+		 * requires an update of the linked drumkit).
 		 * \return true on success
 		 */
-		bool setSong( std::shared_ptr<Song> pSong );
+		bool setSong( std::shared_ptr<Song> pSong, bool bRelinking = true );
 
 	/**
 	 * Loads the drumkit specified in @a sDrumkitPath.

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -745,7 +745,7 @@ QString Filesystem::drumkit_path_search( const QString& dk_name, Lookup lookup, 
 	if ( Hydrogen::get_instance()->isUnderSessionManagement() ) {
 		
 		QString sDrumkitPath = QString( "%1/%2" )
-			.arg( NsmClient::get_instance()->m_sSessionFolderPath )
+			.arg( NsmClient::get_instance()->getSessionFolderPath() )
 			.arg( "drumkit" );
 		
 		// If the path is symbolic link, dereference it.

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -758,14 +758,16 @@ QString Filesystem::drumkit_path_search( const QString& dk_name, Lookup lookup, 
 		// drumkit (using its name).
 		QString sDrumkitXMLPath = QString( "%1/%2" )
 				.arg( sDrumkitPath ).arg( "drumkit.xml" );
+		QString sSessionDrumkitName = Drumkit::loadNameFrom( sDrumkitPath );
 
-		if ( dk_name == Drumkit::loadNameFrom( sDrumkitXMLPath ) ) {
+		if ( dk_name == sSessionDrumkitName ) {
 				// The local drumkit seems legit.	
 				return sDrumkitPath;
 		}
 		else if ( ! bSilent ) {
-			NsmClient::printError( QString( "Local drumkit [%1] and the one referenced in the .h2song file [%2] do not match!" )
+			NsmClient::printError( QString( "Local drumkit [%1] name [%2] and the one stored in .h2song file [%3] do not match!" )
 								   .arg( sDrumkitXMLPath )
+								   .arg( sSessionDrumkitName )
 								   .arg( dk_name ) );
 		}
 	}
@@ -811,6 +813,31 @@ QString Filesystem::drumkit_dir_search( const QString& dk_name, Lookup lookup )
 }
 bool Filesystem::drumkit_valid( const QString& dk_path )
 {
+#ifdef H2CORE_HAVE_OSC
+	auto pHydrogen = Hydrogen::get_instance();
+	if ( pHydrogen != nullptr &&
+		 pHydrogen->isUnderSessionManagement() ) {
+
+		// Explicit handling for relative drumkit paths supported in
+		// the session management.
+		QFileInfo info( dk_path );
+		if ( info.isRelative() ) {
+			QString sAbsoluteDrumkitPath = QString( "%1%2" )
+				.arg( NsmClient::get_instance()->getSessionFolderPath() )
+				// remove the leading dot indicating that the path is relative. 
+				.arg( dk_path.right( dk_path.size() - 1 ) );
+
+			QFileInfo infoAbs( sAbsoluteDrumkitPath );
+			if ( infoAbs.isSymLink() ) {
+				sAbsoluteDrumkitPath = infoAbs.symLinkTarget();
+			}
+
+			return file_readable( sAbsoluteDrumkitPath + "/" +
+								  DRUMKIT_XML, true );
+		}
+	}
+#endif
+		
 	return file_readable( dk_path + "/" + DRUMKIT_XML, true);
 }
 QString Filesystem::drumkit_file( const QString& dk_path )
@@ -962,6 +989,25 @@ QString Filesystem::absolute_path( const QString& sFilename, bool bSilent ) {
 	}
 
 	return QString();
+}
+
+QString Filesystem::ensure_session_compatibility( const QString& sPath ) {
+#ifdef H2CORE_HAVE_OSC
+	auto pHydrogen = Hydrogen::get_instance();
+	if ( pHydrogen != nullptr &&
+		 pHydrogen->isUnderSessionManagement() ) {
+
+		QFileInfo info( sPath );
+		if ( info.isRelative() ) {
+			return QString( "%1%2" )
+				.arg( NsmClient::get_instance()->getSessionFolderPath() )
+				// remove the leading dot indicating that the path is relative. 
+				.arg( sPath.right( sPath.size() - 1 ) );
+		}
+	}
+#endif
+
+	return sPath;
 }
 };
 

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -395,6 +395,12 @@ namespace H2Core
 		 * Convert a direct to an absolute path.
 		 */
 		static QString absolute_path( const QString& sFilename, bool bSilent = false );
+		/** 
+		 * If Hydrogen is under session management, we support for paths
+		 * relative to the session folder. This is required to allow for
+		 * sessions being renamed or duplicated.
+		 */
+		static QString ensure_session_compatibility( const QString& sPath );
 		/**
 		 * writes to a file
 		 * \param dst the destination path

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -111,6 +111,7 @@ Hydrogen::Hydrogen() : m_nSelectedInstrumentNumber( 0 )
 					 , m_oldEngineMode( Song::Mode::Song ) 
 					 , m_bOldLoopEnabled( false )
 					 , m_nLastRecordedMIDINoteTick( 0 )
+					 , m_bSessionDrumkitNeedsRelinking( false )
 {
 	if ( __instance ) {
 		ERRORLOG( "Hydrogen audio engine is already running" );

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -112,6 +112,7 @@ Hydrogen::Hydrogen() : m_nSelectedInstrumentNumber( 0 )
 					 , m_bOldLoopEnabled( false )
 					 , m_nLastRecordedMIDINoteTick( 0 )
 					 , m_bSessionDrumkitNeedsRelinking( false )
+					 , m_bSessionIsExported( false )
 {
 	if ( __instance ) {
 		ERRORLOG( "Hydrogen audio engine is already running" );
@@ -283,7 +284,7 @@ void Hydrogen::loadPlaybackTrack( QString sFilename )
 	EventQueue::get_instance()->push_event( EVENT_PLAYBACK_TRACK_CHANGED, 0 );
 }
 
-void Hydrogen::setSong( std::shared_ptr<Song> pSong )
+void Hydrogen::setSong( std::shared_ptr<Song> pSong, bool bRelinking )
 {
 	assert ( pSong );
 
@@ -308,7 +309,6 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 			pSong->setFilename( pCurrentSong->getFilename() );
 		}
 		removeSong();
-		// delete pCurrentSong;
 	}
 
 	// In order to allow functions like audioEngine_setupLadspaFX() to
@@ -328,8 +328,8 @@ void Hydrogen::setSong( std::shared_ptr<Song> pSong )
 	m_pCoreActionController->initExternalControlInterfaces();
 
 #ifdef H2CORE_HAVE_OSC
-	if ( isUnderSessionManagement() ) {
-		NsmClient::linkDrumkit( NsmClient::get_instance()->m_sSessionFolderPath, true );
+	if ( isUnderSessionManagement() && bRelinking ) {
+		setSessionDrumkitNeedsRelinking( true );
 	}
 #endif
 }

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -443,6 +443,9 @@ void			previewSample( Sample *pSample );
 		supported.*/
 	bool			isUnderSessionManagement() const;
 
+	void			setSessionDrumkitNeedsRelinking( bool bNeedsRelinking );
+	bool			getSessionDrumkitNeedsRelinking() const;
+
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
 
@@ -554,12 +557,29 @@ private:
 	int				m_nSelectedPatternNumber;
 
 	/**
+	 * When using Hydrogen with session management it tries to keep
+	 * all central files within a session folder instead of using the
+	 * once found at the data folder at either user or system
+	 * level. This allows to zip and transfer a session without
+	 * requiring to move the whole data folder as well.
+	 *
+	 * As sample files can be quite large in both size and number the
+	 * drumkit is only linked into the session folder.
+	 *
+	 * This variable indicates whether a different drumkit was loaded
+	 * into the current song (by either directly loading a drumkit or
+	 * replacing the entire song) and thus a relinking is required
+	 * upon saving the song.
+	 */
+	bool			m_bSessionDrumkitNeedsRelinking;
+
+	/**
 	 * Onset of the recorded last in addRealtimeNote(). It is used to
 	 * determine the custom length of the note in case the note on
 	 * event is followed by a note off event.
 	 */
 	int				m_nLastRecordedMIDINoteTick;
-	/*
+	/**
 	 * Central instance of the audio engine. 
 	 */
 	AudioEngine*	m_pAudioEngine;
@@ -625,6 +645,13 @@ inline int Hydrogen::getSelectedPatternNumber() const
 inline int Hydrogen::getSelectedInstrumentNumber() const
 {
 	return m_nSelectedInstrumentNumber;
+}
+
+inline void Hydrogen::setSessionDrumkitNeedsRelinking( bool bNeedsRelinking ) {
+	m_bSessionDrumkitNeedsRelinking = bNeedsRelinking;
+}
+inline bool Hydrogen::getSessionDrumkitNeedsRelinking() const {
+	return m_bSessionDrumkitNeedsRelinking;
 }
 };
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -81,7 +81,7 @@ public:
 	/**
 	 * Returns the current Hydrogen instance #__instance.
 	 */
-	static Hydrogen*	get_instance(){ assert(__instance); return __instance; };
+	static Hydrogen*	get_instance(){ return __instance; };
 
 	/**
 	 * Destructor taking care of most of the clean up.

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -122,8 +122,13 @@ public:
 		/**
 		 * Sets the current song #__song to @a newSong.
 		 * \param newSong Pointer to the new Song object.
+		 * \param bRelinking Whether the drumkit last loaded should be
+		 * relinked when under session management. This flag is used
+		 * to distinguish between the regular load of a song file
+		 * within a session and its replacement by another song (which
+		 * requires an update of the linked drumkit).
 		 */
-		void			setSong	( std::shared_ptr<Song> newSong );
+		void			setSong	( std::shared_ptr<Song> newSong, bool bRelinking = true );
 
 	/**
 	 * Find a PatternList/column corresponding to the supplied tick
@@ -445,6 +450,8 @@ void			previewSample( Sample *pSample );
 
 	void			setSessionDrumkitNeedsRelinking( bool bNeedsRelinking );
 	bool			getSessionDrumkitNeedsRelinking() const;
+	void			setSessionIsExported( bool bIsExported );
+	bool			getSessionIsExported() const;
 
 	///midi lookuptable
 	int 			m_nInstrumentLookupTable[MAX_INSTRUMENTS];
@@ -572,6 +579,11 @@ private:
 	 * upon saving the song.
 	 */
 	bool			m_bSessionDrumkitNeedsRelinking;
+	/**
+	 * Indicates whether NSM session is saved or exported when entering
+	 * the CoreActionController::saveSong() function.
+	 */
+	bool			m_bSessionIsExported;
 
 	/**
 	 * Onset of the recorded last in addRealtimeNote(). It is used to
@@ -652,6 +664,12 @@ inline void Hydrogen::setSessionDrumkitNeedsRelinking( bool bNeedsRelinking ) {
 }
 inline bool Hydrogen::getSessionDrumkitNeedsRelinking() const {
 	return m_bSessionDrumkitNeedsRelinking;
+}
+inline void Hydrogen::setSessionIsExported( bool bSessionIsExported ) {
+	m_bSessionIsExported = bSessionIsExported;
+}
+inline bool Hydrogen::getSessionIsExported() const {
+	return m_bSessionIsExported;
 }
 };
 

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -290,6 +290,8 @@ void NsmClient::linkDrumkit( const QString& sName, bool bCheckLinkage ) {
 			}
 		}
 	}
+
+	pHydrogen->setSessionDrumkitNeedsRelinking( false );
 }
 
 void NsmClient::printError( const QString& msg ) {

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -260,11 +260,6 @@ void NsmClient::linkDrumkit( std::shared_ptr<H2Core::Song> pSong ) {
 			if ( sLinkedDrumkitName == sDrumkitName ) {
 				bRelinkDrumkit = false;
 			}
-			else {
-				NsmClient::printError( QString( "Linked [%1] and loaded [%2] drumkit do not match." )
-									   .arg( sLinkedDrumkitName )
-									   .arg( sDrumkitName ) );
-			}
 		}
 		else {
 			NsmClient::printError( "Symlink does not point to valid drumkit." );
@@ -318,7 +313,7 @@ void NsmClient::linkDrumkit( std::shared_ptr<H2Core::Song> pSong ) {
 
 	// Replace the temporary reference to the "global" drumkit to the
 	// (freshly) linked/found one in the session folder.
-	NsmClient::replaceDrumkitPath( pSong, sLinkedDrumkitPath );
+	NsmClient::replaceDrumkitPath( pSong, "./drumkit" );
 
 	pHydrogen->setSessionDrumkitNeedsRelinking( false );
 }
@@ -427,6 +422,7 @@ void NsmClient::replaceDrumkitPath( std::shared_ptr<H2Core::Song> pSong, const Q
 								QString sNewPath = QString( "%1/%2" )
 									.arg( sDrumkitPath )
 									.arg( pSample->get_filename() );
+
 								pSample->set_filepath( H2Core::Filesystem::prepare_sample_path( sNewPath ) );
 							}
 						}

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -217,27 +217,25 @@ void NsmClient::linkDrumkit( const QString& sName, bool bCheckLinkage ) {
 			// In case of a symbolic link, the target it is pointing to
 			// has to be resolved. If drumkit is a real folder, we will
 			// search for a drumkit.xml therein.
-			QString sDrumkitXMLPath;
+			QString sLinkedDrumkitPath;
 			if ( linkedDrumkitPathInfo.isSymLink() ) {
-				sDrumkitXMLPath = QString( "%1/%2" )
-					.arg( linkedDrumkitPathInfo.symLinkTarget() )
-					.arg( "drumkit.xml" );
+				sLinkedDrumkitPath = QString( "%1" )
+					.arg( linkedDrumkitPathInfo.symLinkTarget() );
 			} else {
-				sDrumkitXMLPath = QString( "%1/%2" )
-					.arg( sLinkedDrumkitPath ).arg( "drumkit.xml" );
+				sLinkedDrumkitPath = QString( "%1" )
+					.arg( sLinkedDrumkitPath );
 			}
-		
-			const QFileInfo drumkitXMLInfo( sDrumkitXMLPath );
-			if ( drumkitXMLInfo.exists() ) {
+	    
+			if ( H2Core::Filesystem::drumkit_valid( sLinkedDrumkitPath ) ) {
 
-				const QString sDrumkitNameXML = H2Core::Drumkit::loadNameFrom( sDrumkitXMLPath );
+				const QString sLinkedDrumkitName = H2Core::Drumkit::loadNameFrom( sLinkedDrumkitPath );
 	
-				if ( sDrumkitNameXML == sDrumkitName ) {
+				if ( sLinkedDrumkitName == sDrumkitName ) {
 					bRelinkDrumkit = false;
 				}
 				else {
 					NsmClient::printError( QString( "Linked [%1] and loaded [%2] drumkit do not match." )
-										   .arg( sDrumkitNameXML )
+										   .arg( sLinkedDrumkitName )
 										   .arg( sDrumkitName ) );
 				}
 			}

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -25,9 +25,14 @@
 #include "core/EventQueue.h"
 #include "core/Hydrogen.h"
 #include "core/Basics/Drumkit.h"
+#include "core/Basics/Instrument.h"
+#include "core/Basics/InstrumentComponent.h"
+#include "core/Basics/InstrumentLayer.h"
+#include "core/Basics/Sample.h"
 #include "core/Basics/Song.h"
 #include "core/AudioEngine/AudioEngine.h"
 #include "core/NsmClient.h"
+#include <core/SoundLibrary/SoundLibraryDatabase.h>
 
 #include <QDir>
 #include <QFile>
@@ -45,7 +50,8 @@ NsmClient::NsmClient()
 	: m_pNsm( nullptr ),
 	  m_bUnderSessionManagement( false ),
 	  m_NsmThread( 0 ),
-	  m_sSessionFolderPath( "" )
+	  m_sSessionFolderPath( "" ),
+	  m_bIsNewSession( false )
 {
 }
 
@@ -94,7 +100,7 @@ int NsmClient::OpenCallback( const char *name,
 
 	NsmClient::copyPreferences( name );
 
-	NsmClient::get_instance()->m_sSessionFolderPath = name;
+	NsmClient::get_instance()->setSessionFolderPath( name );
 	
 	const QFileInfo sessionPath( name );
 	const QString sSongPath = QString( "%1/%2%3" )
@@ -119,7 +125,8 @@ int NsmClient::OpenCallback( const char *name,
 		NsmClient::printError( "Preferences instance is not ready yet!" );
 		return ERR_NOT_NOW;
 	}
-	
+
+	bool bEmptySongOpened = false;
 	std::shared_ptr<H2Core::Song> pSong = nullptr;
 	if ( songFileInfo.exists() ) {
 
@@ -138,9 +145,20 @@ int NsmClient::OpenCallback( const char *name,
 			return ERR_LAUNCH_FAILED;
 		}
 		pSong->setFilename( sSongPath );
+		bEmptySongOpened = true;
+
+		// Mark empty song modified in order to emphasis that an
+		// initial song save is required to generate the song file and
+		// link the associated drumkit in the session folder.
+		pSong->setIsModified( true );
+		NsmClient::get_instance()->setIsNewSession( true );
+
+		// The drumkit of the new song will linked into the session
+		// folder during the next song save.
+		pHydrogen->setSessionDrumkitNeedsRelinking( true );
 	}
 
-	if ( ! pController->openSong( pSong ) ) {
+	if ( ! pController->openSong( pSong, false /*relinking*/ ) ) {
 			NsmClient::printError( "Unable to handle opening action!" );
 			return ERR_LAUNCH_FAILED;
 	}
@@ -196,53 +214,61 @@ void NsmClient::copyPreferences( const char* name ) {
 	NsmClient::printMessage( "Preferences loaded!" );
 }
 
-void NsmClient::linkDrumkit( const QString& sName, bool bCheckLinkage ) {	
+void NsmClient::linkDrumkit( std::shared_ptr<H2Core::Song> pSong ) {
 	
 	const auto pHydrogen = H2Core::Hydrogen::get_instance();
 	
 	bool bRelinkDrumkit = true;
 	
-	const QString sDrumkitName = pHydrogen->getLastLoadedDrumkitName();
-	const QString sDrumkitAbsPath = pHydrogen->getLastLoadedDrumkitPath();
+	const QString sDrumkitName = pSong->getLastLoadedDrumkitName();
+	const QString sDrumkitAbsPath = pSong->getLastLoadedDrumkitPath();
+
+	const QString sSessionFolder = NsmClient::get_instance()->getSessionFolderPath();
+
+	// Sanity check in order to avoid circular linking.
+	if ( sDrumkitAbsPath.contains( sSessionFolder, Qt::CaseInsensitive ) ) {
+		NsmClient::printError( QString( "Last loaded drumkit [%1] with absolute path [%2] is located within the session folder [%3]. Linking skipped." )
+							   .arg( sDrumkitName )
+							   .arg( sDrumkitAbsPath )
+							   .arg( sSessionFolder ) );
+		return;
+	}
 	
 	const QString sLinkedDrumkitPath = QString( "%1/%2" )
-		.arg( sName ).arg( "drumkit" );
+		.arg( sSessionFolder ).arg( "drumkit" );
 	const QFileInfo linkedDrumkitPathInfo( sLinkedDrumkitPath );
 
-	if ( bCheckLinkage ) {
-		// Check whether the linked folder is still valid.
-		if ( linkedDrumkitPathInfo.isSymLink() || 
-			 linkedDrumkitPathInfo.isDir() ) {
+	// Check whether the linked folder is still valid.
+	if ( linkedDrumkitPathInfo.isSymLink() || 
+		 linkedDrumkitPathInfo.isDir() ) {
 		
-			// In case of a symbolic link, the target it is pointing to
-			// has to be resolved. If drumkit is a real folder, we will
-			// search for a drumkit.xml therein.
-			QString sLinkedDrumkitPath;
-			if ( linkedDrumkitPathInfo.isSymLink() ) {
-				sLinkedDrumkitPath = QString( "%1" )
-					.arg( linkedDrumkitPathInfo.symLinkTarget() );
-			} else {
-				sLinkedDrumkitPath = QString( "%1" )
-					.arg( sLinkedDrumkitPath );
-			}
+		// In case of a symbolic link, the target it is pointing to
+		// has to be resolved. If drumkit is a real folder, we will
+		// search for a drumkit.xml therein.
+		QString sLinkedDrumkitPath;
+		if ( linkedDrumkitPathInfo.isSymLink() ) {
+			sLinkedDrumkitPath = QString( "%1" )
+				.arg( linkedDrumkitPathInfo.symLinkTarget() );
+		} else {
+			sLinkedDrumkitPath = QString( "%1" )
+				.arg( sLinkedDrumkitPath );
+		}
 	    
-			if ( H2Core::Filesystem::drumkit_valid( sLinkedDrumkitPath ) ) {
-
-				const QString sLinkedDrumkitName = H2Core::Drumkit::loadNameFrom( sLinkedDrumkitPath );
+		if ( H2Core::Filesystem::drumkit_valid( sLinkedDrumkitPath ) ) {
+			const QString sLinkedDrumkitName = H2Core::Drumkit::loadNameFrom( sLinkedDrumkitPath );
 	
-				if ( sLinkedDrumkitName == sDrumkitName ) {
-					bRelinkDrumkit = false;
-				}
-				else {
-					NsmClient::printError( QString( "Linked [%1] and loaded [%2] drumkit do not match." )
-										   .arg( sLinkedDrumkitName )
-										   .arg( sDrumkitName ) );
-				}
+			if ( sLinkedDrumkitName == sDrumkitName ) {
+				bRelinkDrumkit = false;
 			}
 			else {
-				NsmClient::printError( "Symlink does not point to valid drumkit." );
-			}				   
+				NsmClient::printError( QString( "Linked [%1] and loaded [%2] drumkit do not match." )
+									   .arg( sLinkedDrumkitName )
+									   .arg( sDrumkitName ) );
+			}
 		}
+		else {
+			NsmClient::printError( "Symlink does not point to valid drumkit." );
+		}				   
 	}
 	
 	// The symbolic link either does not exist, is not valid, or does
@@ -259,13 +285,14 @@ void NsmClient::linkDrumkit( const QString& sName, bool bCheckLinkage ) {
 				// renamed to 'drumkit' manually again.
 				QDir oldDrumkitFolder( sLinkedDrumkitPath );
 				if ( ! oldDrumkitFolder.rename( sLinkedDrumkitPath,
-												QString( "%1/drumkit_old" ).arg( sName ) ) ) {
+												QString( "%1/drumkit_old" )
+												.arg( sSessionFolder ) ) ) {
 					NsmClient::printError( QString( "Unable to rename drumkit folder [%1]." )
 										   .arg( sLinkedDrumkitPath ) );
 					return;
 				}
 			} else {
-				if ( !linkedDrumkitFile.remove() ) {
+				if ( ! linkedDrumkitFile.remove() ) {
 					NsmClient::printError( QString( "Unable to remove symlink to drumkit [%1]." )
 										   .arg( sLinkedDrumkitPath ) );
 					return;
@@ -289,7 +316,125 @@ void NsmClient::linkDrumkit( const QString& sName, bool bCheckLinkage ) {
 		}
 	}
 
+	// Replace the temporary reference to the "global" drumkit to the
+	// (freshly) linked/found one in the session folder.
+	NsmClient::replaceDrumkitPath( pSong, sLinkedDrumkitPath );
+
 	pHydrogen->setSessionDrumkitNeedsRelinking( false );
+}
+
+int NsmClient::dereferenceDrumkit( std::shared_ptr<H2Core::Song> pSong ) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	
+	if ( pSong == nullptr ) {
+		ERRORLOG( "no song set" );
+		return -1;
+	}
+
+	const QString sLastLoadedDrumkitPath = pSong->getLastLoadedDrumkitPath();
+	const QString sLastLoadedDrumkitName = pSong->getLastLoadedDrumkitName();
+
+	if ( ! sLastLoadedDrumkitPath.contains( NsmClient::get_instance()->
+											getSessionFolderPath(),
+											Qt::CaseInsensitive ) ) {
+		// Regular path. We do not have to alter it.
+		return 0;
+	}
+
+	const QFileInfo lastLoadedDrumkitInfo( sLastLoadedDrumkitPath );
+	if ( lastLoadedDrumkitInfo.isSymLink() ) {
+		
+		QString sDeferencedDrumkit = lastLoadedDrumkitInfo.symLinkTarget();
+
+		NsmClient::printMessage( QString( "Dereferencing linked drumkit to [%1]" )
+								 .arg( sDeferencedDrumkit ) );
+		NsmClient::replaceDrumkitPath( pSong, sDeferencedDrumkit );
+	}
+	else if ( lastLoadedDrumkitInfo.isDir() ) {
+		// Drumkit is not linked into the session folder but present
+		// within a directory (probably because the session was
+		// transfered from another device to recovered from a
+		// backup).
+		//
+		// This is a little bit tricky as we do not want to install
+		// the kit into the user's data folder on our own (loss of
+		// data etc.). If a kit containing the same name is present,
+		// we will assume the kits do match. That's nowhere near
+		// perfect but we are dealing with an edge-case of an
+		// edge-case in here anyway. If it not exists, we will prompt
+		// a warning dialog (via the GUI) asking the user to install
+		// it herself.
+		bool bDrumkitFound = false;
+		for ( const auto& pDrumkitEntry :
+				  pHydrogen->getSoundLibraryDatabase()->getDrumkitDatabase() ) {
+
+			auto pDrumkit = pDrumkitEntry.second;
+			if ( pDrumkit != nullptr ) {
+				if ( pDrumkit->get_name() == sLastLoadedDrumkitName ) {
+					NsmClient::replaceDrumkitPath( pSong, pDrumkitEntry.first );
+					bDrumkitFound = true;
+					break;
+						
+				}
+			}
+		}
+
+		if ( ! bDrumkitFound ) {
+			ERRORLOG( QString( "Drumkit used in session folder [%1] is not present on the current system. It has to be installed first in order to use the exported song" )
+					  .arg( sLastLoadedDrumkitName ) );
+			NsmClient::replaceDrumkitPath( pSong, "" );
+			return -2;
+		}
+		else {
+			INFOLOG( QString( "Drumkit used in session folder [%1] was dereferenced to [%2]" )
+					 .arg( sLastLoadedDrumkitName )
+					 .arg( pSong->getLastLoadedDrumkitPath() ) );
+		}
+	}
+	else {
+		ERRORLOG( "This should not happen" );
+		return -1;
+	}
+	return 0;
+}
+
+void NsmClient::replaceDrumkitPath( std::shared_ptr<H2Core::Song> pSong, const QString& sDrumkitPath ) {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+
+	// We are only replacing the paths corresponding to the drumkit
+	// which is either about to be linked into the session folder or
+	// the one which is supposed to replace the linked one.
+	const QString sDrumkitToBeReplaced = pSong->getLastLoadedDrumkitPath();
+	
+	pSong->setLastLoadedDrumkitPath( sDrumkitPath );
+
+	for ( auto pInstrument : *pSong->getInstrumentList() ) {
+		if ( pInstrument != nullptr &&
+			 pInstrument->get_drumkit_path() == sDrumkitToBeReplaced ) {
+
+			pInstrument->set_drumkit_path( sDrumkitPath );
+
+			// Use full paths in case the drumkit in sDrumkitPath is
+			// not located in either the user's or system's drumkit
+			// folder or just use the filenames (and load the
+			// relatively) otherwise.
+			for ( auto pComponent : *pInstrument->get_components() ) {
+				if ( pComponent != nullptr ) {
+					for ( auto pInstrumentLayer : *pComponent ) {
+						if ( pInstrumentLayer != nullptr ) {
+							auto pSample = pInstrumentLayer->get_sample();
+							if ( pSample != nullptr ) {
+								QString sNewPath = QString( "%1/%2" )
+									.arg( sDrumkitPath )
+									.arg( pSample->get_filename() );
+								pSample->set_filepath( H2Core::Filesystem::prepare_sample_path( sNewPath ) );
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 void NsmClient::printError( const QString& msg ) {

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -110,6 +110,24 @@ void SoundLibraryDatabase::updateDrumkits( bool bTriggerEvent ) {
 
 			m_drumkitDatabase[ sDrumkitPath ] = pDrumkit;
 		}
+		else {
+			ERRORLOG( QString( "Unable to load drumkit at [%1]" ).arg( sDrumkitPath ) );
+		}
+	}
+
+	if ( bTriggerEvent ) {
+		EventQueue::get_instance()->push_event( EVENT_SOUND_LIBRARY_CHANGED, 0 );
+	}
+}
+
+void SoundLibraryDatabase::updateDrumkit( const QString& sDrumkitPath, bool bTriggerEvent ) {
+
+	auto pDrumkit = Drumkit::load( sDrumkitPath );
+	if ( pDrumkit != nullptr ) {
+		m_drumkitDatabase[ sDrumkitPath ] = pDrumkit;
+	}
+	else {
+		ERRORLOG( QString( "Unable to load drumkit at [%1]" ).arg( sDrumkitPath ) );
 	}
 
 	if ( bTriggerEvent ) {

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -62,6 +62,7 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 	void update();
 
 	void updateDrumkits( bool bTriggerEvent = true );
+	void updateDrumkit( const QString& sDrumkitPath, bool bTriggerEvent = true );
 	std::shared_ptr<Drumkit> getDrumkit( const QString& sDrumkitPath );
 	const std::map<QString,std::shared_ptr<Drumkit>> getDrumkitDatabase() const {
 		return m_drumkitDatabase;

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -760,7 +760,8 @@ void MainForm::action_file_save_as()
 			// if required.
 			action_file_save( sNewFilename );
 		}
-	
+
+#ifdef H2CORE_HAVE_OSC
 		// When Hydrogen is under session management, we only copy a
 		// backup of the song to a different place but keep working on
 		// the original.
@@ -773,6 +774,9 @@ void MainForm::action_file_save_as()
 		else {
 			h2app->showStatusBarMessage( tr("Song saved as: ") + sDefaultFilename );
 		}
+#else
+		h2app->showStatusBarMessage( tr("Song saved as: ") + sDefaultFilename );
+#endif
 		
 		h2app->updateWindowTitle();
 	}

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -531,11 +531,6 @@ int main(int argc, char *argv[])
 
 		// Tell the core that the GUI is now fully loaded and ready.
 		pHydrogen->setGUIState( H2Core::Hydrogen::GUIState::ready );
-#ifdef H2CORE_HAVE_OSC
-		if ( NsmClient::get_instance() != nullptr ) {
-			NsmClient::get_instance()->sendDirtyState( false );
-		}
-#endif
 
 		if ( sShotList != QString() ) {
 			ShotList *sl = new ShotList( sShotList );
@@ -549,7 +544,24 @@ int main(int argc, char *argv[])
 		// the previous session.
 		if ( pHydrogen->getSong()->getFilename() !=
 			 H2Core::Filesystem::empty_song_path() ) {
+#ifdef H2CORE_HAVE_OSC
+			// Mark empty song created in a new NSM session modified
+			// in order to emphasis that an initial song save is
+			// required to generate the song file and link the
+			// associated drumkit in the session folder.
+			if ( NsmClient::get_instance() != nullptr &&
+				 NsmClient::get_instance()->getIsNewSession() ) {
+				
+				NsmClient::get_instance()->sendDirtyState( true );
+				pHydrogen->setIsModified( true );
+			}
+			else {
+				NsmClient::get_instance()->sendDirtyState( false );
+				pHydrogen->setIsModified( false );
+			}
+#else
 			pHydrogen->setIsModified( false );
+#endif
 		}
 
 		H2Core::Logger::setCrashContext( nullptr );


### PR DESCRIPTION
This PR fixes some parts of the NSM support that broke when `SoundLibraryDatabase` was introduced and also fixed a couple of other flaws I noticed. I have to admit that I'm displeased with how much our code base has to be interweaved with NSM support-code. But at least this is session protocol the linux community has agreed on.

The session (NSM) support of Hydrogen is designed to allow the application to retrieve all files required to make a song reproducible from a session folder. This includes either linking a drumkit from the data folder or supporting a
local drumkit directory (in order to make sessions portable).

The above mentioned feature was updated to work with the newly introduced `SoundLibraryDatabase`. In addition, the latter got a new function called `updateDrumkit` for a more efficient update of just a single kit corresponding to a provided path. It can also be used to load a new kit into the database.

The previous implementation also showed some inconsistencies that were fixed too. Whenever a drumkit or a new song with a different kit was loaded, the drumkit was immediately linked into the session folder. If, however, the user decided to discard those changes by closing the session without changing or an e.g. power outage occured, the song in the session got into a bricked state with new kit already linked but the .h2song file still containing references to the old one. This was solved by introducing a transient state into the session support. Whenever a different song or drumkit was loaded `Song::m_lastLoadedDrumkitPath` as well as the kit paths in the instruments were set to the ones corresponding to the drumkits in the data folder. This way the new kit could be used with the old one still linked into the session folder. In addition, a flag will be set that triggers relinking and the usage of session paths for the drumkit as soon as the session is saved. This way song and drumkit are always in sync and changes like song or drumkit importing can be reverted by aborting the session.

New session are adapted to the new concept of transient empty songs. Both song and drumkit will be stored/linked into the session folder at the first explicit save action of the user. To indicate that this is required, new songs under session management
are always flagged modified.

Also, xince the introduction of the `SoundLibraryDatabase` paths to drumkit folders are used as unique identifiers for drumkits. This, however, causes a number of problems in the NSM implementation. Absolute paths not only prevent the session from being portable, they also brick the .h2song in case the session gets renamed or duplicated. To avoid this, we now support drumkit and sample paths relative to the session folder.

(The autosave function does not trigger drumkit relinking)