### PR TITLE
Fix windows pipeline

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,28 +62,18 @@ environment:
       BUILD_TYPE: "Release"
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
       appveyor_build_worker_image: Visual Studio 2019
-      LIBJACK: libjack64.dll
-      OPENSSL_DIR: OpenSSL-Win64
       LIBSSL: libssl-1_1-x64.dll
       LIBCRYPTO: libcrypto-1_1-x64.dll
-
-      CHOCO_ARCH:
-      PROGRAM_FILES: "Program Files"
 
     - job_name: 'Windows32'
       job_group: 'Windows'
       MSYS: 'C:\msys64\mingw32'
-      MSYS_REPO: 'mingw-w64-i686'
+      MSYS_REPO: 'mingw32/mingw-w64-i686'
       BUILD_TYPE: "Release"
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
       appveyor_build_worker_image: Visual Studio 2019
-      LIBJACK: libjack.dll
-      OPENSSL_DIR: OpenSSL-Win32
       LIBSSL: libssl-1_1.dll
       LIBCRYPTO: libcrypto-1_1.dll
-
-      CHOCO_ARCH:  --x86
-      PROGRAM_FILES: "Program Files (x86)"
 
 build:
   verbosity: detailed
@@ -302,11 +292,6 @@ for:
 
           cmake --version
           g++ --version
-          choco install %CHOCO_ARCH% -y jack
-
-          REM *** Results are ignored since a dependency was not properly installed in 32 bit Windows. But the .dll files required are installed regardless, so we don't care.***
-
-          choco install %CHOCO_ARCH% -y openssl --version=1.1.1.1300 || cmd /c "exit /b 1"
 
           REM *** Install dependencies ***
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libarchive
@@ -319,6 +304,7 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q -y %MSYS_REPO%-qt5
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
+          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
 
           ccache -M 256M
           ccache -s
@@ -331,7 +317,7 @@ for:
           rename "C:\Program Files\Git\usr\bin\sh.exe" "sh2.exe"
           mkdir build
           cd build
-          cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% %CMAKE_FLAGS% -DJACK_INCLUDE_DIRS="c:/%PROGRAM_FILES%/JACK2/include" -DJACK_LIBRARIES="c:/%PROGRAM_FILES%/JACK2/lib/%LIBJACK%.a" -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
+          cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% %CMAKE_FLAGS% -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
 
     build_script:
       - cmd: |-
@@ -366,12 +352,9 @@ for:
           %PYTHON% -m pip install -r %APPVEYOR_BUILD_FOLDER%\windows\ci\requirements.txt
           %PYTHON% %APPVEYOR_BUILD_FOLDER%\windows\ci\copy_thirdparty_dlls.py --no-overwrite -V info -L %MSYS%\bin -d %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs src/gui/hydrogen.exe src/core/libhydrogen-core-%TARGET_VERSION%.dll
 
-          REM Chocolatey installs JACK dlls in c:\Windows, so
-          REM copy_third_party_libs.py thinks it's a system lib and
-          REM won't copy it.
-          copy c:\Windows\%LIBJACK% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
-          copy c:\%OPENSSL_DIR%\%LIBSSL% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
-          copy c:\%OPENSSL_DIR%\%LIBCRYPTO% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
+          REM *** libcrypto and libssl are not picked up by the Python script above and needs to be copied manually ***
+          copy %MSYS%\bin\%LIBSSL% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
+          copy %MSYS%\bin\%LIBCRYPTO% %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
 
           REM *** Build installer ***
           cpack -G NSIS -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,13 @@ ELSE()
 	FIND_HELPER(OSS oss sys/soundcard.h OSSlib )
 ENDIF()
 
