### PR TITLE
Fix Windows 32 bugs

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -605,7 +605,16 @@ void AudioEngine::updateBpmAndTickSize( std::shared_ptr<TransportPosition> pPos 
 		AudioEngine::computeTickSize( static_cast<float>(m_pAudioDriver->getSampleRate()),
 									  fNewBpm, pSong->getResolution() );
 	// Nothing changed - avoid recomputing
+#ifndef WIN32
 	if ( fNewTickSize == fOldTickSize ) {
+#else
+	// For some reason two identical numbers (according to their
+	// values when printing them) are not equal to each other in 32bit
+	// Windows. Course graining the tick change in here will do no
+	// harm except of for preventing tiny tempo changes. Integer value
+	// changes should not be affected.
+	if ( std::abs( fNewTickSize - fOldTickSize ) < 1e-2 ) {
+#endif
 		return;
 	}
 
@@ -1666,7 +1675,16 @@ void AudioEngine::updateSongSize() {
 	// Ensure the tick offset is calculated as well (we do not expect
 	// the tempo to change hence the following call is most likely not
 	// executed during updateTransportPosition()).
+#ifndef WIN32
 	if ( fOldTickSize == m_pTransportPosition->getTickSize() ) {
+#else
+	// For some reason two identical numbers (according to their
+	// values when printing them) are not equal to each other in 32bit
+	// Windows. Course graining the tick change in here will do no
+	// harm except of for preventing tiny tempo changes. Integer value
+	// changes should not be affected.
+	if ( std::abs( m_pTransportPosition->getTickSize() - fOldTickSize ) < 1e-2 ) {
+#endif
 		calculateTransportOffsetOnBpmChange( m_pTransportPosition );
 	}
 	
@@ -1905,8 +1923,17 @@ void AudioEngine::handleTimelineChange() {
 	const auto fOldTickSize = m_pTransportPosition->getTickSize();
 	updateBpmAndTickSize( m_pTransportPosition );
 	updateBpmAndTickSize( m_pQueuingPosition );
-	
+
+#ifndef WIN32
 	if ( fOldTickSize == m_pTransportPosition->getTickSize() ) {
+#else
+	// For some reason two identical numbers (according to their
+	// values when printing them) are not equal to each other in 32bit
+	// Windows. Course graining the tick change in here will do no
+	// harm except of for preventing tiny tempo changes. Integer value
+	// changes should not be affected.
+	if ( std::abs( m_pTransportPosition->getTickSize() - fOldTickSize ) < 1e-2 ) {
+#endif
 		// As tempo did not change during the Timeline activation, no
 		// update of the offsets took place. This, however, is not
 		// good, as it makes a significant difference to be located at

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -279,7 +279,8 @@ void* diskWriterDriver_thread( void* param )
 		
 		// this progress bar method is not exact but ok enough to give users a usable visible progress feedback
 		float fPercent = ( float )(patternPosition +1) / ( float )nColumns * 100.0;
-		EventQueue::get_instance()->push_event( EVENT_PROGRESS, ( int )fPercent );
+		EventQueue::get_instance()->push_event(
+			EVENT_PROGRESS, static_cast<int>( std::ceil( fPercent ) ) );
 	}
 	delete[] pData;
 	pData = nullptr;


### PR DESCRIPTION
Running the Windows 32bit pipeline in an artifact branch revealed two rather strange issues:

1. In Windows 32bit builds calculation for the `EVENT_PROGRESS` `(int) ((float)X / (float)X * 100.0)` equates to 99 when exporting audio in some unit tests. This causes the tests to wait forever and the Windows 32bit pipeline to fail.

    Now, a ceiling is used in the combination with the integer conversion which fixes the error.
2. For some reason two identical numbers (according to their values when printing them) are not equal to each other in 32bit Windows. This results in a thorough update of the AudioEngine state in `updateBpmAndTickSize` even when there are no tempo changes encountered and thus the lookahead will be recalculated. These recalculations can result in a small mismatch (+/-1) and tiny inconsistencies. And it makes a totally fine unit test fail.

    E.g. I have two floats printed as `a=479.34783935546875` and `b=479.34783935546875` and  calculating the difference yields `std::abs( a - b ) = 1.326851E-05`. I have no idea why such things could happen or how we should write code if the C++ runtime does such absurd things.

    Course graining the tick change in here will do no harm except of for preventing tiny tempo changes. Integer value changes should not be affected.

For 1. the solution in this PR should be sufficient. But for 2. this should not be the end of the line. Still, it is probably a good idea to postpone it after 1.2-beta. Hopefully we find a better solution, like different compiler options or whatsoever. 