### PR TITLE
Lazy background pixmap updating for better GUI performance

### DIFF
--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -114,7 +114,7 @@ void DrumPatternEditor::updateEditor( bool bPatternOnly )
 	resize( m_nEditorWidth, m_nEditorHeight );
 
 	// redraw all
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -1274,6 +1274,7 @@ void DrumPatternEditor::drawBackground( QPainter& p)
 }
 
 void DrumPatternEditor::createBackground() {
+	m_bBackgroundInvalid = false;
 
 	// Resize pixmap if pixel ratio has changed
 	qreal pixelRatio = devicePixelRatio();
@@ -1301,7 +1302,7 @@ void DrumPatternEditor::paintEvent( QPaintEvent* ev )
 	auto pPref = Preferences::get_instance();
 	
 	qreal pixelRatio = devicePixelRatio();
-	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() ) {
+	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() || m_bBackgroundInvalid ) {
 		createBackground();
 	}
 	

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1203,8 +1203,10 @@ void DrumPatternEditor::drawBackground( QPainter& p)
 	int nSelectedInstrument = pHydrogen->getSelectedInstrumentNumber();
 
 	p.fillRect(0, 0, m_nActiveWidth, m_nEditorHeight, backgroundColor);
-	// p.fillRect(m_nActiveWidth, 0, m_nEditorWidth - m_nActiveWidth, m_nEditorHeight,
-	// 		   backgroundInactiveColor);
+	if ( m_nActiveWidth < m_nEditorWidth ) {
+		p.fillRect(m_nActiveWidth, 0, m_nEditorWidth - m_nActiveWidth, m_nEditorHeight,
+				   backgroundInactiveColor);
+	}
 
 	for ( int ii = 0; ii < nInstruments; ii++ ) {
 		int y = static_cast<int>(m_nGridHeight) * ii;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -165,7 +165,7 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 
 	if ( bValueChanged ) {
 		addUndoAction();
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }
@@ -286,7 +286,7 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 	}
 
 	if ( bValueChanged ) {
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }
@@ -294,7 +294,7 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 void NotePropertiesRuler::selectionMoveEndEvent( QInputEvent *ev ) {
 	//! The "move" has already been reflected in the notes. Now just complete Undo event.
 	addUndoAction();
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -369,7 +369,7 @@ void NotePropertiesRuler::propertyDragStart( QMouseEvent *ev )
 {
 	setCursor( Qt::CrossCursor );
 	prepareUndoAction( ev->x() );
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -529,7 +529,7 @@ void NotePropertiesRuler::propertyDragUpdate( QMouseEvent *ev )
 	}
 
 	m_nDragPreviousColumn = nColumn;
-	createBackground();
+	invalidateBackground();
 	update();
 
 	m_pPatternEditorPanel->getPianoRollEditor()->updateEditor();
@@ -540,7 +540,7 @@ void NotePropertiesRuler::propertyDragEnd()
 {
 	addUndoAction();
 	unsetCursor();
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -826,7 +826,7 @@ void NotePropertiesRuler::keyPressEvent( QKeyEvent *ev )
 	m_selection.updateKeyboardCursorPosition( getKeyboardCursorRect() );
 	
 	if ( bValueChanged ) {
-		createBackground();
+		invalidateBackground();
 	}
 	update();
 	
@@ -886,7 +886,7 @@ void NotePropertiesRuler::paintEvent( QPaintEvent *ev)
 	auto pPref = Preferences::get_instance();
 	
 	qreal pixelRatio = devicePixelRatio();
-	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() ) {
+	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() || m_bBackgroundInvalid ) {
 		createBackground();
 	}
 
@@ -1416,7 +1416,7 @@ void NotePropertiesRuler::updateEditor( bool )
 		m_nActiveWidth = m_nEditorWidth;
 	}
 
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -1446,6 +1446,7 @@ void NotePropertiesRuler::createBackground()
 		createNoteKeyBackground( m_pBackgroundPixmap );
 	}
 	update();
+	m_bBackgroundInvalid = false;
 }
 
 
@@ -1497,7 +1498,7 @@ std::vector<NotePropertiesRuler::SelectionIndex> NotePropertiesRuler::elementsIn
 	}
 
 	// Updating selection, we may need to repaint the whole widget.
-	createBackground();
+	invalidateBackground();
 	update();
 
 	return std::move(result);