-FIND_HELPER(JACK jack jack/jack.h jack)
+IF(WIN64)
+  #64bit Windows
+  FIND_HELPER(JACK jack jack/jack.h jack64)
+ELSE()
+  #32bit Windows and all other OS
+  FIND_HELPER(JACK jack jack/jack.h jack)
+ENDIF()
 CHECK_LIBRARY_EXISTS(jack jack_port_rename "" HAVE_JACK_PORT_RENAME)
 IF(APPLE)
     FIND_LIBRARY(AUDIOUNIT_LIBRARY AudioUnit)

--- a/windows/Build-WinNative.ps1
+++ b/windows/Build-WinNative.ps1
@@ -4,6 +4,7 @@
 
 param (
     [switch]$build=$false,
+    [switch]$test=$false,
     [switch]$installdeps=$false,
     [switch]$deploy=$false,
     [switch]$32bit=$false
@@ -15,12 +16,16 @@ if($32bit)
     $64bit_string = "OFF"
     $msys_repo='mingw32/mingw-w64-i686'
     $msys='C:\msys64\mingw32'
+    $libssl='libssl-1_1.dll'
+    $libcrypto='libcrypto-1_1.dll'
 }
 else
 {
     $64bit_string = "ON"
     $msys_repo='mingw64/mingw-w64-x86_64'
     $msys='C:\msys64\mingw64'
+    $libssl='libssl-1_1-x64.dll'
+    $libcrypto='libcrypto-1_1-x64.dll'
 }
 
 
@@ -28,23 +33,21 @@ $env:QTDIR=$msys
 $env:CMAKE_PREFIX_PATH=$env:QTDIR
 $env:PATH="$msys\bin;$env:PATH"
 $env:PKG_CONFIG_PATH="$msys\lib\pkgconfig"
-$python_exe='C:\python39\python'
+$python_exe="$msys\bin\python.exe"
 $build_type='Debug'
 
 if($installdeps)
 {
-    Write-Host "Installing python-pip"
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-    python get-pip.py
-
     Write-Host 'Installing msys2 dependencies'
-    c:\msys64\usr\bin\pacman --noconfirm -S -q openssh
     c:\msys64\usr\bin\pacman --noconfirm -S -q base-devel
 
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-cmake
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-nsis
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-toolchain
+    c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-python
+    c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-python-pip
 
+    c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-openssl
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-libarchive
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-libsndfile
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-cppunit
@@ -53,6 +56,7 @@ if($installdeps)
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-libwinpthread-git
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-qt5
     c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-ladspa-sdk
+    c:\msys64\usr\bin\pacman --noconfirm -S -q $msys_repo-jack2
 }
 
 if($build)
@@ -96,8 +100,21 @@ if($build)
     $arguments="..\windows\ci\copy_thirdparty_dlls.py","--no-overwrite", "-V", "debug" ,"-L","$msys\bin","-d","windows\extralibs", "src/gui/hydrogen.exe", "src/core/libhydrogen-core-*.dll"
     & $python_exe $arguments
     
+    # libcrypto and libssl are not picked up by the Python script
+    # above and needs to be copied manually
+    cp $msys\bin\$libssl windows\extralibs
+    cp $msys\bin\$libcrypto windows\extralibs
+    
     cd ../windows
-} 
+}
+
+if($test)
+{
+    $currentPath=Get-Location
+    $env:path += ";$currentPath\..\build\src\core"
+
+    ..\build\src\tests\tests.exe
+}
 
 if($deploy) 
 {


### PR DESCRIPTION
Install JACK via MSYS2 and obtain `libssl` and `libcrypto` from the preinstalled MSYS2 `openssl` package. (Even in case it would not be present in future versions of AppVeyor it is a depedency of `qt5` and would be installed anyway).

This allows us to get rid of all the Chocolatey installs which prooved to be less reliable and routinely breaking the Windows build pipeline. (JACK was only added during the recent years to MSYS2 pacman repos and was not present when our AppVeyor script was written).

Fixes https://github.com/hydrogen-music/hydrogen/issues/1704

I also update the Windows Powershell script to build Hydrogen under Windows and introduced a `-test` section.