### PR TITLE
Logger: flush stdout

### DIFF
--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -72,6 +72,7 @@ void* loggerThread_func( void* param ) {
 				last = it;
 				if ( logger->m_bUseStdout ) {
 					fprintf( stdout, "%s", it->toLocal8Bit().data() );
+					fflush( stdout );
 				}
 				if( log_file ) {
 					fprintf( log_file, "%s", it->toLocal8Bit().data() );


### PR DESCRIPTION
Since recently (maybe because of 7f26902da0e12f88cf3b15fef3c25f01020a8e48) our logger lags quite a bit and gets stuck when printing to stdout. Flushing stdout fixes this issue. Not quite sure why. It was not flushed beforehand and did work.