### PR TITLE
AppVeyor: dynamic target version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,6 +44,7 @@
 environment:
   GENERATOR: "MinGW Makefiles"
   ARTIFACT_BRANCH: master-artifacts
+  TARGET_VERSION: '1.2.0'
   matrix:
 
     - job_name: 'Ubuntu 20.04'
@@ -363,7 +364,7 @@ for:
           REM *** Deploy other libraries ***
           set PYTHON=C:\Python38\python
           %PYTHON% -m pip install -r %APPVEYOR_BUILD_FOLDER%\windows\ci\requirements.txt
-          %PYTHON% %APPVEYOR_BUILD_FOLDER%\windows\ci\copy_thirdparty_dlls.py --no-overwrite -V info -L %MSYS%\bin -d %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs src/gui/hydrogen.exe src/core/libhydrogen-core-1.1.1.dll
+          %PYTHON% %APPVEYOR_BUILD_FOLDER%\windows\ci\copy_thirdparty_dlls.py --no-overwrite -V info -L %MSYS%\bin -d %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs src/gui/hydrogen.exe src/core/libhydrogen-core-%TARGET_VERSION%.dll
 
           REM Chocolatey installs JACK dlls in c:\Windows, so
           REM copy_third_party_libs.py thinks it's a system lib and
@@ -389,8 +390,8 @@ on_finish:
   - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
   - cmd: if EXIST %APPVEYOR_BUILD_FOLDER%\build\testOutput.log appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\testOutput.log
 
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win64.exe || cmd /c "exit /b 1"
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-1.1.1-win32.exe || cmd /c "exit /b 1"
+  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win64.exe || cmd /c "exit /b 1"
+  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win32.exe || cmd /c "exit /b 1"
 
   - cmd: |
       if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% curl -F file=@%APPVEYOR_BUILD_FOLDER%\build\test_installation.xml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%

--- a/DEVELOPERS
+++ b/DEVELOPERS
@@ -76,7 +76,9 @@ order to make a release has several, easy-to-forget steps.  They are:
      b. Update linux/debian/changelog
 
      c. Check if nothing has changed and update version and date in
-        linux/hydrogen.1 
+        linux/hydrogen.1
+
+     d. Update the TARGET_VERSION variable in .appveyor.yml
 
   2. Run `src/gui/src/about_dialog_contributor_list_update.sh
      GIT_TAG_OF_LAST_RELEASE HEAD` to update the list of recent


### PR DESCRIPTION
For some reason the Hydrogen version was hard coded into the AppVeyor script. Well, it still is but at least I put it into a variable defined at the very beginning of the file. Now, it can be updated more conveniently.