### PR TITLE
Final 1.2.0-beta fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # Hydrogen
 # Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
-# Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+# Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
 #
 # http://www.hydrogen-music.org
 #

--- a/macos/build_dmg.sh
+++ b/macos/build_dmg.sh
@@ -2,7 +2,7 @@
 
 # Hydrogen
 # Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
-# Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+# Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
 #
 # http://www.hydrogen-music.org
 #

--- a/macos/fixlibs.sh
+++ b/macos/fixlibs.sh
@@ -5,7 +5,7 @@
 
 # Hydrogen
 # Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
-# Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+# Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
 #
 # http://www.hydrogen-music.org
 #

--- a/macos/hydrogen.sh
+++ b/macos/hydrogen.sh
@@ -3,7 +3,7 @@
 
 # Hydrogen
 # Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
-# Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+# Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
 #
 # http://www.hydrogen-music.org
 #

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1779,8 +1779,7 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 
 		for ( const auto& ppattern : *( *( pSong->getPatternGroupVector() ) )[ nColumn ] ) {
 			if ( ppattern != nullptr ) {
-				pPlayingPatterns->add( ppattern );
-				ppattern->addFlattenedVirtualPatterns( pPlayingPatterns );
+				pPlayingPatterns->add( ppattern, true );
 			}
 		}
 
@@ -1802,8 +1801,7 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 			 ! ( pPlayingPatterns->size() == 1 &&
 				 pPlayingPatterns->get( 0 ) == pSelectedPattern ) ) {
 			pPlayingPatterns->clear();
-			pPlayingPatterns->add( pSelectedPattern );
-			pSelectedPattern->addFlattenedVirtualPatterns( pPlayingPatterns );
+			pPlayingPatterns->add( pSelectedPattern, true );
 
 			// GUI does not care about the internals of the audio
 			// engine and just moves along the transport position.
@@ -1824,9 +1822,8 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 
 				if ( ( pPlayingPatterns->del( ppattern ) ) == nullptr ) {
 					// pPattern was not present yet. It will
-					// be added.
-					pPlayingPatterns->add( ppattern );
-					ppattern->addFlattenedVirtualPatterns( pPlayingPatterns );
+					// be added
+					pPlayingPatterns->add( ppattern, true );
 				} else {
 					// pPattern was already present. It will
 					// be deleted.

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1788,7 +1788,7 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 		// We omit the event when passing from one empty column to the
 		// next.
 		if ( pPos == m_pTransportPosition &&
-			 ( nPrevPatternNumber != 0 && pPlayingPatterns->size() != 0 ) ) {
+			 ( nPrevPatternNumber != 0 || pPlayingPatterns->size() != 0 ) ) {
 			EventQueue::get_instance()->push_event( EVENT_PLAYING_PATTERNS_CHANGED, 0 );
 		}
 	}

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1282,6 +1282,11 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 		pAudioEngine->stopPlayback();
 		pAudioEngine->locate( 0 );
 
+		// Tell GUI to move the playhead position to the beginning of
+		// the song again since it only updates it in case transport
+		// is rolling.
+		EventQueue::get_instance()->push_event( EVENT_RELOCATION, 0 );
+
 		if ( dynamic_cast<FakeDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
 			___INFOLOG( "End of song." );
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1512,7 +1512,8 @@ void AudioEngine::updateSongSize() {
 
 	auto updatePatternSize = []( std::shared_ptr<TransportPosition> pPos ) {
 		if ( pPos->getPlayingPatterns()->size() > 0 ) {
-			pPos->setPatternSize( pPos->getPlayingPatterns()->longest_pattern_length() );
+			// No virtual pattern resolution in here
+			pPos->setPatternSize( pPos->getPlayingPatterns()->longest_pattern_length( false ) );
 		} else {
 			pPos->setPatternSize( MAX_NOTES );
 		}
@@ -1846,7 +1847,8 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 	}
 
 	if ( pPlayingPatterns->size() > 0 ) {
-		pPos->setPatternSize( pPlayingPatterns->longest_pattern_length() );
+		// No virtual pattern resolution in here
+		pPos->setPatternSize( pPlayingPatterns->longest_pattern_length( false ) );
 	} else {
 		pPos->setPatternSize( MAX_NOTES );
 	}

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/AudioEngineTests.h
+++ b/src/core/AudioEngine/AudioEngineTests.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/TransportPosition.cpp
+++ b/src/core/AudioEngine/TransportPosition.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/TransportPosition.h
+++ b/src/core/AudioEngine/TransportPosition.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AudioEngine/TransportPosition.h
+++ b/src/core/AudioEngine/TransportPosition.h
@@ -360,6 +360,10 @@ private:
 	 * If transport is in #H2Core::Song::Mode::Song, it corresponds
 	 * to the patterns present in column #m_nColumn.
 	 *
+	 * Due to performance reasons no virtual patterns will be checked
+	 * and expanded in this list. Instead, all contained patterns have
+	 * to be added explicitly.
+	 *
 	 * See AudioEngine::updatePlayingPatterns() for details.
 	 */
 	PatternList*		m_pPlayingPatterns;

--- a/src/core/AutomationPathSerializer.cpp
+++ b/src/core/AutomationPathSerializer.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/AutomationPathSerializer.h
+++ b/src/core/AutomationPathSerializer.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Adsr.h
+++ b/src/core/Basics/Adsr.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/AutomationPath.cpp
+++ b/src/core/Basics/AutomationPath.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/AutomationPath.h
+++ b/src/core/Basics/AutomationPath.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/AutomationPath.h
+++ b/src/core/Basics/AutomationPath.h
@@ -83,7 +83,7 @@ class AutomationPath : public Object<AutomationPath>
 	 * displayed without line breaks.
 	 *
 	 * \return String presentation of current object.*/
-	QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 };
 };
 

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -256,7 +256,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		QString __path;					///< absolute drumkit path

--- a/src/core/Basics/DrumkitComponent.cpp
+++ b/src/core/Basics/DrumkitComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/DrumkitComponent.h
+++ b/src/core/Basics/DrumkitComponent.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/DrumkitComponent.h
+++ b/src/core/Basics/DrumkitComponent.h
@@ -82,7 +82,7 @@ class DrumkitComponent : public H2Core::Object<DrumkitComponent>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 	private:
 		int		__id;
 	        /** Name of the DrumkitComponent. It is set by

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -315,7 +315,7 @@ class Instrument : public H2Core::Object<Instrument>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 	        /** Identifier of an instrument, which should be

--- a/src/core/Basics/InstrumentComponent.cpp
+++ b/src/core/Basics/InstrumentComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/InstrumentComponent.h
+++ b/src/core/Basics/InstrumentComponent.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/InstrumentComponent.h
+++ b/src/core/Basics/InstrumentComponent.h
@@ -81,7 +81,7 @@ class InstrumentComponent : public H2Core::Object<InstrumentComponent>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		/** Component ID of the drumkit. It is set by

--- a/src/core/Basics/InstrumentLayer.cpp
+++ b/src/core/Basics/InstrumentLayer.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/InstrumentLayer.h
+++ b/src/core/Basics/InstrumentLayer.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/InstrumentLayer.h
+++ b/src/core/Basics/InstrumentLayer.h
@@ -126,7 +126,7 @@ namespace H2Core
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		float __gain;               ///< ratio between the input sample and the output signal, 1.0 by default

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/InstrumentList.h
+++ b/src/core/Basics/InstrumentList.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/InstrumentList.h
+++ b/src/core/Basics/InstrumentList.h
@@ -63,7 +63,7 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 				m_license( license ) {
 			};
 			
-			QString toQString( const QString& sPrefix, bool bShort = true ) const;
+			QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 		};
 		
 		/** constructor */
@@ -241,7 +241,7 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 		/** Iteration */
 	std::vector<std::shared_ptr<Instrument>>::iterator begin();

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -341,7 +341,7 @@ void Pattern::flattened_virtual_patterns_compute()
 void Pattern::addFlattenedVirtualPatterns( PatternList* pPatternList ) {
 	for( virtual_patterns_cst_it_t it=__flattened_virtual_patterns.begin();
 		 it!=__flattened_virtual_patterns.end(); ++it ) {
-		pPatternList->add( *it );
+		pPatternList->add( *it, true );
 	}
 }
 

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -229,7 +229,7 @@ class Pattern : public H2Core::Object<Pattern>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		int __length;                                           ///< the length of the pattern

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -94,20 +94,20 @@ void PatternList::save_to( XMLNode* pNode, const std::shared_ptr<Instrument> pIn
 	}
 }
 	