@@ -1523,7 +1524,7 @@ void NotePropertiesRuler::onPreferencesChanged( H2Core::Preferences::Changes cha
 	if ( changes & ( H2Core::Preferences::Changes::Colors |
 					 H2Core::Preferences::Changes::Font ) ) {
 
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -812,10 +812,8 @@ void PatternEditor::focusInEvent( QFocusEvent *ev ) {
 		m_pPatternEditorPanel->getPatternEditorRuler()->update();
 		m_pPatternEditorPanel->getInstrumentList()->update();
 	}
-	
-	// If there are some patterns selected, we have to switch their
-	// border color inactive <-> active.
-	createBackground();
+
+	// Update to show the focus border highlight
 	update();
 }
 
@@ -826,9 +824,7 @@ void PatternEditor::focusOutEvent( QFocusEvent *ev ) {
 		m_pPatternEditorPanel->getInstrumentList()->update();
 	}
 	
-	// If there are some patterns selected, we have to switch their
-	// border color inactive <-> active.
-	createBackground();
+	// Update to remove the focus border highlight
 	update();
 }
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -95,6 +95,7 @@ PatternEditor::PatternEditor( QWidget *pParent,
 	m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
 									   height() * pixelRatio );
 	m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
+	m_bBackgroundInvalid = true;
 }
 
 PatternEditor::~PatternEditor()
@@ -826,6 +827,10 @@ void PatternEditor::focusOutEvent( QFocusEvent *ev ) {
 	
 	// Update to remove the focus border highlight
 	update();
+}
+
+void PatternEditor::invalidateBackground() {
+	m_bBackgroundInvalid = true;
 }
 
 void PatternEditor::createBackground() {

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -272,7 +272,9 @@ protected:
 
 	/** Updates #m_pBackgroundPixmap to show the latest content. */
 	virtual void createBackground();
+	void invalidateBackground();
 	QPixmap *m_pBackgroundPixmap;
+	bool m_bBackgroundInvalid;
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -942,6 +942,13 @@ void PatternEditorPanel::patternModifiedEvent() {
 	selectedPatternChangedEvent();
 }
 
+void PatternEditorPanel::patternChangedEvent() {
+	if ( Hydrogen::get_instance()->getPatternMode() ==
+		 Song::PatternMode::Stacked ) {
+		updateEditors( true );
+	}
+}
+
 void PatternEditorPanel::songModeActivationEvent() {
 	if ( Hydrogen::get_instance()->getPatternMode() ==
 		 Song::PatternMode::Stacked ) {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -942,10 +942,6 @@ void PatternEditorPanel::patternModifiedEvent() {
 	selectedPatternChangedEvent();
 }
 
-void PatternEditorPanel::patternChangedEvent() {
-	updateEditors( true );
-}
-
 void PatternEditorPanel::songModeActivationEvent() {
 	if ( Hydrogen::get_instance()->getPatternMode() ==
 		 Song::PatternMode::Stacked ) {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -90,7 +90,6 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void patternModifiedEvent() override;
-	virtual void patternChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
 	virtual void updateSongEvent( int nValue ) override;
 	virtual void songModeActivationEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -90,6 +90,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void patternModifiedEvent() override;
+	virtual void patternChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
 	virtual void updateSongEvent( int nValue ) override;
 	virtual void songModeActivationEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -306,11 +306,16 @@ void PatternEditorRuler::updateEditor( bool bRedrawAll )
 	updatePosition();
 	
 	if (bRedrawAll) {
-		createBackground();
+		invalidateBackground();
 		update( 0, 0, width(), height() );
 	}
 }
 
+
+void PatternEditorRuler::invalidateBackground()
+{
+	m_bBackgroundInvalid = true;
+}
 
 void PatternEditorRuler::createBackground()
 {
@@ -394,6 +399,7 @@ void PatternEditorRuler::createBackground()
 	painter.drawLine( 0, m_nRulerHeight, m_nRulerWidth, m_nRulerHeight);
 	painter.drawLine( m_nRulerWidth, 0, m_nRulerWidth, m_nRulerHeight );
 
+	m_bBackgroundInvalid = false;
 }
 
 
@@ -413,7 +419,7 @@ void PatternEditorRuler::paintEvent( QPaintEvent *ev)
 	}
 
 	qreal pixelRatio = devicePixelRatio();
-	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() ) {
+	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() || m_bBackgroundInvalid ) {
 		createBackground();
 	}
 
@@ -516,7 +522,7 @@ void PatternEditorRuler::updateActiveRange() {
 	if ( m_nWidthActive != nWidthActive ) {
 		m_nWidthActive = nWidthActive;
 
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }
@@ -533,7 +539,7 @@ void PatternEditorRuler::zoomIn()
 
 	updateActiveRange();
 	
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -551,7 +557,7 @@ void PatternEditorRuler::zoomOut()
 		
 		updateActiveRange();
 		
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }

--- a/src/gui/src/PatternEditor/PatternEditorRuler.h
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.h
@@ -80,6 +80,8 @@ class PatternEditorRuler :  public QWidget, protected WidgetWithScalableFont<8, 
 		};
 
 		void createBackground();
+		void invalidateBackground();
+		bool m_bBackgroundInvalid;
 
 	public slots:
 		void updateEditor( bool bRedrawAll = false );

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -155,7 +155,7 @@ void PianoRollEditor::paintEvent(QPaintEvent *ev)
 	auto pPref = Preferences::get_instance();
 	
 	qreal pixelRatio = devicePixelRatio();
-	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() ) {
+	if ( pixelRatio != m_pBackgroundPixmap->devicePixelRatio() || m_bBackgroundInvalid ) {
 		createBackground();
 	}
 
@@ -354,6 +354,8 @@ void PianoRollEditor::createBackground()
 	
 	p.setPen( QPen( lineColor, 2, Qt::SolidLine ) );
 	p.drawLine( m_nEditorWidth, 0, m_nEditorWidth, m_nEditorHeight );
+
+	m_bBackgroundInvalid = false;
 }
 
 
