### PR TITLE
Pattern and instrument drag & drop preview

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -142,6 +142,8 @@ class PatternEditorInstrumentList :  public QWidget,
 
 
 		virtual void dragEnterEvent(QDragEnterEvent *event) override;
+		virtual void dragMoveEvent(QDragMoveEvent *event) override;
+		virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
 		virtual void dropEvent(QDropEvent *event) override;
 
 	virtual void selectedInstrumentChangedEvent() override;
@@ -167,6 +169,12 @@ class PatternEditorInstrumentList :  public QWidget,
 		QPoint __drag_start_position;
 
 		InstrumentLine* createInstrumentLine();
+
+	enum DropTargetKind { None, Move, Insert };
+	void setDropTarget( DropTargetKind kind, int nDropTarget = -1, int nSource = -1 );
+	int m_nDropTarget;
+	int m_nDropSource;
+	DropTargetKind m_dropTargetKind;
 
 private:
 	void drawFocus( QPainter& painter );

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -299,6 +299,8 @@ class SongEditorPatternList :  public QWidget
 		void inlineEditingFinished();
 		void inlineEditingEntered();
 		virtual void dragEnterEvent(QDragEnterEvent *event) override;
+		virtual void dragMoveEvent(QDragMoveEvent *event) override;
+		virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
 		virtual void dropEvent(QDropEvent *event) override;
 		virtual void timelineUpdateEvent( int nValue ) override;
 		void onPreferencesChanged( H2Core::Preferences::Changes changes );
@@ -325,7 +327,13 @@ class SongEditorPatternList :  public QWidget
 		H2Core::Pattern *	m_pPatternBeingEdited;
 
 		DragScroller *		m_pDragScroller;
-		
+
+		enum DropTargetKind { None, Move, Insert };
+		void setDropTarget( DropTargetKind kind, int nDropTarget = -1, int nSource = -1 );
+		int m_nDropTarget;
+		int m_nDropSource;
+		DropTargetKind m_dropTargetKind;
+
 		void inlineEditPatternName( int row );
 
 		virtual void mousePressEvent( QMouseEvent *ev ) override;


### PR DESCRIPTION
Preview drag and drop operations in the `SongEditorPatternList` and `PatternEditorInstrumentList`, rearranging the patterns (or instruments) in the list to the order which will be imposed if the drag is ended at that position.

(For imports, an empy space is shown, since no details are available until they're loaded)