-void PatternList::add( Pattern* pPattern )
+void PatternList::add( Pattern* pPattern, bool bAddVirtuals )
 {
 	assertAudioEngineLocked();
 	if ( pPattern == nullptr ) {
 		ERRORLOG( "Provided pattern is invalid" );
 		return;
 	}
-	
+
 	// do nothing if already in __patterns
 	if ( index( pPattern ) != -1 ) {
 		INFOLOG( "Provided pattern is already contained" );
 		return;
 	}
-	else {
+	else if ( ! bAddVirtuals ) {
 		// Check whether the pattern is contained as a virtual
 		// pattern.
 		for ( const auto& ppPattern : __patterns ) {
@@ -132,6 +132,10 @@ void PatternList::add( Pattern* pPattern )
 	}
 	
 	__patterns.push_back( pPattern );
+
+	if ( bAddVirtuals ) {
+		pPattern->addFlattenedVirtualPatterns( this );
+	}
 }
 
 void PatternList::insert( int nIdx, Pattern* pPattern )

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -325,10 +325,20 @@ QString PatternList::find_unused_pattern_name( QString sourceName, Pattern* igno
 	return unusedPatternNameCandidate;
 }
 
-int PatternList::longest_pattern_length() const {
+int PatternList::longest_pattern_length( bool bIncludeVirtuals ) const {
 	int nMax = -1;
-	for ( int i = 0; i < __patterns.size(); i++ ) {
-		nMax = std::max( nMax, __patterns[i]->get_length() );
+	for ( const auto ppPattern : __patterns ) {
+		if ( ppPattern->get_length() > nMax ) {
+			nMax = ppPattern->get_length();
+		}
+
+		if ( bIncludeVirtuals ) {
+			for ( const auto ppVirtualPattern : *ppPattern->get_flattened_virtual_patterns() ) {
+				if ( ppVirtualPattern->get_length() > nMax ) {
+					nMax = ppVirtualPattern->get_length();
+				}
+			}
+		}
 	}
 	return nMax;
 }

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -113,7 +113,7 @@ void PatternList::add( Pattern* pPattern, bool bAddVirtuals )
 		for ( const auto& ppPattern : __patterns ) {
 			auto pVirtualPatterns = ppPattern->get_virtual_patterns();
 			if ( pVirtualPatterns->find( pPattern ) != pVirtualPatterns->end() ) {
-				INFOLOG( "Provided pattern is already contained as virtual pattern" );
+				// Provided pattern is already contained as virtual pattern
 				return;
 			}
 		}

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -178,7 +178,7 @@ class XMLNode;
 		 *
 		 * \return pattern length in ticks, -1 if list is empty
 		 */
-		int longest_pattern_length( bool bIncludeVirtuals = false) const;
+		int longest_pattern_length( bool bIncludeVirtuals = true ) const;
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of
 		 * every new line

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -80,8 +80,10 @@ class XMLNode;
 		/**
 		 * add a pattern to the list
 		 * \param pattern a pointer to the pattern to add
+		 * \param bAddVirtuals Whether virtual patterns contained in
+		 * @a pattern should be added too.
 		 */
-		void add( Pattern* pattern );
+	void add( Pattern* pattern, bool bAddVirtuals = false );
 		/**
 		 * insert a pattern into the list
 		 * \param idx the index to insert the pattern at

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -187,7 +187,7 @@ class XMLNode;
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 		/** Iteration */
 		std::vector<Pattern*>::iterator begin();

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -171,9 +171,14 @@ class XMLNode;
 
 		/**
 		 * Get the length of the longest pattern in the list
+		 *
+		 * \param bIncludeVirtuals In case there are virtual patterns
+		 * present this argument specifies whether to include their
+		 * contained patterns as well.
+		 *
 		 * \return pattern length in ticks, -1 if list is empty
 		 */
-		int longest_pattern_length() const;
+		int longest_pattern_length( bool bIncludeVirtuals = false) const;
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of
 		 * every new line

--- a/src/core/Basics/Playlist.cpp
+++ b/src/core/Basics/Playlist.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Playlist.h
+++ b/src/core/Basics/Playlist.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Playlist.h
+++ b/src/core/Basics/Playlist.h
@@ -94,7 +94,7 @@ class Playlist : public H2Core::Object<Playlist>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		/**

--- a/src/core/Basics/Sample.cpp
+++ b/src/core/Basics/Sample.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Sample.h
+++ b/src/core/Basics/Sample.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Sample.h
+++ b/src/core/Basics/Sample.h
@@ -102,7 +102,7 @@ class Sample : public H2Core::Object<Sample>
 				{
 					return ( start_frame==b.start_frame && loop_frame==b.loop_frame && end_frame==b.end_frame && count==b.count && mode==b.mode );
 				}
-				QString toQString( const QString& sPrefix, bool bShort ) const;
+				QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 		};
 
 		/** set of rubberband configuration flags */
@@ -126,7 +126,7 @@ class Sample : public H2Core::Object<Sample>
 				{
 					return ( use==b.use && divider==b.divider && c_settings==b.c_settings && pitch==b.pitch );
 				}
-				QString toQString( const QString& sPrefix, bool bShort ) const;
+				QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 		};
 
 		/**
@@ -277,7 +277,7 @@ class Sample : public H2Core::Object<Sample>
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 	private:
 		/**
 		 * apply #__loops transformation to the sample

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1370,9 +1370,8 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 			// end of the song).
 			nColumnStartTick += MAX_NOTES;
 			continue;
-		} else {
-
-			pColumn->longest_pattern_length();
+		}
+		else {
 			for ( const auto& ppattern : *pColumn ) {
 				if ( ppattern != nullptr ) {
 					FOREACH_NOTE_CST_IT_BEGIN_END( ppattern->get_notes(), it ) {
@@ -1394,7 +1393,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 				}
 			}
 
-			nColumnStartTick += pColumn->longest_pattern_length();
+			nColumnStartTick += pColumn->longest_pattern_length( true );
 		}
 	}
 	

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -154,7 +154,7 @@ long Song::lengthInTicks() const {
 	for ( int i = 0; i < nColumns; i++ ) {
 		PatternList *pColumn = ( *m_pPatternGroupSequence )[ i ];
 		if ( pColumn->size() != 0 ) {
-			nSongLength += pColumn->longest_pattern_length();
+			nSongLength += pColumn->longest_pattern_length( true );
 		} else {
 			nSongLength += MAX_NOTES;
 		}

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -154,7 +154,7 @@ long Song::lengthInTicks() const {
 	for ( int i = 0; i < nColumns; i++ ) {
 		PatternList *pColumn = ( *m_pPatternGroupSequence )[ i ];
 		if ( pColumn->size() != 0 ) {
-			nSongLength += pColumn->longest_pattern_length( true );
+			nSongLength += pColumn->longest_pattern_length();
 		} else {
 			nSongLength += MAX_NOTES;
 		}
@@ -1393,7 +1393,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 				}
 			}
 
-			nColumnStartTick += pColumn->longest_pattern_length( true );
+			nColumnStartTick += pColumn->longest_pattern_length();
 		}
 	}
 	

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -295,7 +295,7 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 	
 private:
 

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/EventQueue.cpp
+++ b/src/core/EventQueue.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -176,8 +176,9 @@ enum EventType {
 	/** Locks the PatternEditor on the pattern currently played back.*/
 	EVENT_PATTERN_EDITOR_LOCKED,
 	/** Triggered in case there is a relocation of the transport
-	 * position due to an user interaction or an incoming
-	 * MIDI/OSC/JACK command.
+	 * position while trasnsport is not rolling. This can be either
+	 * due to an user interaction or an incoming MIDI/OSC/JACK command
+	 * or at the very end of the song in song mode.
 	 */
 	EVENT_RELOCATION,
 	EVENT_SONG_SIZE_CHANGED,

--- a/src/core/FX/Effects.cpp
+++ b/src/core/FX/Effects.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/FX/Effects.h
+++ b/src/core/FX/Effects.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/FX/LadspaFX.h
+++ b/src/core/FX/LadspaFX.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/FX/LadspaFx.cpp
+++ b/src/core/FX/LadspaFx.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Globals.h
+++ b/src/core/Globals.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/H2Exception.h
+++ b/src/core/H2Exception.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Files.cpp
+++ b/src/core/Helpers/Files.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Files.h
+++ b/src/core/Helpers/Files.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Legacy.cpp
+++ b/src/core/Helpers/Legacy.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Legacy.h
+++ b/src/core/Helpers/Legacy.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Random.cpp
+++ b/src/core/Helpers/Random.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Random.h
+++ b/src/core/Helpers/Random.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Translations.h
+++ b/src/core/Helpers/Translations.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Xml.cpp
+++ b/src/core/Helpers/Xml.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Helpers/Xml.h
+++ b/src/core/Helpers/Xml.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1340,7 +1340,14 @@ void Hydrogen::setPatternMode( Song::PatternMode mode )
 		__song->setPatternMode( mode );
 		setIsModified( true );
 		
-		if ( m_pAudioEngine->getState() != AudioEngine::State::Playing ) {
+		if ( m_pAudioEngine->getState() != AudioEngine::State::Playing ||
+			 mode == Song::PatternMode::Selected ) {
+			// Only update the playing patterns in selected pattern
+			// mode or if transport is not rolling. In stacked pattern
+			// mode with transport rolling
+			// AudioEngine::updatePatternTransportPosition() will call
+			// the functions and activate the next patterns once the
+			// current ones are looped.
 			m_pAudioEngine->updatePlayingPatterns();
 			m_pAudioEngine->clearNextPatterns();
 		}

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -437,7 +437,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 					pCurrentPattern = pPattern;
 				}
 			}
-			nTickInPattern += (*pColumns)[nColumn]->longest_pattern_length();
+			nTickInPattern += (*pColumns)[nColumn]->longest_pattern_length( true );
 		}
 		nTickInPattern -= nLookaheadTicks;
 		
@@ -1627,7 +1627,7 @@ long Hydrogen::getTickForColumn( int nColumn ) const
 		
 		if( pColumn->size() > 0)
 		{
-			nPatternSize = pColumn->longest_pattern_length();
+			nPatternSize = pColumn->longest_pattern_length( true );
 		} else {
 			nPatternSize = MAX_NOTES;
 		}
@@ -1635,37 +1635,6 @@ long Hydrogen::getTickForColumn( int nColumn ) const
 	}
 
 	return totalTick;