@@ -1250,7 +1252,7 @@ void PianoRollEditor::onPreferencesChanged( H2Core::Preferences::Changes changes
 {
 	if ( changes & ( H2Core::Preferences::Changes::Colors |
 					 H2Core::Preferences::Changes::Font ) ) {
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -991,6 +991,10 @@ void SongEditor::updatePosition( float fTick ) {
 
 void SongEditor::paintEvent( QPaintEvent *ev )
 {
+	if ( m_bBackgroundInvalid ) {
+		createBackground();
+	}
+
 	// ridisegno tutto solo se sono cambiate le note
 	if (m_bSequenceChanged) {
 		m_bSequenceChanged = false;
@@ -1159,19 +1163,11 @@ void SongEditor::createBackground()
 
 	//~ celle
 	m_bSequenceChanged = true;
+
 }
 
 void SongEditor::invalidateBackground() {
-	static int n = 0;
 	m_bBackgroundInvalid = true;
-}
-
-void SongEditor::cleanUp(){
-
-	delete m_pBackgroundPixmap;
-	m_pBackgroundPixmap = nullptr;
-	delete m_pSequencePixmap;
-	m_pSequencePixmap = nullptr;
 }
 
 // Update the GridCell representation.
@@ -1224,9 +1220,6 @@ void SongEditor::drawSequence()
 {
 	QPainter p;
 
-	if ( m_bBackgroundInvalid ) {
-		createBackground();
-	}
 	p.begin( m_pSequencePixmap );
 	p.drawPixmap( rect(), *m_pBackgroundPixmap, rect() );
 	p.end();
@@ -2408,7 +2401,7 @@ void SongEditorPatternList::onPreferencesChanged( H2Core::Preferences::Changes c
 	if ( changes & ( H2Core::Preferences::Changes::Colors |
 					 H2Core::Preferences::Changes::Font ) ) {
 		
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }
@@ -2478,7 +2471,7 @@ void SongEditorPositionRuler::relocationEvent() {
 
 void SongEditorPositionRuler::songSizeChangedEvent() {
 	m_nActiveColumns = m_pHydrogen->getSong()->getPatternGroupVector()->size();
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -2494,11 +2487,14 @@ void SongEditorPositionRuler::setGridWidth( uint width )
 		m_nGridWidth = width;
 		resize( SongEditor::nMargin +
 				Preferences::get_instance()->getMaxBars() * m_nGridWidth, height() );
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }
 
+void SongEditorPositionRuler::invalidateBackground() {
+	m_bBackgroundInvalid = true;
+}
 
 void SongEditorPositionRuler::createBackground()
 {
@@ -2620,6 +2616,8 @@ void SongEditorPositionRuler::createBackground()
 	p.drawLine( 0, 0, width(), 0 );
 	p.drawLine( 0, height() - 25, width(), height() - 25 );
 	p.drawLine( 0, height(), width(), height() );
+
+	m_bBackgroundInvalid = false;
 }
 
 void SongEditorPositionRuler::tempoChangedEvent( int ) {
@@ -2635,7 +2633,7 @@ void SongEditorPositionRuler::tempoChangedEvent( int ) {
 		return;
 	}
 
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -2714,17 +2712,17 @@ bool SongEditorPositionRuler::event( QEvent* ev ) {
 
 void SongEditorPositionRuler::songModeActivationEvent() {
 	updatePosition();
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
 void SongEditorPositionRuler::timelineActivationEvent() {
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
 void SongEditorPositionRuler::jackTimebaseStateChangedEvent() {
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -2843,6 +2841,10 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	auto pTimeline = m_pHydrogen->getTimeline();
 	auto pPref = Preferences::get_instance();
 	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();
+
+	if ( m_bBackgroundInvalid ) {
+		createBackground();
+	}
 	
 	if (!isVisible()) {
 		return;
@@ -3179,7 +3181,7 @@ void SongEditorPositionRuler::updatePosition()
 
 void SongEditorPositionRuler::timelineUpdateEvent( int nValue )
 {
-	createBackground();
+	invalidateBackground();
 	update();
 }
 
@@ -3190,7 +3192,7 @@ void SongEditorPositionRuler::onPreferencesChanged( H2Core::Preferences::Changes
 			 
 		resize( SongEditor::nMargin +
 				Preferences::get_instance()->getMaxBars() * m_nGridWidth, height() );
-		createBackground();
+		invalidateBackground();
 		update();
 	}
 }

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -84,6 +84,7 @@ class SongEditor : public QWidget
 		~SongEditor();
 
 		void createBackground();
+		void invalidateBackground();
 	void updatePosition( float fTick );
 		
 		void cleanUp();
@@ -143,6 +144,8 @@ class SongEditor : public QWidget
 		bool 					m_bSequenceChanged;
 
 		QMenu *					m_pPopupMenu;
+
+		bool m_bBackgroundInvalid;
 
 
 		//! @name Background pixmap caching
@@ -216,7 +219,6 @@ class SongEditor : public QWidget
 	/** Cached position of the playhead.*/
 	float m_fTick;
 public:
-	void patternModifiedEvent() override;
 
 		//! @name Selection interfaces
 		//! see Selection.h for details.
@@ -270,6 +272,7 @@ class SongEditorPatternList :  public QWidget
 
 		void updateEditor();
 		void createBackground();
+		void invalidateBackground();
 		void movePatternLine( int, int );
 		void acceptPatternPropertiesDialogSettings( QString newPatternName, QString newPatternInfo, QString newPatternCategory, int patternNr );
 		void revertPatternPropertiesDialogSettings(QString oldPatternName, QString oldPatternInfo, QString oldPatternCategory, int patternNr);
@@ -308,6 +311,7 @@ class SongEditorPatternList :  public QWidget
 		static const uint 	m_nInitialHeight = 10;
 
 		QPixmap *			m_pBackgroundPixmap;
+		bool m_bBackgroundInvalid;
 							
 		QPixmap				m_labelBackgroundLight;
 		QPixmap				m_labelBackgroundDark;

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -85,9 +85,7 @@ class SongEditor : public QWidget
 
 		void createBackground();
 		void invalidateBackground();
-	void updatePosition( float fTick );
-		
-		void cleanUp();
+		void updatePosition( float fTick );
 
 		int getGridWidth ();
 		void setGridWidth( uint width);
@@ -386,6 +384,7 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 		void showBpmWidget( int nColumn );
 		void onPreferencesChanged( H2Core::Preferences::Changes changes );
 		void createBackground();
+		void invalidateBackground();
 
 	private:
 		H2Core::Hydrogen* 		m_pHydrogen;
@@ -423,6 +422,7 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 	int m_nActiveColumns;
 
 		QPixmap *			m_pBackgroundPixmap;
+		bool 				m_bBackgroundInvalid;
 		bool				m_bRightBtnPressed;
 		
 		virtual void mouseMoveEvent(QMouseEvent *ev) override;

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -548,12 +548,10 @@ void SongEditorPanel::updateAll()
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 
-	m_pPatternList->createBackground();
+	m_pPatternList->invalidateBackground();
 	m_pPatternList->update();
 
-	m_pSongEditor->cleanUp();
-
-	m_pSongEditor->createBackground();
+	m_pSongEditor->invalidateBackground();
 	m_pSongEditor->update();
 
 	updatePositionRuler();
@@ -610,7 +608,7 @@ void SongEditorPanel::updatePlaybackTrackIfNecessary()
 
 void SongEditorPanel::updatePositionRuler()
 {
-	m_pPositionRuler->createBackground();
+	m_pPositionRuler->invalidateBackground();
 }
 
 ///


### PR DESCRIPTION
Defer background pixmap recalculation for more GUI widgets until repaint. This helps reduce the CPU time taken if transport time jitter causes multiple pattern change events to be emitted.