### PR TITLE
Remove temporary appveyor package fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,6 @@ environment:
       OPENSSL_DIR: OpenSSL-Win64
       LIBSSL: libssl-1_1-x64.dll
       LIBCRYPTO: libcrypto-1_1-x64.dll
-      QT_LOCK_REPO: 'mingw/x86_64/mingw-w64-x86_64'
 
       CHOCO_ARCH:
       PROGRAM_FILES: "Program Files"
@@ -81,7 +80,6 @@ environment:
       OPENSSL_DIR: OpenSSL-Win32
       LIBSSL: libssl-1_1.dll
       LIBCRYPTO: libcrypto-1_1.dll
-      QT_LOCK_REPO: 'mingw/mingw32/mingw-w64-i686'
 
       CHOCO_ARCH:  --x86
       PROGRAM_FILES: "Program Files (x86)"
@@ -302,10 +300,10 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portaudio
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libwinpthread-git
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-qt5
+          REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
+          c:\msys64\usr\bin\pacman --noconfirm -S -q -y %MSYS_REPO%-qt5
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
-          c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/%QT_LOCK_REPO%-qt5-tools-5.15.2-2-any.pkg.tar.zst
 
           ccache -M 256M
           ccache -s

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -289,7 +289,7 @@ for:
 
           cmake --version
           g++ --version
-          choco install %CHOCO_ARCH% jack --version 1.9.17 -my
+          choco install %CHOCO_ARCH% -y jack
 
           REM *** Results are ignored since a dependency was not properly installed in 32 bit Windows. But the .dll files required are installed regardless, so we don't care.***
 


### PR DESCRIPTION
In https://github.com/hydrogen-music/hydrogen/pull/1483 and #1560 I had to fix the Chocolatey version of `JACK` and the MSYS2 pacman `qttools` version in the Windows build in order to prevent the build pipeline from failing. Fortunately, this was just a temporary problem and using the latest version of both packages does work again.

Fixes https://github.com/hydrogen-music/hydrogen/issues/1485
Fixes https://github.com/hydrogen-music/hydrogen/issues/1559