-}
-
-long Hydrogen::getPatternLength( int nPattern ) const
-{
-	std::shared_ptr<Song> pSong = getSong();
-	
-	if ( pSong == nullptr ){
-		return -1;
-	}
-
-	std::vector< PatternList* > *pColumns = pSong->getPatternGroupVector();
-
-	int nPatternGroups = pColumns->size();
-	if ( nPattern >= nPatternGroups ) {
-		if ( pSong->isLoopEnabled() ) {
-			nPattern = nPattern % nPatternGroups;
-		} else {
-			return MAX_NOTES;
-		}
-	}
-
-	if ( nPattern < 1 ){
-		return MAX_NOTES;
-	}
-
-	PatternList* pPatternList = pColumns->at( nPattern - 1 );
-	if ( pPatternList->size() > 0 ) {
-		return pPatternList->longest_pattern_length();
-	} else {
-		return MAX_NOTES;
-	}
 }
 
 void Hydrogen::updateSongSize() {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1541,7 +1541,7 @@ int Hydrogen::getColumnForTick( long nTick, bool bLoopMode, long* pPatternStartT
 	for ( int i = 0; i < nColumns; ++i ) {
 		PatternList *pColumn = ( *pPatternColumns )[ i ];
 		if ( pColumn->size() != 0 ) {
-			nPatternSize = pColumn->longest_pattern_length();
+			nPatternSize = pColumn->longest_pattern_length( true );
 		} else {
 			nPatternSize = MAX_NOTES;
 		}
@@ -1567,7 +1567,7 @@ int Hydrogen::getColumnForTick( long nTick, bool bLoopMode, long* pPatternStartT
 		for ( int i = 0; i < nColumns; ++i ) {
 			PatternList *pColumn = ( *pPatternColumns )[ i ];
 			if ( pColumn->size() != 0 ) {
-				nPatternSize = pColumn->longest_pattern_length();
+				nPatternSize = pColumn->longest_pattern_length( true );
 			} else {
 				nPatternSize = MAX_NOTES;
 			}

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -437,7 +437,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 					pCurrentPattern = pPattern;
 				}
 			}
-			nTickInPattern += (*pColumns)[nColumn]->longest_pattern_length( true );
+			nTickInPattern += (*pColumns)[nColumn]->longest_pattern_length();
 		}
 		nTickInPattern -= nLookaheadTicks;
 		
@@ -1548,7 +1548,7 @@ int Hydrogen::getColumnForTick( long nTick, bool bLoopMode, long* pPatternStartT
 	for ( int i = 0; i < nColumns; ++i ) {
 		PatternList *pColumn = ( *pPatternColumns )[ i ];
 		if ( pColumn->size() != 0 ) {
-			nPatternSize = pColumn->longest_pattern_length( true );
+			nPatternSize = pColumn->longest_pattern_length();
 		} else {
 			nPatternSize = MAX_NOTES;
 		}
@@ -1574,7 +1574,7 @@ int Hydrogen::getColumnForTick( long nTick, bool bLoopMode, long* pPatternStartT
 		for ( int i = 0; i < nColumns; ++i ) {
 			PatternList *pColumn = ( *pPatternColumns )[ i ];
 			if ( pColumn->size() != 0 ) {
-				nPatternSize = pColumn->longest_pattern_length( true );
+				nPatternSize = pColumn->longest_pattern_length();
 			} else {
 				nPatternSize = MAX_NOTES;
 			}
@@ -1627,7 +1627,7 @@ long Hydrogen::getTickForColumn( int nColumn ) const
 		
 		if( pColumn->size() > 0)
 		{
-			nPatternSize = pColumn->longest_pattern_length( true );
+			nPatternSize = pColumn->longest_pattern_length();
 		} else {
 			nPatternSize = MAX_NOTES;
 		}

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -474,7 +474,7 @@ void			previewSample( Sample *pSample );
 	 * displayed without line breaks.
 	 *
 	 * \return String presentation of current object.*/
-	QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 private:
 	/**

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -160,19 +160,6 @@ public:
 	 *  - >= 0 : the total number of ticks passed.
 	 */
 	long			getTickForColumn( int nColumn ) const;
-	/**
-	 * Get the length (in ticks) of the @a nPattern th pattern.
-	 *
-	 * \param nPattern Position + 1 of the desired PatternList.
-	 * \return 
-	 * - __-1__ : if not Song was initialized yet.
-	 * - #MAX_NOTES : if @a nPattern was smaller than 1, larger
-	 * than the length of the vector of the PatternList in
-	 * Song::m_pPatternGroupSequence or no Pattern could be found
-	 * in the PatternList at @a nPattern - 1.
-	 * - __else__ : length of first Pattern found at @a nPattern.
-	 */
-	long			getPatternLength( int nPattern ) const;
 
 	Song::Mode getMode() const;
 	/** Wrapper around Song::setMode() which also triggers

--- a/src/core/IO/AlsaAudioDriver.cpp
+++ b/src/core/IO/AlsaAudioDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/AlsaAudioDriver.h
+++ b/src/core/IO/AlsaAudioDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/AlsaMidiDriver.cpp
+++ b/src/core/IO/AlsaMidiDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/AlsaMidiDriver.h
+++ b/src/core/IO/AlsaMidiDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/AudioOutput.h
+++ b/src/core/IO/AudioOutput.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/CoreAudioDriver.cpp
+++ b/src/core/IO/CoreAudioDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://hydrogen.sourceforge.net
  *

--- a/src/core/IO/CoreAudioDriver.h
+++ b/src/core/IO/CoreAudioDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://hydrogen.sourceforge.net
  *

--- a/src/core/IO/CoreMidiDriver.cpp
+++ b/src/core/IO/CoreMidiDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/CoreMidiDriver.h
+++ b/src/core/IO/CoreMidiDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -165,7 +165,7 @@ void* diskWriterDriver_thread( void* param )
 		
 		PatternList *pColumn = ( *pPatternColumns )[ patternPosition ];
 		if ( pColumn->size() != 0 ) {
-			nPatternSize = pColumn->longest_pattern_length( true );
+			nPatternSize = pColumn->longest_pattern_length();
 		} else {
 			nPatternSize = MAX_NOTES;
 		}

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -165,7 +165,7 @@ void* diskWriterDriver_thread( void* param )
 		
 		PatternList *pColumn = ( *pPatternColumns )[ patternPosition ];
 		if ( pColumn->size() != 0 ) {
-			nPatternSize = pColumn->longest_pattern_length();
+			nPatternSize = pColumn->longest_pattern_length( true );
 		} else {
 			nPatternSize = MAX_NOTES;
 		}

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -278,9 +278,11 @@ void* diskWriterDriver_thread( void* param )
 		}
 		
 		// this progress bar method is not exact but ok enough to give users a usable visible progress feedback
-		float fPercent = ( float )(patternPosition +1) / ( float )nColumns * 100.0;
-		EventQueue::get_instance()->push_event(
-			EVENT_PROGRESS, static_cast<int>( std::ceil( fPercent ) ) );
+		int nPercent = static_cast<int>( ( float )(patternPosition +1) /
+										 ( float )nColumns * 100.0 );
+		if ( nPercent < 100 ) {
+			EventQueue::get_instance()->push_event( EVENT_PROGRESS, nPercent );
+		}
 	}
 
 	// Explicitly mark export as finished.

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -282,6 +282,10 @@ void* diskWriterDriver_thread( void* param )
 		EventQueue::get_instance()->push_event(
 			EVENT_PROGRESS, static_cast<int>( std::ceil( fPercent ) ) );
 	}
+
+	// Explicitly mark export as finished.
+	EventQueue::get_instance()->push_event( EVENT_PROGRESS, 100 );
+	
 	delete[] pData;
 	pData = nullptr;
 

--- a/src/core/IO/DiskWriterDriver.h
+++ b/src/core/IO/DiskWriterDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/FakeDriver.cpp
+++ b/src/core/IO/FakeDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/FakeDriver.h
+++ b/src/core/IO/FakeDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/MidiInput.h
+++ b/src/core/IO/MidiInput.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/MidiOutput.cpp
+++ b/src/core/IO/MidiOutput.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/MidiOutput.h
+++ b/src/core/IO/MidiOutput.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/NullDriver.cpp
+++ b/src/core/IO/NullDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/NullDriver.h
+++ b/src/core/IO/NullDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/OssDriver.cpp
+++ b/src/core/IO/OssDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/OssDriver.h
+++ b/src/core/IO/OssDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/PortAudioDriver.cpp
+++ b/src/core/IO/PortAudioDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/PortAudioDriver.h
+++ b/src/core/IO/PortAudioDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/PortMidiDriver.h
+++ b/src/core/IO/PortMidiDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/PulseAudioDriver.cpp
+++ b/src/core/IO/PulseAudioDriver.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/IO/PulseAudioDriver.h
+++ b/src/core/IO/PulseAudioDriver.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Lash/LashClient.cpp
+++ b/src/core/Lash/LashClient.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Lash/LashClient.h
+++ b/src/core/Lash/LashClient.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/License.cpp
+++ b/src/core/License.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/License.h
+++ b/src/core/License.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Lilipond/Lilypond.cpp
+++ b/src/core/Lilipond/Lilypond.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Lilipond/Lilypond.h
+++ b/src/core/Lilipond/Lilypond.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -77,7 +77,7 @@ class Action : public H2Core::Object<Action> {
 		 * displayed without line breaks.
 		 *
 		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		QString m_sType;

--- a/src/core/MidiMap.cpp
+++ b/src/core/MidiMap.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/MidiMap.h
+++ b/src/core/MidiMap.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/NsmClient.h
+++ b/src/core/NsmClient.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Object.cpp
+++ b/src/core/Object.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Object.h
+++ b/src/core/Object.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Preferences/Theme.cpp
+++ b/src/core/Preferences/Theme.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Preferences/Theme.h
+++ b/src/core/Preferences/Theme.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Sampler/Interpolation.h
+++ b/src/core/Sampler/Interpolation.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -1,7 +1,7 @@
 ﻿/*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Sampler/Sampler.h
+++ b/src/core/Sampler/Sampler.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Smf/SMF.h
+++ b/src/core/Smf/SMF.h
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
- * Copyright(c) 2002-2004 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Smf/SMFEvent.h
+++ b/src/core/Smf/SMFEvent.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Smf/Smf.cpp
+++ b/src/core/Smf/Smf.cpp
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
- * Copyright(c) 2002-2004 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Smf/SmfEvent.cpp
+++ b/src/core/Smf/SmfEvent.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/SoundLibrary/SoundLibraryInfo.cpp
+++ b/src/core/SoundLibrary/SoundLibraryInfo.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/SoundLibrary/SoundLibraryInfo.h
+++ b/src/core/SoundLibrary/SoundLibraryInfo.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Synth/Synth.cpp
+++ b/src/core/Synth/Synth.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Synth/Synth.h
+++ b/src/core/Synth/Synth.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Timehelper.cpp
+++ b/src/core/Timehelper.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Timehelper.h
+++ b/src/core/Timehelper.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Timeline.h
+++ b/src/core/Timeline.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Timeline.h
+++ b/src/core/Timeline.h
@@ -191,7 +191,7 @@ public:
 	 * displayed without line breaks.
 	 *
 	 * \return String presentation of current object.*/
-	QString toQString( const QString& sPrefix, bool bShort = true ) const override;
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 private:
 	void		sortTempoMarkers();
 	void		sortTags();

--- a/src/core/Version.cpp
+++ b/src/core/Version.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/Version.h
+++ b/src/core/Version.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/core/rt_clock.h
+++ b/src/core/rt_clock.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AboutDialog.cpp
+++ b/src/gui/src/AboutDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AboutDialog.h
+++ b/src/gui/src/AboutDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AboutDialogContributorList.cpp
+++ b/src/gui/src/AboutDialogContributorList.cpp
@@ -3,6 +3,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AboutDialogContributorList.h
+++ b/src/gui/src/AboutDialogContributorList.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AudioEngineInfoForm.cpp
+++ b/src/gui/src/AudioEngineInfoForm.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AudioEngineInfoForm.h
+++ b/src/gui/src/AudioEngineInfoForm.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
+++ b/src/gui/src/AudioFileBrowser/AudioFileBrowser.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/ExportMidiDialog.cpp
+++ b/src/gui/src/ExportMidiDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/ExportMidiDialog.h
+++ b/src/gui/src/ExportMidiDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/ExportSongDialog.h
+++ b/src/gui/src/ExportSongDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/FilesystemInfoForm.cpp
+++ b/src/gui/src/FilesystemInfoForm.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/FilesystemInfoForm.h
+++ b/src/gui/src/FilesystemInfoForm.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/LayerPreview.h
+++ b/src/gui/src/InstrumentEditor/LayerPreview.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentEditor/WaveDisplay.h
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/InstrumentRack.h
+++ b/src/gui/src/InstrumentRack.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/LadspaFXProperties.h
+++ b/src/gui/src/LadspaFXProperties.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/LadspaFXSelector.cpp
+++ b/src/gui/src/LadspaFXSelector.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/LadspaFXSelector.h
+++ b/src/gui/src/LadspaFXSelector.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Mixer/Mixer.h
+++ b/src/gui/src/Mixer/Mixer.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Mixer/MixerLine.h
+++ b/src/gui/src/Mixer/MixerLine.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Mixer/MixerSettingsDialog.cpp
+++ b/src/gui/src/Mixer/MixerSettingsDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Mixer/MixerSettingsDialog.h
+++ b/src/gui/src/Mixer/MixerSettingsDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -95,7 +95,7 @@ void DrumPatternEditor::updateEditor( bool bPatternOnly )
 			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pAudioEngine->getPlayingPatterns()->longest_pattern_length( true ) + 1,
+						  pAudioEngine->getPlayingPatterns()->longest_pattern_length() + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		}
 		else {

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1403,6 +1403,10 @@ void DrumPatternEditor::drumkitLoadedEvent() {
 	updateEditor();
 }
 
+void DrumPatternEditor::songModeActivationEvent() {
+	updateEditor();
+}
+
 ///NotePropertiesRuler undo redo action
 void DrumPatternEditor::undoRedoAction( int column,
 										PatternEditor::Mode mode,

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -90,12 +90,15 @@ void DrumPatternEditor::updateEditor( bool bPatternOnly )
 		m_nActiveWidth = PatternEditor::nMargin + m_fGridWidth *
 			m_pPattern->get_length();
 		
-		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
+		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
+			 ( pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
+			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pAudioEngine->getPlayingPatterns()->longest_pattern_length() + 1,
+						  pAudioEngine->getPlayingPatterns()->longest_pattern_length( true ) + 1,
 						  static_cast<float>(m_nActiveWidth) );
-		} else {
+		}
+		else {
 			m_nEditorWidth = m_nActiveWidth;
 		}
 	}

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -93,9 +93,12 @@ void DrumPatternEditor::updateEditor( bool bPatternOnly )
 		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
 			 ( pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
 			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
+			// Virtual patterns are already expanded in the playing
+			// patterns and must not be considered when determining
+			// the longest one.
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pAudioEngine->getPlayingPatterns()->longest_pattern_length() + 1,
+						  pAudioEngine->getPlayingPatterns()->longest_pattern_length( false ) + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		}
 		else {

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -56,6 +56,7 @@ class DrumPatternEditor : public PatternEditor, protected WidgetWithScalableFont
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
+	virtual void songModeActivationEvent() override;
 		//~ Implements EventListener interface
 		void addOrDeleteNoteAction(		int nColumn,
 										int row,

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1408,9 +1408,12 @@ void NotePropertiesRuler::updateEditor( bool )
 		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
 			 ( pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
 			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
+			// Virtual patterns are already expanded in the playing
+			// patterns and must not be considered when determining
+			// the longest one.
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length() + 1,
+						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length( false ) + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		} else {
 			m_nEditorWidth = m_nActiveWidth;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1405,11 +1405,12 @@ void NotePropertiesRuler::updateEditor( bool )
 		m_nActiveWidth = PatternEditor::nMargin + m_fGridWidth *
 			m_pPattern->get_length();
 		
-		if ( pHydrogen->getPatternMode() ==
-			 Song::PatternMode::Stacked ) {
+		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
+			 ( pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
+			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length() + 1,
+						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length( true ) + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		} else {
 			m_nEditorWidth = m_nActiveWidth;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1410,7 +1410,7 @@ void NotePropertiesRuler::updateEditor( bool )
 			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length( true ) + 1,
+						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length() + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		} else {
 			m_nEditorWidth = m_nActiveWidth;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1465,6 +1465,10 @@ void NotePropertiesRuler::selectedInstrumentChangedEvent()
 	updateEditor();
 }
 
+void NotePropertiesRuler::songModeActivationEvent() {
+	updateEditor();
+}
+
 std::vector<NotePropertiesRuler::SelectionIndex> NotePropertiesRuler::elementsIntersecting( QRect r ) {
 	std::vector<SelectionIndex> result;
 	if ( m_pPattern == nullptr ) {

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -123,6 +123,7 @@ class NotePropertiesRuler : public PatternEditor, protected WidgetWithScalableFo
 		// Implements EventListener interface
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
+	virtual void songModeActivationEvent() override;
 		//~ Implements EventListener interface
 		
 		int m_nSelectedPatternNumber;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by the Hydrogen Team
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -845,12 +845,22 @@ std::vector< Pattern *> PatternEditor::getPatternsToShow( void )
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	std::vector<Pattern *> patterns;
 
-	// Add stacked-mode patterns
-	if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
+	// Add stacked-mode patterns as well as virtual ones.
+	if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
+		 ( m_pPattern != nullptr &&
+		   pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
+		   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
+			 
 		m_pAudioEngine->lock( RIGHT_HERE );
 		std::set< Pattern *> patternSet;
-		for ( const PatternList *pPatternList : { m_pAudioEngine->getPlayingPatterns(),
-												 m_pAudioEngine->getNextPatterns() } ) {
+
+		std::vector<const PatternList*> patternLists;
+		patternLists.push_back( m_pAudioEngine->getPlayingPatterns() );
+		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
+			patternLists.push_back( m_pAudioEngine->getNextPatterns() );
+		}
+		
+		for ( const PatternList *pPatternList : patternLists ) {
 			for ( int i = 0; i <  pPatternList->size(); i++) {
 				Pattern *pPattern = pPatternList->get( i );
 				if ( pPattern != m_pPattern ) {

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2020 by the Hydrogen Team
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -515,7 +515,7 @@ void PatternEditorRuler::updateActiveRange() {
 
 	auto pPlayingPatterns = pAudioEngine->getPlayingPatterns();
 	if ( pPlayingPatterns->size() != 0 ) {
-		nTicksInPattern = pPlayingPatterns->longest_pattern_length( true );
+		nTicksInPattern = pPlayingPatterns->longest_pattern_length();
 	}
 	
 	int nWidthActive = PatternEditor::nMargin + nTicksInPattern * m_fGridWidth;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -515,11 +515,14 @@ void PatternEditorRuler::updateActiveRange() {
 
 	auto pPlayingPatterns = pAudioEngine->getPlayingPatterns();
 	if ( pPlayingPatterns->size() != 0 ) {
-		nTicksInPattern = pPlayingPatterns->longest_pattern_length();
+		// Virtual patterns are already expanded in the playing
+		// patterns and must not be considered when determining the
+		// longest one.
+		nTicksInPattern = pPlayingPatterns->longest_pattern_length( false );
 	}
-	
-	int nWidthActive = PatternEditor::nMargin + nTicksInPattern * m_fGridWidth;
 
+	int nWidthActive = PatternEditor::nMargin + nTicksInPattern * m_fGridWidth;
+	
 	if ( m_nWidthActive != nWidthActive ) {
 		m_nWidthActive = nWidthActive;
 

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -515,7 +515,7 @@ void PatternEditorRuler::updateActiveRange() {
 
 	auto pPlayingPatterns = pAudioEngine->getPlayingPatterns();
 	if ( pPlayingPatterns->size() != 0 ) {
-		nTicksInPattern = pPlayingPatterns->longest_pattern_length();
+		nTicksInPattern = pPlayingPatterns->longest_pattern_length( true );
 	}
 	
 	int nWidthActive = PatternEditor::nMargin + nTicksInPattern * m_fGridWidth;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -566,7 +566,7 @@ void PatternEditorRuler::zoomOut()
 
 void PatternEditorRuler::songModeActivationEvent()
 {
-	updatePosition();
+	updateEditor( true );
 }
 
 void PatternEditorRuler::stateChangedEvent( H2Core::AudioEngine::State )

--- a/src/gui/src/PatternEditor/PatternEditorRuler.h
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -93,9 +93,12 @@ void PianoRollEditor::updateEditor( bool bPatternOnly )
 		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
 			 ( pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
 			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
+			// Virtual patterns are already expanded in the playing
+			// patterns and must not be considered when determining
+			// the longest one.
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length() + 1,
+						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length( false ) + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		} else {
 			m_nEditorWidth = m_nActiveWidth;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -90,10 +90,12 @@ void PianoRollEditor::updateEditor( bool bPatternOnly )
 
 		m_nActiveWidth = PatternEditor::nMargin + m_fGridWidth *
 			m_pPattern->get_length();
-		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ) {
+		if ( pHydrogen->getPatternMode() == Song::PatternMode::Stacked ||
+			 ( pHydrogen->getPatternMode() == Song::PatternMode::Selected &&
+			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length() + 1,
+						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length( true ) + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		} else {
 			m_nEditorWidth = m_nActiveWidth;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -95,7 +95,7 @@ void PianoRollEditor::updateEditor( bool bPatternOnly )
 			   m_pPattern->get_flattened_virtual_patterns()->size() > 0 ) ) {
 			m_nEditorWidth =
 				std::max( PatternEditor::nMargin + m_fGridWidth *
-						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length( true ) + 1,
+						  pHydrogen->getAudioEngine()->getPlayingPatterns()->longest_pattern_length() + 1,
 						  static_cast<float>(m_nActiveWidth) );
 		} else {
 			m_nEditorWidth = m_nActiveWidth;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -140,13 +140,14 @@ void PianoRollEditor::selectedInstrumentChangedEvent()
 	updateEditor( true );
 }
 
-
 void PianoRollEditor::selectedPatternChangedEvent()
 {
 	updateEditor();
 }
 
-
+void PianoRollEditor::songModeActivationEvent() {
+	updateEditor();
+}
 
 void PianoRollEditor::paintEvent(QPaintEvent *ev)
 {

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -49,6 +49,7 @@ class PianoRollEditor: public PatternEditor, protected WidgetWithScalableFont<7,
 		// Implements EventListener interface
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
+	virtual void songModeActivationEvent() override;
 		//~ Implements EventListener interface
 
 		void addOrDeleteNoteAction( int nColumn,

--- a/src/gui/src/PatternPropertiesDialog.cpp
+++ b/src/gui/src/PatternPropertiesDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PatternPropertiesDialog.h
+++ b/src/gui/src/PatternPropertiesDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.h
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Reporter.cpp
+++ b/src/gui/src/Reporter.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Reporter.h
+++ b/src/gui/src/Reporter.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/DetailWaveDisplay.h
+++ b/src/gui/src/SampleEditor/DetailWaveDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/SampleEditor.h
+++ b/src/gui/src/SampleEditor/SampleEditor.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.h
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/ShotList.cpp
+++ b/src/gui/src/ShotList.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/ShotList.h
+++ b/src/gui/src/ShotList.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Skin.cpp
+++ b/src/gui/src/Skin.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Skin.h
+++ b/src/gui/src/Skin.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/PatternFillDialog.cpp
+++ b/src/gui/src/SongEditor/PatternFillDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/PatternFillDialog.h
+++ b/src/gui/src/SongEditor/PatternFillDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/PlaybackTrackWaveDisplay.cpp
+++ b/src/gui/src/SongEditor/PlaybackTrackWaveDisplay.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/PlaybackTrackWaveDisplay.h
+++ b/src/gui/src/SongEditor/PlaybackTrackWaveDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1188,7 +1188,7 @@ void SongEditor::updateGridCells() {
 
 	for ( int nColumn = 0; nColumn < pColumns->size(); nColumn++ ) {
 		PatternList *pColumn = (*pColumns)[nColumn];
-		int nMaxLength = pColumn->longest_pattern_length( true );
+		int nMaxLength = pColumn->longest_pattern_length();
 
 		for ( uint nPat = 0; nPat < pColumn->size(); nPat++ ) {
 			Pattern *pPattern = (*pColumn)[ nPat ];
@@ -3142,7 +3142,7 @@ void SongEditorPositionRuler::updatePosition()
 
 	if ( pPatternGroupVector->size() > m_nColumn &&
 		 pPatternGroupVector->at( m_nColumn )->size() > 0 ) {
-		int nLength = pPatternGroupVector->at( m_nColumn )->longest_pattern_length( true );
+		int nLength = pPatternGroupVector->at( m_nColumn )->longest_pattern_length();
 		fTick += (float)m_pAudioEngine->getTransportPosition()->getPatternTickPosition() /
 			(float)nLength;
 	} else {

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -990,6 +990,13 @@ void SongEditor::updatePosition( float fTick ) {
 	}
 }
 
+void SongEditor::patternModifiedEvent() {
+	// This can change the length of one pattern in a column
+	// containing multiple ones.
+	invalidateBackground();
+	update();
+}
+
 void SongEditor::paintEvent( QPaintEvent *ev )
 {
 	if ( m_bBackgroundInvalid ) {

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1181,7 +1181,7 @@ void SongEditor::updateGridCells() {
 
 	for ( int nColumn = 0; nColumn < pColumns->size(); nColumn++ ) {
 		PatternList *pColumn = (*pColumns)[nColumn];
-		int nMaxLength = pColumn->longest_pattern_length();
+		int nMaxLength = pColumn->longest_pattern_length( true );
 
 		for ( uint nPat = 0; nPat < pColumn->size(); nPat++ ) {
 			Pattern *pPattern = (*pColumn)[ nPat ];
@@ -3135,7 +3135,7 @@ void SongEditorPositionRuler::updatePosition()
 
 	if ( pPatternGroupVector->size() > m_nColumn &&
 		 pPatternGroupVector->at( m_nColumn )->size() > 0 ) {
-		int nLength = pPatternGroupVector->at( m_nColumn )->longest_pattern_length();
+		int nLength = pPatternGroupVector->at( m_nColumn )->longest_pattern_length( true );
 		fTick += (float)m_pAudioEngine->getTransportPosition()->getPatternTickPosition() /
 			(float)nLength;
 	} else {

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -213,6 +213,8 @@ class SongEditor : public QWidget
 		std::map< QPoint, GridCell > m_gridCells;
 		void updateGridCells();
 		bool m_bEntered;
+
+	virtual void patternModifiedEvent() override;
 	
 	/** Cached position of the playhead.*/
 	float m_fTick;

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -175,7 +175,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	m_pPlaySelectedSingleBtn = new Button( pBackPanel, QSize( 25, 21 ),
 										 Button::Type::Push, "single_layer.svg",
 										 "", false, QSize( 17, 13 ),
-										 tr( "single pattern mode"),
+										 tr( "selected pattern mode"),
 										 false, true );
 	m_pPlaySelectedSingleBtn->move( 168, 25 );
 	connect( m_pPlaySelectedSingleBtn, &QPushButton::clicked, [=]() {

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/VirtualPatternDialog.cpp
+++ b/src/gui/src/SongEditor/VirtualPatternDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongEditor/VirtualPatternDialog.h
+++ b/src/gui/src/SongEditor/VirtualPatternDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SongPropertiesDialog.h
+++ b/src/gui/src/SongPropertiesDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/FileBrowser.cpp
+++ b/src/gui/src/SoundLibrary/FileBrowser.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/FileBrowser.h
+++ b/src/gui/src/SoundLibrary/FileBrowser.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryRepositoryDialog.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryTree.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryTree.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SoundLibrary/SoundLibraryTree.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryTree.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SplashScreen.cpp
+++ b/src/gui/src/SplashScreen.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/SplashScreen.h
+++ b/src/gui/src/SplashScreen.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/WidgetScrollArea.h
+++ b/src/gui/src/WidgetScrollArea.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/AutomationPathView.h
+++ b/src/gui/src/Widgets/AutomationPathView.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/ColorSelectionButton.cpp
+++ b/src/gui/src/Widgets/ColorSelectionButton.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/ColorSelectionButton.h
+++ b/src/gui/src/Widgets/ColorSelectionButton.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/CpuLoadWidget.cpp
+++ b/src/gui/src/Widgets/CpuLoadWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/CpuLoadWidget.h
+++ b/src/gui/src/Widgets/CpuLoadWidget.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/DownloadWidget.cpp
+++ b/src/gui/src/Widgets/DownloadWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/DownloadWidget.h
+++ b/src/gui/src/Widgets/DownloadWidget.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/Fader.h
+++ b/src/gui/src/Widgets/Fader.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/InfoBar.cpp
+++ b/src/gui/src/Widgets/InfoBar.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/InfoBar.h
+++ b/src/gui/src/Widgets/InfoBar.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LCDDisplay.cpp
+++ b/src/gui/src/Widgets/LCDDisplay.cpp
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LCDDisplay.h
+++ b/src/gui/src/Widgets/LCDDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LED.cpp
+++ b/src/gui/src/Widgets/LED.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
-  * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/LED.h
+++ b/src/gui/src/Widgets/LED.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/MidiLearnable.h
+++ b/src/gui/src/Widgets/MidiLearnable.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/MidiSenseWidget.cpp
+++ b/src/gui/src/Widgets/MidiSenseWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/MidiSenseWidget.h
+++ b/src/gui/src/Widgets/MidiSenseWidget.h
@@ -1,7 +1,7 @@
 /*
 	 * Hydrogen
 	 * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
 	 *
 	 * http://www.hydrogen-music.org
 	 *

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/MidiTable.h
+++ b/src/gui/src/Widgets/MidiTable.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/PixmapWidget.cpp
+++ b/src/gui/src/Widgets/PixmapWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/PixmapWidget.h
+++ b/src/gui/src/Widgets/PixmapWidget.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/Rotary.h
+++ b/src/gui/src/Widgets/Rotary.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/StatusMessageDisplay.cpp
+++ b/src/gui/src/Widgets/StatusMessageDisplay.cpp
@@ -1,6 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/StatusMessageDisplay.h
+++ b/src/gui/src/Widgets/StatusMessageDisplay.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/WidgetWithHighlightedList.h
+++ b/src/gui/src/Widgets/WidgetWithHighlightedList.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/WidgetWithLicenseProperty.h
+++ b/src/gui/src/Widgets/WidgetWithLicenseProperty.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2008-2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/Widgets/WidgetWithScalableFont.h
+++ b/src/gui/src/Widgets/WidgetWithScalableFont.h
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright (C) 2021 The hydrogen development team <hydrogen-devel@lists.sourceforge.net>
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/gui/src/about_dialog_contributor_list_update.sh
+++ b/src/gui/src/about_dialog_contributor_list_update.sh
@@ -5,7 +5,7 @@
 
 # Hydrogen
 # Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
-# Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+# Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
 #
 # http://www.hydrogen-music.org
 #
@@ -52,6 +52,7 @@ cat > AboutDialogContributorList.cpp <<"EOF"
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/player/main.cpp
+++ b/src/player/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/AdsrTest.cpp
+++ b/src/tests/AdsrTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/AdsrTest.h
+++ b/src/tests/AdsrTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/AudioBenchmark.cpp
+++ b/src/tests/AudioBenchmark.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/AudioBenchmark.h
+++ b/src/tests/AudioBenchmark.h
@@ -1,3 +1,24 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
 #ifndef AUDIO_BENCHMARK_H
 #define AUDIO_BENCHMARK_H
 

--- a/src/tests/AutomationPathSerializerTest.cpp
+++ b/src/tests/AutomationPathSerializerTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/AutomationPathTest.cpp
+++ b/src/tests/AutomationPathTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/CoreActionControllerTest.cpp
+++ b/src/tests/CoreActionControllerTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/CoreActionControllerTest.h
+++ b/src/tests/CoreActionControllerTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/EventQueueTest.cpp
+++ b/src/tests/EventQueueTest.cpp
@@ -1,6 +1,6 @@
 /*
  * Hydrogen
- * Copyright(c) 2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/FilesystemTest.cpp
+++ b/src/tests/FilesystemTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/FilesystemTest.h
+++ b/src/tests/FilesystemTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/FunctionalTests.cpp
+++ b/src/tests/FunctionalTests.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/InstrumentListTest.cpp
+++ b/src/tests/InstrumentListTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/LicenseTest.cpp
+++ b/src/tests/LicenseTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/LicenseTest.h
+++ b/src/tests/LicenseTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/MemoryLeakageTest.cpp
+++ b/src/tests/MemoryLeakageTest.cpp
@@ -1,3 +1,24 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
 #include "MemoryLeakageTest.h"
 
 #include <memory>

--- a/src/tests/MemoryLeakageTest.h
+++ b/src/tests/MemoryLeakageTest.h
@@ -1,3 +1,24 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
 #ifndef MEMORY_LEAKAGE_TEST_H
 #define MEMORY_LEAKAGE_TEST_H
 

--- a/src/tests/MidiNoteTest.cpp
+++ b/src/tests/MidiNoteTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/NetworkTest.cpp
+++ b/src/tests/NetworkTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/NetworkTest.h
+++ b/src/tests/NetworkTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/NoteTest.cpp
+++ b/src/tests/NoteTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/OscServerTest.cpp
+++ b/src/tests/OscServerTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/OscServerTest.h
+++ b/src/tests/OscServerTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/PatternTest.cpp
+++ b/src/tests/PatternTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/PatternTest.h
+++ b/src/tests/PatternTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/RubberbandTest.cpp
+++ b/src/tests/RubberbandTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/SampleTest.cpp
+++ b/src/tests/SampleTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/TestHelper.cpp
+++ b/src/tests/TestHelper.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/TestHelper.h
+++ b/src/tests/TestHelper.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/TimeTest.cpp
+++ b/src/tests/TimeTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/TimeTest.h
+++ b/src/tests/TimeTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/Translations.cpp
+++ b/src/tests/Translations.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/TransportTest.h
+++ b/src/tests/TransportTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/XmlTest.h
+++ b/src/tests/XmlTest.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/assertions/AudioFile.cpp
+++ b/src/tests/assertions/AudioFile.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/assertions/AudioFile.h
+++ b/src/tests/assertions/AudioFile.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/assertions/File.cpp
+++ b/src/tests/assertions/File.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/assertions/File.h
+++ b/src/tests/assertions/File.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/registeredTests.h
+++ b/src/tests/registeredTests.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/utils/AppveyorRestClient.cpp
+++ b/src/tests/utils/AppveyorRestClient.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/utils/AppveyorRestClient.h
+++ b/src/tests/utils/AppveyorRestClient.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/utils/AppveyorTestListener.cpp
+++ b/src/tests/utils/AppveyorTestListener.cpp
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/tests/utils/AppveyorTestListener.h
+++ b/src/tests/utils/AppveyorTestListener.h
@@ -1,7 +1,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *

--- a/src/www/hydrogen.php
+++ b/src/www/hydrogen.php
@@ -2,7 +2,7 @@
 /*
  * Hydrogen
  * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
- * Copyright(c) 2008-2021 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ * Copyright(c) 2008-2022 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
  *
  * http://www.hydrogen-music.org
  *


### PR DESCRIPTION
Some final fixes to strike out from my local TODO list. Well, it's a never ending story but from my point of view we are ready to do the 1.2.0-beta with these ones merged.

Most notably: 
- Update of license notices
- missing PatternEditor updates when switching states (especially while being in stacked mode)
- fix playhead repositioning at the end of the song
- fix virtual patterns handling (thanks for the hint @oddtime ! ).

    Turns out these did never worked properly as soon as one of the patterns contained in the virtual one was longer than the virtual one itself. This was not accounted for when calculating the longest pattern in a column and the length of the song. While at it I activated the new stacked mode view in the pattern editor when working with virtual patterns.