### PR TITLE
attach output to Windows console

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -20,6 +20,11 @@
  *
  */
 
+#ifdef WIN32
+#include <windows.h>
+#include <stdio.h>
+#endif
+
 #include <QLibraryInfo>
 #include <QStringList>
 #include <QThread>
@@ -126,6 +131,16 @@ int main(int argc, char *argv[])
 	int nReturnCode = 0;
 	
 	try {
+#ifdef WIN32
+		// In case Hydrogen was started using a CLI attach its output to
+		// the latter. 
+		if ( AttachConsole(ATTACH_PARENT_PROCESS)) {
+			freopen("CONOUT$", "w", stdout);
+			freopen("CONOUT$", "w", stderr);
+			freopen("CONIN$", "w", stdin);
+		}
+#endif
+	
 		// Options...
 		char *cp;
 		struct option *op;

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -41,6 +41,11 @@
 #include <core/Lash/LashClient.h>
 #endif
 
+#ifdef WIN32
+#include <windows.h>
+#include <stdio.h>
+#endif
+
 #include <core/MidiMap.h>
 #include <core/AudioEngine/AudioEngine.h>
 #include <core/Hydrogen.h>
@@ -188,6 +193,16 @@ public:
 
 int main(int argc, char *argv[])
 {
+
+#ifdef WIN32
+	// In case Hydrogen was started using a CLI attach its output to
+	// the latter. 
+	if ( AttachConsole(ATTACH_PARENT_PROCESS)) {
+		freopen("CONOUT$", "w", stdout);
+		freopen("CONOUT$", "w", stderr);
+		freopen("CONIN$", "w", stdin);
+	}
+#endif
 	Reporter::spawn( argc, argv );
 	try {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)

--- a/src/player/main.cpp
+++ b/src/player/main.cpp
@@ -20,6 +20,11 @@
  *
  */
 
+#ifdef WIN32
+#include <windows.h>
+#include <stdio.h>
+#endif
+
 #include <iostream>
 #include <cstdio>
 #include <cstdlib>
@@ -47,6 +52,16 @@ void usage()
 
 int main(int argc, char** argv){
 
+#ifdef WIN32
+	// In case Hydrogen was started using a CLI attach its output to
+	// the latter. 
+	if ( AttachConsole(ATTACH_PARENT_PROCESS)) {
+		freopen("CONOUT$", "w", stdout);
+		freopen("CONOUT$", "w", stderr);
+		freopen("CONIN$", "w", stdin);
+	}
+#endif
+	
 	unsigned logLevelOpt = H2Core::Logger::Error;
 	H2Core::Logger::create_instance();
 	H2Core::Logger::set_bit_mask( logLevelOpt );


### PR DESCRIPTION
In case either `hydrogen`, `h2cli`, or `h2player` is started from Windows console this patch binds stdout, stderr, and stdin to this very console.

The default behavior in Windows (+Qt?) is to open a new console window once the application is started and put all messages into this dedicated one. This works fine for the GUI of `hydrogen`. But if the `--help` or `--version` argument is provided Qt prints the help or version to stdout and exits. This, however, causes the new console to live just a tiny fraction of a second and it is impossible to get either the output of the help command or Hydrogen version.

`h2cli` and `h2player` on the other hand are pretty unusable in Windows as none of their output is shown in the console their are called in and no dedicated console opens up.

With this patch all output for all of this applications is bound to the calling console. But it is not pretty. At all. Prompt does not move with incoming stdout and e.g. help output just paints the background below it. Also one can still use the console and e.g. start up another Hydrogen instance by accident.

This seems to be a Windows deficiency and we have to decide whether to have a more pretty and clean separate console or usable `--help`, `--version`, `h2cli`, and `h2player` commands. I would go for usability.

In case Hydrogen is started graphically (double clicking) nothing changes.

Fixes #1671