### PR TITLE
Fixing non-functional AudioEngine test and bugs uncovered on the way

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1906,26 +1906,30 @@ void AudioEngine::updateSongSize() {
 
 	bool bEndOfSongReached = false;
 
-	double fNewSongSizeInTicks = static_cast<double>( pSong->lengthInTicks() );
-
-	// WARNINGLOG( QString( "[Before] frame: %1, bpm: %2, tickSize: %3, column: %4, tick: %5, mod(tick): %6, pTickPos: %7, pStartPos: %8, m_fLastTickIntervalEnd: %9, m_fSongSizeInTicks: %10" )
-	// 			.arg( getFrames() ).arg( getBpm() )
-	// 			.arg( getTickSize(), 0, 'f' )
-	// 			.arg( m_nColumn )
-	// 			.arg( getDoubleTick(), 0, 'g', 30 )
-	// 			.arg( std::fmod( getDoubleTick(), m_fSongSizeInTicks ), 0, 'g', 30 )
-	// 			.arg( m_nPatternTickPosition )
-	// 			.arg( m_nPatternStartTick )
-	// 			.arg( m_fLastTickIntervalEnd )
-	// 			.arg( m_fSongSizeInTicks )
-	// 			);
+	const double fNewSongSizeInTicks = static_cast<double>( pSong->lengthInTicks() );
 
 	// Strip away all repetitions when in loop mode but keep their
 	// number. m_nPatternStartTick and m_nColumn are only defined
 	// between 0 and m_fSongSizeInTicks.
 	double fNewTick = std::fmod( getDoubleTick(), m_fSongSizeInTicks );
-	double fRepetitions =
+	const double fRepetitions =
 		std::floor( getDoubleTick() / m_fSongSizeInTicks );
+
+	// WARNINGLOG( QString( "[Before] getFrames(): %1, getBpm(): %2, getTickSize(): %3, m_nColumn: %4, getDoubleTick(): %5, fNewTick: %6, fRepetitions: %7. m_nPatternTickPosition: %8, m_nPatternStartTick: %9, m_fLastTickIntervalEnd: %10, m_fSongSizeInTicks: %11, fNewSongSizeInTicks: %12, m_nFrameOffset: %13, m_fTickMismatch: %14" )
+	// 			.arg( getFrames() ).arg( getBpm() )
+	// 			.arg( getTickSize(), 0, 'f' )
+	// 			.arg( m_nColumn )
+	// 			.arg( getDoubleTick(), 0, 'g', 30 )
+	// 			.arg( fNewTick, 0, 'g', 30 )
+	// 			.arg( fRepetitions, 0, 'f' )
+	// 			.arg( m_nPatternTickPosition )
+	// 			.arg( m_nPatternStartTick )
+	// 			.arg( m_fLastTickIntervalEnd )
+	// 			.arg( m_fSongSizeInTicks )
+	// 			.arg( fNewSongSizeInTicks )
+	// 			.arg( m_nFrameOffset )
+	// 			.arg( m_fTickMismatch )
+	// 			);
 
 	m_fSongSizeInTicks = fNewSongSizeInTicks;
 
@@ -1945,7 +1949,7 @@ void AudioEngine::updateSongSize() {
 	// We strive for consistency in audio playback and make both the
 	// current column/pattern and the transport position within the
 	// pattern invariant in this transformation.
-	long nNewPatternStartTick = pHydrogen->getTickForColumn( getColumn() );
+	const long nNewPatternStartTick = pHydrogen->getTickForColumn( getColumn() );
 
 	if ( nNewPatternStartTick == -1 ) {
 		bEndOfSongReached = true;
@@ -1965,7 +1969,7 @@ void AudioEngine::updateSongSize() {
 	fNewTick += fRepetitions * fNewSongSizeInTicks;
 	
 	// Ensure transport state is consistent
-	long long nNewFrames = computeFrameFromTick( fNewTick, &m_fTickMismatch );
+	const long long nNewFrames = computeFrameFromTick( fNewTick, &m_fTickMismatch );
 
 	m_nFrameOffset = nNewFrames - getFrames() + m_nFrameOffset;
 	m_fTickOffset = fNewTick - getDoubleTick();
@@ -1977,16 +1981,17 @@ void AudioEngine::updateSongSize() {
 	m_fTickOffset = std::round( m_fTickOffset );
 	m_fTickOffset *= 1e-8;
 		
-	// INFOLOG(QString( "[update] nNewFrame: %1, old frame: %2, frame offset: %3, new tick: %4, old tick: %5, tick offset : %6, tick offset (without rounding): %7, fNewSongSizeInTicks: %8, fRepetitions: %9")
-	// 		 .arg( nNewFrames ).arg( getFrames() )
-	// 		 .arg( m_nFrameOffset )
-	// 		 .arg( fNewTick, 0, 'g', 30 )
-	// 		 .arg( getDoubleTick(), 0, 'g', 30 )
-	// 		 .arg( m_fTickOffset, 0, 'g', 30 )
+	// INFOLOG(QString( "[update] nNewFrame: %1, getFrames() (old): %2, m_nFrameOffset: %3, fNewTick: %4, getDoubleTick() (old): %5, m_fTickOffset : %6, tick offset (without rounding): %7, fNewSongSizeInTicks: %8, fRepetitions: %9")
+	// 		.arg( nNewFrames )
+	// 		.arg( getFrames() )
+	// 		.arg( m_nFrameOffset )
+	// 		.arg( fNewTick, 0, 'g', 30 )
+	// 		.arg( getDoubleTick(), 0, 'g', 30 )
+	// 		.arg( m_fTickOffset, 0, 'g', 30 )
 	// 		.arg( fNewTick - getDoubleTick(), 0, 'g', 30 )
-	// 		 .arg( fNewSongSizeInTicks, 0, 'g', 30 )
-	// 		 .arg( fRepetitions, 0, 'g', 30 )
-	// 		 );
+	// 		.arg( fNewSongSizeInTicks, 0, 'g', 30 )
+	// 		.arg( fRepetitions, 0, 'g', 30 )
+	// 		);
 
 	setFrames( nNewFrames );
 	setTick( fNewTick );
@@ -2010,13 +2015,21 @@ void AudioEngine::updateSongSize() {
 		locate( 0 );
 	}
 
-	// WARNINGLOG( QString( "[After] frame: %1, bpm: %2, tickSize: %3, column: %4, tick: %5, pTickPos: %6, pStartPos: %7, m_fLastTickIntervalEnd: %8" )
+	// WARNINGLOG( QString( "[After] getFrames(): %1, getBpm(): %2, getTickSize(): %3, m_nColumn: %4, getDoubleTick(): %5, fNewTick: %6, fRepetitions: %7. m_nPatternTickPosition: %8, m_nPatternStartTick: %9, m_fLastTickIntervalEnd: %10, m_fSongSizeInTicks: %11, fNewSongSizeInTicks: %12, m_nFrameOffset: %13, m_fTickMismatch: %14" )
 	// 			.arg( getFrames() ).arg( getBpm() )
 	// 			.arg( getTickSize(), 0, 'f' )
-	// 			.arg( m_nColumn ).arg( getDoubleTick(), 0, 'f' )
+	// 			.arg( m_nColumn )
+	// 			.arg( getDoubleTick(), 0, 'g', 30 )
+	// 			.arg( fNewTick, 0, 'g', 30 )
+	// 			.arg( fRepetitions, 0, 'f' )
 	// 			.arg( m_nPatternTickPosition )
 	// 			.arg( m_nPatternStartTick )
-	// 			.arg( m_fLastTickIntervalEnd ) );
+	// 			.arg( m_fLastTickIntervalEnd )
+	// 			.arg( m_fSongSizeInTicks )
+	// 			.arg( fNewSongSizeInTicks )
+	// 			.arg( m_nFrameOffset )
+	// 			.arg( m_fTickMismatch )
+	// 			);
 	
 }
 
@@ -2282,12 +2295,16 @@ long long AudioEngine::computeTickInterval( double* fTickStart, double* fTickEnd
 		nFrameStart += nLookahead;
 	}
 	
-	*fTickStart = computeTickFromFrame( nFrameStart );
-	*fTickEnd = computeTickFromFrame( nFrameEnd );
+	*fTickStart = computeTickFromFrame( nFrameStart ) + m_fTickMismatch;
+	*fTickEnd = computeTickFromFrame( nFrameEnd ) + m_fTickMismatch;
 
-	// INFOLOG( QString( "nFrameStart: %1, nFrameEnd: %2, fTickStart: %3, fTickEnd: %4" )
-	// 		 .arg( nFrameStart ).arg( nFrameEnd )
-	// 		 .arg( *fTickStart, 0, 'f' ).arg( *fTickEnd, 0, 'f' ) );
+	// INFOLOG( QString( "nFrameStart: %1, nFrameEnd: %2, fTickStart: %3, fTickEnd: %4, m_fTickMismatch: %5" )
+	// 		 .arg( nFrameStart )
+	// 		 .arg( nFrameEnd )
+	// 		 .arg( *fTickStart, 0, 'f' )
+	// 		 .arg( *fTickEnd, 0, 'f' )
+	// 		 .arg( m_fTickMismatch, 0, 'f' )
+	// 		 );
 
 	if ( getState() == State::Playing || getState() == State::Testing ) {
 		// If there was a change in ticksize, account for the last used

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -4244,9 +4244,9 @@ bool AudioEngine::testToggleAndCheckConsistency( int nToggleColumn, int nToggleR
 	
 	updateNoteQueue( nBufferSize );
 
-	auto prevNotes = testCopySongNoteQueue();
-
 	processAudio( nBufferSize );
+
+	auto prevNotes = testCopySongNoteQueue();
 
 	// Cache some stuff in order to compare it later on.
 	long nOldSongSize = pSong->lengthInTicks();

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1657,7 +1657,10 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 
 		if ( dynamic_cast<FakeDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
 			___INFOLOG( "End of song." );
-			
+
+			// TODO: This part of the code might not be reached
+			// anymore.
+			pAudioEngine->unlock();
 			return 1;	// kill the audio AudioDriver thread
 		}
 	}

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -725,7 +725,14 @@ private:
 	 */
 	void handleDriverChange();
 	
-	/** Helper function */
+	/**
+	 * Checks the consistency of the current transport position by
+	 * converting the current tick, frame, column, pattern start tick
+	 * etc. into each other and comparing the results. 
+	 *
+	 * \param sContext String identifying the calling function and
+	 * used for logging
+	 */
 	bool testCheckTransportPosition( const QString& sContext ) const;
 	/**
 	 * Takes two instances of Sampler::m_playingNotesQueue and checks

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -632,22 +632,23 @@ private:
 	 * Apart from the MIDI queue, the extraction of all notes will be
 	 * based on their position measured in ticks. Since Hydrogen does
 	 * support humanization, which also involves triggering a Note
-	 * earlier or later than its actual position, the loop over all ticks
-	 * won't be done starting from the current position but at some
-	 * position in the future. This value, also called @e lookahead, is
-	 * set to the sum of the maximum offsets introduced by both the random
-	 * humanization (2000 frames) and the deterministic lead-lag offset (5
-	 * times TransportInfo::m_nFrames) plus 1 (note that it's not given in
-	 * ticks but in frames!). Hydrogen thus loops over @a nFrames frames
-	 * starting at the current position + the lookahead (or at 0 when at
-	 * the beginning of the Song).
+	 * earlier or later than its actual position, the loop over all
+	 * ticks won't be done starting from the current position but at
+	 * some position in the future. This value, also called @e
+	 * lookahead, is set to the sum of the maximum offsets introduced
+	 * by both the random humanization (2000 frames) and the
+	 * deterministic lead-lag offset (5 times
+	 * TransportInfo::m_nFrames) plus 1 (note that it's not given in
+	 * ticks but in frames!). Hydrogen thus loops over @a
+	 * nIntervalLengthInFrames frames starting at the current position
+	 * + the lookahead (or at 0 when at the beginning of the Song).
 	 *
 	 * \return
 	 * - -1 if in Song::SONG_MODE and no patterns left.
 	 */
-	int				updateNoteQueue( unsigned nFrames );
+	int				updateNoteQueue( unsigned nIntervalLengthInFrames );
 	void 			processAudio( uint32_t nFrames );
-	long long 		computeTickInterval( double* fTickStart, double* fTickEnd, unsigned nFrames );
+	long long 		computeTickInterval( double* fTickStart, double* fTickEnd, unsigned nIntervalLengthInFrames );
     
 	void			updateBpmAndTickSize();
 	
@@ -742,7 +743,7 @@ private:
 	 * nToggleRow twice and checks whether the transport position and
 	 * the audio processing remains consistent.
 	 */
-	bool testCheckConsistency( int nToggleColumn, int nToggleRow, const QString& sContext );
+	bool testToggleAndCheckConsistency( int nToggleColumn, int nToggleRow, const QString& sContext );
 	
 	std::vector<std::shared_ptr<Note>> testCopySongNoteQueue();
 	/**

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -40,9 +40,12 @@ void TransportTest::setUp(){
 	m_pSongDemo = Song::load( QString( "%1/GM_kit_demo3.h2song" ).arg( Filesystem::demos_dir() ) );
 
 	m_pSongSizeChanged = Song::load( QString( H2TEST_FILE( "song/AE_songSizeChanged.h2song" ) ) );
+	m_pSongNoteEnqueuing = Song::load( QString( H2TEST_FILE( "song/AE_noteEnqueuing.h2song" ) ) );
 
 	CPPUNIT_ASSERT( m_pSongDemo != nullptr );
 	CPPUNIT_ASSERT( m_pSongSizeChanged != nullptr );
+	CPPUNIT_ASSERT( m_pSongNoteEnqueuing != nullptr );
+
 	Preferences::get_instance()->m_bUseMetronome = false;
 }
 
@@ -129,6 +132,15 @@ void TransportTest::testSongSizeChange() {
 
 	pCoreActionController->openSong( m_pSongSizeChanged );
 
+	// Depending on buffer size and sample rate transport might be
+	// loop when toggling a pattern at the end of the song. If there
+	// were tempo markers present, the chunk of the interval covered
+	// by AudioEngine::computeTickInterval being looped would have a
+	// different tickSize than its first part. This is itself no
+	// problem but it would make the test much more complex as we test
+	// against those calculated intervals to remain constant.
+	pCoreActionController->activateTimeline( false );
+
 	for ( int ii = 0; ii < 15; ++ii ) {
 		TestHelper::varyAudioDriverConfig( ii );
 		
@@ -160,7 +172,7 @@ void TransportTest::testNoteEnqueuing() {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 
-	pHydrogen->getCoreActionController()->openSong( m_pSongSizeChanged );
+	pHydrogen->getCoreActionController()->openSong( m_pSongNoteEnqueuing );
 
 	// This test is quite time consuming.
 	std::vector<int> indices{ 0, 1, 2, 5, 7, 9, 12, 15 };

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -125,20 +125,22 @@ void TransportTest::testComputeTickInterval() {
 void TransportTest::testSongSizeChange() {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
+	auto pCoreActionController = pHydrogen->getCoreActionController();
 
-	pHydrogen->getCoreActionController()->openSong( m_pSongSizeChanged );
+	pCoreActionController->openSong( m_pSongSizeChanged );
 
 	for ( int ii = 0; ii < 15; ++ii ) {
+		TestHelper::varyAudioDriverConfig( ii );
+		
 		// For larger sample rates no notes will remain in the
 		// AudioEngine::m_songNoteQueue after one process step.
 		if ( H2Core::Preferences::get_instance()->m_nSampleRate <= 48000 ) {
-			TestHelper::varyAudioDriverConfig( ii );
 			bool bNoMismatch = pAudioEngine->testSongSizeChange();
 			CPPUNIT_ASSERT( bNoMismatch );
 		}
 	}
-
-	pHydrogen->getCoreActionController()->activateLoopMode( false );
+	
+	pCoreActionController->activateLoopMode( false );
 }		
 
 void TransportTest::testSongSizeChangeInLoopMode() {

--- a/src/tests/TransportTest.h
+++ b/src/tests/TransportTest.h
@@ -39,7 +39,8 @@ class TransportTest : public CppUnit::TestFixture {
 private:
 	std::shared_ptr<H2Core::Song> m_pSongDemo;
 	std::shared_ptr<H2Core::Song> m_pSongSizeChanged;
-	
+	std::shared_ptr<H2Core::Song> m_pSongNoteEnqueuing;
+
 public:
 	void setUp();
 	void tearDown();

--- a/src/tests/data/song/AE_noteEnqueuing.h2song
+++ b/src/tests/data/song/AE_noteEnqueuing.h2song
@@ -15,7 +15,7 @@
  <playbackTrackVolume>0</playbackTrackVolume>
  <action_mode>0</action_mode>
  <isPatternEditorLocked>false</isPatternEditorLocked>
- <isTimelineActivated>false</isTimelineActivated>
+ <isTimelineActivated>true</isTimelineActivated>
  <mode>song</mode>
  <pan_law_type>RATIO_STRAIGHT_POLYGONAL</pan_law_type>
  <pan_law_k_norm>1.33333</pan_law_k_norm>
@@ -2986,7 +2986,20 @@
    <volume>0</volume>
   </fx>
  </ladspa>
- <BPMTimeLine/>
+ <BPMTimeLine>
+  <newBPM>
+   <BAR>0</BAR>
+   <BPM>100</BPM>
+  </newBPM>
+  <newBPM>
+   <BAR>2</BAR>
+   <BPM>180</BPM>
+  </newBPM>
+  <newBPM>
+   <BAR>4</BAR>
+   <BPM>70</BPM>
+  </newBPM>
+ </BPMTimeLine>
  <timeLineTag/>
  <automationPaths>
   <path adjust="velocity"/>

--- a/src/tests/data/song/AE_songSizeChanged.h2song
+++ b/src/tests/data/song/AE_songSizeChanged.h2song
@@ -19,8 +19,8 @@
  <mode>song</mode>
  <pan_law_type>RATIO_STRAIGHT_POLYGONAL</pan_law_type>
  <pan_law_k_norm>1.33333</pan_law_k_norm>
- <humanize_time>0.07</humanize_time>
- <humanize_velocity>0.1</humanize_velocity>
+ <humanize_time>1</humanize_time>
+ <humanize_velocity>1</humanize_velocity>
  <swing_factor>0</swing_factor>
  <last_loaded_drumkit>/usr/local/share/hydrogen/data/drumkits/GMRockKit</last_loaded_drumkit>
  <last_loaded_drumkit_name>GMRockKit</last_loaded_drumkit_name>
@@ -175,7 +175,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>1000</Release>
+   <Release>999</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
    <midiOutNote>37</midiOutNote>
@@ -298,7 +298,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>1000</Release>
+   <Release>999</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
    <midiOutNote>38</midiOutNote>
@@ -2075,7 +2075,7 @@
    <Attack>0</Attack>
    <Decay>0</Decay>
    <Sustain>1</Sustain>
-   <Release>1000</Release>
+   <Release>999</Release>
    <muteGroup>-1</muteGroup>
    <midiOutChannel>-1</midiOutChannel>
    <midiOutNote>81</midiOutNote>
@@ -2313,7 +2313,7 @@
     <note>
      <position>0</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.89</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2325,7 +2325,7 @@
     <note>
      <position>6</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.87</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2337,7 +2337,7 @@
     <note>
      <position>12</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.83</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2361,7 +2361,7 @@
     <note>
      <position>24</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.78</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2373,7 +2373,7 @@
     <note>
      <position>30</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.75</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2385,7 +2385,7 @@
     <note>
      <position>36</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.73</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2397,7 +2397,7 @@
     <note>
      <position>42</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.7</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2421,7 +2421,7 @@
     <note>
      <position>48</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.65</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2433,7 +2433,7 @@
     <note>
      <position>54</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.62</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2445,7 +2445,7 @@
     <note>
      <position>60</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.59</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2457,7 +2457,7 @@
     <note>
      <position>66</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.56</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2469,7 +2469,7 @@
     <note>
      <position>72</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.53</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2481,7 +2481,7 @@
     <note>
      <position>78</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.51</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2493,7 +2493,7 @@
     <note>
      <position>84</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.47</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2505,7 +2505,7 @@
     <note>
      <position>90</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.44</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2529,7 +2529,7 @@
     <note>
      <position>96</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.41</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2541,7 +2541,7 @@
     <note>
      <position>102</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.37</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2553,7 +2553,7 @@
     <note>
      <position>108</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.36</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2565,7 +2565,7 @@
     <note>
      <position>114</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.32</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2577,7 +2577,7 @@
     <note>
      <position>120</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.3</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2589,7 +2589,7 @@
     <note>
      <position>126</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.27</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2601,7 +2601,7 @@
     <note>
      <position>132</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.26</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2613,7 +2613,7 @@
     <note>
      <position>138</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.22</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2637,7 +2637,7 @@
     <note>
      <position>144</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.21</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2649,7 +2649,7 @@
     <note>
      <position>150</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.17</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2661,7 +2661,7 @@
     <note>
      <position>156</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.13</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2673,7 +2673,7 @@
     <note>
      <position>162</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.11</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2685,7 +2685,7 @@
     <note>
      <position>168</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.08</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2697,7 +2697,7 @@
     <note>
      <position>174</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.06</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2709,7 +2709,7 @@
     <note>
      <position>180</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.03</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2721,7 +2721,7 @@
     <note>
      <position>186</position>
      <leadlag>0</leadlag>
-     <velocity>0.8</velocity>
+     <velocity>0.01</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>
@@ -2742,7 +2742,7 @@
     <note>
      <position>0</position>
      <leadlag>0</leadlag>
-     <velocity>0.78</velocity>
+     <velocity>1</velocity>
      <pan>0</pan>
      <pitch>0</pitch>
      <key>C0</key>


### PR DESCRIPTION
`AudioEngine::testSongSizeChange` was not executed properly and contained a number of bugs. They were fixed and it is now running smoothly again. Apart from checking the integrity of transport position and computed tick interval in `AudioEngine::testSongSizeChange()` the consistency of the column transport resides in is checked as well. After all, glitches in this variable will result in jumps of the playhead and are annoying for the user. This also uncovered two (minor) bugs in the `AudioEngine` itself.

After changing the song size `AudioEngine::computeTickInterval` needs to take the `AudioEngine::m_fTickMismatch` into account when calculating start and end position in ticks of an interval governed by the current position in frames and its length in frames. This itsy-bitsy bug was nothing noticeable but was caught by the unit tests.

There is an edge case not properly handled in `AudioEngine::updateSongSize()` yet. Whenever the current column before toggling is beyond the end of the song after toggling transport is loop to a particular position within the song. E.g. there are several empty patterns in front of a final one, playhead resides in one of the empty ones, and the users deactivates the final pattern. From the user perspective, however, it is not obvious why transport is not just wrapped to the beginning of the song but to somewhere within it. This is now fixed.
