### PR TITLE
More proper fix for Win32 precision issue

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -605,15 +605,15 @@ void AudioEngine::updateBpmAndTickSize( std::shared_ptr<TransportPosition> pPos 
 		AudioEngine::computeTickSize( static_cast<float>(m_pAudioDriver->getSampleRate()),
 									  fNewBpm, pSong->getResolution() );
 	// Nothing changed - avoid recomputing
-#ifndef WIN32
-	if ( fNewTickSize == fOldTickSize ) {
-#else
+#if defined(WIN32) and !defined(WIN64)
 	// For some reason two identical numbers (according to their
 	// values when printing them) are not equal to each other in 32bit
 	// Windows. Course graining the tick change in here will do no
 	// harm except of for preventing tiny tempo changes. Integer value
 	// changes should not be affected.
 	if ( std::abs( fNewTickSize - fOldTickSize ) < 1e-2 ) {
+#else
+	if ( fNewTickSize == fOldTickSize ) {
 #endif
 		return;
 	}
@@ -1677,19 +1677,19 @@ void AudioEngine::updateSongSize() {
 
 	const auto fOldTickSize = m_pTransportPosition->getTickSize();
 	updateTransportPosition( fNewTick, nNewFrame, m_pTransportPosition );
-
-	// Ensure the tick offset is calculated as well (we do not expect
-	// the tempo to change hence the following call is most likely not
-	// executed during updateTransportPosition()).
-#ifndef WIN32
-	if ( fOldTickSize == m_pTransportPosition->getTickSize() ) {
-#else
+	
+    // Ensure the tick offset is calculated as well (we do not expect
+    // the tempo to change hence the following call is most likely not
+    // executed during updateTransportPosition()).
+#if defined(WIN32) and !defined(WIN64)
 	// For some reason two identical numbers (according to their
 	// values when printing them) are not equal to each other in 32bit
 	// Windows. Course graining the tick change in here will do no
 	// harm except of for preventing tiny tempo changes. Integer value
 	// changes should not be affected.
 	if ( std::abs( m_pTransportPosition->getTickSize() - fOldTickSize ) < 1e-2 ) {
+#else
+	if ( fOldTickSize == m_pTransportPosition->getTickSize() ) {
 #endif
 		calculateTransportOffsetOnBpmChange( m_pTransportPosition );
 	}
@@ -1928,15 +1928,15 @@ void AudioEngine::handleTimelineChange() {
 	updateBpmAndTickSize( m_pTransportPosition );
 	updateBpmAndTickSize( m_pQueuingPosition );
 
-#ifndef WIN32
-	if ( fOldTickSize == m_pTransportPosition->getTickSize() ) {
-#else
+#if defined(WIN32) and !defined(WIN64)
 	// For some reason two identical numbers (according to their
 	// values when printing them) are not equal to each other in 32bit
 	// Windows. Course graining the tick change in here will do no
 	// harm except of for preventing tiny tempo changes. Integer value
 	// changes should not be affected.
 	if ( std::abs( m_pTransportPosition->getTickSize() - fOldTickSize ) < 1e-2 ) {
+#else
+	if ( fOldTickSize == m_pTransportPosition->getTickSize() ) {
 #endif
 		// As tempo did not change during the Timeline activation, no
 		// update of the offsets took place. This, however, is not

--- a/windows/Build-WinNative.ps1
+++ b/windows/Build-WinNative.ps1
@@ -124,11 +124,12 @@ if($deploy)
     cd ../windows
 } 
 
-if(!$deploy -and !$build -and !$installdeps )
+if(!$deploy -and !$build -and !$installdeps -and !$test )
 {
     Write-Host 'Usage: '
     Write-Host 'Build-WinNative -build: Build hydrogen (64bit)'
     Write-Host 'Build-WinNative -build -32bit : Build hydrogen (32bit)'
+    Write-Host 'Build-WinNative -test : Run unit tests after successful build'
     Write-Host 'Build-WinNative -installdeps: Install build dependencies via pacman (64bit)'
     Write-Host 'Build-WinNative -installdeps -32bit: Install build dependencies via pacman (32bit)'
     Write-Host 'Build-WinNative -deploy: Create installer'


### PR DESCRIPTION
The fix provided in https://github.com/hydrogen-music/hydrogen/pull/1679 reduced the precision in tick size comparisons within the AudioEngine for both 64 and 32bit Windows systems. AFAICS there is no way around it or at least not a simple solution.

However, with this patch the lower precision fix only affect Win 32bit system (for which it is relevant).

Fixes https://github.com/hydrogen-music/hydrogen/issues/1687