### PR TITLE
Fix translation tips and update German translation

### DIFF
--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -169,6 +169,10 @@
         <source>Realtime frames</source>
         <translation>Marcos en tiempo real</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -305,6 +309,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Silenciar</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">General</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Capes</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mesclador</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Atac</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Decaiment</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sosteniment</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Alliberament</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Canal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Entrada</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Velocitat</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Guardar</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Cancelar</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Descartar les modificacions</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -319,8 +887,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Configurar volum de l&apos;instrument [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -355,10 +931,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -462,6 +1034,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -669,31 +1257,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Efectes si/no</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Sortida principal</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -710,24 +1315,6 @@ Overwrite the existing file?</source>
         <translation>Propietats de la llibreria de sò</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;O Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Això no és possible, només es poden desar canvis a instruments en la llibreria de sò actual</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Atenció! Si canvies el nom del kit de bateria en crearàs un de nom amb aquest nom
-N&apos;estàs segur?</translation>
-    </message>
-    <message>
         <source>Open Image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -739,13 +1326,45 @@ N&apos;estàs segur?</translation>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Llicència</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Kit de bateria carregat: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Editor de cançó</translation>
@@ -761,10 +1380,6 @@ N&apos;estàs segur?</translation>
     <message>
         <source>modified</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Cançó desada.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -785,6 +1400,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -811,22 +1446,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Ressonància en el filtre</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>Atac</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Decaiment</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sosteniment</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Alliberament</translation>
-    </message>
-    <message>
         <source>Layer gain</source>
         <translation>Guany de capa</translation>
     </message>
@@ -837,14 +1456,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Instrument gain</source>
         <translation>Guany de l&apos;instrument</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>General</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Capes</translation>
     </message>
     <message>
         <source>Layer pitch (Coarse)</source>
@@ -895,7 +1506,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -911,10 +1542,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">Sol</translation>
     </message>
     <message>
@@ -1009,16 +1642,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Mostar editor d&apos;instrument</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrument</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Veure llibreria de sò</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Llibreria de sò</translation>
     </message>
 </context>
 <context>
@@ -1068,6 +1693,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1232,10 +1865,6 @@ MIDI = %2</source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Descartar les modificacions</translation>
-    </message>
-    <message>
         <source>Hydrogen Ready.</source>
         <translation>Hydrogen apunt.</translation>
     </message>
@@ -1270,10 +1899,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;About</source>
         <translation>&amp;A Sobre</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1316,16 +1941,8 @@ MIDI = %2</source>
         <translation>&amp;Info</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Cançó desada.</translation>
-    </message>
-    <message>
         <source>Clear all instruments?</source>
         <translation>Borrar tots els instruments?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Acceptar</translation>
     </message>
     <message>
         <source>Unknown error %1</source>
@@ -1354,10 +1971,6 @@ MIDI = %2</source>
     <message>
         <source>Open Pattern</source>
         <translation>Obrir Patró</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>No tornar a mostrar aquest missatge</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1398,7 +2011,6 @@ Vols desar les modificacions?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>Drum&amp;kits</source>
@@ -1481,10 +2093,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1691,16 +2299,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Reproduïnt.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Configura Volum principal [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1711,39 +2358,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Humanitzar velocitat</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Configura el paràmetre d&apos;humanització del temps [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Configura el paràmetre d&apos;humanització de velocitat [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Configura el Factor de swing [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Event</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Paràm.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Acció</translation>
@@ -1751,6 +2391,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>Prem el botó per grabar event midi</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1772,14 +2432,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Mostrar pics d&apos;instrument = No</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Configura nivell Efecte %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Configura volum efecte LADSPA ( %1 )</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1789,6 +2441,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1811,11 +2471,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Balanceig</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Configurar volum de l&apos;instrument [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1908,14 +2576,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1963,6 +2623,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1995,7 +2659,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2045,18 +2753,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Allunyar</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>No és possible canviar la mida del patró durant la reproducció.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Seleccionar mida del patró</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Seleccionar resolució de la graella</translation>
-    </message>
-    <message>
         <source>Select note properties</source>
         <translation>Seleccionar propietats de la nota</translation>
     </message>
@@ -2094,10 +2790,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2141,35 +2833,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2269,6 +2937,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Song Mode</source>
@@ -2297,10 +2972,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Mode de patró seleccionat.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Nou valor de PPM</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2335,20 +3006,8 @@ Maximum = 16/4</source>
         <translation>Veure mesclador</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mesclador</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Veure taula d&apos;instruments</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Taula d&apos;instruments</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Panell contador de polsacions activat</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2404,19 +3063,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2429,11 +3075,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2603,14 +3281,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Descartar les modificacions</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>no Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2667,32 +3337,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Driver restart required.
  Restart driver?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2708,10 +3354,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2720,19 +3362,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2757,6 +3391,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">General</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Editor de cançó</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Error inicialitzant el controlador d&apos;àudio</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2802,14 +3708,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Font per a l&apos;aplicació</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Font per al mesclador</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Seleccionar font</translation>
     </message>
     <message>
         <source>Sample rate</source>
@@ -3036,15 +3934,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3089,7 +3979,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3168,17 +4058,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3209,14 +4215,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3280,10 +4278,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3303,37 +4297,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3727,32 +4730,12 @@ Are you sure?</source>
 N&apos;estàs segur?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Acceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>mode apilat</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>mode patrons apilats</translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation>mode de patró únic</translation>
-    </message>
-    <message>
         <source>Pattern %1</source>
         <translation>Patró %1</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3779,19 +4762,15 @@ N&apos;estàs segur?</translation>
         <translation type="unfinished">Velocitat</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3800,22 +4779,6 @@ N&apos;estàs segur?</translation>
     <message>
         <source>Form</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished">500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation type="unfinished">500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3880,18 +4843,6 @@ N&apos;estàs segur?</translation>
         <translation>Carregar Patró</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Obrir Patró</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Patró 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>no_categoritzat</translation>
-    </message>
-    <message>
         <source>Export Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3903,14 +4854,6 @@ N&apos;estàs segur?</translation>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
         <source>Could not export pattern.</source>
@@ -3934,6 +4877,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3986,24 +4940,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Exportar llibreria de sons</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportar</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Tot</translation>
     </message>
 </context>
 <context>
@@ -4011,10 +4977,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Exportar</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4213,14 +5175,6 @@ Overwrite the existing pattern?</source>
         <translation>Kits de bateria de l&apos;usuari</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;O Acceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Cançons</translation>
     </message>
@@ -4269,17 +5223,7 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4306,10 +5250,6 @@ Current kit:</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Desar els canvis fets als instruments a la llibreria de sò</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4323,6 +5263,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4361,76 +5305,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Desar llibreria de sò</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Si us plau, proporciona almenys un nom vàlid</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Diàleg</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Nom</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informació</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Llicència</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Desar</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4456,6 +5330,19 @@ Current kit:</source>
     </message>
     <message>
         <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Realtimeové snímky</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Ztlumit</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Hlavní</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Nástroj</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Vrstvy</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mixér</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Síla</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Útlum</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Výdrž</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Uvolnění</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Kanál</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Vstup</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Kolísání</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Sila uderu</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;OK</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Uložit</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Storno</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Zahodit</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Nastavit hlasitost nástroje [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Zapnout/vypnout efekt</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Hlavní výstup (master)</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Storno</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -709,24 +1314,6 @@ Overwrite the existing file?</source>
         <translation>Vlastnosti zvukové knihovny</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Storno</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Toto není dostupné, můžete pouze uložit změny nástroje do aktuálně nahrané zvukové knihovny</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Pozor! Změna názvu bicí sady bude mít za následek vytvoření nové bicí sady s tímto jménem.￼
-Určitě to chcete?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -738,13 +1325,45 @@ Určitě to chcete?</translation>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Nástroj</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Licence</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Nahraná bicí sada: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Editor skladby</translation>
@@ -760,10 +1379,6 @@ Určitě to chcete?</translation>
     <message>
         <source>modified</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Skladba uložena.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -786,6 +1401,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
@@ -800,22 +1435,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Rezonance filtru</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Síla</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Útlum</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Výdrž</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Uvolnění</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -844,14 +1463,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>New instrument name</source>
         <translation>Nový název nástroje</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Hlavní</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Vrstvy</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -894,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -938,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">Sólo</translation>
     </message>
     <message>
@@ -1008,16 +1641,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Zobrazit editor nástrojů</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Nástroj</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Zobrazit knihovnu zvuků</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Knihovna zvuků</translation>
     </message>
 </context>
 <context>
@@ -1067,6 +1692,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1275,20 +1908,8 @@ MIDI = %2</source>
         <translation>O &amp;aplikaci</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Zahodit</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Storno</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Uložit skladbu</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Skladba uložena.</translation>
     </message>
     <message>
         <source>Open song</source>
@@ -1327,10 +1948,6 @@ MIDI = %2</source>
         <translation>Vymazat všechny nástroje?</translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation>OK</translation>
-    </message>
-    <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
         <translation>Používáte vývojovou verzi Hydrogenu. Prosíme, pomozte nám hlášením chyb nebo nápady na kontaktní adrese hydrogen-devel týmu.&lt;br&gt;&lt;br&gt;Děkujeme!</translation>
     </message>
@@ -1353,10 +1970,6 @@ MIDI = %2</source>
     <message>
         <source>Open Pattern</source>
         <translation>Otevřít patern</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Příště tuto zprávu již nezobrazovat</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1389,7 +2002,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1476,10 +2088,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1686,6 +2294,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Prehrava se.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1698,53 +2349,62 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Lidský faktor přesnosti</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>Kolísání</translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
         <translation>Nastavit celkovou hlasitost [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Nastavit lidský faktor přesnosti [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Nastavit lidský faktor síly úderu [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation>Nastavit faktor kolísání [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
     <message>
-        <source>Event</source>
-        <translation>Událost</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Param.</translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation>Akce</translation>
     </message>
     <message>
         <source>press button to record midi event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1759,20 +2419,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Zobrazit špičky nástrojů</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Nastavit úroveň efektu %1 </translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation>Zobrazování spicek nastroju zapnuto</translation>
     </message>
     <message>
         <source>Show instrument peaks = Off</source>
         <translation>Zobrazování spicek nastroju vypnuto</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Nastavit hlasitost LADSPA efektu ( %1 )</translation>
     </message>
     <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
@@ -1784,6 +2436,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1806,11 +2466,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Panorama</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Nastavit hlasitost nástroje [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1903,14 +2571,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1958,6 +2618,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1990,7 +2654,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2003,14 +2711,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 </context>
 <context>
     <name>PatternEditorPanel</name>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Vybrat velikost paternu</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Vybrat rozlišení mřížky</translation>
-    </message>
     <message>
         <source>Hear new notes</source>
         <translation>Poslech nových not</translation>
@@ -2052,10 +2752,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Vypnout přichytávání not z klávesnice / MIDI</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Není možné změnit patern během přehrávání.</translation>
-    </message>
-    <message>
         <source>Select note properties</source>
         <translation>Vybrat vlatnosti noty</translation>
     </message>
@@ -2089,10 +2785,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2136,35 +2828,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2264,6 +2932,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2298,16 +2973,8 @@ Maximum = 16/4</source>
         <translation>Zobrazit mixér</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mixér</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Zobrazit nástrojový panel</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Nástrojový panel</translation>
     </message>
     <message>
         <source>Playing.</source>
@@ -2330,20 +2997,12 @@ Maximum = 16/4</source>
         <translation>Rezim paternu vybran.</translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation>Nová hodnota BPM</translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation>Opakovani skladby zapnuto</translation>
     </message>
     <message>
         <source>Loop song = Off</source>
         <translation>Opakovani skladby vypnuto</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Panel rytmu</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2399,19 +3058,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2424,11 +3070,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2622,14 +3300,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Zahodit</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Storno</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2663,31 +3333,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Storno</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2703,10 +3349,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2715,19 +3357,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2752,6 +3386,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Hlavní</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Editor skladby</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Chyba při zavádění audio ovladače</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2914,10 +3820,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Písmo aplikace</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation>Vybrat písmo</translation>
-    </message>
-    <message>
         <source>Style</source>
         <translation>Styl</translation>
     </message>
@@ -2937,10 +3839,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Meters falloff speed</source>
         <extracomment>In case of a rapid sound lasting for just a milli second the meters in the Mixer would raise to peak value and fall of immediately without the user being able to see them. The falloff speed introduces a delay. The smaller the value, the longer the meter requires to reach 0dB again.</extracomment>
         <translation>Rychlost poklesu indikátorů</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Písmo mixéru</translation>
     </message>
     <message>
         <source>Audio output details</source>
@@ -3015,15 +3913,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3084,7 +3974,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3163,17 +4053,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3204,14 +4210,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3275,10 +4273,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3298,37 +4292,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Storno</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3722,28 +4725,8 @@ Are you sure?</source>
 Určitě to chcete?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Storno</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>Hromadný režim</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>Režim více paternů</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>Režim jednoho paternu</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pattern %1</source>
@@ -3774,19 +4757,15 @@ Určitě to chcete?</translation>
         <translation type="unfinished">Sila uderu</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3795,22 +4774,6 @@ Určitě to chcete?</translation>
     <message>
         <source>Form</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished">500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation type="unfinished">500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3875,10 +4838,6 @@ Určitě to chcete?</translation>
         <translation>Nahrát patern</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Otevřít patern</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3886,22 +4845,6 @@ Určitě to chcete?</translation>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Storno</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation type="unfinished">Nekategorizováno</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3929,6 +4872,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3981,24 +4935,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Export knihovny zvuků</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Export</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Všechno</translation>
     </message>
 </context>
 <context>
@@ -4006,10 +4972,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Export</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4208,14 +5170,6 @@ Overwrite the existing pattern?</source>
         <translation>Uživatelské bicí sady</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Storno</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Skladby</translation>
     </message>
@@ -4264,17 +5218,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4301,10 +5245,6 @@ Current kit:</source>
         <translation>Storno</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Uložit provedené změny nástrojů do knihovny zvuků</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4318,6 +5258,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4356,76 +5300,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Uložit knihovnu zvuků</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Dialog</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Název</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informace</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Storno</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Licence</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Uložit</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Najít</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4452,6 +5326,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Storno</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Echtzeit-Frames</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Stumm</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Übersicht</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Ebenen</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mixer</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Attack</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Dämpfung (decay)</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sustain</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Freigabe (release)</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Kanal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Eingang</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">BPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Anschlag (velocity)</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Piano-Roll anzeigen</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished">Jack Timebase Unterstützung ist in den Einstellungen deaktiviert</translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished">Konnte Instrument nicht laden</translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">aus</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished">Nicht einkompiliert</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;OK</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Speichern</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Abbrechen</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Änderungen &amp;verwerfen</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Abspielen</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished">Ungespeichterte Änderungen. Diese werden verloren gehen. Trotzdem beenden?</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished">Zeige diese Meldung nicht wieder an</translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation>Komponentenname</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Instrumentenlautstärke [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -355,10 +931,6 @@
     <message>
         <source>Cannot paste multi-pattern selection</source>
         <translation>Kann Multi-Pattern Selektion nicht einfügen</translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
-        <translation>Konnte Instrument nicht laden</translation>
     </message>
 </context>
 <context>
@@ -462,6 +1034,22 @@ Overwrite the existing file?</source>
     <message>
         <source>Directory %1 does not exist</source>
         <translation>Verzeichnis %1 existiert nicht</translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation>Verzeichnis für Systemdaten</translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>FX an/aus</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Master-Ausgang</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>BPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -709,25 +1314,6 @@ Overwrite the existing file?</source>
         <translation>Eigenschaften der Soundbibliothek</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Nicht möglich. Es lassen sich nur Änderungen an Instrumenten innerhalb der aktuell verwendeten Soundbibliothek speichern.</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Achtung! Bei Änderungen des Schlagzeugnames wird ein neues Schlagzeug eben jenes Namens erstellt.
-Bist Du sicher?
-</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Speichern des Schlagzeugs ist fehlgeschlagen.</translation>
     </message>
@@ -739,13 +1325,45 @@ Bist Du sicher?
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>Bilddatei (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Komponente</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Lizenz</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Schlagzeug geladen: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Song-Editor</translation>
@@ -761,10 +1379,6 @@ Bist Du sicher?
     <message>
         <source>modified</source>
         <translation>geändert</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Song gespeichert.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -785,6 +1399,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished">Song gespeichert unter: </translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -811,22 +1445,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Resonanz des Filters</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>Attack</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Dämpfung (decay)</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sustain</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Freigabe (release)</translation>
-    </message>
-    <message>
         <source>Layer gain</source>
         <translation>Verstärkung (gain) der Ebene</translation>
     </message>
@@ -845,14 +1463,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>Tonhöhe des Layers (fein)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Übersicht</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Ebenen</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -895,8 +1505,28 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Wähle den Algorithmus zur Auswahl von Samples aus</translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
-        <translation>Layer Tonlage: %1</translation>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -939,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Schalte Instrument stumm</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Solo</translation>
     </message>
     <message>
@@ -1009,16 +1641,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Instrumenteneditor anzeigen</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrument</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Soundbibliothek anzeigen</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Soundbibliothek</translation>
     </message>
 </context>
 <context>
@@ -1069,6 +1693,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>Effekt löschen</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1257,10 +1889,6 @@ MIDI = %2</translation>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>Änderungen &amp;verwerfen</translation>
-    </message>
-    <message>
         <source>Hydrogen Ready.</source>
         <translation>Hydrogen ist bereit.</translation>
     </message>
@@ -1295,10 +1923,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;About</source>
         <translation>&amp;Über Hydrogen</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1341,10 +1965,6 @@ MIDI = %2</translation>
         <translation>&amp;Info</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Lied gespeichert.</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Unbekannter Fehler %1</translation>
     </message>
@@ -1375,10 +1995,6 @@ MIDI = %2</translation>
     <message>
         <source>Open Pattern</source>
         <translation>Öffne Pattern</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Diese Nachricht nicht mehr anzeigen</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1412,7 +2028,6 @@ Willst Du die Änderungen speichern?</translation>
     <message>
         <source>&amp;Undo</source>
         <translation>Rückgängig machen</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1524,10 +2139,6 @@ Are you sure you want to save?</source>
     <message>
         <source>Save &amp;As...</source>
         <translation>Speichern &amp;unter...</translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
-        <translation>Zeige &amp;Info</translation>
     </message>
     <message>
         <source>E&amp;xport Pattern As...</source>
@@ -1709,12 +2320,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>OSC Server: Konnte nicht zu dem ausgewählten Port verbinden, verwende Port %1 stattdessen</translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation>OK</translation>
-    </message>
-    <message>
         <source>Playing.</source>
         <translation>Spielt ab.</translation>
+    </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1725,10 +2375,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Master-Lautstaerke [%1]</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
-    </message>
-    <message>
         <source>Humanize time</source>
         <translation>Zeitpunkt vermenschlichen</translation>
     </message>
@@ -1737,39 +2383,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Anschlag (velocity) vermenschlichen</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Setzen des vermenschlichten Zeitpunkt-Parameters [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Setzen des vermenschlichten Anschlag-Parameters [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Swingfaktor [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation>Dieses Element kann nicht per MIDI angesprochen werden.</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>Warte auf MIDI Eingabe...</translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Ereignis</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Param.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Aktion</translation>
@@ -1777,6 +2416,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>Knopf drücken, um Midi-Event aufzunehmen</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1798,14 +2457,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Peaks anzeigen = deaktiviert</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Effekt-Intensität %1 </translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>LADSPA-Effekt-Lautstärke (%1)</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation>LADSPA-Effekte stehen in dieser Hydrogenversion nicht zur Verfügung.</translation>
     </message>
@@ -1816,6 +2467,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Mixer Settings</source>
         <translation>Mixer Einstellungen</translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1837,12 +2496,20 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Pan</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Instrumentenlautstärke [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
-        <translation>Name des Instruments</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1934,14 +2601,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Lösche Selektion</translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation>Setze Noten-Anschlagsstärke [%1]</translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation>Editiere Eigenschaft %1 von %2 Noten</translation>
-    </message>
-    <message>
         <source>B</source>
         <translation>B</translation>
     </message>
@@ -1989,6 +2648,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation>C</translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2021,8 +2684,52 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
-        <translation>Zeige diese Meldung nicht wieder an</translation>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2071,18 +2778,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Verkleinern</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Während des Abspielens kann die Patternlänge nicht verändert werden.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Patternlänge wählen</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Gitterauflösung wählen</translation>
-    </message>
-    <message>
         <source>No pattern selected</source>
         <translation>Kein Pattern ausgewählt</translation>
     </message>
@@ -2121,10 +2816,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Probability</source>
         <translation>Wahrscheinlichkeit</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>quarter</source>
@@ -2167,36 +2858,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>aus</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation>Neue Pattern Länge (Schläge/Notenwert)</translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation>Die Patternlänge ist zu groß. Maximalwert: 16/4</translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
-        <translation>Ungültige Eingabe</translation>
     </message>
 </context>
 <context>
@@ -2295,6 +2962,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Stop</source>
@@ -2323,10 +2997,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Patternmodus gewählt.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Neuer BPM-Wert</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2361,21 +3031,8 @@ Maximum = 16/4</source>
         <translation>Mixer anzeigen</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mixer</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Instrumenten Rack anzeigen</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Instrumenten Rack</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Beatcounter
- sichtbar</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2431,19 +3088,6 @@ Maximum = 16/4</source>
         <translation>JACK Transport an/aus</translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation>JACK Timebase master an/aus</translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation>Jack Timebase Unterstützung ist in den Einstellungen deaktiviert</translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation>Das Tempo kann in Hydrogen nicht geändert werden, solange ein externer JACK Timebase Master aktiv ist</translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation>Der JACK Transport funktioniert nur mit dem JACK Treiber.</translation>
     </message>
@@ -2456,12 +3100,44 @@ Maximum = 16/4</source>
         <translation>JACK Transport Modus = Aus</translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
-        <translation>JACK Timebase Master Modus = An</translation>
+        <source>Toggle the BeatCounter Panel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
-        <translation>JACK Timebase Master Modus = Aus</translation>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2653,14 +3329,6 @@ Do you want to discard the changes?
 	  Möchtest Du diese verwerfen?</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>Änderungen &amp;verwerfen</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2694,32 +3362,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Treiber-Neustart notwendig. Soll der Treiber nun neu gestartet werden?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
-    </message>
-    <message>
         <source>Automatic</source>
         <translation>Automatisch</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation>Schritte</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>Unveränderlich</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>Anzahl der Schritte</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Farbe (hue)</translation>
     </message>
     <message>
         <source>Automatic driver selection</source>
@@ -2738,16 +3382,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Wähle deinen MIDI Treiber</translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation>Der gewählte Port ist nicht verfügbar. Diese Instanz benutzt nun folgenden temporären Port:</translation>
-    </message>
-    <message>
-        <source>selected</source>
-        <translation>ausgewählt</translation>
     </message>
     <message>
         <source>Open Sound System</source>
@@ -2756,10 +3392,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
-        <translation>Nicht einkompiliert</translation>
     </message>
     <message>
         <source>JACK Audio Connection Kit Driver</source>
@@ -2784,6 +3416,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>PulseAudio Driver</source>
         <translation>PulseAudio Treiber</translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Übersicht</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Fehler beim Starten des Audiotreibers</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2904,14 +3808,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Anwendungs-Schriftart</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Mixer-Schriftart</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Schriftart wählen</translation>
     </message>
     <message>
         <source>###</source>
@@ -3046,16 +3942,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Tabular</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>Text-Label</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>Farbgebung für Elemente des Lied-Editors</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Nachdem die Schriftart oder Farbe der Schnittstelle verändert wurde, muss die Anwendung neugestartet werden.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;OSC</source>
@@ -3147,7 +4035,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation>Verwende &amp;LASH</translation>
     </message>
     <message>
@@ -3194,17 +4082,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>&amp;Use output note as input note</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished">B</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation>Fühe Pattern hinzu ( %1, %2 )</translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation>Lösche Pattern ( %1, %2 )</translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation>Verschiebe Eintrag in Pattern-Liste (%1, %2 )</translation>
@@ -3236,14 +4240,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Fill/remove range of pattern</source>
         <translation>Fülle/Leere Teil eines Patterns</translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation>Editiere Tempo-Eintrag der Timeline</translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
-        <translation>Lösche Tempo-Eintrag der Timeline</translation>
     </message>
     <message>
         <source>Edit timeline tag</source>
@@ -3306,10 +4302,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Füge Piano-Roll NOTE_OFF Note hinzu ( %1, %2 )</translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation>Ändere Länge einer Piano-Roll Note </translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation>Ändere Eigenschaft einer Piano-Roll Note</translation>
     </message>
@@ -3329,39 +4321,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation>Punkt verschieben</translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Schließe Fenster. Möglicherweise sind noch ungespeicherte Änderungen in diesen Samplen.
-Bist Du sicher?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation>Ungespeichterte Änderungen. Diese werden verloren gehen. Trotzdem beenden?</translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation>Sample Editor </translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation>&amp;Abspielen</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation>Spie&amp;le Original</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3777,29 +4777,8 @@ Are you sure?</source>
 Fortsetzen?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>Gestapelter Modus
-</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>Gestapelter Pattern-Modus</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>Einfacher Pattern-Modus</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Zeitstrahl-Editor aktivieren</translation>
     </message>
     <message>
         <source>Pattern %1</source>
@@ -3830,20 +4809,16 @@ Fortsetzen?</translation>
         <translation>Anschlag (velocity)</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
-        <translation>Die Verwendung der Timeline ist deaktiviert, solange JACK als timebase master verwendet wird</translation>
+        <source>selected pattern mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation> Timeline aus</translation>
+        <source>Playback track volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = On</source>
-        <translation> Timeline an</translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation>Das Tempo kann in Hydrogen nicht geändert werden, solange ein externer JACK timebase master aktiv ist</translation>
+        <source>Playback volume set to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3851,22 +4826,6 @@ Fortsetzen?</translation>
     <message>
         <source>Form</source>
         <translation>Formular</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>BPM des aktuellen Beats bearbeiten</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Beat in Zeitstrahl bearbeiten</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3931,34 +4890,14 @@ Fortsetzen?</translation>
         <translation>Lade Pattern</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Öffne Pattern</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>Virtuelles Pattern</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Pattern 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>nicht_kategorisiert</translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>Die Pattern-Datei existiert bereits.
 Soll sie überschrieben werden?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3987,6 +4926,17 @@ Soll sie überschrieben werden?</translation>
     <message>
         <source>Fill/Clear...</source>
         <translation>Füllen/Leeren...</translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4038,24 +4988,36 @@ Soll sie überschrieben werden?</translation>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Soundbibliothek exportieren</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Verzeichnis</translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
-        <translation>Schlagzeug exportiert.</translation>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportieren</translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
-        <translation>Schlagzeugexport fehlgeschlagen. Operation nicht unterstützt.</translation>
+        <source>Export Drumkit</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
-        <translation>Konnte Archiv nicht erzeugen</translation>
+        <source>invalid drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file [%1] does already exist and will be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Alle</translation>
     </message>
 </context>
 <context>
@@ -4063,10 +5025,6 @@ Soll sie überschrieben werden?</translation>
     <message>
         <source>Export</source>
         <translation>Exportieren</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Schlagzeug</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4265,14 +5223,6 @@ Soll sie überschrieben werden?</translation>
         <translation>Schlagzeuge des Benutzers</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Lieder</translation>
     </message>
@@ -4325,18 +5275,8 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation>Doppelklick zum Aufblättern der Liste</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
         <translation>ist ein System Drumkit und kann nicht gelöscht werden.</translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
-        <translation>Noch nicht implementiert.</translation>
     </message>
 </context>
 <context>
@@ -4362,10 +5302,6 @@ Current kit:</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Änderungen an den Instrumenten übernehmen</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Schlagzeug-Lizenz</translation>
     </message>
@@ -4380,6 +5316,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Bild-Lizenz</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4417,76 +5357,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Soundbibliothek speichern</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Bitte gültigen Dateinamen angeben</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>Es gibt bereits ein Bibliothek mit diesem Namen. Soll sie überschrieben werden?</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Speichern der Bibliothek ist fehlgeschlagen.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Bild öffnen</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Bild-Dateien (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Dialog</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Name</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Information</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Abbrechen</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Lizenz</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Speichern</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Bild</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Durchsuchen</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Bild-Lizenz</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4513,6 +5383,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -304,7 +304,7 @@
     </message>
     <message>
         <source>Set automatic velocity</source>
-        <translation>Setze Anschlaghärte (Velocity= automatisch</translation>
+    <translation>Setze Anschlaghärte (Velocity) automatisch</translation>
     </message>
 </context>
 <context>
@@ -338,7 +338,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     <message>
         <source>Mute</source>
         <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
-        <translation>Stumm</translation>
+        <translation>Mute</translation>
     </message>
     <message>
         <source>BYP</source>
@@ -348,7 +348,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     <message>
         <source>Edit</source>
         <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
-        <translation>Ändern</translation>
+        <translation>Edit</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -408,7 +408,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     <message>
         <source>Edit Layer</source>
         <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
-        <translation>Ändere Ebene</translation>
+        <translation>Edit Ebene</translation>
     </message>
     <message>
         <source>B
@@ -514,7 +514,7 @@ B</translation>
     <message>
         <source>Gain</source>
         <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
-        <translation>Verstärkung</translation>
+        <translation>Gain</translation>
     </message>
     <message>
         <source>Mute Group</source>
@@ -529,7 +529,7 @@ B</translation>
     <message>
         <source>Apply Velocity</source>
         <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
-        <translation>Anschlag anwenden</translation>
+        <translation>Anschlag anw.</translation>
     </message>
     <message>
         <source>HH Press. Grp</source>
@@ -549,7 +549,7 @@ B</translation>
     <message>
         <source>Cutoff</source>
         <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation>Overgrenze</translation>
+        <translation>Cutoff</translation>
     </message>
     <message>
         <source>Resonance</source>
@@ -574,7 +574,7 @@ B</translation>
     <message>
         <source>Size</source>
         <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
-        <translation>Größe</translation>
+        <translation>Länge</translation>
     </message>
     <message>
         <source>Res</source>
@@ -594,7 +594,7 @@ B</translation>
     <message>
         <source>Input</source>
         <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
-        <translation>Eingabe</translation>
+        <translation>Input</translation>
     </message>
     <message>
         <source>MIDI-In</source>
@@ -5405,12 +5405,12 @@ Would you like to keep or discard the remaining instruments and notes?
     <message>
         <source>Other</source>
         <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
-        <translation>Kennzeichnung, welche für alle Lizenzen verwendet wird, die nicht direkt in der Auswahlbox unterstützt werden.</translation>
+        <translation>Andere</translation>
     </message>
     <message>
         <source>Unspecified</source>
         <extracomment>Label used if no license was specified.</extracomment>
-        <translation>Kennzeichnung, die genutzt wird, wenn keine Lizenz spezifiert wurde.</translation>
+        <translation>Unspezifiziert</translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -9,7 +9,7 @@
     </message>
     <message>
         <source>Website</source>
-        <translation>Website</translation>
+        <translation>Webseite</translation>
     </message>
     <message>
         <source>Project page</source>
@@ -86,7 +86,7 @@
     <name>AudioEngineInfoForm_UI</name>
     <message>
         <source>Playing notes</source>
-        <translation>Playing notes</translation>
+        <translation>Gespielte Noten</translation>
     </message>
     <message>
         <source>Process time</source>
@@ -162,7 +162,7 @@
     </message>
     <message>
         <source>Audio output</source>
-        <translation>Audio-Ausgang</translation>
+        <translation>Audio Ausgang</translation>
     </message>
     <message>
         <source>Realtime frames</source>
@@ -170,7 +170,7 @@
     </message>
     <message>
         <source>Latency (estimated)</source>
-        <translation type="unfinished"></translation>
+        <translation>Latenz (geschätzt)</translation>
     </message>
 </context>
 <context>
@@ -229,7 +229,7 @@
     </message>
     <message>
         <source>Play selected</source>
-        <translation>Selektierte Datei abspielen</translation>
+        <translation>Ausgewählte Datei abspielen</translation>
     </message>
     <message>
         <source>Stop</source>
@@ -300,18 +300,18 @@
     </message>
     <message>
         <source>Be careful, this change all Layer velocity settings </source>
-        <translation>Vorsicht. Hierdurch werden alle Velocity Einstellungen der Layer geändert </translation>
+        <translation>Vorsicht. Hierdurch werden die Anschlaghärte (Velocity) Einstellungen aller Layer geändert </translation>
     </message>
     <message>
         <source>Set automatic velocity</source>
-        <translation>Setze Velocity automatisch</translation>
+        <translation>Setze Anschlaghärte (Velocity= automatisch</translation>
     </message>
 </context>
 <context>
     <name>ColorSelectionButton</name>
     <message>
         <source>Pick a pattern color</source>
-        <translation type="unfinished"></translation>
+        <translation>Wähle eine Farbe</translation>
     </message>
 </context>
 <context>
@@ -321,554 +321,559 @@
         <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
 ----------
 Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>P</translation>
     </message>
     <message>
         <source>S</source>
         <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
 ----------
 Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>S</translation>
     </message>
     <message>
         <source>M</source>
         <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>M</translation>
     </message>
     <message>
         <source>Mute</source>
         <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
-        <translation type="unfinished">Stumm</translation>
+        <translation>Stumm</translation>
     </message>
     <message>
         <source>BYP</source>
         <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>BYP</translation>
     </message>
     <message>
         <source>Edit</source>
         <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Ändern</translation>
     </message>
     <message>
         <source>Clear</source>
         <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Löschen</translation>
     </message>
     <message>
         <source>T</source>
         <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>T</translation>
     </message>
     <message>
         <source>Timeline</source>
         <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Timeline</translation>
     </message>
     <message>
         <source>FX</source>
         <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>FX</translation>
     </message>
     <message>
         <source>Peak</source>
         <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Peak</translation>
     </message>
     <message>
         <source>General</source>
         <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
-        <translation type="unfinished">Übersicht</translation>
+        <translation>Übersicht</translation>
     </message>
     <message>
         <source>Instrument</source>
         <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
-        <translation type="unfinished">Instrument</translation>
+        <translation>Instrument</translation>
     </message>
     <message>
         <source>Sound Library</source>
         <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sound Bibliothek</translation>
     </message>
     <message>
         <source>Layers</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
-        <translation type="unfinished">Ebenen</translation>
+        <translation>Ebenen</translation>
     </message>
     <message>
         <source>Load Layer</source>
         <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Lade Ebene</translation>
     </message>
     <message>
         <source>Delete Layer</source>
         <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Lösche Ebene</translation>
     </message>
     <message>
         <source>Edit Layer</source>
         <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Ändere Ebene</translation>
     </message>
     <message>
         <source>B
 C</source>
         <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>B
+C</translation>
     </message>
     <message>
         <source>R
 U
 B</source>
         <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>R
+U
+B</translation>
     </message>
     <message>
         <source>J.Trans</source>
         <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>J.Trans</translation>
     </message>
     <message>
         <source>J.Master</source>
         <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>J.Master</translation>
     </message>
     <message>
         <source>Mixer</source>
         <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
-        <translation type="unfinished">Mixer</translation>
+        <translation>Mixer</translation>
     </message>
     <message>
         <source>Instrument Rack</source>
         <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Instrument Editor</translation>
     </message>
     <message>
         <source>Pattern</source>
         <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Pattern</translation>
     </message>
     <message>
         <source>Song</source>
         <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Song</translation>
     </message>
     <message>
         <source>Attack</source>
         <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished">Attack</translation>
+        <translation>Attack</translation>
     </message>
     <message>
         <source>Decay</source>
         <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
-        <translation type="unfinished">Dämpfung (decay)</translation>
+        <translation>Decay</translation>
     </message>
     <message>
         <source>Sustain</source>
         <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
-        <translation type="unfinished">Sustain</translation>
+        <translation>Sustain</translation>
     </message>
     <message>
         <source>Release</source>
         <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
-        <translation type="unfinished">Freigabe (release)</translation>
+        <translation>Release</translation>
     </message>
     <message>
         <source>Channel</source>
         <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
-        <translation type="unfinished">Kanal</translation>
+        <translation>Kanal</translation>
     </message>
     <message>
         <source>Note</source>
         <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Note</translation>
     </message>
     <message>
         <source>MIDI Output</source>
         <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>MIDI Ausgabe</translation>
     </message>
     <message>
         <source>Pitch</source>
         <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Tonhöhe</translation>
     </message>
     <message>
         <source>Coarse</source>
         <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Grob</translation>
     </message>
     <message>
         <source>Fine</source>
         <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Fein</translation>
     </message>
     <message>
         <source>Random</source>
         <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Zufall</translation>
     </message>
     <message>
         <source>Gain</source>
         <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Verstärkung</translation>
     </message>
     <message>
         <source>Mute Group</source>
         <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Mute Gruppe</translation>
     </message>
     <message>
         <source>Auto-Stop Note</source>
         <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Auto-Stop Note</translation>
     </message>
     <message>
         <source>Apply Velocity</source>
         <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Anschlag anwenden</translation>
     </message>
     <message>
         <source>HH Press. Grp</source>
         <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>HH Press. Grp</translation>
     </message>
     <message>
         <source>Max Range</source>
         <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Interval Max</translation>
     </message>
     <message>
         <source>Min Range</source>
         <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Interval Min</translation>
     </message>
     <message>
         <source>Cutoff</source>
         <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Overgrenze</translation>
     </message>
     <message>
         <source>Resonance</source>
         <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Resonanz</translation>
     </message>
     <message>
         <source>L. Gain</source>
         <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>L. Gain</translation>
     </message>
     <message>
         <source>C. Gain</source>
         <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>C. Gain</translation>
     </message>
     <message>
         <source>Sample Sel.</source>
         <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sample Ausw.</translation>
     </message>
     <message>
         <source>Size</source>
         <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Größe</translation>
     </message>
     <message>
         <source>Res</source>
         <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Res</translation>
     </message>
     <message>
         <source>Hear</source>
         <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Hören</translation>
     </message>
     <message>
         <source>Quant</source>
         <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Quant</translation>
     </message>
     <message>
         <source>Input</source>
         <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
-        <translation type="unfinished">Eingang</translation>
+        <translation>Eingabe</translation>
     </message>
     <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>MIDI-In</translation>
     </message>
     <message>
         <source>CPU</source>
         <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>CPU</translation>
     </message>
     <message>
         <source>BPM</source>
         <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished">BPM</translation>
+        <translation>BPM</translation>
     </message>
     <message>
         <source>Hrs</source>
         <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Std</translation>
     </message>
     <message>
         <source>Min</source>
         <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Min</translation>
     </message>
     <message>
         <source>Sec</source>
         <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sek</translation>
     </message>
     <message>
         <source>1/1000</source>
         <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
-        <translation type="unfinished">1/1000</translation>
+        <translation>1/1000</translation>
     </message>
     <message>
         <source>Humanize</source>
         <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Humanize</translation>
     </message>
     <message>
         <source>Swing</source>
         <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
-        <translation type="unfinished">Swing</translation>
+        <translation>Swing</translation>
     </message>
     <message>
         <source>Timing</source>
         <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Timing</translation>
     </message>
     <message>
         <source>Velocity</source>
         <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
-        <translation type="unfinished">Anschlag (velocity)</translation>
+        <translation>Anschlag (velocity)</translation>
     </message>
     <message>
         <source>Master</source>
         <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Master</translation>
     </message>
     <message>
         <source>Return</source>
         <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Rückgabe</translation>
     </message>
     <message>
         <source>Range</source>
         <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Interval</translation>
     </message>
     <message>
         <source>MIDI</source>
         <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>MIDI</translation>
     </message>
     <message>
         <source>bound to</source>
         <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>verknüft mit</translation>
     </message>
     <message>
         <source>not bound</source>
         <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>nicht verknüpft</translation>
     </message>
     <message>
         <source>It&apos;s not possible to change the pattern size when playing.</source>
         <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Die Länge eines Patterns kann nicht während der Wiedergabe geändert werden.</translation>
     </message>
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Drumkit Editor anzeigen</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
-        <translation type="unfinished">Piano-Roll anzeigen</translation>
+        <translation>Piano-Roll Editor anzeigen</translation>
     </message>
     <message>
         <source>Unable to start audio driver!</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio Treiber konnte nicht gestartet werden!</translation>
     </message>
     <message>
         <source>Please use the Preferences to select a different one.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitte wählen Sie über die Einstellungen eine andere Option.</translation>
     </message>
     <message>
         <source>No audio driver set!</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Audio Treiber geladen!</translation>
     </message>
     <message>
         <source>Register Hydrogen as JACK Timebase master</source>
-        <translation type="unfinished"></translation>
+        <translation>Hydrogen als JACK Timebase master registieren</translation>
     </message>
     <message>
         <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Hydrogen reagiert auch Tempo und Positionsänderungen. Drücken, um Hydrogen stattdessen selbst als JACK Timebase master zu registieren.</translation>
     </message>
     <message>
         <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished">Jack Timebase Unterstützung ist in den Einstellungen deaktiviert</translation>
+        <translation>Jack Timebase Unterstützung ist in den Einstellungen deaktiviert</translation>
     </message>
     <message>
         <source>Waiting...</source>
         <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Warten...</translation>
     </message>
     <message>
         <source>Waiting for MIDI input...</source>
         <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Warten auf MIDI Eingabe...</translation>
     </message>
     <message>
         <source>This element is not MIDI operable.</source>
         <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Diese Element kann nicht über MIDI gesteuert werden.</translation>
     </message>
     <message>
         <source>Unable to load pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Pattern konnte nicht geladen werden</translation>
     </message>
     <message>
         <source>Unable to load instrument</source>
-        <translation type="unfinished">Konnte Instrument nicht laden</translation>
+        <translation>Instrument konnte nicht geladen werden</translation>
     </message>
     <message>
         <source>on</source>
         <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>an</translation>
     </message>
     <message>
         <source>off</source>
         <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished">aus</translation>
+        <translation>aus</translation>
     </message>
     <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>aktiv</translation>
     </message>
     <message>
         <source>disabled</source>
         <extracomment>Displayed within a status message when disabling a widget.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>deaktiv</translation>
     </message>
     <message>
         <source>Enable the Timeline for custom tempo changes</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktiviere den Zeitstrahl (timeline) für benutzerdefinierte Tempoänderungen</translation>
     </message>
     <message>
         <source>The Timeline is only available in Song Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeitstrahl (timeline) ist nur im Song Modus verfügbar</translation>
     </message>
     <message>
         <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
+        <translation>Während Hydrogen auf Tempoinformationen eines externen JACK Timebase master hört, kann das Tempo nicht intern geändert werden</translation>
     </message>
     <message>
         <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
-        <translation type="unfinished"></translation>
+        <translation>Pattern Editor fixieren, um im Song Modus immer das Pattern anzuzeigen, in welches aufgenommene Noten platziert werden.</translation>
     </message>
     <message>
         <source>Not compiled</source>
         <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
-        <translation type="unfinished">Nicht einkompiliert</translation>
+        <translation>Nicht einkompiliert</translation>
     </message>
     <message>
         <source>None</source>
         <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Keiner</translation>
     </message>
     <message>
         <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
         <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Sowohl Buffergröße als auch Samplerate können nur direkt in den Einstellungen des JACK Servers geändert werden</translation>
     </message>
     <message>
         <source>&amp;Ok</source>
         <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
-        <translation type="unfinished">&amp;OK</translation>
+        <translation>&amp;OK</translation>
     </message>
     <message>
         <source>&amp;Save</source>
         <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
-        <translation type="unfinished">&amp;Speichern</translation>
+        <translation>&amp;Speichern</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
         <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
-        <translation type="unfinished">&amp;Abbrechen</translation>
+        <translation>&amp;Abbrechen</translation>
     </message>
     <message>
         <source>&amp;Discard</source>
         <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
-        <translation type="unfinished">Änderungen &amp;verwerfen</translation>
+        <translation>Änderungen &amp;verwerfen</translation>
     </message>
     <message>
         <source>&amp;Play</source>
         <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
-        <translation type="unfinished">&amp;Abspielen</translation>
+        <translation>&amp;Abspielen</translation>
     </message>
     <message>
         <source>Play &amp;original sample</source>
         <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Ursprüngliches Sample abspielen</translation>
     </message>
     <message>
         <source>Unsaved changes left. These changes will be lost. 
 Are you sure?</source>
         <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
 &apos; character introduces a linebreak and must not be translated</extracomment>
-        <translation type="unfinished">Ungespeichterte Änderungen. Diese werden verloren gehen. Trotzdem beenden?</translation>
+        <translation>Ungespeichterte Änderungen. Diese werden verloren gehen. Trotzdem beenden?</translation>
     </message>
     <message>
         <source>Don&apos;t show this message again</source>
-        <translation type="unfinished">Zeige diese Meldung nicht wieder an</translation>
+        <translation>Zeige diese Meldung nicht wieder an</translation>
     </message>
     <message>
         <source>License String</source>
         <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Lizenz Beschreibung</translation>
     </message>
     <message>
         <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
         <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Von der Lizenz Beschreibung abgeleitete Lizenz. Mit dieser Auswahlbox kann die aktuelle Lizenz mit einer vordefinierten überschrieben werden</translation>
     </message>
     <message>
         <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
-        <translation type="unfinished"></translation>
+        <translation>Lizenz Beschreibung, welche im Schlagzeug abgelegt wird. Sie ist frei änderbar (man kann z.B. Autorenschaft (attribution) hinzufügen), wird aber beim Auswählen einer anderen Lizenz überschrieben</translation>
     </message>
     <message>
         <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>Das verwendete Schlagzeug enthält &lt;b&gt;copyleft&lt;/b&gt; Lizenzen. Daraus folgt die &lt;b&gt;gesetzliche Verpflichtung eine Kopie öffentlich verfügbar zu machen und eine Weiterverbreitung kann nicht untersagt werden&lt;/b&gt;.</translation>
     </message>
     <message>
         <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
-        <translation type="unfinished"></translation>
+        <translation>Alle Lizenzen mit dem Kürzel &apos;CC BY&apos; &lt;b&gt;erfordern die Angabe der Autorenschaft (attribution)&lt;/b&gt; über die Nennung des Schlagzeugs, der Autorin und der Lizenz.</translation>
     </message>
     <message>
         <source>License Warning</source>
         <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Lizenz Warnung</translation>
     </message>
     <message>
         <source>Drumkit registered in the current song can not be found on disk.
 Please load an existing drumkit first.
 Current kit:</source>
-        <translation type="unfinished"></translation>
+<translation>Schlagzeug des aktuellen Liedes konnte nicht auf der Festplatte gefunden werden
+Bitte laden Sie erst ein existierendes Schlagzeug.
+Aktuelles:</translation>
     </message>
     <message>
         <source>system</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>system</translation>
     </message>
 </context>
 <context>
@@ -887,15 +892,15 @@ Current kit:</source>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Lautstärke</translation>
     </message>
     <message>
         <source>Peak</source>
-        <translation type="unfinished"></translation>
+        <translation>Höchstwert</translation>
     </message>
     <message>
         <source>Set volume [%1] of component</source>
-        <translation type="unfinished"></translation>
+        <translation>Lautstärke [%1] von Komponent geändert</translation>
     </message>
 </context>
 <context>
@@ -930,14 +935,14 @@ Current kit:</source>
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation>Kann Multi-Pattern Selektion nicht einfügen</translation>
+        <translation>Kann Multi-Pattern Auswahl nicht einfügen</translation>
     </message>
 </context>
 <context>
     <name>ExportMidiDialog</name>
     <message>
         <source>Export midi</source>
-        <translation>Exportiere Midi</translation>
+        <translation>Exportiere MIDI</translation>
     </message>
     <message>
         <source>SMF1 single: export all instruments to a single track</source>
@@ -949,15 +954,15 @@ Current kit:</source>
     </message>
     <message>
         <source>SMF0: export all events to one track</source>
-        <translation>SMF0: exportiere alle Midi Events in eine Spur</translation>
+        <translation>SMF0: exportiere alle MIDI Events in eine Spur</translation>
     </message>
     <message>
         <source>Midi file (*%1)</source>
-        <translation>Midi Datei (*%1)</translation>
+        <translation>MIDI Datei (*%1)</translation>
     </message>
     <message>
         <source>Export MIDI file</source>
-        <translation>Mididatei exportieren</translation>
+        <translation>MIDI Datei exportieren</translation>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
@@ -1037,19 +1042,19 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>No sample in the current song uses Rubberband</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Samples des aktuellen Liedes benutzt Rubberband</translation>
     </message>
     <message>
         <source>Your song uses samples of the following license:</source>
-        <translation type="unfinished"></translation>
+        <translation>Dein Lied nutzt Samples folgender Lizenzen:</translation>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
+        <translation>Stellen Sie sicher, dass sie alle Lizenzvereinbarungen erfüllen und die notwenige Autorenschaft ausweisen.</translation>
     </message>
     <message>
         <source>Unable to export song</source>
-        <translation type="unfinished"></translation>
+        <translation>Lied konnte nicht exportiert werden</translation>
     </message>
 </context>
 <context>
@@ -1258,46 +1263,46 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Filesystem is not writable!</source>
-        <translation type="unfinished"></translation>
+        <translation>Verzeichnissystem ist nicht schreibbar!</translation>
     </message>
     <message>
         <source>User data folder is not writable!</source>
-        <translation type="unfinished"></translation>
+        <translation>Ordner mit Benutzerdaten ist nicht schreibbar!</translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
         <source>Please enter a number within the range of </source>
-        <translation type="unfinished"></translation>
+        <translation>Bitte geben Sie eine Zahl innerhalb des Intervals </translation>
     </message>
     <message>
         <source>Edit Tempo Marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo Marker editieren</translation>
     </message>
     <message>
         <source>Create New Tempo Marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Neuen Tempo Marker erstellen</translation>
     </message>
     <message>
         <source>Alter tempo of selected tempo marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo des gewählten Tempo Markers ändern</translation>
     </message>
     <message>
         <source>Set tempo of new tempo marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo eines neuen Tempo Markers setzen</translation>
     </message>
     <message>
         <source>Move tempo marker to different column</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo Marker in eine andere Spalte verschieben</translation>
     </message>
     <message>
         <source>Set column of new tempo marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Spalte eines neuen Tempo Markers setzen</translation>
     </message>
     <message>
         <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
-        <translation type="unfinished"></translation>
+        <translation>Für diese Spalte existiert bereits ein Tempo Marker. Durch Anklicken mit der liken Maustaste kann dieser geändert werden.</translation>
     </message>
 </context>
 <context>
@@ -1327,39 +1332,39 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Änderung des Schlagzeugnamen führt zum Erzeugen eines neuen Schlagzeuges. Dafür muss das Schlagzeug mittels Rechtsklick geladen werden und Schlagzeug &gt; Speichern Unter im Hauptmenü ausgewählt werden</translation>
     </message>
     <message>
         <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das aktuellen Schlagzeug ist nur les- aber nicht schreibbar. Bitte erstellen Sie über Schlagzeug &gt; Speichern Unter im Hauptmenü erst eine Neues.</translation>
     </message>
     <message>
         <source>Instrument</source>
-        <translation type="unfinished">Instrument</translation>
+        <translation>Instrument</translation>
     </message>
     <message>
         <source>Component</source>
-        <translation type="unfinished">Komponente</translation>
+        <translation>Komponente</translation>
     </message>
     <message>
         <source>Sample</source>
-        <translation type="unfinished"></translation>
+        <translation>Sample</translation>
     </message>
     <message>
         <source>License</source>
-        <translation type="unfinished">Lizenz</translation>
+        <translation>Lizenz</translation>
     </message>
     <message>
         <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gesetzte Lizenz Beschreibung stimmt nicht mit der Lizenz in der Auswahlbox überein.</translation>
     </message>
     <message>
         <source>Specified image License String does not comply with the license selected in the combo box.</source>
-        <translation type="unfinished"></translation>
+        <translation>Gesetzte Bildlizenz Beschreibung stimmt nicht mit der Lizenz in der Auswahlbox überein.</translation>
     </message>
     <message>
         <source>The name of the drumkit must not be left empty</source>
-        <translation type="unfinished"></translation>
+        <translation>Der Name des Schlagzeuges muss gesetzt werden</translation>
     </message>
 </context>
 <context>
@@ -1399,27 +1404,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Input Midi Note</source>
-        <translation type="unfinished"></translation>
+        <translation>Eingehende MIDI Note</translation>
     </message>
     <message>
         <source>There are unsaved changes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Es gibt ungespeicherte Änderungen.</translation>
     </message>
     <message>
         <source>Do you want to recover them?</source>
-        <translation type="unfinished"></translation>
+        <translation>Sollen diese wiederhergestellt werden?</translation>
     </message>
     <message>
         <source>Drumkit [%1] loaded from [%2]</source>
-        <translation type="unfinished"></translation>
+        <translation>Schlagzeug [%1] geladen aus [%2]</translation>
     </message>
     <message>
         <source>Song saved as: </source>
-        <translation type="unfinished">Song gespeichert unter: </translation>
+        <translation>Song gespeichert unter: </translation>
     </message>
     <message>
         <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>Einige Sample Lizenzen weichen von der Schlagzeug Lizenz [%1] ab und werden überschrieben. Sind Sie sich sicher?</translation>
     </message>
 </context>
 <context>
@@ -1508,25 +1513,33 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Length of Attack phase.
 
 Value</source>
-        <translation type="unfinished"></translation>
+<translation>Länge der Attack Phase.
+
+Wert</translation>
     </message>
     <message>
         <source>Length of Decay phase.
 
 Value</source>
-        <translation type="unfinished"></translation>
+<translation>Länge der Decay (Abkling-) Phase.
+
+Wert</translation>
     </message>
     <message>
         <source>Sample volume in Sustain phase.
 
 Value</source>
-        <translation type="unfinished"></translation>
+<translation>Sample Lautstärke in der Sustain Phase.
+
+Wert</translation>
     </message>
     <message>
         <source>Length of Release phase.
 
 Value</source>
-        <translation type="unfinished"></translation>
+<translation>Länge der Release (Abkling-) Phase.
+
+Wert</translation>
     </message>
 </context>
 <context>
@@ -1696,11 +1709,11 @@ Value</source>
     </message>
     <message>
         <source>Input control param. value</source>
-        <translation type="unfinished"></translation>
+        <translation>Eingangs-Kontrollparameter</translation>
     </message>
     <message>
         <source>Output control param. value</source>
-        <translation type="unfinished"></translation>
+        <translation>Ausgangs-Kontrollparameter</translation>
     </message>
 </context>
 <context>
@@ -2162,7 +2175,7 @@ Are you sure you want to save?</source>
     </message>
     <message>
         <source>Undo &amp;History</source>
-        <translation type="unfinished"></translation>
+        <translation>Historie</translation>
     </message>
     <message>
         <source>&amp;Properties</source>
@@ -2294,7 +2307,7 @@ Are you sure you want to save?</source>
     </message>
     <message>
         <source>Export song from Session</source>
-        <translation type="unfinished"></translation>
+        <translation>Lied aus Session exportieren</translation>
     </message>
     <message>
         <source>Song exported as: </source>
@@ -2306,7 +2319,7 @@ Are you sure you want to save?</source>
     </message>
     <message>
         <source>Import song into Session</source>
-        <translation type="unfinished"></translation>
+        <translation>Lied in Session importierten</translation>
     </message>
     <message>
         <source>
@@ -2325,46 +2338,48 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Song Properties</source>
-        <translation type="unfinished"></translation>
+        <translation>Lied-Eigenschaften</translation>
     </message>
     <message>
         <source>Replace current song with empty one?</source>
-        <translation type="unfinished"></translation>
+        <translation>Das aktuelle Lied mit einem leeren ersetzen?</translation>
     </message>
     <message>
         <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Diese Aktion kann nach dem Speichern nicht rückgängig gemacht werden! Bitte exportieren sie den aktuellen Song erst aus der Session, um eine Kopie anzulegen.</translation>
     </message>
     <message>
         <source>
 There have been recent changes to the drumkit settings.
 The session needs to be saved before exporting will can be continued.
 </source>
-        <translation type="unfinished"></translation>
+<translation>
+Es gibt ungespeicherte Änderungen in den Schlagzeug Eigenschaften.
+Die Session muss gespeichert werden, ehe mit dem Export fortgefahren werden kann.</translation>
     </message>
     <message>
         <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
-        <translation type="unfinished"></translation>
+        <translation>Schlagzeug [%1] in Session konnte nicht auf der Festplatte gefunden werden. Bitte installieren Sie es erst, damit der Export reibungslos funktioniert.</translation>
     </message>
     <message>
         <source>Song saved into</source>
-        <translation type="unfinished"></translation>
+        <translation>Lied gepeichert in</translation>
     </message>
     <message>
         <source>No pattern selected.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Pattern ausgewählt.</translation>
     </message>
     <message>
         <source>Open Demo Song</source>
-        <translation type="unfinished"></translation>
+        <translation>Demo-Lied öffnen</translation>
     </message>
     <message>
         <source>Import Demo Song into Session</source>
-        <translation type="unfinished"></translation>
+        <translation>Demo-Lied in Session importieren</translation>
     </message>
     <message>
         <source>Playback track couldn&apos;t be read</source>
-        <translation type="unfinished"></translation>
+        <translation>Playback Track konnte nicht gelesen werden</translation>
     </message>
 </context>
 <context>
@@ -2388,23 +2403,23 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>Master volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Master Lautstärke</translation>
     </message>
     <message>
         <source>Peak</source>
-        <translation type="unfinished"></translation>
+        <translation>Höchstwert</translation>
     </message>
     <message>
         <source>16th-note Swing</source>
-        <translation type="unfinished"></translation>
+        <translation>16tel Noten Swing</translation>
     </message>
     <message>
         <source>Set humanize time param [%1]</source>
-        <translation type="unfinished"></translation>
+        <translation>Zeitl. Humanisierung [%1] gesetzt</translation>
     </message>
     <message>
         <source>Set humanize vel. param [%1]</source>
-        <translation type="unfinished"></translation>
+        <translation>Anschlag-Humanisierung [%1] gesetzt</translation>
     </message>
 </context>
 <context>
@@ -2419,23 +2434,23 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>Incoming Event</source>
-        <translation type="unfinished"></translation>
+        <translation>Eingehendes Event</translation>
     </message>
     <message>
         <source>Event Para.</source>
-        <translation type="unfinished"></translation>
+        <translation>Event Para.</translation>
     </message>
     <message>
         <source>Para. 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Para. 1</translation>
     </message>
     <message>
         <source>Para. 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Para. 2</translation>
     </message>
     <message>
         <source>Para. 3</source>
-        <translation type="unfinished"></translation>
+        <translation>Para. 3</translation>
     </message>
 </context>
 <context>
@@ -2470,11 +2485,11 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>Set FX %1 level [%2] of instrument</source>
-        <translation type="unfinished"></translation>
+        <translation>Effekt %1 Pegel [%2] gesetzt für Instrument</translation>
     </message>
     <message>
         <source>Set volume [%1] of FX</source>
-        <translation type="unfinished"></translation>
+        <translation>Effekt-Lautstärke [%1] gesetzt</translation>
     </message>
 </context>
 <context>
@@ -2497,19 +2512,19 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>FX %1 send</source>
-        <translation type="unfinished"></translation>
+        <translation>Effect %1 Pegel</translation>
     </message>
     <message>
         <source>Volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Lautstärke</translation>
     </message>
     <message>
         <source>Peak</source>
-        <translation type="unfinished"></translation>
+        <translation>Höchstwert</translation>
     </message>
     <message>
         <source>Set volume [%1] of instrument</source>
-        <translation type="unfinished"></translation>
+        <translation>Lautstärke [%1] gesetzt für Instrument</translation>
     </message>
 </context>
 <context>
@@ -2520,54 +2535,54 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>------ Linear pan parameter ------</source>
-        <translation type="unfinished"></translation>
+        <translation>------ Linearer Pan Parameter ------</translation>
     </message>
     <message>
         <source>Balance Law (0dB)</source>
-        <translation type="unfinished"></translation>
+        <translation>Balance Law (0dB)</translation>
     </message>
     <message>
         <source>Constant Power (-3dB)</source>
-        <translation type="unfinished"></translation>
+        <translation>Konstante Leistung (-3dB)</translation>
     </message>
     <message>
         <source>Constant Sum (-6dB)</source>
-        <translation type="unfinished"></translation>
+        <translation>Konstante Summe (-6dB)</translation>
     </message>
     <message>
         <source>Constant k-Norm (Custom dB compensation)</source>
-        <translation type="unfinished"></translation>
+        <translation>Konstante k-Norm (Custom dB Kompensierung)</translation>
     </message>
     <message>
         <source>------ Polar pan parameter ------</source>
-        <translation type="unfinished"></translation>
+        <translation>------ Polarer Pan Parameter ------</translation>
     </message>
     <message>
         <source>------ Ratio pan parameter ------</source>
-        <translation type="unfinished"></translation>
+        <translation>------ Verhältnis Pan Parameter ------</translation>
     </message>
     <message>
         <source>------ Quadratic pan parameter ------</source>
-        <translation type="unfinished"></translation>
+        <translation>------ Quadratischer Pan Parameter ------</translation>
     </message>
     <message>
         <source>Relationship between the sound&apos;s apparent image position and the pan knob control</source>
-        <translation type="unfinished"></translation>
+        <translation>Beziehung zwischen der wahrgenommenen Position des Klanges und dem Pan Knopf</translation>
     </message>
     <message>
         <source>dB Center Compensation rejected</source>
-        <translation type="unfinished"></translation>
+        <translation>dB Mitten-Kompensierung verweigert</translation>
     </message>
     <message>
         <source>dB Center Compensation must be less than -0.01</source>
-        <translation type="unfinished"></translation>
+        <translation>dB Mitten-Kompensierung muss weniger als -0.01 betragen</translation>
     </message>
 </context>
 <context>
     <name>MixerSettingsDialog_UI</name>
     <message>
         <source>Select Pan Law:</source>
-        <translation type="unfinished"></translation>
+        <translation>Pan Methode auswählen</translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -2587,7 +2602,7 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>dB SPL Center Compensation</source>
-        <translation type="unfinished"></translation>
+        <translation>dB SPL Mitten-Kompensierung</translation>
     </message>
 </context>
 <context>
@@ -2650,7 +2665,7 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>Edit [%1] property of [%2] notes</source>
-        <translation type="unfinished"></translation>
+        <translation>Eigenschaft [%1] von [%2] Noten geändert</translation>
     </message>
 </context>
 <context>
@@ -2681,55 +2696,55 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>Placing these notes here will overwrite %1 duplicate notes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Diese Noten hier einzufügen wird %1 Duplikate überschreiben</translation>
     </message>
     <message>
         <source>ticks</source>
-        <translation type="unfinished"></translation>
+        <translation>Ticks</translation>
     </message>
     <message>
         <source>Set note velocity</source>
-        <translation type="unfinished"></translation>
+        <translation>Anschlagshärte der Note setzen</translation>
     </message>
     <message>
         <source>Note panned to the right by</source>
-        <translation type="unfinished"></translation>
+        <translation>Note nach recht geschwenkt (pan) um</translation>
     </message>
     <message>
         <source>Note panned to the left by</source>
-        <translation type="unfinished"></translation>
+        <translation>Note nach links geschwenkt (pan) um</translation>
     </message>
     <message>
         <source>Note centered</source>
-        <translation type="unfinished"></translation>
+        <translation>Note mittig</translation>
     </message>
     <message>
         <source>Leading beat by</source>
-        <translation type="unfinished"></translation>
+        <translation>Dem Beat vorauseilend um</translation>
     </message>
     <message>
         <source>Lagging beat by</source>
-        <translation type="unfinished"></translation>
+        <translation>Dem Beat hinterher hängen um</translation>
     </message>
     <message>
         <source>Note on beat</source>
-        <translation type="unfinished"></translation>
+        <translation>Note auf Beat</translation>
     </message>
     <message>
         <source>Set pitch</source>
-        <translation type="unfinished"></translation>
+        <translation>Tonhöhe setzen</translation>
     </message>
     <message>
         <source>key</source>
-        <translation type="unfinished"></translation>
+        <translation>Tonart</translation>
     </message>
     <message>
         <source>octave</source>
-        <translation type="unfinished"></translation>
+        <translation>Oktave</translation>
     </message>
     <message>
         <source>Set note probability to</source>
-        <translation type="unfinished"></translation>
+        <translation>Noten Wahrscheinlichkeit gesetzt auf</translation>
     </message>
 </context>
 <context>
@@ -2859,11 +2874,11 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mit &apos;/&apos; kann zwischen den Pattern-Längen Boxen hin- und hergesprungen.</translation>
     </message>
     <message>
         <source>Pattern editor - No pattern selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Pattern Editor - Kein Pattern ausgewählt</translation>
     </message>
 </context>
 <context>
@@ -2965,7 +2980,7 @@ The session needs to be saved before exporting will can be continued.
     <name>PlaybackTrackWaveDisplay</name>
     <message>
         <source>No playback track selected</source>
-        <translation type="unfinished"></translation>
+        <translation>Kein Playback Track ausgewählt</translation>
     </message>
 </context>
 <context>
@@ -3101,43 +3116,43 @@ The session needs to be saved before exporting will can be continued.
     </message>
     <message>
         <source>Toggle the BeatCounter Panel</source>
-        <translation type="unfinished"></translation>
+        <translation>BeatCounter Konsole umschalten</translation>
     </message>
     <message>
         <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
-        <translation type="unfinished"></translation>
+        <translation>Um BeatCounter zu benutzen muss zuerst der Zeitstrahl (timeline) ausgeschalten werden</translation>
     </message>
     <message>
         <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
-        <translation type="unfinished"></translation>
+        <translation>BeatCounter kann nicht in Kombination mit einem externen JACK Timebase master genutzt werden</translation>
     </message>
     <message>
         <source>Alter the Playback Speed</source>
-        <translation type="unfinished"></translation>
+        <translation>Wiedergabe-Geschwindigkeit ändern</translation>
     </message>
     <message>
         <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
-        <translation type="unfinished"></translation>
+        <translation>Während der Zeitstrahl (timeline) aktiviert ist, ist dieses Element schreibgeschützt und zeigt das Tempo der aktuellen Wiedergabe-Position an</translation>
     </message>
     <message>
         <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
-        <translation type="unfinished"></translation>
+        <translation>In Kombination mit einem externen JACK Timebase master zeigt diese Element nur das über JACK empfangene Tempo an</translation>
     </message>
     <message>
         <source>JACK-transport will work only with JACK driver.</source>
-        <translation type="unfinished"></translation>
+        <translation>JACK Transport ist nur über den JACK Audio Treiber verfügbar.</translation>
     </message>
     <message>
         <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Eine Tempoänderung über MIDI, OSC, BeatCounter oder TapTempo wurde registriert. Diese wird erst nach Deaktivierung des Zeitstrahls (timeline) übernommen und auch für den Bereich links vom ersten Tempo Marker nach anschließender wiederholter Aktivierung übernommen.</translation>
     </message>
     <message>
         <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
-        <translation type="unfinished"></translation>
+        <translation>Eine Tempoänderung über MIDI, OSC, BeatCounter oder TapTempo wurde registriert. Diese wird erst nach Deaktivierung des JACK BBT Transport oder nach dem Registieren von Hydrogen als Timebase master übernommen</translation>
     </message>
     <message>
         <source>JACK Timebase mode</source>
-        <translation type="unfinished"></translation>
+        <translation>JACK Timebase modus</translation>
     </message>
 </context>
 <context>
@@ -3391,7 +3406,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
+        <translation>Einfacher Audio Treiber [/dev/dsp]</translation>
     </message>
     <message>
         <source>JACK Audio Connection Kit Driver</source>
@@ -3419,275 +3434,275 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
-        <translation type="unfinished"></translation>
+        <translation>Hydrogen muss neugestartet werden, um Änderungen des Schnittstellen-Layouts zu übernehmen</translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation>Benutzerdefiniert</translation>
     </message>
     <message>
         <source>General</source>
-        <translation type="unfinished">Übersicht</translation>
+        <translation>Übersicht</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"></translation>
+        <translation>Fenster</translation>
     </message>
     <message>
         <source>Window Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Fenster Text</translation>
     </message>
     <message>
         <source>Base</source>
-        <translation type="unfinished"></translation>
+        <translation>Basis</translation>
     </message>
     <message>
         <source>Alternate Base</source>
-        <translation type="unfinished"></translation>
+        <translation>Alternative Basis</translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Text</translation>
     </message>
     <message>
         <source>Button</source>
-        <translation type="unfinished"></translation>
+        <translation>Taste</translation>
     </message>
     <message>
         <source>Button Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Tastentext</translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"></translation>
+        <translation>Hell</translation>
     </message>
     <message>
         <source>Mid Light</source>
-        <translation type="unfinished"></translation>
+        <translation>Mittel-hell</translation>
     </message>
     <message>
         <source>Mid</source>
-        <translation type="unfinished"></translation>
+        <translation>Mittel</translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"></translation>
+        <translation>Dunkel</translation>
     </message>
     <message>
         <source>Shadow Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Schattierungstext</translation>
     </message>
     <message>
         <source>Highlight</source>
-        <translation type="unfinished"></translation>
+        <translation>Hervorhebung</translation>
     </message>
     <message>
         <source>Highlight Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Hervorhebungstext</translation>
     </message>
     <message>
         <source>Selection Highlight</source>
-        <translation type="unfinished"></translation>
+        <translation>Auswahl Hervorhebung</translation>
     </message>
     <message>
         <source>Selection Inactive</source>
-        <translation type="unfinished"></translation>
+        <translation>Auswahl inaktiv</translation>
     </message>
     <message>
         <source>Tool Tip Base</source>
-        <translation type="unfinished"></translation>
+        <translation>Elementhilfe Basis</translation>
     </message>
     <message>
         <source>Tool Tip Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Elementhilfe Text</translation>
     </message>
     <message>
         <source>Widgets</source>
-        <translation type="unfinished"></translation>
+        <translation>Elemente</translation>
     </message>
     <message>
         <source>Widget</source>
-        <translation type="unfinished"></translation>
+        <translation>Element</translation>
     </message>
     <message>
         <source>Widget Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Elementtext</translation>
     </message>
     <message>
         <source>Accent</source>
-        <translation type="unfinished"></translation>
+        <translation>Akzent</translation>
     </message>
     <message>
         <source>Accent Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Akzenttext</translation>
     </message>
     <message>
         <source>Button Red</source>
-        <translation type="unfinished"></translation>
+        <translation>Rote Taste</translation>
     </message>
     <message>
         <source>Button Red Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Rote Taste Text</translation>
     </message>
     <message>
         <source>Spin Box</source>
-        <translation type="unfinished"></translation>
+        <translation>Drehfeld</translation>
     </message>
     <message>
         <source>Spin Box Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Drehfeldtext</translation>
     </message>
     <message>
         <source>Playhead</source>
-        <translation type="unfinished"></translation>
+        <translation>Playhead</translation>
     </message>
     <message>
         <source>Cursor</source>
-        <translation type="unfinished"></translation>
+        <translation>Positionsmarker</translation>
     </message>
     <message>
         <source>Song Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Song Editor</translation>
     </message>
     <message>
         <source>Background</source>
-        <translation type="unfinished"></translation>
+        <translation>Hintergrund</translation>
     </message>
     <message>
         <source>Alternate Row</source>
-        <translation type="unfinished"></translation>
+        <translation>Reihe alternierend</translation>
     </message>
     <message>
         <source>Selected Row</source>
-        <translation type="unfinished"></translation>
+        <translation>Reihe ausgewählt</translation>
     </message>
     <message>
         <source>Selected Row Text</source>
-        <translation type="unfinished"></translation>
+        <translation>Reihentext ausgewählt</translation>
     </message>
     <message>
         <source>Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Linie</translation>
     </message>
     <message>
         <source>Automation Background</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatisierungs-Hintergrund</translation>
     </message>
     <message>
         <source>Automation Line</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatisierungs-Linie</translation>
     </message>
     <message>
         <source>Automation Node</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatisierungs-Knoten</translation>
     </message>
     <message>
         <source>Stacked Mode On</source>
-        <translation type="unfinished"></translation>
+        <translation>Gestapelter Modus an</translation>
     </message>
     <message>
         <source>Stacked Mode On Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Gestapelter Modus als nächstes</translation>
     </message>
     <message>
         <source>Stacked Mode Off Next</source>
-        <translation type="unfinished"></translation>
+        <translation>Gestapelter Modus aus</translation>
     </message>
     <message>
         <source>Pattern Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Pattern Editor</translation>
     </message>
     <message>
         <source>Octave Row</source>
-        <translation type="unfinished"></translation>
+        <translation>Oktaven Reihe</translation>
     </message>
     <message>
         <source>Note (Full Velocity)</source>
-        <translation type="unfinished"></translation>
+        <translation>Note (Voller Anschlag)</translation>
     </message>
     <message>
         <source>Note (Default Velocity)</source>
-        <translation type="unfinished"></translation>
+        <translation>Note (Standard Anschlag)</translation>
     </message>
     <message>
         <source>Note (Half Velocity)</source>
-        <translation type="unfinished"></translation>
+        <translation>Note (Halber Anschlag)</translation>
     </message>
     <message>
         <source>Note (Zero Velocity)</source>
-        <translation type="unfinished"></translation>
+        <translation>Note (Kein Anschlag)</translation>
     </message>
     <message>
         <source>Note Off</source>
-        <translation type="unfinished"></translation>
+        <translation>Note Off</translation>
     </message>
     <message>
         <source>Grid Line 1</source>
-        <translation type="unfinished"></translation>
+        <translation>Gitter Linie 1</translation>
     </message>
     <message>
         <source>Grid Line 2</source>
-        <translation type="unfinished"></translation>
+        <translation>Gitter Linie 2</translation>
     </message>
     <message>
         <source>Grid Line 3</source>
-        <translation type="unfinished"></translation>
+        <translation>Gitter Linie 3</translation>
     </message>
     <message>
         <source>Grid Line 4</source>
-        <translation type="unfinished"></translation>
+        <translation>Gitter Linie 4</translation>
     </message>
     <message>
         <source>Grid Line 5</source>
-        <translation type="unfinished"></translation>
+        <translation>Gitter Linie 5</translation>
     </message>
     <message>
         <source>Grid Line 6</source>
-        <translation type="unfinished"></translation>
+        <translation>Gitter Linie 6</translation>
     </message>
     <message>
         <source>Are you sure you want to proceed?</source>
-        <translation type="unfinished"></translation>
+        <translation>Wollen Sie wirklich fortfahren?</translation>
     </message>
     <message>
         <source>Currently connected to device: </source>
-        <translation type="unfinished"></translation>
+        <translation>Aktuell verbunden mit Gerät: </translation>
     </message>
     <message>
         <source>Error starting audio driver</source>
-        <translation type="unfinished">Fehler beim Starten des Audiotreibers</translation>
+        <translation>Fehler beim Starten des Audiotreibers</translation>
     </message>
     <message>
         <source>Unable to start audio driver</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio Treiber konnte nicht gestartert werden</translation>
     </message>
     <message>
         <source>Import Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme importieren</translation>
     </message>
     <message>
         <source>Theme couldn&apos;t be found.</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme konnte nicht gefunden werden.</translation>
     </message>
     <message>
         <source>Theme imported from </source>
-        <translation type="unfinished"></translation>
+        <translation>Theme importert aus </translation>
     </message>
     <message>
         <source>Export Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme exportieren</translation>
     </message>
     <message>
         <source>Theme can not be exported.</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme konnte nicht exportiert werden.</translation>
     </message>
     <message>
         <source>Theme exported to </source>
-        <translation type="unfinished"></translation>
+        <translation>Theme exportiert nach </translation>
     </message>
     <message>
         <source>Theme reset</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme zurückgesetzt</translation>
     </message>
 </context>
 <context>
@@ -4084,127 +4099,127 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
-        <translation type="unfinished"></translation>
+        <translation>Anzahl der automatischen Speicherungen pro Stunde (0 zum Deaktivieren)</translation>
     </message>
     <message>
         <source>Host API</source>
-        <translation type="unfinished"></translation>
+        <translation>Host API</translation>
     </message>
     <message>
         <source>Latency target</source>
-        <translation type="unfinished"></translation>
+        <translation>Latenzziel</translation>
     </message>
     <message>
         <source>Interface</source>
-        <translation type="unfinished"></translation>
+        <translation>Schnittstelle</translation>
     </message>
     <message>
         <source>Selected colors</source>
-        <translation type="unfinished"></translation>
+        <translation>Ausgewählte Farben</translation>
     </message>
     <message>
         <source>Icon color</source>
-        <translation type="unfinished"></translation>
+        <translation>Symbolfarbe</translation>
     </message>
     <message>
         <source>Number of colors in Song Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Anzahl der Farben im Song Editor</translation>
     </message>
     <message>
         <source>Black</source>
-        <translation type="unfinished"></translation>
+        <translation>Schwarz</translation>
     </message>
     <message>
         <source>White</source>
-        <translation type="unfinished"></translation>
+        <translation>Weiß</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Colors</source>
-        <translation type="unfinished"></translation>
+        <translation>Farben</translation>
     </message>
     <message>
         <source>Items</source>
-        <translation type="unfinished"></translation>
+        <translation>Elemente</translation>
     </message>
     <message>
         <source>B</source>
-        <translation type="unfinished">B</translation>
+        <translation>B</translation>
     </message>
     <message>
         <source>S</source>
-        <translation type="unfinished"></translation>
+        <translation>S</translation>
     </message>
     <message>
         <source>H</source>
-        <translation type="unfinished"></translation>
+        <translation>H</translation>
     </message>
     <message>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation>V</translation>
     </message>
     <message>
         <source>G</source>
-        <translation type="unfinished">G</translation>
+        <translation>G</translation>
     </message>
     <message>
         <source>R</source>
-        <translation type="unfinished"></translation>
+        <translation>R</translation>
     </message>
     <message>
         <source>Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Schriftart</translation>
     </message>
     <message>
         <source>Font size</source>
-        <translation type="unfinished"></translation>
+        <translation>Schriftgröße</translation>
     </message>
     <message>
         <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
-        <translation type="unfinished"></translation>
+        <translation>Schriftart für Aufzählungen, wie die NAmen der verfügbaren Pattern und Instrumente.</translation>
     </message>
     <message>
         <source>Item font</source>
-        <translation type="unfinished"></translation>
+        <translation>Element-Schriftart</translation>
     </message>
     <message>
         <source>Font used for larger buttons.</source>
-        <translation type="unfinished"></translation>
+        <translation>Schriftart größerer Tasten.</translation>
     </message>
     <message>
         <source>Widget font</source>
-        <translation type="unfinished"></translation>
+        <translation>Element Schriftart</translation>
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"></translation>
+        <translation>Klein</translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation>Mittel</translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"></translation>
+        <translation>Groß</translation>
     </message>
     <message>
         <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
-        <translation type="unfinished"></translation>
+        <translation>Schriftart des größten Teils der Oberfläche, wie Menüs, Überschriften und des Gitters des Song und Pattern Editor.</translation>
     </message>
     <message>
         <source>Export Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme exportieren</translation>
     </message>
     <message>
         <source>Import Theme</source>
-        <translation type="unfinished"></translation>
+        <translation>Theme importieren</translation>
     </message>
     <message>
         <source>Reset Appearance Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Aussehen zurücksetzen</translation>
     </message>
 </context>
 <context>
@@ -4271,7 +4286,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Paste instrument notes</source>
-        <translation type="unfinished"></translation>
+        <translation>Instrumenten-Noten einfügen</translation>
     </message>
     <message>
         <source>Fill notes</source>
@@ -4323,38 +4338,38 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Toggle Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
+        <translation>Pattern ( %1, %2 ) umschalten</translation>
     </message>
     <message>
         <source>Edit tempo marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo Marker ändern</translation>
     </message>
     <message>
         <source>Delete tempo marker</source>
-        <translation type="unfinished"></translation>
+        <translation>Tempo Marker löschen</translation>
     </message>
     <message>
         <source>Altering the length of the current pattern</source>
-        <translation type="unfinished"></translation>
+        <translation>Länge des aktuellen Patterns ändern</translation>
     </message>
 </context>
 <context>
     <name>Reporter</name>
     <message>
         <source>Hydrogen exited abnormally</source>
-        <translation type="unfinished"></translation>
+        <translation>Hydrogen wurde unerwartet beendet</translation>
     </message>
     <message>
         <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sie können in Hydrogens Issue Tracker auf Github überprüfen, ob dieses Issue bereits bekannt ist. Wenn nicht, können Sie es erstellen, damit sich das Entwicklerteam diesem annehmen kann.</translation>
     </message>
     <message>
         <source>Open log file...</source>
-        <translation type="unfinished"></translation>
+        <translation>Öffne Log Daten...</translation>
     </message>
     <message>
         <source>Github Issue tracker...</source>
-        <translation type="unfinished"></translation>
+        <translation>Github Issue Tracker...</translation>
     </message>
 </context>
 <context>
@@ -4373,7 +4388,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source> RB-Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>RB-Ratio</translation>
     </message>
 </context>
 <context>
@@ -4810,15 +4825,15 @@ Fortsetzen?</translation>
     </message>
     <message>
         <source>selected pattern mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Ausgewähltes Pattern-Modus</translation>
     </message>
     <message>
         <source>Playback track volume</source>
-        <translation type="unfinished"></translation>
+        <translation>Playback Track Lautstärke</translation>
     </message>
     <message>
         <source>Playback volume set to</source>
-        <translation type="unfinished"></translation>
+        <translation>Playback Track Lautstärke gesetzt zu</translation>
     </message>
 </context>
 <context>
@@ -4929,14 +4944,14 @@ Soll sie überschrieben werden?</translation>
     </message>
     <message>
         <source>Open Pattern to Replace </source>
-        <translation type="unfinished"></translation>
+        <translation>Öffne Pattern zum Ersetzen </translation>
     </message>
 </context>
 <context>
     <name>SongEditorPositionRuler</name>
     <message>
         <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
-        <translation type="unfinished"></translation>
+        <translation>Das Tempo, welches im BPM Element eingestellt wurde, wird am Anfang des Songs verwendet. Es kann mit links Klick überschrieben werden.</translation>
     </message>
 </context>
 <context>
@@ -4993,31 +5008,31 @@ Soll sie überschrieben werden?</translation>
     </message>
     <message>
         <source>&amp;Export</source>
-        <translation type="unfinished">&amp;Exportieren</translation>
+        <translation>&amp;Exportieren</translation>
     </message>
     <message>
         <source>Export Drumkit</source>
-        <translation type="unfinished"></translation>
+        <translation>Schlagzeug exportieren</translation>
     </message>
     <message>
         <source>invalid drumkit</source>
-        <translation type="unfinished"></translation>
+        <translation>Ungültiges Schlagzeug</translation>
     </message>
     <message>
         <source>The file [%1] does already exist and will be overwritten.</source>
-        <translation type="unfinished"></translation>
+        <translation>Die Datei [%1] existiert bereits und wird überschrieben.</translation>
     </message>
     <message>
         <source>Unable to export drumkit</source>
-        <translation type="unfinished"></translation>
+        <translation>Schlagzeug konnte nicht exportiert werden</translation>
     </message>
     <message>
         <source>Drumkit exported to</source>
-        <translation type="unfinished"></translation>
+        <translation>Schlagzeug exportiert nach</translation>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished">Alle</translation>
+        <translation>Alle</translation>
     </message>
 </context>
 <context>
@@ -5319,7 +5334,7 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
     <message>
         <source>Content</source>
-        <translation type="unfinished"></translation>
+        <translation>Inhalt</translation>
     </message>
 </context>
 <context>
@@ -5390,12 +5405,12 @@ Would you like to keep or discard the remaining instruments and notes?
     <message>
         <source>Other</source>
         <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Kennzeichnung, welche für alle Lizenzen verwendet wird, die nicht direkt in der Auswahlbox unterstützt werden.</translation>
     </message>
     <message>
         <source>Unspecified</source>
         <extracomment>Label used if no license was specified.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Kennzeichnung, die genutzt wird, wenn keine Lizenz spezifiert wurde.</translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Καρέ πραγματικού χρόνου</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Σίγηση</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Γενικά</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Όργανο</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Στρώματα</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Μείκτης</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Πτώση</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Διάρκεια</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Απελευθέρωση</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Κανάλι</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Εισαγόμενο</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">Χτ.ΑνάΛεπ.</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Ταχύτητα</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">ανενεργό</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Εντάξει</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Αποθήκευση</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Α&amp;κύρωση</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Από&amp;ρριψη</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Ανα&amp;παραγωγή</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation>Όνομα του συστατικού</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Όρισε την ένταση του οργάνου [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>FX ενεργά ή όχι</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Κύρια εξαγωγή</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>Χτ.ΑνάΛεπ.</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">Α&amp;κύρωση</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -709,24 +1314,6 @@ Overwrite the existing file?</source>
         <translation>Ιδιότητες της Βιβλιοθήκης Ήχων</translation>
     </message>
     <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Αυτό δεν είναι δυνατό. Μπορείς, μονάχα, να αποθηκεύσεις αλλαγές μέσα σε όργανα στην τωρινή φορτωμένη βιβλιοθήκη ήχων</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Προειδοποίηση: Η αλλαγή του ονόματος της ομάδας κρουστών, θα έχει σαν αποτέλεσμα τη δημιουργία μιας νέας ομάδας κρουστών, με αυτό το νέο όνομα.
-Είσαι σίγουρος;</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Εντάξει</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Αποτυχία αποθήκευσης αυτής της ομάδας κρουστών.</translation>
     </message>
@@ -737,6 +1324,42 @@ Are you sure?</source>
     <message>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>Αρχεία Εικόνας (*.png *.jpg *.jpeg)</translation>
+    </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Όργανο</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Συστατικό</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Άδεια</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -754,16 +1377,8 @@ Are you sure?</source>
         <translation>Μείκτης</translation>
     </message>
     <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Φορτώθηκε η ομάδα κρουστών: [%1]</translation>
-    </message>
-    <message>
         <source>modified</source>
         <translation>μετατράπηκε</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Το τραγούδι αποθηκεύτηκε.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -786,20 +1401,32 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
     <message>
-        <source>General</source>
-        <translation>Γενικά</translation>
-    </message>
-    <message>
         <source>Show instrument properties</source>
         <translation>Προβολή των ιδιοτήτων του οργάνου</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Στρώματα</translation>
     </message>
     <message>
         <source>Show layers properties</source>
@@ -816,22 +1443,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Αντήχηση φίλτρου</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Πτώση</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation type="unfinished">Διάρκεια</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Απελευθέρωση</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -894,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -902,10 +1533,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <name>InstrumentLine</name>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Σίγηση οργάνου</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Μόνο του</translation>
     </message>
     <message>
@@ -1008,16 +1641,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Προβολή του επεξεργαστή οργάνου</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Όργανο</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Προβολή της βιβλιοθήκης ήχων</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Βιβλιοθήκη ήχων</translation>
     </message>
 </context>
 <context>
@@ -1068,6 +1693,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>No plugin</source>
         <translation>Κανένα ένθεμα</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1291,7 +1924,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;Undo</source>
         <translation>Α&amp;ναίρεση</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>&amp;Mixer</source>
@@ -1326,10 +1958,6 @@ MIDI = %2</source>
         <translation>Αδυναμία αποθήκευσης του τραγουδιού.</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Το τραγούδι αποθηκεύτηκε.</translation>
-    </message>
-    <message>
         <source>Save Pattern as ...</source>
         <translation>Αποθήκευση της Μήτρας ως ...</translation>
     </message>
@@ -1352,10 +1980,6 @@ MIDI = %2</source>
     <message>
         <source>Clear all instruments?</source>
         <translation>Καθάρισμα όλων των οργάνων;</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Εντάξει</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1394,10 +2018,6 @@ MIDI = %2</source>
         <translation>Χρησιμοποιείς μια δοκιμαστική έκδοση του Υδρογόνου. Μπορείς να μας βοηθήσεις αναφέροντας δυσλειτουργίες και προτάσεις στο κατάστιχο ηλεκτρονικού ταχυδρομείου ανάπτυξης του Υδρογόνου.&lt;br&gt;&lt;br&gt;Εκ των προτέρων, σε ευχαριστούμε!</translation>
     </message>
     <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Να μην προβάλλεται αυτό το μήνυμα, από εδώ και πέρα</translation>
-    </message>
-    <message>
         <source>Playlist: Song No. %1</source>
         <translation>Κατάστιχο αναπαραγωγής. Τραγούδι Νο. %1</translation>
     </message>
@@ -1410,14 +2030,6 @@ Do you want to save the changes?
 
 Θέλεις να αποθηκεύσεις τις αλλαγές;
 </translation>
-    </message>
-    <message>
-        <source>&amp;Discard</source>
-        <translation>Από&amp;ρριψη</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1511,10 +2123,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1721,6 +2329,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Παίζει.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1733,35 +2384,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Εξανθρωπισμός του χρόνου</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
         <translation>Όρισε την κύρια ένταση [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Όρισε την παράμετρο εξανθρωπισμού του χρόνου [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Όρισε την παράμετρο εξανθρωπισμού της ταχύτητας [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation>Αυτό το στοιχείο δεν είναι λειτουργίσιμο από το ΜΙΝΤΙ.</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>Αναμονή για το εισαγόμενο από το ΜΙΝΤΙ...</translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1771,16 +2419,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>πίεσε το πλήκτρο για να καταγράψεις τα ΜΙΝΤΙ γενόμενα</translation>
     </message>
     <message>
-        <source>Event</source>
-        <translation>Γενόμενο</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Παράμ.</translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation>Ενέργεια</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1794,20 +2454,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Προβολή των κορυφών του οργάνου</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Όρισε το επίπεδου του FX %1</translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation>Προβολή των κορυφών του οργάνου = Ενεργό</translation>
     </message>
     <message>
         <source>Show instrument peaks = Off</source>
         <translation>Προβολή των κορυφών του οργάνου = Ανενεργό</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Όρισε την ένταση του LADSPA FX ( %1 )</translation>
     </message>
     <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
@@ -1819,6 +2471,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1841,11 +2501,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Πανόψη</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Όρισε την ένταση του οργάνου [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1938,14 +2606,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1993,6 +2653,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2025,7 +2689,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2041,14 +2749,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Loaded Soundlibrary</source>
         <translation>Φορτωμένη Βιβλιοθήκη Ήχων</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Επέλεξε το μέγεθος της μήτρας</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Επέλεξε την ανάλυση του πλέγματος</translation>
     </message>
     <message>
         <source>Hear new notes</source>
@@ -2119,16 +2819,8 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Προβολή του επεξεργαστή κρουστών</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Δεν είναι δυνατή η αλλαγή του μέγεθους της μήτρας κατά την αναπαραγωγή.</translation>
-    </message>
-    <message>
         <source>Probability</source>
         <translation>Πιθανότητα</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>quarter</source>
@@ -2171,35 +2863,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">ανενεργό</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2299,6 +2967,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2333,10 +3008,6 @@ Maximum = 16/4</source>
         <translation>Κατάσταση Λειτουργίας Τραγουδιού</translation>
     </message>
     <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Το Πλαίσιο του Μετρητή Χτύπων ενεργό</translation>
-    </message>
-    <message>
         <source>Set BPM / Set BPM and play</source>
         <translation>Όρισε τους Χτ.ΑνάΛεπ. ή Ορισμός των Χτ.ΑνάΛεπ. και αναπαραγωγή</translation>
     </message>
@@ -2353,16 +3024,8 @@ Maximum = 16/4</source>
         <translation>Προβολή του Μείκτη</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Μείκτης</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Προβολή της Ραφιέρας των Οργάνων</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Ραφιέρα Οργάνων</translation>
     </message>
     <message>
         <source>Record midi events = On</source>
@@ -2417,10 +3080,6 @@ Maximum = 16/4</source>
         <translation>Επανϋπολογισμός όλων των δειγμάτων με χρήση του Ράμπερμπανντ: ΑΝΕΝΕΡΓΟΣ</translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation>Νέα τιμή Χτ.ΑνάΛεπ.</translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation>Επανάληψη τραγουδιού = Ενεργή</translation>
     </message>
@@ -2431,19 +3090,6 @@ Maximum = 16/4</source>
     <message>
         <source>JACK transport on/off</source>
         <extracomment>Using the JACK the audio/midi input and output ports of any number of application can be connected.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2459,11 +3105,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2661,14 +3339,6 @@ Do you want to discard the changes?
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>Από&amp;ρριψη</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2702,36 +3372,12 @@ The path to the script and the scriptname must be without whitespaces.</source>
 Να επανεκκινηθεί ο οδηγός;</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Εντάξει</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
         <source>Please restart hydrogen to enable/disable LASH support</source>
         <translation>Παρακαλείσαι να επανεκκινήσεις το Υδρογόνο, για να ενεργοποιήσεις ή να απενεργοποιήσεις την υποστήριξη του LASH</translation>
     </message>
     <message>
         <source>Automatic</source>
         <translation>Αυτόματο</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation>Βήματα</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>Σταθερό</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>Πλήθος βημάτων</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Χρώμα (τιμή απόχρωσης)</translation>
     </message>
     <message>
         <source>Automatic driver selection</source>
@@ -2746,10 +3392,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2758,19 +3400,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2795,6 +3429,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Γενικά</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Επεξεργαστής Τραγουδιού</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Σφάλμα στο ξεκίνημα του οδηγού ήχου</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2840,14 +3746,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Γραμματοσειρά της εφαρμογής</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Γραμματοσειρά του μείκτη</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Επιλογή γραμματοσειράς</translation>
     </message>
     <message>
         <source>Polyphony</source>
@@ -3060,16 +3958,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Με καρτέλες</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>ΕτικέταΚείμενου</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>Μέθοδος χρωματισμού για τα στοιχεία του Επεξεργαστή Τραγουδιών</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Μετά την αλλαγή μιας γραμματοσειράς, ή της διάταξης της διεπαφής, θα πρέπει να επανεκκινηθεί η εφαρμογή.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;OSC</source>
@@ -3129,7 +4019,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3208,17 +4098,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3249,14 +4255,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3320,10 +4318,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3343,41 +4337,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Εντάξει</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Διάλογος κλεισίματος: 
-ίσως να υπάρχει μη αποθηκευμένο έργο στο δείγμα.
-
-Στα σίγουρα;</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">Ανα&amp;παραγωγή</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">Αναπα&amp;ραγωγή του αρχικού δείγματος</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3763,10 +4763,6 @@ p, li { white-space: pre-wrap; }
         <translation>Επεξεργαστής Τραγουδιού</translation>
     </message>
     <message>
-        <source>Enable time line edit</source>
-        <translation>Ενεργοποίηση της επεξεργασίας της χρονικής γραμμής</translation>
-    </message>
-    <message>
         <source>Clear pattern sequence</source>
         <translation>Καθάρισμα της ακολουθίας της μήτρας</translation>
     </message>
@@ -3791,10 +4787,6 @@ p, li { white-space: pre-wrap; }
         <translation>Κατάσταση λειτουργίας σχεδίασης</translation>
     </message>
     <message>
-        <source>stacked mode</source>
-        <translation>κατάσταση λειτουργίας στοιβάγματος</translation>
-    </message>
-    <message>
         <source>Pattern %1</source>
         <translation>Μήτρα %1</translation>
     </message>
@@ -3806,20 +4798,8 @@ Are you sure?</source>
 Στα σίγουρα;</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Εντάξει</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>κατάσταση λειτουργίας στοιβάγματος μήτρας</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>κατάσταση λειτουργίας μονής μήτρας</translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3846,19 +4826,15 @@ Are you sure?</source>
         <translation>Ταχύτητα</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3867,22 +4843,6 @@ Are you sure?</source>
     <message>
         <source>Form</source>
         <translation>Προμόρφωμα</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Επεξεργασία της τιμής των ΧτύπωνΑνάΛεπτό για το συγκεκριμένο χτύπο</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Επεξεργασία του χτύπου στη χρονογραμμή</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3951,31 +4911,11 @@ Are you sure?</source>
         <translation>Εικονική Μήτρα</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Άνοιγμα Μήτρας</translation>
-    </message>
-    <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>Υπάρχει το αρχείο μήτρας.
 
 Να επανωγραφεί η υπάρχουσα μήτρα;</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Εντάξει</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Μήτρα 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>μη_ταξινομημένο</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -4003,6 +4943,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4055,24 +5006,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Εξαγωγή Βιβλιοθήκης Ήχων</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Κατάλογος</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Εξαγωγή</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Όλα</translation>
     </message>
 </context>
 <context>
@@ -4080,10 +5043,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Εξαγωγή</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Ομάδα Κρουστών</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4294,14 +5253,6 @@ Overwrite the existing pattern?</source>
         <translation>Μήτρες</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Εντάξει</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>Α&amp;κύρωση</translation>
-    </message>
-    <message>
         <source>Warning, the selected pattern will be deleted from disk.
 Are you sure?</source>
         <translation>Προειδοποίηση: η επιλεγμένη μήτρα θα διαγραφεί από το δίσκο.
@@ -4347,17 +5298,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation>Διπλό κλικ για την επέκταση του κατάστιχου</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4384,10 +5325,6 @@ Current kit:</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Αποθήκευσε στη βιβλιοθήκη ήχων αυτές τις αλλαγές που έγιναν στα όργανα</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Άδεια της Ομάδας Κρουστών</translation>
     </message>
@@ -4402,6 +5339,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Άδεια της Εικόνας</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4439,78 +5380,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Αποθήκευση της Βιβλιοθήκης Ήχων</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Παρακαλώ, δώσε τουλάχιστον ένα έγκυρο όνομα</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>Υπάρχει, ήδη, μία βιβλιοθήκη με το ίδιο όνομα. 
-
-Θέλεις να επανωγραφεί η υπάρχουσα βιβλιοθήκη;</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Αποτυχία αποθήκευσης αυτής της βιβλιοθήκης.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Άνοιγμα Εικόνας</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Αρχεία Εικόνας (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Διάλογος</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Όνομα</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Δημιουργός</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Πληροφορίες</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Ακύρωση</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Άδεια</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Αποθήκευση</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Εικόνα</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Εξερεύνηση</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Άδεια της Εικόνας</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4537,6 +5406,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -168,6 +168,10 @@
         <source>Frames</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation></translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation></translation>
     </message>
 </context>
@@ -462,6 +1034,22 @@ Overwrite the existing file?</source>
         <source>The file %1 exists. 
 Overwrite the existing file?</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation></translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation></translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -717,25 +1322,44 @@ Overwrite the existing file?</source>
         <translation></translation>
     </message>
     <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -754,14 +1378,6 @@ Are you sure?</source>
     </message>
     <message>
         <source>modified</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
         <translation></translation>
     </message>
     <message>
@@ -785,19 +1401,31 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
     <message>
-        <source>General</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show instrument properties</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Layers</source>
         <translation></translation>
     </message>
     <message>
@@ -822,22 +1450,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Filter resonance</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Release</source>
         <translation></translation>
     </message>
     <message>
@@ -893,18 +1505,40 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
-        <translation></translation>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InstrumentLine</name>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation></translation>
     </message>
     <message>
@@ -1007,15 +1641,7 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show sound library</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Sound library</source>
         <translation></translation>
     </message>
 </context>
@@ -1067,6 +1693,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>No plugin</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1258,7 +1892,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;Undo</source>
         <translation></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>Drum&amp;kits</source>
@@ -1314,10 +1947,6 @@ Are you sure you want to save?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Save Pattern as ...</source>
         <translation></translation>
     </message>
@@ -1346,10 +1975,6 @@ Are you sure you want to save?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Saving of this library failed.</source>
         <translation></translation>
     </message>
@@ -1375,10 +2000,6 @@ Are you sure you want to save?</source>
     </message>
     <message>
         <source>Set default values</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
         <translation></translation>
     </message>
     <message>
@@ -1430,10 +2051,6 @@ Are you sure you want to save?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Playlist: Song No. %1</source>
         <translation></translation>
     </message>
@@ -1442,10 +2059,6 @@ Are you sure you want to save?</source>
 The document contains unsaved changes.
 Do you want to save the changes?
 </source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Discard</source>
         <translation></translation>
     </message>
     <message>
@@ -1481,10 +2094,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation></translation>
     </message>
     <message>
@@ -1674,6 +2283,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1686,35 +2338,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
         <translation></translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation></translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation></translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation></translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1724,16 +2373,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Event</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1751,10 +2412,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation></translation>
     </message>
@@ -1767,12 +2424,16 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
+        <source>Mixer Settings</source>
         <translation></translation>
     </message>
     <message>
-        <source>Mixer Settings</source>
-        <translation></translation>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1794,12 +2455,20 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation></translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
-        <translation></translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1891,14 +2560,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation></translation>
     </message>
@@ -1946,6 +2607,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1978,8 +2643,52 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
-        <translation></translation>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1993,14 +2702,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <name>PatternEditorPanel</name>
     <message>
         <source>Loaded Soundlibrary</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
         <translation></translation>
     </message>
     <message>
@@ -2076,14 +2777,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation></translation>
     </message>
@@ -2124,36 +2817,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
-        <translation></translation>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
-        <translation></translation>
+        <source>Pattern editor - No pattern selected</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2252,6 +2921,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2286,10 +2962,6 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>BeatCounter Panel on</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Set BPM / Set BPM and play</source>
         <translation></translation>
     </message>
@@ -2306,15 +2978,7 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
         <translation></translation>
     </message>
     <message>
@@ -2370,10 +3034,6 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation></translation>
     </message>
@@ -2384,19 +3044,6 @@ Maximum = 16/4</source>
     <message>
         <source>JACK transport on/off</source>
         <extracomment>Using the JACK the audio/midi input and output ports of any number of application can be connected.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
         <translation></translation>
     </message>
     <message>
@@ -2412,12 +3059,44 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
-        <translation></translation>
+        <source>Toggle the BeatCounter Panel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
-        <translation></translation>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2530,14 +3209,6 @@ Do you want to discard the changes?
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>no Script</source>
         <translation></translation>
     </message>
@@ -2642,24 +3313,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Steps</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Driver restart required.
  Restart driver?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
         <translation></translation>
     </message>
     <message>
@@ -2668,14 +3323,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Please restart hydrogen to enable/disable LASH support</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation></translation>
     </message>
     <message>
@@ -2691,15 +3338,7 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>selected</source>
         <translation></translation>
     </message>
     <message>
@@ -2708,10 +3347,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation></translation>
     </message>
     <message>
@@ -2737,6 +3372,278 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>PulseAudio Driver</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2982,10 +3889,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Meters falloff speed</source>
         <extracomment>In case of a rapid sound lasting for just a milli second the meters in the Mixer would raise to peak value and fall of immediately without the user being able to see them. The falloff speed introduces a delay. The smaller the value, the longer the meter requires to reach 0dB again.</extracomment>
         <translation></translation>
@@ -3003,10 +3906,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Mixer font</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Default interface layout</source>
         <translation></translation>
     </message>
@@ -3019,15 +3918,7 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation></translation>
     </message>
     <message>
@@ -3068,7 +3959,7 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation></translation>
     </message>
     <message>
@@ -3147,17 +4038,133 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Prefer larger</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation></translation>
@@ -3188,14 +4195,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation></translation>
     </message>
     <message>
@@ -3259,10 +4258,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation></translation>
     </message>
@@ -3282,37 +4277,46 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Move point</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation></translation>
     </message>
     <message>
@@ -3676,14 +4680,6 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <source>Enable time line edit</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Clear pattern sequence</source>
         <translation></translation>
     </message>
@@ -3705,10 +4701,6 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Draw mode</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
         <translation></translation>
     </message>
     <message>
@@ -3745,54 +4737,26 @@ Are you sure?</source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation></translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation></translation>
+        <source>selected pattern mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation></translation>
+        <source>Playback track volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
-        <translation></translation>
+        <source>Playback volume set to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SongEditorPanelBpmWidget_UI</name>
     <message>
         <source>Form</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>500</source>
         <translation></translation>
     </message>
     <message>
@@ -3866,10 +4830,6 @@ Are you sure?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Could not export pattern.</source>
         <translation></translation>
     </message>
@@ -3883,23 +4843,7 @@ Overwrite the existing pattern?</source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Pattern saved.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
         <translation></translation>
     </message>
     <message>
@@ -3913,6 +4857,17 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Could not save pattern to temporary directory.</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3964,32 +4919,40 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
-        <translation></translation>
+        <source>&amp;Export</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
-        <translation></translation>
+        <source>Export Drumkit</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
-        <translation></translation>
+        <source>invalid drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file [%1] does already exist and will be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SoundLibraryExportDialog_UI</name>
-    <message>
-        <source>Drumkit</source>
-        <translation></translation>
-    </message>
     <message>
         <source>Component</source>
         <translation></translation>
@@ -4238,25 +5201,7 @@ Are you sure?</source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation></translation>
     </message>
 </context>
@@ -4287,10 +5232,6 @@ Current kit:</source>
         <translation></translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Image</source>
         <translation></translation>
     </message>
@@ -4301,6 +5242,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4338,76 +5283,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4434,6 +5309,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation></translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -168,6 +168,10 @@
         <source>Frames</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation></translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation></translation>
     </message>
 </context>
@@ -462,6 +1034,22 @@ Overwrite the existing file?</source>
         <source>The file %1 exists. 
 Overwrite the existing file?</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation></translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation></translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -717,25 +1322,44 @@ Overwrite the existing file?</source>
         <translation></translation>
     </message>
     <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -754,14 +1378,6 @@ Are you sure?</source>
     </message>
     <message>
         <source>modified</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
         <translation></translation>
     </message>
     <message>
@@ -785,19 +1401,31 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
     <message>
-        <source>General</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show instrument properties</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Layers</source>
         <translation></translation>
     </message>
     <message>
@@ -822,22 +1450,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Filter resonance</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Release</source>
         <translation></translation>
     </message>
     <message>
@@ -893,18 +1505,40 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
-        <translation></translation>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InstrumentLine</name>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation></translation>
     </message>
     <message>
@@ -1007,15 +1641,7 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show sound library</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Sound library</source>
         <translation></translation>
     </message>
 </context>
@@ -1067,6 +1693,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>No plugin</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1258,7 +1892,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;Undo</source>
         <translation></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>Drum&amp;kits</source>
@@ -1314,10 +1947,6 @@ Are you sure you want to save?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Save Pattern as ...</source>
         <translation></translation>
     </message>
@@ -1346,10 +1975,6 @@ Are you sure you want to save?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Saving of this library failed.</source>
         <translation></translation>
     </message>
@@ -1375,10 +2000,6 @@ Are you sure you want to save?</source>
     </message>
     <message>
         <source>Set default values</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
         <translation></translation>
     </message>
     <message>
@@ -1430,10 +2051,6 @@ Are you sure you want to save?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Playlist: Song No. %1</source>
         <translation></translation>
     </message>
@@ -1442,10 +2059,6 @@ Are you sure you want to save?</source>
 The document contains unsaved changes.
 Do you want to save the changes?
 </source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Discard</source>
         <translation></translation>
     </message>
     <message>
@@ -1481,10 +2094,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation></translation>
     </message>
     <message>
@@ -1674,6 +2283,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1686,35 +2338,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
         <translation></translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation></translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation></translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation></translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1724,16 +2373,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Event</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1751,10 +2412,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation></translation>
     </message>
@@ -1767,12 +2424,16 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
+        <source>Mixer Settings</source>
         <translation></translation>
     </message>
     <message>
-        <source>Mixer Settings</source>
-        <translation></translation>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1794,12 +2455,20 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation></translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
-        <translation></translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1891,14 +2560,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation></translation>
     </message>
@@ -1946,6 +2607,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1978,8 +2643,52 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
-        <translation></translation>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1993,14 +2702,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <name>PatternEditorPanel</name>
     <message>
         <source>Loaded Soundlibrary</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
         <translation></translation>
     </message>
     <message>
@@ -2076,14 +2777,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>It is not possible to change the pattern size when playing.</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation></translation>
     </message>
@@ -2124,36 +2817,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
-        <translation></translation>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
-        <translation></translation>
+        <source>Pattern editor - No pattern selected</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2252,6 +2921,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2286,10 +2962,6 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>BeatCounter Panel on</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Set BPM / Set BPM and play</source>
         <translation></translation>
     </message>
@@ -2306,15 +2978,7 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
         <translation></translation>
     </message>
     <message>
@@ -2370,10 +3034,6 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation></translation>
     </message>
@@ -2384,19 +3044,6 @@ Maximum = 16/4</source>
     <message>
         <source>JACK transport on/off</source>
         <extracomment>Using the JACK the audio/midi input and output ports of any number of application can be connected.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
         <translation></translation>
     </message>
     <message>
@@ -2412,12 +3059,44 @@ Maximum = 16/4</source>
         <translation></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
-        <translation></translation>
+        <source>Toggle the BeatCounter Panel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
-        <translation></translation>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2530,14 +3209,6 @@ Do you want to discard the changes?
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>no Script</source>
         <translation></translation>
     </message>
@@ -2642,24 +3313,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Steps</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Driver restart required.
  Restart driver?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
         <translation></translation>
     </message>
     <message>
@@ -2669,14 +3324,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Please restart hydrogen to enable/disable LASH support</source>
         <translation></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Colour (Hue value)</translation>
     </message>
     <message>
         <source>Hydrogen must be restarted for language change to take effect</source>
@@ -2691,15 +3338,7 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>selected</source>
         <translation></translation>
     </message>
     <message>
@@ -2708,10 +3347,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation></translation>
     </message>
     <message>
@@ -2737,6 +3372,278 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>PulseAudio Driver</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2982,10 +3889,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Meters falloff speed</source>
         <extracomment>In case of a rapid sound lasting for just a milli second the meters in the Mixer would raise to peak value and fall of immediately without the user being able to see them. The falloff speed introduces a delay. The smaller the value, the longer the meter requires to reach 0dB again.</extracomment>
         <translation></translation>
@@ -3003,10 +3906,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Mixer font</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Default interface layout</source>
         <translation></translation>
     </message>
@@ -3019,16 +3918,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>Colouring method for Song Editor elements</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -3068,7 +3959,7 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation></translation>
     </message>
     <message>
@@ -3147,17 +4038,133 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Prefer larger</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation></translation>
@@ -3188,14 +4195,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation></translation>
     </message>
     <message>
@@ -3259,10 +4258,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation></translation>
     </message>
@@ -3282,37 +4277,46 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Move point</source>
         <translation></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation></translation>
     </message>
     <message>
@@ -3676,14 +4680,6 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <source>Enable time line edit</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Clear pattern sequence</source>
         <translation></translation>
     </message>
@@ -3705,10 +4701,6 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Draw mode</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
         <translation></translation>
     </message>
     <message>
@@ -3745,54 +4737,26 @@ Are you sure?</source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation></translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation></translation>
+        <source>selected pattern mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation></translation>
+        <source>Playback track volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
-        <translation></translation>
+        <source>Playback volume set to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SongEditorPanelBpmWidget_UI</name>
     <message>
         <source>Form</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>500</source>
         <translation></translation>
     </message>
     <message>
@@ -3866,10 +4830,6 @@ Are you sure?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Could not export pattern.</source>
         <translation></translation>
     </message>
@@ -3883,23 +4843,7 @@ Overwrite the existing pattern?</source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Pattern saved.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
         <translation></translation>
     </message>
     <message>
@@ -3913,6 +4857,17 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Could not save pattern to temporary directory.</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3964,32 +4919,40 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
-        <translation></translation>
+        <source>&amp;Export</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
-        <translation></translation>
+        <source>Export Drumkit</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
-        <translation></translation>
+        <source>invalid drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file [%1] does already exist and will be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SoundLibraryExportDialog_UI</name>
-    <message>
-        <source>Drumkit</source>
-        <translation></translation>
-    </message>
     <message>
         <source>Component</source>
         <translation></translation>
@@ -4238,25 +5201,7 @@ Are you sure?</source>
         <translation></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation></translation>
     </message>
 </context>
@@ -4287,10 +5232,6 @@ Current kit:</source>
         <translation></translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Image</source>
         <translation></translation>
     </message>
@@ -4301,6 +5242,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4338,76 +5283,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4434,6 +5309,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation></translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Marcos en tiempo real</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,572 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Silencio</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">General</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrumento</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Capas</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mezclador</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Ataque</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Decay</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sustain</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Release</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Canal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Entrada</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">PPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Intensidad</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Mostrar editor del piano roll</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished">El soporte del Timebase de JACK está deshabilitado en Preferencias</translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished">No se puede cargar el instrumento</translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">apagado</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished">No compilado</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Aceptar</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Guardar</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Cancelar</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Descartar</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Reproducir</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished">Cambios sin guardar. Estos cambios se perderán. ¿Seguir?</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished">No volver a mostrar este mensaje</translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished">El drumkit registrado en la canción actual no se pudo encontrar en el disco.
+Por favor carga un drumkit existente primero.
+Kit actual:</translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +888,16 @@
         <translation>Nombre componente</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Fijar volumen del instrumento [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -355,10 +933,6 @@
     <message>
         <source>Cannot paste multi-pattern selection</source>
         <translation>No se puede pegar selección multi-patrón</translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
-        <translation>No se puede cargar el instrumento</translation>
     </message>
 </context>
 <context>
@@ -464,6 +1038,22 @@ Overwrite the existing file?</source>
     <message>
         <source>Directory %1 does not exist</source>
         <translation>El directorio %1 no existe</translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -670,31 +1260,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation>Directorio datos de usuario</translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Efectos si/no</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Salida Master</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>PPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation>Por favor introduce un número dentro del rango de </translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -711,24 +1318,6 @@ Overwrite the existing file?</source>
         <translation>Propiedades de la Biblioteca de Sonidos</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Esto no es posible, solo puede guardar las modificaciones de los instrumentos en la biblioteca de sonidos cargada actualmente</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>¡Atención! Cambiar el nombre del drumkit resultará en la creación de otro drumkit con este nombre.
-¿Seguir?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Error al guardar drumkit.</translation>
     </message>
@@ -740,13 +1329,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>Archivos de Imagen (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrumento</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Componente</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Licencia</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Drumkit cargado: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Editor de canciones</translation>
@@ -762,10 +1383,6 @@ Are you sure?</source>
     <message>
         <source>modified</source>
         <translation>modificado</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Canción guardada.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -787,6 +1404,26 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished">Canción guardada como: </translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -813,22 +1450,6 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
         <translation>Filtro de resonancia</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>Ataque</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Decay</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sustain</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Release</translation>
-    </message>
-    <message>
         <source>Layer gain</source>
         <translation>Ganancia de capa</translation>
     </message>
@@ -839,14 +1460,6 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
     <message>
         <source>Instrument gain</source>
         <translation>Ganancia del instrumento</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>General</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Capas</translation>
     </message>
     <message>
         <source>Layer pitch (Coarse)</source>
@@ -897,8 +1510,28 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
         <translation>Seleccionar algoritmo de selección</translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
-        <translation>Tono de capa: %1</translation>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -941,10 +1574,12 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Silenciar instrumento</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Solo</translation>
     </message>
     <message>
@@ -1011,16 +1646,8 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
         <translation>Ver editor de instrumentos</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrumento</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Ver biblioteca de sonidos</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Biblioteca de sonidos</translation>
     </message>
 </context>
 <context>
@@ -1071,6 +1698,14 @@ Utiliza &apos;Guardar como&apos; para habilitar el auto-guardado.</translation>
     <message>
         <source>Remove FX</source>
         <translation>Quitar efectos</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1259,10 +1894,6 @@ MIDI = %2</translation>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Descartar</translation>
-    </message>
-    <message>
         <source>Hydrogen Ready.</source>
         <translation>Hydrogen Listo.</translation>
     </message>
@@ -1297,10 +1928,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;About</source>
         <translation>&amp;Acerca de</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1343,16 +1970,8 @@ MIDI = %2</translation>
         <translation>&amp;Info</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Canción guardada.</translation>
-    </message>
-    <message>
         <source>Clear all instruments?</source>
         <translation>¿Eliminar todos los instrumentos?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Aceptar</translation>
     </message>
     <message>
         <source>Unknown error %1</source>
@@ -1381,10 +2000,6 @@ MIDI = %2</translation>
     <message>
         <source>Open Pattern</source>
         <translation>Abrir Patrón</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>No mostrar este mensaje de nuevo</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1420,7 +2035,6 @@ El documento contiene cambios sin guardar.
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Deshacer</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1511,10 +2125,6 @@ El playlist actual contiene cambios sin guardar.
     <message>
         <source>Save &amp;As...</source>
         <translation>Guard&amp;ar Como...</translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
-        <translation>Mostrar &amp;Info</translation>
     </message>
     <message>
         <source>E&amp;xport Pattern As...</source>
@@ -1724,16 +2334,55 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <source>Playing.</source>
         <translation>Reproduciendo.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Volumen principal [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1744,39 +2393,32 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>Humanizar velocidad</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Parametro de humanización de tiempo [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Parámetro de humanización de intensidad [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Factor de swing [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation>Este elemento no puede operar con midi.</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>Esperando entrada midi...</translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Evento</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Parám.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Acción</translation>
@@ -1784,6 +2426,26 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
     <message>
         <source>press button to record midi event</source>
         <translation>Pulse el botón para grabar evento midi</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1805,14 +2467,6 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>Mostrar picos de instrumento = No</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Nivel Efecto %1 </translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Volumen Efecto LADSPA ( %1 )</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation>Los efectos LADSPA no están disponibles en esta versión de Hydrogen.</translation>
     </message>
@@ -1823,6 +2477,14 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
     <message>
         <source>Mixer Settings</source>
         <translation>Configuración Mezclador</translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1844,12 +2506,20 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>Balance</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Fijar volumen del instrumento [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
-        <translation>Nombre del instrumento</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1941,14 +2611,6 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>Limpiar selección</translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation>Establecer velocidad de nota [%1]</translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation>Editar %1 propiedad de %2 notas</translation>
-    </message>
-    <message>
         <source>B</source>
         <translation>B</translation>
     </message>
@@ -1996,6 +2658,10 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <source>C</source>
         <translation>C</translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2028,8 +2694,52 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>Colocar estas notas aquí sobreescribirá %1 notas duplicadas.</translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
-        <translation>No volver a mostrar este mensaje</translation>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2078,18 +2788,6 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>Alejar</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>No es posible cambiar el tamaño del patrón durante la reproducción.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Seleccionar tamaño del patrón</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Seleccionar resolución de rejilla</translation>
-    </message>
-    <message>
         <source>Select note properties</source>
         <translation>Seleccionar propiedades de nota</translation>
     </message>
@@ -2128,10 +2826,6 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
     <message>
         <source>Probability</source>
         <translation>Probabilidad</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation>Denominador de nota no soportado. Haz clic para más información.</translation>
     </message>
     <message>
         <source>quarter</source>
@@ -2174,40 +2868,12 @@ Debería funcionar de maravilla siempre que utilices el GMRockKit y que no utili
         <translation>apagado</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
-        <translation>Hydrogen solo puede representar notas hasta 1/%1 de una nota entera, por tanto los valores de notas deben ser múltiplos de esto.
-Los valores soportados son: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</translation>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation>Nueva longitud de Patrón (pulsaciones/valor nota)</translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation>Valor de denominador rechazado.
-Límites: (0, %1]</translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation>Tamaño de patrón excesivo.
-Máximo = 16/4</translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation>La longitud del patrón en notas de 1/%1 no está soportada. La longitud se puede aproximar.</translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation>Se aproximó el tamaño del patrón.
-(resolución = %1 pulsos/negra)</translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
-        <translation>Texto rechazado</translation>
+        <source>Pattern editor - No pattern selected</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2306,6 +2972,13 @@ Máximo = 16/4</translation>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Song Mode</source>
@@ -2334,10 +3007,6 @@ Máximo = 16/4</translation>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Modo de patrón seleccionado.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Nuevo valor de PPM</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2372,20 +3041,8 @@ Máximo = 16/4</translation>
         <translation>Ver mezclador</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mezclador</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Ver rack de instrumentos</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Rack de instrumentos</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Panel del Contador de Pulsaciones sí</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2441,19 +3098,6 @@ Máximo = 16/4</translation>
         <translation>Transporte JACK encendido/apagado</translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation>Timebase maestro JACK encendido/apagado</translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation>El soporte del Timebase de JACK está deshabilitado en Preferencias</translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation>En la presencia de un Timebase maestro externo de JACK el tempo no se puede alterar desde dentro de Hydrogen</translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation>El transporte JACK solo funcionará con el driver JACK.</translation>
     </message>
@@ -2466,12 +3110,44 @@ Máximo = 16/4</translation>
         <translation>Modo transporte JACK: = Apagado</translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
-        <translation>Modo Timebase maestro JACK = Encendido</translation>
+        <source>Toggle the BeatCounter Panel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
-        <translation>Modo Timebase maestro JACK = Apagado</translation>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2667,14 +3343,6 @@ El playlist actual contiene cambios sin guardar.
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Descartar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2711,32 +3379,8 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
  ¿Reiniciar controlador?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Automatic</source>
         <translation>Automático</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation>Pasos</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>Fijo</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>Número de pasos</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Color (Tono valor)</translation>
     </message>
     <message>
         <source>Automatic driver selection</source>
@@ -2751,10 +3395,6 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <translation>Selecciona tu Driver de MIDI</translation>
     </message>
     <message>
-        <source>None</source>
-        <translation>Ninguno</translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation>El puerto seleccionado no está disponible. Esta instancia utiliza el siguiente puerto temporal en su lugar:</translation>
     </message>
@@ -2763,20 +3403,12 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <translation>Hydrogen debe reiniciarse para que el cambio de idioma surta efecto</translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation>seleccionado</translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation>Open Sound System</translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
         <translation>Simple audio driver [/dev/dsp]</translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
-        <translation>No compilado</translation>
     </message>
     <message>
         <source>JACK Audio Connection Kit Driver</source>
@@ -2801,6 +3433,278 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     <message>
         <source>PulseAudio Driver</source>
         <translation>Driver PulseAudio</translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">General</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Editor de canciones</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Error iniciando controlador de audio</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2845,14 +3749,6 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     <message>
         <source>Application font</source>
         <translation>Fuente para la aplicación</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Fuente para el mixer</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Seleccionar fuente</translation>
     </message>
     <message>
         <source>Sample rate</source>
@@ -3063,16 +3959,8 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <translation>Pestañas</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>Etiqueta Texto</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>Método coloreo para elementos Editor Canciones</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Tras cambiar una fuente o el formato de interfaz se debe reiniciar la aplicación.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;OSC</source>
@@ -3132,7 +4020,7 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation>Utilizar &amp;LASH</translation>
     </message>
     <message>
@@ -3211,17 +4099,133 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <source>Prefer larger</source>
         <translation>Preferir más grande</translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished">B</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation>Añadir Patrón ( %1, %2 )</translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation>Borrar Patrón ( %1, %2 )</translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation>Mover ítem de la lista de patrones ( %1, %2 )</translation>
@@ -3253,14 +4257,6 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     <message>
         <source>Fill/remove range of pattern</source>
         <translation>Rellenar/quitar rango de patrón</translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation>Editar tempo línea de tiempo</translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
-        <translation>Borrar tempo línea de tiempo</translation>
     </message>
     <message>
         <source>Edit timeline tag</source>
@@ -3323,10 +4319,6 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <translation>Añadir nota NOTE_OFF de piano roll ( %1, %2 )</translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation>Cambiar longitud de nota de piano roll </translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation>Cambiar propiedades de notas en piano roll</translation>
     </message>
@@ -3346,39 +4338,47 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <source>Move point</source>
         <translation>Mover punto</translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>¡Cerrar diálogo! quizá haya trabajo sin guardar en el sample.
-¿Seguir?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation>Cambios sin guardar. Estos cambios se perderán. ¿Seguir?</translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation>Editor de samples </translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation>&amp;Reproducir</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation>R&amp;eproducir sample original</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3794,28 +4794,8 @@ Are you sure?</source>
 ¿Seguir?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>modo apilado</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>modo patrones apilados</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>modo patrón único</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Activar edición de línea de tiempo</translation>
     </message>
     <message>
         <source>Pattern %1</source>
@@ -3846,20 +4826,16 @@ Are you sure?</source>
         <translation>Intensidad</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
-        <translation>El uso de la línea de tiempo en la presencia de un Timebase maestro de JACK está deshabilitado</translation>
+        <source>selected pattern mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation>En la presencia de un Timebase maestro de JACK externo el tempo no puede alterarse desde Hydrogen</translation>
+        <source>Playback track volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation> Línea de tiempo = Apagado</translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
-        <translation> Línea de tiempo = Encendido</translation>
+        <source>Playback volume set to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3867,22 +4843,6 @@ Are you sure?</source>
     <message>
         <source>Form</source>
         <translation>Forma</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Editar valor de ppm para ritmo actual</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Editar ritmo en línea de tiempo</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3947,34 +4907,14 @@ Are you sure?</source>
         <translation>Cargar Patrón</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Abrir Patrón</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>Patrón Virtual</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Patrón 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>sin_categorizar</translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>El archivo de patrones existe. 
 ¿Sobreescribir el patron actual?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -4003,6 +4943,17 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Could not save pattern to temporary directory.</source>
         <translation>No se pudo guardar el patrón en un directorio temporal.</translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4054,24 +5005,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Exportar Biblioteca de Sonidos</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Directorio</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
-        <translation>No se pudo crear el archivo</translation>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportar</translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
-        <translation>Drumkit exportado.</translation>
+        <source>Export Drumkit</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
-        <translation>Drumkit no exportado. Operación no soportada.</translation>
+        <source>invalid drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file [%1] does already exist and will be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Todo</translation>
     </message>
 </context>
 <context>
@@ -4079,10 +5042,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Exportar</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Drumkit</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4281,14 +5240,6 @@ Overwrite the existing pattern?</source>
         <translation>Drumkits del usuario</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Canciones</translation>
     </message>
@@ -4343,20 +5294,8 @@ Los primeros %2 instrumentos serán reemplazados con los nuevos intrumentos y ma
         <translation>Hacer doble clic para expandir la lista</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation>El drumkit registrado en la canción actual no se pudo encontrar en el disco.
-Por favor carga un drumkit existente primero.
-Kit actual:</translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
         <translation>es un drumkit del sistema y no se puede eliminar.</translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
-        <translation>No implementado aún.</translation>
     </message>
 </context>
 <context>
@@ -4382,10 +5321,6 @@ Kit actual:</translation>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Guardar cambios a los instrumentos en la biblioteca de sonidos</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Licencia Drumkit</translation>
     </message>
@@ -4400,6 +5335,10 @@ Kit actual:</translation>
     <message>
         <source>Image License</source>
         <translation>Licencia Imagen</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4437,76 +5376,6 @@ Kit actual:</translation>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Guardar Biblioteca de sonidos</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Por favor proporcione al menos un nombre válido</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>Ya existe una biblioteca con el mismo nombre. ¿Quiere sobreescribir la biblioteca existente?</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Error al guardar esta biblioteca.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Abrir Imagen</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Archivos de Imagen (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Nombre</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Info</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Licencia</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Guardar </translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Imagen</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Examinar</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Licencia Imagen</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4533,6 +5402,19 @@ Kit actual:</translation>
     <message>
         <source>Cancel</source>
         <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -347,7 +347,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Edit</source>
-        <extracomment>Text displayed on the button for editin an element. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
         <translation>Édit</translation>
     </message>
     <message>
@@ -362,12 +362,12 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Timeline</source>
-        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold three characters.</extracomment>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
         <translation>LdT</translation>
     </message>
     <message>
         <source>FX</source>
-        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold eight characters.</extracomment>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
         <translation>FX</translation>
     </message>
     <message>
@@ -768,7 +768,7 @@ B</translation>
     </message>
     <message>
         <source>The Timeline is only available in Song Mode</source>
-        <translation>La base de temps est uniquement disponible en mode morceau></translation>
+        <translation>La base de temps est uniquement disponible en mode morceau&gt;</translation>
     </message>
     <message>
         <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
@@ -2040,7 +2040,6 @@ Voulez-vous sauvegarder les changements?
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Défaire</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Cadros en tempo real</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Silencio</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Xeral</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrumento</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Capas</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Misturador</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Ataque</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Decaemento</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sustain</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Publicación</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Canle</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Entrada</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">BPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Velocidade</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Amosar o editor da pianola</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">apagado</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Aceptar</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Gardar</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Cancelar</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Desbotar</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Reproducir</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Estabelecer o volume do instrumento [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -463,6 +1035,22 @@ Sobrescribir o ficheiro existente?</translation>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -670,30 +1258,47 @@ Sobrescribir o ficheiro existente?</translation>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Efectos si/non</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Saída principal</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>BPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -711,24 +1316,6 @@ Sobrescribir o ficheiro existente?</translation>
         <translation>Propiedades da biblioteca de son</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Isto non é posíbel, só se pode gardar os cambios dentro dos instrumentos para a biblioteca de son cargada actualmente</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Aviso! O cambio do nome da batería resultará na creación dunha nova batería con este nome.
-Está seguro?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Non foi posíbel gardar esta batería.</translation>
     </message>
@@ -740,13 +1327,45 @@ Está seguro?</translation>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrumento</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Licenza</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Batería cargada: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Editor de cancións</translation>
@@ -762,10 +1381,6 @@ Está seguro?</translation>
     <message>
         <source>modified</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Canción gardada.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -788,6 +1403,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
@@ -802,22 +1437,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Filtro de resonancia</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Ataque</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Decaemento</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sustain</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Publicación</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -846,14 +1465,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>New instrument name</source>
         <translation>Novo nome do instrumento</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Xeral</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Capas</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -896,7 +1507,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -912,10 +1543,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Silenciar instrumento</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Solo</translation>
     </message>
     <message>
@@ -1010,16 +1643,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Amosar o editor de instrumento</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrumento</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Amosar a biblioteca de son</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Biblioteca de son</translation>
     </message>
 </context>
 <context>
@@ -1070,6 +1695,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>Retirar efectos</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1262,10 +1895,6 @@ MIDI = %2</translation>
         <translation>&amp;Gardar</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Desbotar</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Gardar a canción</translation>
     </message>
@@ -1296,10 +1925,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;About</source>
         <translation>&amp;Sobre</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1342,20 +1967,12 @@ MIDI = %2</translation>
         <translation>&amp;Información</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Canción gardada.</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Erro descoñecido: %1</translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
         <translation>Limpar todos os instrumento?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Aceptar</translation>
     </message>
     <message>
         <source>Could not save song.</source>
@@ -1406,7 +2023,6 @@ Quere gardar os cambios?
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Desfacer</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source></source>
@@ -1417,10 +2033,6 @@ Quere gardar os cambios?
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
         <translation>Está a usar unha versión de desenvolvemento de Hydrogen, axúdenos informándonos dos fallos ou con suxestións na la lista de correo hydrogen-devel.&lt;br&gt;&lt;br&gt;Grazas!</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Non volver amosar esta mensaxe</translation>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1507,10 +2119,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1717,20 +2325,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Reproducindo.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Estabelecer o volume principal [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Parámetro de humanización do tempo [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Parámetro de humanización da velocidade [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
@@ -1745,31 +2388,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Humanizar o tempo</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
-    </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
-    <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Actividade</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Parám.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Acción</translation>
@@ -1777,6 +2417,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>prema o botón para gravar a actividade MIDI</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1798,23 +2458,23 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Amosar os picos do instrumento = Non</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Nivel do efecto %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Volume do efecto LADSPA ( %1 )</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mixer</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Misturador</translation>
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1837,11 +2497,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Panorama</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Estabelecer o volume do instrumento [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1904,7 +2572,7 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&amp;Cancelar</translation>
     </message>
     <message>
         <source>Alt+C</source>
@@ -1931,14 +2599,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1989,6 +2649,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2021,7 +2685,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2059,14 +2767,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Cuantizar eventos teclado/MIDI entrantes = Si</translation>
     </message>
     <message>
-        <source>Select pattern size</source>
-        <translation>Seleccionar o tamaño do patrón</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Seleccionar a resolución da rella</translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation>Acercar</translation>
     </message>
@@ -2077,10 +2777,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>No pattern selected</source>
         <translation>Non hai ningún patrón seleccionado</translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Non é posíbel cambiar o tamaño do patrón durante a reprodución.</translation>
     </message>
     <message>
         <source>Select note properties</source>
@@ -2120,10 +2816,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2167,35 +2859,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">apagado</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2295,6 +2963,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Stop</source>
@@ -2345,24 +3020,12 @@ Maximum = 16/4</source>
         <translation>Repetir canción</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mesturador</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Amosar o armario de instrumentos</translation>
     </message>
     <message>
-        <source>Instrument rack</source>
-        <translation>Armario de instrumentos</translation>
-    </message>
-    <message>
         <source>Pause.</source>
         <translation>Pausa.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Novo valor de PPM</translation>
     </message>
     <message>
         <source>Loop song = On</source>
@@ -2371,10 +3034,6 @@ Maximum = 16/4</source>
     <message>
         <source>Loop song = Off</source>
         <translation>Repetir canción = Non</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Panel de Conta_de_pulsos (beats) activado</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2430,19 +3089,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2455,11 +3101,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2653,14 +3331,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Desbotar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2695,31 +3365,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
  Reiniciar o controlador?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2735,10 +3381,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2747,19 +3389,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2784,6 +3418,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Xeral</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Editor de cancións</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Produciuse un erro ao iniciar o controlador de son</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2837,14 +3743,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Tipo de letra para o aplicativo</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Seleccionar o tipo de letra</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Tipo de letra para o mesturador</translation>
     </message>
     <message>
         <source>Style</source>
@@ -3047,15 +3945,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>En páxinas</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3116,7 +4006,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3195,17 +4085,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3236,14 +4242,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3307,10 +4305,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3330,39 +4324,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Pechar o diálogo! Semella que hai traballo sobre a mostra sen gardar.
-Está seguro?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">&amp;Reproducir</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">R&amp;eproducir a mostra orixinal</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3747,10 +4749,6 @@ p, li { white-space: pre-wrap; }
         <translation>Editor de cancións</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancel</translation>
-    </message>
-    <message>
         <source>Clear pattern sequence</source>
         <translation>Eliminar a secuencia do patrón</translation>
     </message>
@@ -3769,28 +4767,12 @@ Are you sure?</source>
 Está seguro?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>patróns amoreados</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>modo de patróns amoreados</translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation>modo de patrón único</translation>
-    </message>
-    <message>
         <source>Pattern %1</source>
         <translation>Patrón %1</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Activar a edición da liña de tempo</translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3817,19 +4799,15 @@ Está seguro?</translation>
         <translation type="unfinished">Velocidade</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3838,22 +4816,6 @@ Está seguro?</translation>
     <message>
         <source>Form</source>
         <translation>Forma</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Editar o valor de BPM para o ritmo actual</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Editar o ritmo na liña de tempo</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3918,30 +4880,10 @@ Está seguro?</translation>
         <translation>Cargar un patrón</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Abrir un patrón</translation>
-    </message>
-    <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>Xa existe o ficheiro patrón. 
 Sobrescribir o patrón existente?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Patrón 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>sen categoría</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3973,6 +4915,17 @@ Sobrescribir o patrón existente?</translation>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4025,24 +4978,36 @@ Sobrescribir o patrón existente?</translation>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Exportar a biblioteca de son</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Directorio</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportar</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Todo</translation>
     </message>
 </context>
 <context>
@@ -4050,10 +5015,6 @@ Sobrescribir o patrón existente?</translation>
     <message>
         <source>Export</source>
         <translation>Exportar</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished">Batería</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4252,14 +5213,6 @@ Sobrescribir o patrón existente?</translation>
         <translation>Baterías do usuario</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Aceptar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Cancións</translation>
     </message>
@@ -4311,17 +5264,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4348,10 +5291,6 @@ Current kit:</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Gardar os cambios feitos aos instrumentos na biblioteca de son</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4365,6 +5304,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4403,76 +5346,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Gardar a biblioteca de son</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Forneza polo menos un nome correcto</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Nome</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Información</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Licenza</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Gardar</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Examinar</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4499,6 +5372,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Stvarni framerate</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Escludi</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Generale</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mixer</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Attack</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Kanal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Ulaz</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Frekvencija</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Spremi</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Otkaži</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Odbaci promje&amp;ne</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Volume strumento [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,30 +1256,47 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Efekti on/off</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Glavni izlaz</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -709,24 +1314,6 @@ Overwrite the existing file?</source>
         <translation>Karakteristike &apos;Zvučne knjižnice&apos;</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Otkaži</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>To nije moguće, možeš spremiti promjene unutar instrumenta u samo trenutno otvorenoj &apos;zvučnoj knjižnici&apos;</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Upozorenje! Mijenjanje imena seta bubnjeva će rezultirati stvaranjem novog seta bubnjeva s tim imenom.
-Jesi li siguran da to želiš napraviti?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -738,13 +1325,45 @@ Jesi li siguran da to želiš napraviti?</translation>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Licenca</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Set bubnjeva učitan: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Editor pjesme</translation>
@@ -774,16 +1393,32 @@ Jesi li siguran da to želiš napraviti?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Pjesma spremljena.</translation>
-    </message>
-    <message>
         <source>Song is read-only.
 Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -822,36 +1457,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Filter rezonancija</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>Attack</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Layer pitch (Coarse)</source>
         <translation>Layer pitch (grezzo)</translation>
     </message>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>Layer pitch (Fine)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Generale</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation></translation>
     </message>
     <message>
         <source>New component name</source>
@@ -894,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -938,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">Solo</translation>
     </message>
     <message>
@@ -1008,16 +1641,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Prikaži uređivač instrumenta</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrument</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Prikaži &apos;zvučnu knjižnicu&apos;</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Zvučna knjižnica</translation>
     </message>
 </context>
 <context>
@@ -1067,6 +1692,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1231,10 +1864,6 @@ MIDI = %2</source>
         <translation>&amp;Spremi</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>Odbaci promje&amp;ne</translation>
-    </message>
-    <message>
         <source>Hydrogen Ready.</source>
         <translation>Hydrogen je spreman za rad.</translation>
     </message>
@@ -1278,10 +1907,6 @@ Do you want to save the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Otkaži</translation>
-    </message>
-    <message>
         <source>Unknown audio driver</source>
         <translation>Nepoznati audio driver</translation>
     </message>
@@ -1322,10 +1947,6 @@ Do you want to save the changes?
         <translation>&amp;Informacije</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Pjesma spremljena.</translation>
-    </message>
-    <message>
         <source>Could not export pattern.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1336,10 +1957,6 @@ Do you want to save the changes?
     <message>
         <source>Clear all instruments?</source>
         <translation>Izbrisati sve instrumente?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Ok</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
@@ -1366,10 +1983,6 @@ Do you want to save the changes?
         <translation>Otvori uzorak</translation>
     </message>
     <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Nemoj više prikazivati ovu poruku</translation>
-    </message>
-    <message>
         <source>Playlist: Set song No. %1</source>
         <translation>Playlist: Pjesma br. %1</translation>
     </message>
@@ -1389,7 +2002,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1468,10 +2080,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1686,16 +2294,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Svira.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Podesi glavnu glasnoću [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1706,26 +2353,27 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Humaniziraj intenzitet</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Podesi parametar za humaniziranje tempa [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Podesi parametar za humaniziranje raspona [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Swing faktor [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1736,16 +2384,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Event</source>
-        <translation>Događaj</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Param.</translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation>Poduzimanje</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1767,14 +2427,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Prikaži visinu točke instrumenta = Neaktivno</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Postavi razinu FX-a %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Postavi glasnoću LADSPA FX-a ( %1 )</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1784,6 +2436,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1806,11 +2466,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Pan</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Volume strumento [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1873,7 +2541,7 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&amp;Otkaži</translation>
     </message>
     <message>
         <source>Alt+C</source>
@@ -1900,14 +2568,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1958,6 +2618,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1990,7 +2654,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2030,18 +2738,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>Kvantiziranje nadolazećih klavijaturnih/midi sesija = Neaktivno</translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Nije moguće promijeniti veličinu uzorka za vrijeme trajanja preslušavanja.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Izaberi veličinu uzorka</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Odaberi veličinu rešetke</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -2092,10 +2788,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2136,35 +2828,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2264,6 +2932,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Song Mode</source>
@@ -2288,10 +2963,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Uzorak Mod odabran.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Nova vrijednost broja udaraca u minuti (BPM)</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2330,20 +3001,8 @@ Maximum = 16/4</source>
         <translation>Stani</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mixer</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Prikaži Rack</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Rack</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Ploča brojača udaraca uključena</translation>
     </message>
     <message>
         <source>Record</source>
@@ -2399,19 +3058,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2424,11 +3070,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2622,14 +3300,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">Odbaci promje&amp;ne</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2655,14 +3325,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Preferences</source>
         <translation>Postavke</translation>
     </message>
@@ -2675,31 +3337,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Select your Audio Driver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select your MIDI Driver</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2715,19 +3357,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2752,6 +3386,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Generale</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Editor pjesme</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Problem pri pokretanju drivera zvuka</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2797,14 +3703,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Font aplikacije</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Font Mixera</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Odaberi font</translation>
     </message>
     <message>
         <source>Polyphony</source>
@@ -3015,15 +3913,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3068,7 +3958,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3163,17 +4053,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3204,14 +4210,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3275,10 +4273,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3298,37 +4292,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3708,10 +4711,6 @@ p, li { white-space: pre-wrap; }
         <translation>Editor pjesme</translation>
     </message>
     <message>
-        <source>Enable time line edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Select mode</source>
         <translation>Odaberi Mod</translation>
     </message>
@@ -3730,24 +4729,8 @@ Are you sure?</source>
 Da li to želiš napraviti?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Otkaži</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>Skupni Mod</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>Skupni Mod uzorka</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>Pojedinačni Mod uzoraka</translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3774,19 +4757,15 @@ Da li to želiš napraviti?</translation>
         <translation type="unfinished">Frekvencija</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3795,22 +4774,6 @@ Da li to želiš napraviti?</translation>
     <message>
         <source>Form</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished">500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation type="unfinished">500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3830,7 +4793,7 @@ Da li to želiš napraviti?</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Otkaži</translation>
     </message>
     <message>
         <source>Ok</source>
@@ -3849,7 +4812,7 @@ Da li to želiš napraviti?</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Otkaži</translation>
     </message>
     <message>
         <source>Ok</source>
@@ -3872,22 +4835,6 @@ Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation type="unfinished">Nije kategorizirano</translation>
-    </message>
-    <message>
         <source>Save Pattern</source>
         <translation>Spremi uzorak</translation>
     </message>
@@ -3898,10 +4845,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Virtual Pattern</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Pattern</source>
-        <translation>Otvori uzorak</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3930,6 +4873,17 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Pattern saved.</source>
         <translation type="unfinished">Uzorak spremljen.</translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3981,24 +4935,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Izbaci zvučnu knjižnicu</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Izbaci</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Sve</translation>
     </message>
 </context>
 <context>
@@ -4006,10 +4972,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Izbaci</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4037,7 +4999,7 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Otkaži</translation>
     </message>
 </context>
 <context>
@@ -4182,7 +5144,7 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Otkaži</translation>
     </message>
 </context>
 <context>
@@ -4206,14 +5168,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>User drumkits</source>
         <translation>Korisnički setovi bubnjeva</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Odustani</translation>
     </message>
     <message>
         <source>Songs</source>
@@ -4264,17 +5218,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4301,10 +5245,6 @@ Current kit:</source>
         <translation>Otkaži</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Spremi promjene napravljene na instrumentima u zvučnoj knjižnici</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4318,6 +5258,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4356,76 +5300,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Spremi zvučnu knjižnicu</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Dijalog</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Ime</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informacije</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Odustani</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Licenca</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Spremi</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Pretraži</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4451,6 +5325,19 @@ Current kit:</source>
     </message>
     <message>
         <source>Cancel</source>
+        <translation type="unfinished">Otkaži</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Némít</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Általános</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Keverő</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Csatorna</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Bemenet</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Mentés</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Eldobás</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">[%1] hangszer hangerejének beállítása</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,30 +1256,47 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation type="unfinished">FX be/ki</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation type="unfinished">Master kimenet</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -709,23 +1314,6 @@ Overwrite the existing file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -737,13 +1325,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Jogok</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation type="unfinished">Dobszerkó betöltve: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Számszerkesztő</translation>
@@ -773,16 +1393,32 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Song is read-only.
 Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -798,22 +1434,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Filter resonance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Release</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -842,14 +1462,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>New instrument name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="unfinished">Általános</translation>
-    </message>
-    <message>
-        <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -893,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -937,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">Szóló</translation>
     </message>
     <message>
@@ -1007,15 +1641,7 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sound library</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1066,6 +1692,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1228,10 +1862,6 @@ MIDI = %2</source>
         <translation type="unfinished">&amp;Mentés</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Eldobás</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation type="unfinished">Szám mentése</translation>
     </message>
@@ -1304,23 +1934,11 @@ MIDI = %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1345,10 +1963,6 @@ MIDI = %2</source>
     </message>
     <message>
         <source>Open Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1382,7 +1996,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1461,10 +2074,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1679,6 +2288,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Lejátszás.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1695,43 +2347,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Action</source>
         <translation type="unfinished"></translation>
@@ -1740,17 +2381,29 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>press button to record midi event</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Mixer</name>
-    <message>
-        <source>Set FX %1 level </source>
-        <translation type="unfinished">Effekt %1 szint</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation type="unfinished">LADSPA ( %1 ) effekt hangereje</translation>
-    </message>
     <message>
         <source>Show FX panel</source>
         <translation type="unfinished"></translation>
@@ -1779,6 +2432,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Mixer Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MixerLine</name>
@@ -1799,11 +2460,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">Balansz</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">[%1] hangszer hangerejének beállítása</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1896,14 +2565,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1951,6 +2612,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1983,7 +2648,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2025,14 +2734,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">Események illesztése a hálóhoz = Nem</translation>
     </message>
     <message>
-        <source>Select pattern size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2042,10 +2743,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>No pattern selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2082,10 +2779,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2129,35 +2822,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2257,6 +2926,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Stop</source>
@@ -2307,23 +2983,11 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation type="unfinished">Keverő</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument rack</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Pause.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2332,10 +2996,6 @@ Maximum = 16/4</source>
     </message>
     <message>
         <source>Loop song = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2392,19 +3052,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2417,11 +3064,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2611,14 +3290,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Eldobás</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2652,31 +3323,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2685,10 +3332,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Select your MIDI Driver</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2704,19 +3347,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2741,6 +3376,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Általános</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Számszerkesztő</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Audió meghajtó indítási hiba</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2783,10 +3690,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished">Stílus</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation type="unfinished">Betütípus kiválasztása</translation>
-    </message>
-    <message>
         <source>Slow</source>
         <translation type="unfinished">Lassú</translation>
     </message>
@@ -2797,10 +3700,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Fast</source>
         <translation type="unfinished">Gyors</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation type="unfinished">Keverő betütípusa</translation>
     </message>
     <message>
         <source>Meters falloff speed</source>
@@ -3004,15 +3903,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3057,7 +3948,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3152,17 +4043,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3193,14 +4200,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3264,10 +4263,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3287,37 +4282,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3710,27 +4714,7 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3762,19 +4746,15 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3782,22 +4762,6 @@ Are you sure?</source>
     <name>SongEditorPanelBpmWidget_UI</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3863,32 +4827,12 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3917,6 +4861,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Pattern saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3969,24 +4924,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file [%1] does already exist and will be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Összes</translation>
     </message>
 </context>
 <context>
@@ -3994,10 +4961,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation type="unfinished">Exportálás</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4196,14 +5159,6 @@ Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4251,17 +5206,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4288,10 +5233,6 @@ Current kit:</source>
         <translation type="unfinished">Mégsem</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4305,6 +5246,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4343,76 +5288,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation type="unfinished">Szerző</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Mégsem</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation type="unfinished">Jogok</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Tallóz</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4439,6 +5314,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Mégsem</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -79,7 +79,7 @@
     <name>AudioEngineInfoForm</name>
     <message>
         <source>Audio Engine Info</source>
-        <translation>Informazioni sull'engine sonoro</translation>
+        <translation>Informazioni sull&apos;engine sonoro</translation>
     </message>
 </context>
 <context>
@@ -167,6 +167,10 @@
     <message>
         <source>Realtime frames</source>
         <translation>Frame in tempo reale</translation>
+    </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -304,6 +308,572 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Escludi</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Generale</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Strumento</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Livelli</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mixer</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Attacco</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Decadimento</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sostegno</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Rilascio</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Canale</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Ingresso</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">BPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Velocità</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Mostra editor del piano</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished">Non è possibile caricare lo strumento</translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">off</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Salva</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Annulla</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Ri&amp;produci</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished">Il drumkit utilizzato nella canzone corrente non può essere trovato sul disco.
+        Per piacere, carica prima un drumkit esistente.
+        Kit corrente:</translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +888,16 @@
         <translation>Nome componente</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Volume strumento [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -355,10 +933,6 @@
     <message>
         <source>Cannot paste multi-pattern selection</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
-        <translation>Non è possibile caricare lo strumento</translation>
     </message>
 </context>
 <context>
@@ -464,6 +1038,22 @@ Sovrascrivere il file esistente?</translation>
     <message>
         <source>Directory %1 does not exist</source>
         <translation>La directory %1 non esiste</translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -670,31 +1260,48 @@ Sovrascrivere il file esistente?</translation>
         <source>User data directory</source>
         <translation>Directory con i dati utente</translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>FX acceso/spento</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Uscita principale</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>BPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -711,24 +1318,6 @@ Sovrascrivere il file esistente?</translation>
         <translation>Proprietà Libreria</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Non è possibile, puoi salvare le modifiche solo per gli strumenti attualmente aggiunti alla libreria suoni</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Attenzione! Cambiare il nome del drumkit sarà come creare un nuovo drumkit con lo stesso nome.
-Sei sicuro?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Salvataggio del drumkit fallito.</translation>
     </message>
@@ -740,13 +1329,45 @@ Sei sicuro?</translation>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>File immagine (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Strumento</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Componente</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Licenza</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Drumkit caricato: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Editor canzone</translation>
@@ -762,10 +1383,6 @@ Sei sicuro?</translation>
     <message>
         <source>modified</source>
         <translation>modificato</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Canzone salvata.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -787,6 +1404,26 @@ Utilizza &apos;Salva come&apos; per abilitare il salvataggio automatico.</transl
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished">Canzone salvata con nome: </translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -825,36 +1462,12 @@ Utilizza &apos;Salva come&apos; per abilitare il salvataggio automatico.</transl
         <translation>Filtro di risonanza</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>Attacco</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Decadimento</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sostegno</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Rilascio</translation>
-    </message>
-    <message>
         <source>Layer pitch (Coarse)</source>
         <translation>Layer pitch (grezzo)</translation>
     </message>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>Layer pitch (Fine)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Generale</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Livelli</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -897,7 +1510,27 @@ Utilizza &apos;Salva come&apos; per abilitare il salvataggio automatico.</transl
         <translation>Seleziona algoritmo di selezione</translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -941,10 +1574,12 @@ Utilizza &apos;Salva come&apos; per abilitare il salvataggio automatico.</transl
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Isola strumento</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Assolo</translation>
     </message>
     <message>
@@ -1011,16 +1646,8 @@ Utilizza &apos;Salva come&apos; per abilitare il salvataggio automatico.</transl
         <translation>Mostra editor strumento</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Strumento</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Mostra libreria sonora</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>LIbreria sonora</translation>
     </message>
 </context>
 <context>
@@ -1071,6 +1698,14 @@ Utilizza &apos;Salva come&apos; per abilitare il salvataggio automatico.</transl
     <message>
         <source>Remove FX</source>
         <translation>Rimuovi FX</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1235,10 +1870,6 @@ MIDI = %2</translation>
         <translation>&amp;Salva</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>Annulla modifiche</translation>
-    </message>
-    <message>
         <source>Hydrogen Ready.</source>
         <translation>Hydrogen, pronto.</translation>
     </message>
@@ -1273,10 +1904,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;About</source>
         <translation>&amp;Informazioni</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1319,20 +1946,12 @@ MIDI = %2</translation>
         <translation>&amp;Informazioni</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Canzone salvata</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Errore sconosciuto %1</translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
         <translation>Eliminare tutti gli strumenti?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Ok</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
@@ -1357,10 +1976,6 @@ MIDI = %2</translation>
     <message>
         <source>Open Pattern</source>
         <translation>Apri pattern</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Non mostrare più questo messaggio</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1395,7 +2010,6 @@ Vuoi salvare i cambiamenti?</translation>
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Indietro</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1422,7 +2036,7 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Non è possibile salvare la libreria.</translation>
     </message>
     <message>
         <source>Drum&amp;kits</source>
@@ -1483,10 +2097,6 @@ Do you want to discard the changes?
     <message>
         <source>Save &amp;As...</source>
         <translation>Salva &amp;con nome...</translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
-        <translation>Mostra &amp;informazioni</translation>
     </message>
     <message>
         <source>E&amp;xport Pattern As...</source>
@@ -1692,16 +2302,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation>In esecuzione.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Volume principale [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1712,39 +2361,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Umanizza intensità</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Umanizza (tempo) [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Umanizza (intensità) [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Fattore di swing [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Evento</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Param.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Azione</translation>
@@ -1752,6 +2394,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>premi il bottone per registrare un evento MIDI</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1773,14 +2435,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Visualizza valore di picco degli strumenti = Non attivo</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Imposta livello effetto %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Imposta volume effetto LADSPA ( %1 )</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1790,6 +2444,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1812,11 +2474,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Pan</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Volume strumento [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1906,15 +2576,7 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pulisci selezione</translation>
     </message>
     <message>
         <source>B</source>
@@ -1964,24 +2626,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
     <message>
         <source>&amp;Cut</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&amp;Taglia</translation>
     </message>
     <message>
         <source>&amp;Copy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&amp;Copia</translation>
     </message>
     <message>
         <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&amp;Incolla</translation>
     </message>
     <message>
         <source>&amp;Delete</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&amp;Elimina</translation>
     </message>
     <message>
         <source>Select &amp;all</source>
@@ -1989,14 +2655,58 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Pulisci selezione</translation>
     </message>
     <message>
         <source>Placing these notes here will overwrite %1 duplicate notes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2036,18 +2746,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>Quantizza eventi in arrivo da tastiera/midi = Non attivo</translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Non è possibile cambiare la dimensione del pattern durante la riproduzione.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Seleziona la dimensione del pattern</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Seleziona la risoluzione della griglia</translation>
     </message>
     <message>
         <source>Zoom in</source>
@@ -2098,10 +2796,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2142,35 +2836,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">off</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2270,6 +2940,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Song Mode</source>
@@ -2294,10 +2971,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Modalità pattern selezionata.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Nuovo valore per BPM</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2336,20 +3009,8 @@ Maximum = 16/4</source>
         <translation>Ferma</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mixer</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Mostra Rack strumenti</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Rack strumenti</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Pannello contatore BPM attivo</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2405,19 +3066,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,11 +3078,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2628,14 +3308,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">Annulla le &amp;modifiche</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Annulla</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2670,31 +3342,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
  Riavvio il driver?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2710,10 +3358,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2722,19 +3366,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2759,6 +3395,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Generale</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Errore durante l&apos;avvio del driver audio</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2804,14 +3712,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Caratteri Applicazione</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Caratteri mixer</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Seleziona caratteri</translation>
     </message>
     <message>
         <source>Polyphony</source>
@@ -3022,15 +3922,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Tab</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3091,7 +3983,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3170,17 +4062,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3211,14 +4219,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3282,10 +4282,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3305,39 +4301,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Finestra di chiusura! possono esserci dei lavori non salvati.
-Sei sicuro?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">Ri&amp;produci</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">Riproduci i&amp;l campione originale</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3730,28 +4734,8 @@ Are you sure?</source>
 Confermi?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>modalità multipli</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>modalità pattern multipli</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>modalità pattern singolo</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Abilita la modifica della timeline</translation>
     </message>
     <message>
         <source>Pattern %1</source>
@@ -3782,20 +4766,16 @@ Confermi?</translation>
         <translation>Velocità</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation> Timeline = Off</translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
-        <translation> Timeline = On</translation>
+        <source>Playback volume set to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3803,22 +4783,6 @@ Confermi?</translation>
     <message>
         <source>Form</source>
         <translation>Form</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Modifica il BPM</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Modifica il beat sulla timeline</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3883,34 +4847,14 @@ Confermi?</translation>
         <translation>Carica Pattern</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Apri Pattern</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>Modello Virtuale</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Modello 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>Nessuna categoria</translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>Il file del modello esiste.
 Sovrascrivere il modello esistente?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3938,6 +4882,17 @@ Sovrascrivere il modello esistente?</translation>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3990,24 +4945,36 @@ Sovrascrivere il modello esistente?</translation>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Esporta libreria</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Cartella</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Esporta</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Tutti</translation>
     </message>
 </context>
 <context>
@@ -4015,10 +4982,6 @@ Sovrascrivere il modello esistente?</translation>
     <message>
         <source>Export</source>
         <translation>Esporta</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Drumkit</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4217,14 +5180,6 @@ Sovrascrivere il modello esistente?</translation>
         <translation>Drumkit utente</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annulla</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Canzoni</translation>
     </message>
@@ -4277,20 +5232,8 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation>Doppio clic per espandere la lista</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation>Il drumkit utilizzato nella canzone corrente non può essere trovato sul disco.
-        Per piacere, carica prima un drumkit esistente.
-        Kit corrente:</translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
         <translation>è un drumkit di sistema e non può essere eliminato.</translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
-        <translation>Non ancora implementato.</translation>
     </message>
 </context>
 <context>
@@ -4316,10 +5259,6 @@ Current kit:</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Salva le modifiche fatte agli strumenti nella libreria sonora</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Licenza drumkit</translation>
     </message>
@@ -4334,6 +5273,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Licenza immagine</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4371,76 +5314,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Salva libreria sonora</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Per piacere, indica almeno un nome valido</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Non è possibile salvare la libreria.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Apri immagine</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>File immagine (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Dialogo</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Nome</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autore</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informazioni</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Annulla</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Licenza</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Salva</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Immagine</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Cerca</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Licenza immagine</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4467,6 +5340,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Annulla</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -169,6 +169,10 @@
         <source>Realtime frames</source>
         <translation>リアルタイムフレーム</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -305,6 +309,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">ミュート</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">一般</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">インストルメント</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">レイヤー</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">ミキサー</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">アタック</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">ディケイ</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">サステイン</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">リリース</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">キャンセル</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">入力</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">スウィング</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">ベロシティー</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">ピアノロールエディターの表示</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">オフ</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">保存(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">キャンセル(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">破棄(&amp;D)</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">再生(&amp;P)</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -319,8 +887,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">インストルメントの音量設定 [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -355,10 +931,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -464,6 +1036,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -671,31 +1259,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>プラグイン on/off</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>マスター出力</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">キャンセル(&amp;C)</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -712,24 +1317,6 @@ Overwrite the existing file?</source>
         <translation>サウンドライブラリーのプロパティー</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>現在ロードされているサウンドライブラリーに属するインストルメントでなければ変更を保存できません</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>警告! ドラムキット名を変更すると新規にドラムキットを作ることになります。
-よろしいですか？</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -741,13 +1328,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">インストルメント</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">ライセンス</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>読み込まれたドラムキット: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">ソングエディタ</translation>
@@ -763,10 +1382,6 @@ Are you sure?</source>
     <message>
         <source>modified</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">ソングを保存しました。</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -787,6 +1402,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -813,22 +1448,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>レゾナンスフィルター</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>アタック</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>ディケイ</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>サステイン</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>リリース</translation>
-    </message>
-    <message>
         <source>Layer gain</source>
         <translation>レイヤーのゲイン</translation>
     </message>
@@ -847,14 +1466,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>レイヤーのピッチ (細やか)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>一般</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>レイヤー</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -897,7 +1508,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -941,10 +1572,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">ソロ</translation>
     </message>
     <message>
@@ -1011,16 +1644,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>インストルメントエディターの表示</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>インストルメント</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>サウンドライブラリーの表示</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>サウンドライブラリー</translation>
     </message>
 </context>
 <context>
@@ -1071,6 +1696,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>プラグインの削除</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1257,10 +1890,6 @@ MIDI = %2</source>
         <translation>保存(&amp;S)</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>破棄(&amp;D)</translation>
-    </message>
-    <message>
         <source>Hydrogen Ready.</source>
         <translation></translation>
     </message>
@@ -1295,10 +1924,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;About</source>
         <translation>このプログラムについて(&amp;A)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1341,20 +1966,12 @@ MIDI = %2</source>
         <translation>情報(&amp;I)</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>ソングを保存しました。</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>不明なエラーです %1</translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
         <translation>すべてのインストルメントを除去しますか？</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation></translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
@@ -1379,10 +1996,6 @@ MIDI = %2</source>
     <message>
         <source>Open Pattern</source>
         <translation>パターンを開く</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>このメッセージをこれ以上は表示しない</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1416,7 +2029,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1503,10 +2115,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1713,16 +2321,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">再生。</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>マスター音量の設定 [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>スウィング</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1733,39 +2380,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>ベロシティーのヒューマナイズ</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>時間パラメーターをヒューマナイズ [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>ベロシティーパラメーターをヒューマナイズ [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>スウィング要素の設定 [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>イベント</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>パラメーター。</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>アクション</translation>
@@ -1773,6 +2413,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>ボタンを押してMIDIイベントを記録します</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1790,14 +2450,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>インストルメントのピークの表示 = Off</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>プラグインに %1 レベルを設定</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>LADSPAプラグインにボリュームを設定 ( %1 )</translation>
-    </message>
-    <message>
         <source>Show FX panel</source>
         <translation>プラグインパネルの表示</translation>
     </message>
@@ -1811,6 +2463,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1833,11 +2493,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>パン</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>インストルメントの音量設定 [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1930,14 +2598,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1985,6 +2645,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2017,7 +2681,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2067,18 +2775,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>縮小</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>再生中はパターンのサイズを変更できません。</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>パターンサイズの選択</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>グリッド解像度の選択</translation>
-    </message>
-    <message>
         <source>No pattern selected</source>
         <translation>パターンが選択されていません</translation>
     </message>
@@ -2116,10 +2812,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2163,35 +2855,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">オフ</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2291,6 +2959,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Song Mode</source>
@@ -2319,10 +2994,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>パターンモードの選択。</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>新しいBPM値</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2357,20 +3028,8 @@ Maximum = 16/4</source>
         <translation>ミキサーを表示</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>ミキサー</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>インストルメントラックの表示</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>インストルメントラック</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>ビートカウンターパネルのon</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2426,19 +3085,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2451,11 +3097,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2649,14 +3327,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">破棄(&amp;D)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">キャンセル(&amp;C)</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2691,31 +3361,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
 再起動しますか？</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2731,10 +3377,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2743,19 +3385,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2780,6 +3414,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">一般</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">ソングエディタ</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">オーディオドライバーにエラーが発生</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2825,14 +3731,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>アプリケーションのフォント</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>ミキサーのフォント</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>フォントの選択</translation>
     </message>
     <message>
         <source>Sample rate</source>
@@ -3043,15 +3941,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3112,7 +4002,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3191,17 +4081,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3232,14 +4238,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3303,10 +4301,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3326,39 +4320,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>ダイアログを閉じますが、保存されていない変更があるかもしれません。
-よろしいですか？</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">再生(&amp;P)</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">オリジナルサンプルの再生(&amp;L)</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3761,28 +4763,8 @@ Are you sure?</source>
 よろしいですか?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>スタックモード</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>スタックパターンモード</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>シングルパターンモード</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>タイムライン編集を有効にする</translation>
     </message>
     <message>
         <source>Pattern %1</source>
@@ -3813,19 +4795,15 @@ Are you sure?</source>
         <translation type="unfinished">ベロシティー</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3833,22 +4811,6 @@ Are you sure?</source>
     <name>SongEditorPanelBpmWidget_UI</name>
     <message>
         <source>Form</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>現在のBPM値を編集</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>タイムライン上のビートを編集</translation>
-    </message>
-    <message>
-        <source>500</source>
         <translation></translation>
     </message>
     <message>
@@ -3914,34 +4876,14 @@ Are you sure?</source>
         <translation>パターンの読み込み</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>パターンを開く</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>仮想パターン</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>パターン 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>未分類</translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>パターンファイルが存在しています。
 上書きしますか？</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3969,6 +4911,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4021,24 +4974,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>サウンドライブラリーのエクスポート</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">エクスポート(&amp;E)</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">すべて</translation>
     </message>
 </context>
 <context>
@@ -4046,10 +5011,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>エクスポート</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4248,14 +5209,6 @@ Overwrite the existing pattern?</source>
         <translation>ユーザーのドラムキット</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>キャンセル(&amp;C)</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>ソング</translation>
     </message>
@@ -4304,17 +5257,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4341,10 +5284,6 @@ Current kit:</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>インストルメントの変更をサウンドライブラリーに保存します</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4358,6 +5297,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4396,76 +5339,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>サウンドライブラリーの保存</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>ダイアログ</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>名前</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>作者</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>情報</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>キャンセル</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>ライセンス</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>保存 </translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">参照</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4492,6 +5365,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>キャンセル</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Realtime frames</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Dempen</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Algemeen</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Lagen</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mixer</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Attack</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Decay</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sustain</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Release</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Kanaal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Ingang</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Velocity</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">Op&amp;slaan</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Annuleren</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Negeren</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Instrument volume [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>FX aan/uit</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Master uitgang</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Annuleren</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -709,24 +1314,6 @@ Overwrite the existing file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annuleren</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Dit is niet mogelijk, je kan enkel wijzigingen opslaan van instrumment in de geladen geluids bibliotheek</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Opgelet! Door de drumkit naam te wijzigen wordt een nieuwe drumkit met deze naam aangemaakt
-Ben je zeker dat je de naam wilt wijzigen?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -738,13 +1325,45 @@ Ben je zeker dat je de naam wilt wijzigen?</translation>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Licentie</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation type="unfinished">Geladen drumkit:[%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Opname editor</translation>
@@ -774,16 +1393,32 @@ Ben je zeker dat je de naam wilt wijzigen?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Opname opgeslaan.</translation>
-    </message>
-    <message>
         <source>Song is read-only.
 Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -800,22 +1435,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Filter tonen</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Attack</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Decay</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sustain</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Release</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -844,14 +1463,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>Laag pitch (fijn)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Algemeen</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Lagen</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -894,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -938,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">Solo</translation>
     </message>
     <message>
@@ -1008,16 +1641,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Toon instrument bewerker</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrument</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Toon geluids bibliotheek</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Geluids bibliotheek</translation>
     </message>
 </context>
 <context>
@@ -1067,6 +1692,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1263,14 +1896,6 @@ MIDI = %2</source>
         <translation>&amp;Over</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Negeren</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annuleren</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Opname opslaan</translation>
     </message>
@@ -1315,20 +1940,12 @@ MIDI = %2</source>
         <translation>&amp;Info</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Opname opgeslaan.</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Ongekende error: %1</translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
         <translation>Wis alle instrumenten?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Ok</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
@@ -1353,10 +1970,6 @@ MIDI = %2</source>
     <message>
         <source>Open Pattern</source>
         <translation>Open patroon</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Toon deze boodschap niet meer</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1390,7 +2003,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1469,10 +2081,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1687,6 +2295,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Gestart.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1699,53 +2350,62 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Menselijke tijd</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
         <translation>Master volume [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Menselijke tijd parameter [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Menselijke velocity parameter [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation>Swing factor [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
     <message>
-        <source>Event</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>press button to record midi event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1760,20 +2420,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Toon piek volumes</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Stel FX %1 volume in</translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation>Toon piek volumes = Aan</translation>
     </message>
     <message>
         <source>Show instrument peaks = Off</source>
         <translation>Toon piek volumes = Uit</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Stel LADSPA FX ( %1 ) volume in</translation>
     </message>
     <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
@@ -1785,6 +2437,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1807,11 +2467,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Pan</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Instrument volume [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1904,14 +2572,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1959,6 +2619,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1991,7 +2655,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2004,14 +2712,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 </context>
 <context>
     <name>PatternEditorPanel</name>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Selecteer patroon groote</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Selecteer raster resolutie</translation>
-    </message>
     <message>
         <source>Hear new notes</source>
         <translation>Speel nieuwe noten</translation>
@@ -2047,10 +2747,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>Quantiseer toetsenbord/midi = Uit</translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Het is niet mogelijk om de patroon grootte te wijzigen gedurende het spelen.</translation>
     </message>
     <message>
         <source>No pattern selected</source>
@@ -2090,10 +2786,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2137,35 +2829,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2265,6 +2933,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2315,10 +2990,6 @@ Maximum = 16/4</source>
         <translation>Patroon mode geselecteerd.</translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation>Nieuwe BPM waarde</translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation>Herhaal opame = Aan</translation>
     </message>
@@ -2331,20 +3002,8 @@ Maximum = 16/4</source>
         <translation>Toon mixer</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mixer</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Toon instrument rack</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Instrument rack</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>BeatCounter paneel aan</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2400,19 +3059,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2425,11 +3071,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2619,14 +3297,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Negeren</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Annuleren</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2660,31 +3330,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Annuleren</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2693,10 +3339,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Select your MIDI Driver</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2712,19 +3354,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2749,6 +3383,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Algemeen</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Opname editor</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Fout bij het starten van de audio driver</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2911,10 +3817,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Stijl</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation>Selecteer lettertype</translation>
-    </message>
-    <message>
         <source>Slow</source>
         <translation>Traag</translation>
     </message>
@@ -2925,10 +3827,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Fast</source>
         <translation>Snel</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Mixer lettertype</translation>
     </message>
     <message>
         <source>Meters falloff speed</source>
@@ -3012,15 +3910,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3065,7 +3955,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3160,17 +4050,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3201,14 +4207,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3272,10 +4270,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3295,37 +4289,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Annuleren</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3719,27 +4722,7 @@ Are you sure?</source>
 Ben je zeker?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annuleren</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3771,19 +4754,15 @@ Ben je zeker?</translation>
         <translation type="unfinished">Velocity</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3792,22 +4771,6 @@ Ben je zeker?</translation>
     <message>
         <source>Form</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished">500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation type="unfinished">500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3872,33 +4835,13 @@ Ben je zeker?</translation>
         <translation>Patroon laden</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Patroon openen</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Annuleren</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3927,6 +4870,17 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Pattern saved.</source>
         <translation type="unfinished">Patroon opgeslaan.</translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3978,24 +4932,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Exporteer geluid bibliotheek</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exporteren</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Alles</translation>
     </message>
 </context>
 <context>
@@ -4003,10 +4969,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Exporteren</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4205,14 +5167,6 @@ Overwrite the existing pattern?</source>
         <translation>Gebruiker drumkits</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annuleren</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Opnames</translation>
     </message>
@@ -4261,17 +5215,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4298,10 +5242,6 @@ Current kit:</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Gemaakte wijzigingen opslaan in geluids bibliotheek</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4315,6 +5255,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4353,76 +5297,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Geluid bibliotheek opslaan</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Naam</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Auteur</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informatie</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Annuleren</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Licentie</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Opslaan</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Bladeren</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4449,6 +5323,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Ramki czasu rzeczywistego</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Wyciszenie</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Ogólne</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Warstwy</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mikser</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Atak</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Zanik</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Podtrzymanie</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Uwolnienie</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Kanał</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Wejście</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Kołysanie</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Głośność</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Ok</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Zapisz</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Anuluj</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Porzuć</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Ustawia głośność instrumentu [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>włącz/wyłącz efekt</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Wyjście główne (master)</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Anuluj</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -709,23 +1314,6 @@ Overwrite the existing file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Anuluj</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -737,13 +1325,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrument</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation type="unfinished">Zestaw załadowany: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Edytor utworu</translation>
@@ -773,16 +1393,32 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Utwór zapisany.</translation>
-    </message>
-    <message>
         <source>Song is read-only.
 Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -799,22 +1435,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Częstotliwość rezonansowa filtru</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Atak</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Zanik</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Podtrzymanie</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Uwolnienie</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -843,14 +1463,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>New instrument name</source>
         <translation>Nowa nazwa instrumentu</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Ogólne</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Warstwy</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -893,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -937,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished">Solo</translation>
     </message>
     <message>
@@ -1007,16 +1641,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Pokazuje edytor instrumentów</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrument</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Pokazuje bibliotekę dźwięków</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Biblioteka dźwięków</translation>
     </message>
 </context>
 <context>
@@ -1066,6 +1692,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1271,20 +1905,8 @@ MIDI = %2</source>
         <translation>O progr&amp;amie</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Porzuć</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Anuluj</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Zapisz utwór</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Utwór zapisany.</translation>
     </message>
     <message>
         <source>Open song</source>
@@ -1323,10 +1945,6 @@ MIDI = %2</source>
         <translation>Wyczyścić wszystkie instrumenty?</translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation>Ok</translation>
-    </message>
-    <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
         <translation>Używasz wersji rozwojowej Hydrogen. Proszę, pomóż nam zgłaszając błędy lub sugestie (w języku angielskim) na listę hydrogen-devel.&lt;br&gt;&lt;br&gt;Dziękujemy!</translation>
     </message>
@@ -1349,10 +1967,6 @@ MIDI = %2</source>
     <message>
         <source>Open Pattern</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation type="unfinished">Nie pokazuj więcej tego komunikatu</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1385,7 +1999,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1464,10 +2077,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1682,6 +2291,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Odtwarzanie.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1694,53 +2346,62 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Humanizacja czasu</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>Kołysanie</translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
         <translation>Ustawia głośność główną (master) [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Ustawia parametr czasu humanizacji [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Ustawia parametr humanizacji głośności [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation>Ustawia współczynnik swingowania [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
     <message>
-        <source>Event</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>press button to record midi event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1755,20 +2416,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Pokazuje szczyty głośności instrumentów</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Ustawia poziom efektu %1 </translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation>Pomiar głośności instrumentów = Włączony</translation>
     </message>
     <message>
         <source>Show instrument peaks = Off</source>
         <translation>Pomiar głośności instrumentów = Wyłączony</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Ustawia głośność efektu LADSPA ( %1 )</translation>
     </message>
     <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
@@ -1780,6 +2433,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1802,11 +2463,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Panorama</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Ustawia głośność instrumentu [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1899,14 +2568,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1954,6 +2615,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1986,7 +2651,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1999,14 +2708,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 </context>
 <context>
     <name>PatternEditorPanel</name>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Wybór rozmiaru układu rytmicznego</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Wybór rozdzielczości siatki</translation>
-    </message>
     <message>
         <source>Hear new notes</source>
         <translation>Odtwarzanie nowych nut</translation>
@@ -2048,10 +2749,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Dopasuj nadchodzące zdarzenia z klawiatury/midi = Wyłączone</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Nie można zmieniać rozmiaru układu rytmicznego podczas odtwarzania.</translation>
-    </message>
-    <message>
         <source>Select note properties</source>
         <translation>Wybór właściwości nut</translation>
     </message>
@@ -2085,10 +2782,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2132,35 +2825,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2260,6 +2929,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2294,16 +2970,8 @@ Maximum = 16/4</source>
         <translation>Pokazuje mikser</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mikser</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Pokazuje Panel Instrumentów</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Panel Instrumentów</translation>
     </message>
     <message>
         <source>Playing.</source>
@@ -2326,20 +2994,12 @@ Maximum = 16/4</source>
         <translation>Wybrano tryb: układ rytmiczny.</translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation>Nowa wartość BPM</translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation>Zapętlanie utworu = Włączone</translation>
     </message>
     <message>
         <source>Loop song = Off</source>
         <translation>Zapętlanie utworu = Wyłączone</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2395,19 +3055,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2420,11 +3067,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2614,14 +3293,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;Porzuć</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Anuluj</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2655,31 +3326,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Anuluj</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2688,10 +3335,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Select your MIDI Driver</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2707,19 +3350,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2744,6 +3379,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Ogólne</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Edytor utworu</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Błąd podczas uruchamiania sterownika audio</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2906,10 +3813,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Czcionka programu</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation>Wybór czcionki</translation>
-    </message>
-    <message>
         <source>Style</source>
         <translation>Styl</translation>
     </message>
@@ -2929,10 +3832,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Meters falloff speed</source>
         <extracomment>In case of a rapid sound lasting for just a milli second the meters in the Mixer would raise to peak value and fall of immediately without the user being able to see them. The falloff speed introduces a delay. The smaller the value, the longer the meter requires to reach 0dB again.</extracomment>
         <translation>Szybkość zanikania wskazań miernika</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Czcionka miksera</translation>
     </message>
     <message>
         <source>Audio output details</source>
@@ -3007,15 +3906,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3060,7 +3951,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3155,17 +4046,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3196,14 +4203,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3267,10 +4266,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3290,37 +4285,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Anuluj</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3714,27 +4718,7 @@ Are you sure?</source>
 Kontynuować?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Anuluj</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3766,19 +4750,15 @@ Kontynuować?</translation>
         <translation type="unfinished">Głośność</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3787,22 +4767,6 @@ Kontynuować?</translation>
     <message>
         <source>Form</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished">500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation type="unfinished">500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3867,33 +4831,13 @@ Kontynuować?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished">&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Anuluj</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3921,6 +4865,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Pattern saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3973,24 +4928,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Eksportuj</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Wszystkie</translation>
     </message>
 </context>
 <context>
@@ -3998,10 +4965,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation type="unfinished">Eksportuj</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4200,14 +5163,6 @@ Overwrite the existing pattern?</source>
         <translation>Zestawy perkusyjne użytkownika</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Anuluj</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4255,17 +5210,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4292,10 +5237,6 @@ Current kit:</source>
         <translation type="unfinished">Anuluj</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4309,6 +5250,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4347,76 +5292,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Zachowaj Bibliotekę Dźwięków</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Dialog</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Nazwa</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informacja</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Anuluj</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Przeglądaj</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4443,6 +5318,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Anuluj</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Quadros em tempo real</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Mudo</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Geral</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Instrumento</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Camadas</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Mixer</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Ataque</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Decaimento</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Sustentação</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Liberação</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Canal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Entrada</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">BPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Swing</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Velocidade</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Exibir editor de piano automático</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">desligado</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Ok</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Salvar</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Cancelar</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Descartar</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Reproduzir</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation>Nome do componente</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Ajustar volume do instrumento [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -463,6 +1035,22 @@ Sobrescrever o arquivo existente?</translation>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -670,31 +1258,48 @@ Sobrescrever o arquivo existente?</translation>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Efeitos lig/des</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Saída master</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>BPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Cancelar</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -711,24 +1316,6 @@ Sobrescrever o arquivo existente?</translation>
         <translation>Propriedades da biblioteca de som</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Isto não é possível, você pode salvar mudanças apenas em instrumentos para a biblioteca de som carregada atualmente</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Atenção! Mudar o nome do drumkit resultará na criação de um novo drumkit com este nome.
-Está certo disto?</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Erro ao salvar este drumkit.</translation>
     </message>
@@ -740,13 +1327,45 @@ Está certo disto?</translation>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>Arquivos de Imagem (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Instrumento</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Component</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Lincença</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Drumkit carregado: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Editor de música</translation>
@@ -776,16 +1395,32 @@ Está certo disto?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Música salva.</translation>
-    </message>
-    <message>
         <source>Song is read-only.
 Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -812,22 +1447,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Filtro de ressonância</translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation>Ataque</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Decaimento</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Sustentação</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Liberação</translation>
-    </message>
-    <message>
         <source>Layer gain</source>
         <translation>Ganho na camada</translation>
     </message>
@@ -846,14 +1465,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>Tom da camada (Fino)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Geral</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Camadas</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -896,7 +1507,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -940,10 +1571,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Silenciar instrumento</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Solo</translation>
     </message>
     <message>
@@ -1010,16 +1643,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Exibir editor de instrumento</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Instrumento</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Exibir biblioteca de som</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Biblioteca de som</translation>
     </message>
 </context>
 <context>
@@ -1070,6 +1695,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>Remover efeito</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1261,10 +1894,6 @@ MIDI = %2</translation>
         <translation>&amp;Salvar</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Descartar</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Salvar canção</translation>
     </message>
@@ -1295,10 +1924,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;About</source>
         <translation>&amp;Sobre</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1341,20 +1966,12 @@ MIDI = %2</translation>
         <translation>&amp;Info</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Música salva.</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Erro desconhecido %1</translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
         <translation>Limpar todos os instrumentos?</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>Ok</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
@@ -1379,10 +1996,6 @@ MIDI = %2</translation>
     <message>
         <source>Open Pattern</source>
         <translation>Abrir Padrão</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Não exibir mais esta mensagem</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1418,7 +2031,6 @@ Deseja salvar as mudanças?
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Desfazer</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1500,10 +2112,6 @@ Deseja descartar as mudanças?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1718,16 +2326,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Executando.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Ajustar volume principal [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Swing</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1738,39 +2385,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Humanizar velocidade</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Ajustar o parâmetro de humanização de tempo [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Ajustar o parmetro de humanização de velocidade [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Ajustar o fator de swing [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>Esperando pela entrada MIDI</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Evento</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Param.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Ação</translation>
@@ -1778,6 +2418,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>pressione o botão para gravar evento MIDI</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1791,20 +2451,12 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Mostrar picos dos instrumentos</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Ajustar nível %1 de efeito</translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation>Mostrar picos dos instrumentos = Lig.</translation>
     </message>
     <message>
         <source>Show instrument peaks = Off</source>
         <translation>Mostrar picos dos instrumentos = Des.</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Ajustar volume do efeito LADSPA ( %1 )</translation>
     </message>
     <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
@@ -1816,6 +2468,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1834,15 +2494,23 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Solo</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Ajustar volume [%1] do instrumento</translation>
-    </message>
-    <message>
         <source>Pan</source>
         <translation>Pan</translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1935,14 +2603,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1990,6 +2650,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2022,7 +2686,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2072,18 +2780,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Menos zoom</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Não é possível mudar o tamanho do padrão enquanto estiver tocando.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Selecionar tamanho do padrão</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Selecionar resolução da grade</translation>
-    </message>
-    <message>
         <source>No pattern selected</source>
         <translation>Nenhum padrão selecionado</translation>
     </message>
@@ -2122,10 +2818,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Probability</source>
         <translation>Probabilidade</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>quarter</source>
@@ -2168,35 +2860,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">desligado</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2296,6 +2964,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Stop</source>
@@ -2324,10 +2999,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Modo padrão selecionado.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Novo valor de BPM</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2362,20 +3033,8 @@ Maximum = 16/4</source>
         <translation>Exibir mixer</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Mixer</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Exibir Rack de Instrumentos </translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Rack de instrumentos</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Painel do Contador de Batidas Lig.</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2431,19 +3090,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2456,11 +3102,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2657,14 +3335,6 @@ Deseja descartar as mudanças?
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Descartar</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2701,32 +3371,8 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
  Reiniciar driver?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Automatic</source>
         <translation>Automático</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation>Passos</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>Fixo</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>Número de passos</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Cor (valor da Matiz)</translation>
     </message>
     <message>
         <source>Select your Audio Driver</source>
@@ -2734,10 +3380,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     </message>
     <message>
         <source>Select your MIDI Driver</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2753,19 +3395,11 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2790,6 +3424,278 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Geral</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Editor de música</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Erro ao iniciar driver de áudio</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2832,10 +3738,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <translation>Estilo</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation>Selecionar fontes</translation>
-    </message>
-    <message>
         <source>Slow</source>
         <translation>Lento</translation>
     </message>
@@ -2846,10 +3748,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     <message>
         <source>Fast</source>
         <translation>Rápido</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Fonte do Mixer</translation>
     </message>
     <message>
         <source>Meters falloff speed</source>
@@ -3053,16 +3951,8 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <translation>Com abas</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>TextoEtiqueta</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation> Método de coloração para elementos do Editor de Músicas</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&gt;&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Depois de alterar uma fonte ou o layout da interface, o aplicativo deve ser reiniciado.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;OSC</source>
@@ -3106,7 +3996,7 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3201,17 +4091,133 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3242,14 +4248,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3313,10 +4311,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3336,39 +4330,47 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Fechar caixa de diálogo! Talvez haja algum trabalho não salvo na amostra.
-Está certo disto?</translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">&amp;Reproduzir</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">R&amp;eproduzir amostra original</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3784,28 +4786,8 @@ Are you sure?</source>
 Está certo disto?</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>modo empilhado</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>modo padrão empilhado</translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation>modo padrão único</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Ativar edição de linha do tempo</translation>
     </message>
     <message>
         <source>Pattern %1</source>
@@ -3836,19 +4818,15 @@ Está certo disto?</translation>
         <translation>Velocidade</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3857,22 +4835,6 @@ Está certo disto?</translation>
     <message>
         <source>Form</source>
         <translation>Forma</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Editar o valor do BPM para batida atual</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Editar batida na linha do tempo</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3937,34 +4899,14 @@ Está certo disto?</translation>
         <translation>Carregar Padrão</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Abrir Padrão</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>Padrão Virtual</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Padrão 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>não_categorizado</translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation>O padrão-arquivo existe.
 Sobrescrever o padrão existente?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3993,6 +4935,17 @@ Sobrescrever o padrão existente?</translation>
     <message>
         <source>Pattern saved.</source>
         <translation type="unfinished">Padrão salvo.</translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4044,24 +4997,36 @@ Sobrescrever o padrão existente?</translation>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Exportar biblioteca de som</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Diretório</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportar</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Todos</translation>
     </message>
 </context>
 <context>
@@ -4069,10 +5034,6 @@ Sobrescrever o padrão existente?</translation>
     <message>
         <source>Export</source>
         <translation>Exportar</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Drumkit</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4271,14 +5232,6 @@ Sobrescrever o padrão existente?</translation>
         <translation>Drumkits do usuário</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Ok</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Músicas</translation>
     </message>
@@ -4333,17 +5286,7 @@ Você gostaria de manter ou descartar os instrumentos e anotações restantes?
         <translation>Clique duplo pra expandir a lista</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4370,10 +5313,6 @@ Current kit:</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Salvar mudanças feitas a instrumentos na biblioteca de som</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Licença do drumkit</translation>
     </message>
@@ -4388,6 +5327,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Licença da imagem</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4425,76 +5368,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Salvar biblioteca de Som</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Por favor, forneça pelo menos um nome válido</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>Uma biblioteca com o mesmo nome já existe. Deseja sobrescrever a biblioteca existente?</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Falha ao salvar esta biblioteca.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Abrir Imagem</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Arquivos de imagens (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Diálogo</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Nome</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Autor</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Informação</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Lincença</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Salvar </translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Imagem</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Procurar</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Licença da Imagem</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4521,6 +5394,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Cancelar</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Выборок в релаьном времени</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Тихо</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Общие</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Инструмент</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Слои</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Микшер</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Атака</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Первое затухание</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Стабильная фаза</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Конечное затухание</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Канал</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Вход</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">BPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Свинг</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Сила нажатия</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Показать матричный редактор</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">выкл</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;OK</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Сохранить</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">О&amp;тменить</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">С&amp;ыграть</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation type="unfinished">Название компонента</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation type="unfinished">Установить громкость инструмента [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -464,6 +1036,22 @@ Overwrite the existing file?</source>
     <message>
         <source>Directory %1 does not exist</source>
         <translation type="unfinished">Каталог %1 не существует</translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -670,30 +1258,47 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Эффекты вкл/выкл</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Общий выход</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>BPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -711,24 +1316,6 @@ Overwrite the existing file?</source>
         <translation>Свойства звуковой библиотеки</translation>
     </message>
     <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Вы можете сохранять изменения в инструментах только для текущей загруженной библиотеки.</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Внимание! Смена названия драмкита приведет к созданию нового драмкита.
-Вы уверены?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Не удалось сохранить этот драмкит.</translation>
     </message>
@@ -740,13 +1327,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished">Файлы изображений (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Инструмент</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Компонент</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Лицензия</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Загружен драмкит: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Редактор композиций</translation>
@@ -762,10 +1381,6 @@ Are you sure?</source>
     <message>
         <source>modified</source>
         <translation>изменено</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Композиция сохранена.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -788,6 +1403,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
@@ -806,22 +1441,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Резонансный фильтр</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Атака</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Первое затухание</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Стабильная фаза</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Конечное затухание</translation>
     </message>
     <message>
         <source>Layer gain</source>
@@ -846,14 +1465,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Общие</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Слои</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -896,7 +1507,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -940,10 +1571,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Приглушить инструмент</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Соло</translation>
     </message>
     <message>
@@ -1010,16 +1643,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Показать редактор инструментов</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Инструмент</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Показать библиотеку звуков</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Библиотека звуков</translation>
     </message>
 </context>
 <context>
@@ -1070,6 +1695,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>Удалить эффект</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1261,10 +1894,6 @@ MIDI = %2</source>
         <translation>&amp;Сохранить</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Отказаться от изменений</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Сохранить композицию</translation>
     </message>
@@ -1295,10 +1924,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;About</source>
         <translation>О &amp;программе</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1341,10 +1966,6 @@ MIDI = %2</source>
         <translation>&amp;Справка</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Композиция сохранена.</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Неизвестная ошибка %1</translation>
     </message>
@@ -1353,20 +1974,12 @@ MIDI = %2</source>
         <translation>Очистить все инструменты?</translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation>ОК</translation>
-    </message>
-    <message>
         <source>Could not save song.</source>
         <translation>Не удалось сохранить композицию.</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
         <translation>Вы используете нестабильную версию Hydrogen. Помогите нам улучшить ее, присылая в список рассылки hydrogen-devel свои отчеты об ошибках и предложения. &lt;br&gt;&lt;br&gt;Спасибо!</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Больше не показывать это сообщение</translation>
     </message>
     <message>
         <source>Open &amp;Pattern</source>
@@ -1418,7 +2031,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Действия</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1505,10 +2117,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1715,16 +2323,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Идёт воспроизведение</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Установить общую громкость [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Свинг</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1735,39 +2382,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Очеловечить силу</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Установить параметр «человеческого» времени [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Установить параметр «человеческой» силы нажатия [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Установить свинг-фактор [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Событие</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Парам.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Действие</translation>
@@ -1775,6 +2415,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>Нажмите кнопку для записи MIDI-события</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1796,14 +2456,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Отображение пиков инструментов = Выкл</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Установить уровень эффекта %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Установить уровень эффекта LADSPA %1</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation>Эффекты LADSPA недоступны в этой версии Hydrogen.</translation>
     </message>
@@ -1813,6 +2465,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1835,11 +2495,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Панорама</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Установить громкость инструмента [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1902,7 +2570,7 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">О&amp;тменить</translation>
     </message>
     <message>
         <source>Alt+C</source>
@@ -1929,14 +2597,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1987,6 +2647,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2019,7 +2683,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2069,18 +2777,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Уменьшить</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>При воспроизведении размер паттерна изменить нельзя.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Выбрать размер паттерна</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Выбрать разрешение сетки</translation>
-    </message>
-    <message>
         <source>No pattern selected</source>
         <translation>Ни один паттерн не выбран</translation>
     </message>
@@ -2119,10 +2815,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Probability</source>
         <translation>Вероятность</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>quarter</source>
@@ -2165,35 +2857,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">выкл</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2293,6 +2961,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Stop</source>
@@ -2321,10 +2996,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Выбран режим редактора паттерна</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Новое значение BPM</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2359,20 +3030,8 @@ Maximum = 16/4</source>
         <translation>Показать микшер</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Микшер</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Показать банк инструментов</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Стойка инструментов</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2428,19 +3087,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2453,11 +3099,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2648,14 +3326,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Отказаться</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тмена</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2690,31 +3360,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
 Запустить его заново?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2730,10 +3376,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2742,19 +3384,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2779,6 +3413,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Общие</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Редактор композиций</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Ошибка при загрузке звукового драйвера</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2900,14 +3806,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Шрифт приложения</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Шрифт в микшере</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Выбрать шрифт</translation>
     </message>
     <message>
         <source>Polyphony</source>
@@ -3042,15 +3940,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Со вкладками</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3111,7 +4001,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3190,17 +4080,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3231,14 +4237,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3302,10 +4300,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3325,39 +4319,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Закрыть диалог! Возможно, осталась какая-то несохранённая работа.
-Вы уверены?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">С&amp;ыграть</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">&amp;Сыграть исходный сэмпл</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3756,32 +4758,12 @@ Are you sure?</source>
 Вы уверены?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pattern %1</source>
         <translation>Паттерн %1</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3808,19 +4790,15 @@ Are you sure?</source>
         <translation>Сила нажатия</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3829,22 +4807,6 @@ Are you sure?</source>
     <message>
         <source>Form</source>
         <translation>Form</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Изменить значение bpm для текущей доли</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Указать долю на линии времени</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3909,18 +4871,6 @@ Are you sure?</source>
         <translation>Загрузить паттерн</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Открыть паттерн</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Паттерн 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>Без категории</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>Виртуальный паттерн</translation>
     </message>
@@ -3929,14 +4879,6 @@ Are you sure?</source>
 Overwrite the existing pattern?</source>
         <translation>Такой файл паттерна уже существует.
 Перезаписать его?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3964,6 +4906,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4016,24 +4969,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Экспортировать библиотеку звуков</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Каталог</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Экспорт</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Все</translation>
     </message>
 </context>
 <context>
@@ -4041,10 +5006,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Экспорт</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Драмкит</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4243,14 +5204,6 @@ Overwrite the existing pattern?</source>
         <translation>Пользовательские драмкиты</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;OK</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>О&amp;тменить</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Композиции</translation>
     </message>
@@ -4299,17 +5252,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4336,10 +5279,6 @@ Current kit:</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Сохранить в библиотеку изменения, внесенные в инструменты</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Лицензия на драмкит</translation>
     </message>
@@ -4354,6 +5293,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Лицензия на изображение</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,76 +5334,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Сохранить библиотеку звуков</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Укажите хотя бы корректное название</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Не удалось сохранить эту библиотеку</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Открыть изображение</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Файлы изображений (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Диалог</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Название</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Автор</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Информация</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Отменить</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Лицензия</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Сохранить</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Изображение</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Просмотр</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Лицензия на изображение</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4487,6 +5360,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Отменить</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Оквири у реалном времену</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Утишај</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Опште</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Инструменат</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Слојеви</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Миксета</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Вр. пораста</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Вр. пада</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Вр. задршке</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Вр. стишавања</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Канал</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Улаз</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">о/м</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Напетост (Свинг)</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Јачина удара</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Прикажи уредника са клав. диркама</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">искљ</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;У реду</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Сачувај</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Поништи</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Одбаци</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Свирај</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation>Назив компоненте</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Постави гласнођу инструмента [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -463,6 +1035,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -670,31 +1258,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Ефекат УКЉ/ИСКЉ</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Главни излаз</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>о/м</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Поништи</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -707,26 +1312,8 @@ Overwrite the existing file?</source>
 <context>
     <name>H2Core::SoundLibraryPropertiesDialog</name>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
         <source>SoundLibrary Properties</source>
         <translation>Особине бубњева</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;У реду</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Не можете то да урадите. Промене у инструменту можете да сачувате само у тренутно учитаним бубњевима из листе бубњева.</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>УПОЗОРЕЊЕ! Промена назива бубњева ће довести до стварања нових бубњева оваквог назива.
-Желите ли то да урадите?</translation>
     </message>
     <message>
         <source>Saving of this drumkit failed.</source>
@@ -740,13 +1327,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>Датотеке са сликама (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Инструменат</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Компонента</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Лиценца:</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Бубњеви су учитани: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Уредник песме</translation>
@@ -762,10 +1381,6 @@ Are you sure?</source>
     <message>
         <source>modified</source>
         <translation>измењено</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Песма је сачувана.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -788,6 +1403,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
@@ -802,22 +1437,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Резонантни филтар</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Вр. пораста</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Вр. пада</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Вр. задршке</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Вр. стишавања</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -846,14 +1465,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>New instrument name</source>
         <translation>Назив новог инструмента</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Опште</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Слојеви</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -896,7 +1507,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -912,10 +1543,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Утишај инструменат</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Соло</translation>
     </message>
     <message>
@@ -1010,16 +1643,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Прикажи уредника инструмента</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Инструменат</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Прикажи листу бубњева</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Бубњеви</translation>
     </message>
 </context>
 <context>
@@ -1070,6 +1695,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>Уклони ефекат</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1254,14 +1887,6 @@ MIDI = %2</source>
 <context>
     <name>MainForm</name>
     <message>
-        <source>Ok</source>
-        <translation>У реду</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
         <source>Unknown audio driver</source>
         <translation>Непознат зв. посредник</translation>
     </message>
@@ -1292,10 +1917,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;Save</source>
         <translation>&amp;Сачувај</translation>
-    </message>
-    <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Одбаци</translation>
     </message>
     <message>
         <source>Save song</source>
@@ -1344,10 +1965,6 @@ MIDI = %2</source>
     <message>
         <source>&amp;Info</source>
         <translation>По&amp;моћ</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>Песма је сачувана.</translation>
     </message>
     <message>
         <source>Unknown error %1</source>
@@ -1406,15 +2023,10 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Опозови</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
         <translation>Користите развојно издање програма, па Вас молимо да пошаљете извештаје о грешкама и предлоге на дописну листу програма.&lt;br&gt;&lt;br&gt;Хвала Вам!</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Не приказуј више ову поруку</translation>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1504,10 +2116,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1714,20 +2322,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Свирам.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Постави гласноћу Мастера  [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Поставите вредност за уљудније интервале [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Поставите вредност за уљуднију јачину удараца [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
@@ -1742,31 +2385,28 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Уљуди инервале</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>Напетост (Свинг)</translation>
-    </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
-    <message>
-        <source>This element is not midi operable.</source>
-        <translation>Овај елеменат није употребљив за миди.</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>Ослушкујем на миди-улазу...</translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Догађај</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Особина</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Радња</translation>
@@ -1774,6 +2414,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>Притисните ово дугме да би снимили Миди-догађаје</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1795,14 +2455,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation> Прикажи вршне вредности = ИСКЉ</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Поставите ниво еф. %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Поставите гласноћу ЛАДСПА еф.  ( %1 )</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation>У овом издању програма нису доступи ЛАДСПА-ефекти.</translation>
     </message>
@@ -1812,6 +2464,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1834,11 +2494,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Пан.</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Поставите гласнођу инструмента [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1931,14 +2599,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1986,6 +2646,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2018,7 +2682,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2060,14 +2768,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Квантизуј долазне догађаје МИДИ/клавијатуре = Укљ</translation>
     </message>
     <message>
-        <source>Select pattern size</source>
-        <translation>Одабери величину мустре</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Обаберите резолуцију мреже</translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation>Приближи</translation>
     </message>
@@ -2078,10 +2778,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>No pattern selected</source>
         <translation>Нема одабране мустре</translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>За време свирања не може се мењати величина мустре.</translation>
     </message>
     <message>
         <source>Select note properties</source>
@@ -2117,10 +2813,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Probability</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2164,35 +2856,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">искљ</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2292,11 +2960,14 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
-    <name>PlayerControl</name>
+    <name>PlaybackTrackWaveDisplay</name>
     <message>
-        <source>Mixer</source>
-        <translation>Миксета</translation>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
     </message>
+</context>
+<context>
+    <name>PlayerControl</name>
     <message>
         <source>Stop</source>
         <translation>Заустави</translation>
@@ -2350,16 +3021,8 @@ Maximum = 16/4</source>
         <translation>Прикажи бубњарски прибор</translation>
     </message>
     <message>
-        <source>Instrument rack</source>
-        <translation>Прибор</translation>
-    </message>
-    <message>
         <source>Pause.</source>
         <translation>Пауза.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Број о/м</translation>
     </message>
     <message>
         <source>Loop song = On</source>
@@ -2368,10 +3031,6 @@ Maximum = 16/4</source>
     <message>
         <source>Loop song = Off</source>
         <translation>Понављај песму = ИСКЉ</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Укљ. пано бројача откуцаја</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2427,19 +3086,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2452,11 +3098,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2653,14 +3331,6 @@ Do you want to discard the changes?
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Одбаци</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2697,32 +3367,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
  Желите ли да то урадим за Вас?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;У реду</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
         <source>Automatic</source>
         <translation>Сам одлучи</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation>У корацима</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>Једнообразно</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>Број корака</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Нијанса боје</translation>
     </message>
     <message>
         <source>Automatic driver selection</source>
@@ -2737,10 +3383,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2749,19 +3391,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2786,6 +3420,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Опште</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Уредник песме</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Грешка при покретању зв. посредника</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2863,14 +3769,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Словолик у програму</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Одабери словолик</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Словолик у миксети</translation>
     </message>
     <message>
         <source>Style</source>
@@ -3049,16 +3947,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>у посебним језичцима</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>СловнОзнака</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>Боја елемената Уредника песме</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;По промени словолика и окружења поново покрените програм.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;OSC</source>
@@ -3118,7 +4008,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3197,17 +4087,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3238,14 +4244,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3309,10 +4307,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3332,39 +4326,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;У реду</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Завршно прозорче! Можда имате несачуваних измена на узорку.
-Да ли сте сигурни?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">&amp;Свирај</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">Свирај изворни &amp;узорак</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3746,14 +4748,6 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>SongEditorPanel</name>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;У реду</translation>
-    </message>
-    <message>
         <source>Create new pattern</source>
         <translation>Додај нову мустру</translation>
     </message>
@@ -3788,24 +4782,12 @@ Are you sure?</source>
 обришем исцртана поља у свим мустрама?</translation>
     </message>
     <message>
-        <source>stacked mode</source>
-        <translation>Сложен режим</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>Режим сложене мустре</translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation>Режим једне мустре</translation>
-    </message>
-    <message>
         <source>Pattern %1</source>
         <translation>Мустра %1</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Омогући уређивање временске линије</translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3832,19 +4814,15 @@ Are you sure?</source>
         <translation>Јачина удара</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3853,22 +4831,6 @@ Are you sure?</source>
     <message>
         <source>Form</source>
         <translation>Формулар</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Уреди број о/м за текуће доба</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Уреди доба на врем. линији</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3917,22 +4879,6 @@ Are you sure?</source>
 <context>
     <name>SongEditorPatternList</name>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;У реду</translation>
-    </message>
-    <message>
-        <source>Open Pattern</source>
-        <translation>Отвори мустру</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>не_сврстано</translation>
-    </message>
-    <message>
         <source>Delete</source>
         <translation>Обриши</translation>
     </message>
@@ -3953,10 +4899,6 @@ Are you sure?</source>
 Overwrite the existing pattern?</source>
         <translation>Датотека предлошка већ постоји. 
 Да ли да преписујем преко ње?</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Мустра 1</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3988,6 +4930,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4040,24 +4993,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Извези бубњеве</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Директоријум</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Извези</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Све</translation>
     </message>
 </context>
 <context>
@@ -4065,10 +5030,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Извоз</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Бубњеви</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4259,14 +5220,6 @@ Overwrite the existing pattern?</source>
         <translation>Извоз</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Поништи</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;У реду</translation>
-    </message>
-    <message>
         <source>Delete</source>
         <translation>Обриши</translation>
     </message>
@@ -4329,17 +5282,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation>Двоклик за проширење ове листе</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4366,10 +5309,6 @@ Current kit:</source>
         <translation>Сачувај </translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Сачувај измењени инструменат у бубњеве</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Лиценца за бубњеве</translation>
     </message>
@@ -4384,6 +5323,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Лиценца за слику</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4421,76 +5364,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Сачувај бубњеве</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Унесите бар ваљан назив</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>Бубњеви са оваквим називом већ постоје. Желите ли да препишем преко њих?</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Није успело чување ових бубњева.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Отвори слику</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Датотеке са сликама (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>License</source>
-        <translation>Лиценца</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Назив</translation>
-    </message>
-    <message>
-        <source>Dialog</source>
-        <translation>Прозорче</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Поништи</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Аутор</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Подаци</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Сачувај </translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Слика</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Разгледај</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Лиценца за слику</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4517,6 +5390,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Поништи</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Ljudlöst</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Kanal</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Spara</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Avbryt</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;No</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,7 +886,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -461,6 +1033,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -668,31 +1256,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation type="unfinished">FX på/av</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
+        <source>User data folder is not writable!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -709,23 +1314,6 @@ Overwrite the existing file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -737,13 +1325,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation type="unfinished">Drumkit laddat: [1%]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation type="unfinished">Sång Editor</translation>
@@ -773,16 +1393,32 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Song is read-only.
 Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -813,22 +1449,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Attack</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Instrument gain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -842,14 +1462,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Layer pitch (Fine)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -893,7 +1505,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -937,10 +1569,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1007,15 +1641,7 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sound library</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1066,6 +1692,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Remove FX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1252,14 +1886,6 @@ MIDI = %2</source>
         <translation type="unfinished">&amp;Om...</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;No</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation type="unfinished">Spara sång</translation>
     </message>
@@ -1308,19 +1934,11 @@ MIDI = %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear all instruments?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ok</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1346,10 +1964,6 @@ MIDI = %2</source>
     <message>
         <source>Open Pattern</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation type="unfinished">Visa inte detta meddelande igen</translation>
     </message>
     <message>
         <source>Playlist: Set song No. %1</source>
@@ -1382,7 +1996,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1461,10 +2074,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1679,6 +2288,49 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Spelar.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1691,53 +2343,62 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">Förmänskliga tid</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
+        <source>Master volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
     <message>
-        <source>Event</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>press button to record midi event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1752,19 +2413,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show instrument peaks = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1777,6 +2430,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1799,11 +2460,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
+        <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1896,14 +2565,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1951,6 +2612,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -1983,7 +2648,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1996,14 +2705,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 </context>
 <context>
     <name>PatternEditorPanel</name>
-    <message>
-        <source>Select pattern size</source>
-        <translation type="unfinished">Välj mönster storlek</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation type="unfinished">Välj grid upplösning</translation>
-    </message>
     <message>
         <source>Hear new notes</source>
         <translation type="unfinished">Hör nya noter</translation>
@@ -2027,10 +2728,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Hear new notes = Off</source>
         <translation type="unfinished">Hör nya noter = Av</translation>
-    </message>
-    <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation type="unfinished">Ej möjligt att ändra i mönstret medans den spelas.</translation>
     </message>
     <message>
         <source>Quantize keyboard/midi events to grid</source>
@@ -2085,10 +2782,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2129,35 +2822,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2257,6 +2926,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2303,10 +2979,6 @@ Maximum = 16/4</source>
         <translation type="unfinished">Mönster läge valt.</translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation type="unfinished">Nytt BPM värde</translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation type="unfinished">Loopa sång = På</translation>
     </message>
@@ -2319,23 +2991,11 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument rack</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Pause.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2392,19 +3052,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2417,11 +3064,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2611,14 +3290,6 @@ Do you want to discard the changes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation type="unfinished">&amp;No</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2652,31 +3323,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
         <source>Automatic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2685,10 +3332,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Select your MIDI Driver</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2704,19 +3347,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2741,6 +3376,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Sång Editor</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Kunde inte starta ljud drivrutin</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2795,20 +3702,12 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished">Stil</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation type="unfinished">Välj teckensnitt</translation>
-    </message>
-    <message>
         <source>Slow</source>
         <translation type="unfinished">Långsam</translation>
     </message>
     <message>
         <source>Fast</source>
         <translation type="unfinished">Snabb</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation type="unfinished">Mixer teckensnitt</translation>
     </message>
     <message>
         <source>Alt+C</source>
@@ -3004,15 +3903,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3057,7 +3948,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3152,17 +4043,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3193,14 +4200,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3264,10 +4263,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3287,37 +4282,46 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3707,31 +4711,11 @@ Are you sure?</source>
 Är du säker?</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
         <source>Draw mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>single pattern mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3763,19 +4747,15 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3783,22 +4763,6 @@ Are you sure?</source>
     <name>SongEditorPanelBpmWidget_UI</name>
     <message>
         <source>Form</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>500</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3864,33 +4828,13 @@ Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The pattern-file exists. 
 Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3918,6 +4862,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Pattern saved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3970,24 +4925,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Exportera</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Alla</translation>
     </message>
 </context>
 <context>
@@ -3995,10 +4962,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation type="unfinished">Exportera</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Component</source>
@@ -4197,14 +5160,6 @@ Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Avbryt</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4252,17 +5207,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4289,10 +5234,6 @@ Current kit:</source>
         <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4306,6 +5247,10 @@ Current kit:</source>
     </message>
     <message>
         <source>Image License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Content</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4344,76 +5289,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation type="unfinished">Upphovsman</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="unfinished">Avbryt</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation type="unfinished">Bläddra</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4440,6 +5315,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation type="unfinished">Avbryt</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -168,6 +168,10 @@
         <source>Realtime frames</source>
         <translation>Вибірок в реальному часі</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,570 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">Приглушити</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Загальні</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Інструмент</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">Шари</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">Мікшер</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">Атака</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Перше затухання</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Стабільна фаза</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Кінцеве затухання</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">Канал</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">Вхід</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">уд/хв</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">Свінг</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">Сила натиску</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">Показати матричний редактор</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">вимкн</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Гаразд</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Записати</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Скасувати</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Відмовитися від змін</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">&amp;Програти</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +886,16 @@
         <translation>Назва компонента</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Задати гучність інструмента [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -354,10 +930,6 @@
     <name>DrumPatternEditor</name>
     <message>
         <source>Cannot paste multi-pattern selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -463,6 +1035,22 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Directory %1 does not exist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -670,31 +1258,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation type="unfinished"></translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>Ефекти увімкн/вимкн</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>Загальний вихід</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>уд/хв</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation type="unfinished">&amp;Скасувати</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -711,24 +1316,6 @@ Overwrite the existing file?</source>
         <translation>Властивості звукової бібліотеки</translation>
     </message>
     <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>Ви можете зберігати зміни в інструментах тільки в поточній завантаженій бібліотеці.</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>Увага! Змінення назви набору спричинить створення нового набору.
-Ви впевнені?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Гаразд</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>Не вдалось записати набір.</translation>
     </message>
@@ -740,13 +1327,45 @@ Are you sure?</source>
         <source>Image Files (*.png *.jpg *.jpeg)</source>
         <translation>Файли зображень (*.png *.jpg *.jpeg)</translation>
     </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">Інструмент</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">Компонент</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">Ліцензія</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>HydrogenApp</name>
-    <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>Завантажено набір: [%1]</translation>
-    </message>
     <message>
         <source>Song Editor</source>
         <translation>Редактор композицій</translation>
@@ -762,10 +1381,6 @@ Are you sure?</source>
     <message>
         <source>modified</source>
         <translation>змінено</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation type="unfinished">Композицію збережено.</translation>
     </message>
     <message>
         <source>Error loading song.</source>
@@ -788,6 +1403,26 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Input Midi Note</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
@@ -806,22 +1441,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>Резонансний фільтр</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>Атака</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>Перше затухання</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>Стабільна фаза</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>Кінцеве затухання</translation>
     </message>
     <message>
         <source>Layer gain</source>
@@ -846,14 +1465,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Layer pitch (Fine)</source>
         <translation>Тон шару (точно)</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation>Загальні</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>Шари</translation>
     </message>
     <message>
         <source>New component name</source>
@@ -896,7 +1507,27 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -940,10 +1571,12 @@ Use &apos;Save as&apos; to enable autosave.</source>
     </message>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>Приглушити інструмент</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>Соло</translation>
     </message>
     <message>
@@ -1010,16 +1643,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>Показати редактор інструментів</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>Інструмент</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>Показати бібліотеку звуків</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>Бібліотека звуків</translation>
     </message>
 </context>
 <context>
@@ -1070,6 +1695,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Remove FX</source>
         <translation>Видалити ефект</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1262,10 +1895,6 @@ MIDI = %2</translation>
         <translation>&amp;Записати</translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Відмовитися від змін</translation>
-    </message>
-    <message>
         <source>Save song</source>
         <translation>Записати композицію</translation>
     </message>
@@ -1296,10 +1925,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;About</source>
         <translation>&amp;Про програму</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
     </message>
     <message>
         <source>Unknown audio driver</source>
@@ -1342,10 +1967,6 @@ MIDI = %2</translation>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>Композицію збережено.</translation>
-    </message>
-    <message>
         <source>Unknown error %1</source>
         <translation>Невідома помилка %1</translation>
     </message>
@@ -1354,20 +1975,12 @@ MIDI = %2</translation>
         <translation>Очистити всі інструменти?</translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation>Гаразд</translation>
-    </message>
-    <message>
         <source>Could not save song.</source>
         <translation>Не вдалось зберегти композицію.</translation>
     </message>
     <message>
         <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
         <translation>Ви користуєтеся нестабільною версією Hydrogen. Допоможіть нам покращити її, надаючи до списку розсилання hydrogen-devel свої звіти про помилки і пропозиції. &lt;br&gt;&lt;br&gt;Дякуємо!</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>Більше не показувати це повідомлення</translation>
     </message>
     <message>
         <source>Open &amp;Pattern</source>
@@ -1419,7 +2032,6 @@ Do you want to save the changes?
     <message>
         <source>&amp;Undo</source>
         <translation>&amp;Дії</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1509,10 +2121,6 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1719,16 +2327,55 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>Playing.</source>
         <translation type="unfinished">Відтворюється.</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
     <message>
         <source>Set master volume [%1]</source>
         <translation>Задати загальну гучність [%1]</translation>
-    </message>
-    <message>
-        <source>Swing</source>
-        <translation>Свінг</translation>
     </message>
     <message>
         <source>Humanize time</source>
@@ -1739,39 +2386,32 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Олюднити силу</translation>
     </message>
     <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>Встановити параметр «людського» часу [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>Встановити параметр «людської»  сили натиску [%1]</translation>
-    </message>
-    <message>
         <source>Set swing factor [%1]</source>
         <translation>Встановити свінг-фактор [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation>Цей елемент не обробляється в MIDI.</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>Очікування вводу MIDI...</translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MidiTable</name>
-    <message>
-        <source>Event</source>
-        <translation>Подія</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>Парам.</translation>
-    </message>
     <message>
         <source>Action</source>
         <translation>Дія</translation>
@@ -1779,6 +2419,26 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>press button to record midi event</source>
         <translation>натисніть кнопку для запису MIDI-події</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1800,14 +2460,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Показ піків інструментів = Вимкн</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>Задати рівень ефекту %1</translation>
-    </message>
-    <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>Задати рівень ефекту LADSPA (%1)</translation>
-    </message>
-    <message>
         <source>LADSPA effects are not available in this version of Hydrogen.</source>
         <translation>В цій версії Hydrogen не доступні ефекти LADSPA.</translation>
     </message>
@@ -1817,6 +2469,14 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Mixer Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1839,11 +2499,19 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Панорама</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>Задати гучність інструмента [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1936,14 +2604,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>B</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1991,6 +2651,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2023,7 +2687,51 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2073,18 +2781,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Зменшити</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>Під час відтворення розмір патерна змінювати не можна.</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>Вибрати розмір патерна</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>Вибрати роздільність сітки</translation>
-    </message>
-    <message>
         <source>No pattern selected</source>
         <translation>Не вибрано жодного патерна</translation>
     </message>
@@ -2123,10 +2819,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Probability</source>
         <translation>Ймовірність</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>quarter</source>
@@ -2169,35 +2861,11 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished">вимкн</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
+        <source>Pattern editor - No pattern selected</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2297,6 +2965,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Stop</source>
@@ -2325,10 +3000,6 @@ Maximum = 16/4</source>
     <message>
         <source>Pattern mode selected.</source>
         <translation>Вибрано режим патерна.</translation>
-    </message>
-    <message>
-        <source>New BPM value</source>
-        <translation>Нове значення уд/хв</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -2363,20 +3034,8 @@ Maximum = 16/4</source>
         <translation>Показати мікшер</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>Мікшер</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>Показати стійку інструментів</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>Стійка інструментів</translation>
-    </message>
-    <message>
-        <source>BeatCounter Panel on</source>
-        <translation>Увімкнути панель лічильника бітів</translation>
     </message>
     <message>
         <source>Set BPM / Set BPM and play</source>
@@ -2432,19 +3091,6 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master on/off</source>
-        <extracomment>Using the JACK Timebase Master functionality one of the connected programs can broadcast both speed and measure information to all other connected applications in order to have a more fine-grained transport control.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>JACK transport will work only with JACK driver.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2457,11 +3103,43 @@ Maximum = 16/4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
+        <source>Toggle the BeatCounter Panel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2658,14 +3336,6 @@ Do you want to discard the changes?
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>&amp;Відмовитися від змін</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
-    </message>
-    <message>
         <source>Script name or path to the script contains whitespaces.
 IMPORTANT
 The path to the script and the scriptname must be without whitespaces.</source>
@@ -2702,32 +3372,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
 Перезапустити?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Гаразд</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
-    </message>
-    <message>
         <source>Automatic</source>
         <translation>Автоматично</translation>
-    </message>
-    <message>
-        <source>Steps</source>
-        <translation>Покроково</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>Фіксовано</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>Число кроків</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>Колір (тон)</translation>
     </message>
     <message>
         <source>Automatic driver selection</source>
@@ -2742,10 +3388,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>None</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2754,19 +3396,11 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>selected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open Sound System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2791,6 +3425,278 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>PulseAudio Driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">Загальні</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">Редактор композицій</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">Помилка при завантаженні звукового драйвера</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2912,14 +3818,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Application font</source>
         <translation>Шрифт застосунку</translation>
-    </message>
-    <message>
-        <source>Mixer font</source>
-        <translation>Шрифт мікшера</translation>
-    </message>
-    <message>
-        <source>Select font</source>
-        <translation>Вибрати шрифт</translation>
     </message>
     <message>
         <source>Polyphony</source>
@@ -3054,16 +3952,8 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Зі вкладками</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>Напис</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>Спосіб фарбування в редакторі композицій</translation>
-    </message>
-    <message>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;After changing a font or the interface layout the application must be restarted.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;Після змінення шрифту або розкладки інтерфейсу програму слід перезапустити.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>&amp;OSC</source>
@@ -3123,7 +4013,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
-        <extracomment>LASH (acronym for LASH Linux Audio Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3202,17 +4092,133 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Prefer larger</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation type="unfinished"></translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation type="unfinished"></translation>
@@ -3243,14 +4249,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Fill/remove range of pattern</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3314,10 +4312,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3337,39 +4331,47 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <source>Move point</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Гаразд</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>Закрити діалог! Можливо, залишилась якась незбережена робота.
-Ви впевнені?</translation>
-    </message>
-    <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation type="unfinished">&amp;Програти</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation type="unfinished">&amp;Зіграти початковий зразок</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3785,32 +4787,12 @@ Are you sure?</source>
 Ви впевнені?</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Гаразд</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>стековий режим</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>режим стеку патернів</translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation>режим одного патерна</translation>
-    </message>
-    <message>
         <source>Pattern %1</source>
         <translation>Патерн %1</translation>
-    </message>
-    <message>
-        <source>Enable time line edit</source>
-        <translation>Увімкнути редагування шкали часу</translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3837,19 +4819,15 @@ Are you sure?</source>
         <translation>Сила натиску</translation>
     </message>
     <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
+        <source>selected pattern mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <source>Playback track volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
+        <source>Playback volume set to</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3858,22 +4836,6 @@ Are you sure?</source>
     <message>
         <source>Form</source>
         <translation>Форма</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>Змінити значення уд/хв для поточної долі</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500,55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>Вказати долю на шкалі часу</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3938,18 +4900,6 @@ Are you sure?</source>
         <translation>Завантажити патерн</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>Відкрити патерн</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>Патерн 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>Без категорії</translation>
-    </message>
-    <message>
         <source>Virtual Pattern</source>
         <translation>Віртуальний патерн</translation>
     </message>
@@ -3958,14 +4908,6 @@ Are you sure?</source>
 Overwrite the existing pattern?</source>
         <translation>Такий файл патерна вже є.
 Перезаписати його?</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Гаразд</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
     </message>
     <message>
         <source>Export Pattern</source>
@@ -3993,6 +4935,17 @@ Overwrite the existing pattern?</source>
     </message>
     <message>
         <source>Could not save pattern to temporary directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4045,24 +4998,36 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>Експортувати бібліотеку звуків</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>Тека</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
+        <source>&amp;Export</source>
+        <translation type="unfinished">&amp;Експорт</translation>
+    </message>
+    <message>
+        <source>Export Drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
+        <source>invalid drumkit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
+        <source>The file [%1] does already exist and will be overwritten.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">Всі</translation>
     </message>
 </context>
 <context>
@@ -4070,10 +5035,6 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Export</source>
         <translation>Експорт</translation>
-    </message>
-    <message>
-        <source>Drumkit</source>
-        <translation>Набір</translation>
     </message>
     <message>
         <source>Component</source>
@@ -4272,14 +5233,6 @@ Overwrite the existing pattern?</source>
         <translation>Користувацькі набори</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>&amp;Гаразд</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Скасувати</translation>
-    </message>
-    <message>
         <source>Songs</source>
         <translation>Композиції</translation>
     </message>
@@ -4334,17 +5287,7 @@ Would you like to keep or discard the remaining instruments and notes?
         <translation>Двічі клацніть, щоб розширити список</translation>
     </message>
     <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4371,10 +5314,6 @@ Current kit:</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>Зберегти в бібліотеці зміни, внесені в інструменти</translation>
-    </message>
-    <message>
         <source>Drumkit License</source>
         <translation>Ліцензія набору</translation>
     </message>
@@ -4389,6 +5328,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>Ліцензія зображення</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4426,76 +5369,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>Зберегти бібліотеку звуків</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>Вкажіть принаймні коректну назву</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>Бібліотека з такою назвою вже є. Перезаписати наявну бібліотеку?</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>Не вдалось зберегти цю бібліотеку.</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>Відкрити зображення</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>Файли зображень (*.png *.jpg *.jpeg)</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>Діалог</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Назва</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>Автор</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>Інформація</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Скасувати</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>Ліцензія</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>Зберегти</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>Зображення</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>Огляд</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>Ліцензія зображення</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4522,6 +5395,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>Скасувати</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE TS []>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
     <name>AboutDialog</name>
@@ -168,6 +168,10 @@
         <source>Frames</source>
         <translation>帧</translation>
     </message>
+    <message>
+        <source>Latency (estimated)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AudioFileBrowser</name>
@@ -304,6 +308,573 @@
     </message>
 </context>
 <context>
+    <name>ColorSelectionButton</name>
+    <message>
+        <source>Pick a pattern color</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CommonStrings</name>
+    <message>
+        <source>P</source>
+        <extracomment>Text displayed on the button to show the Playback track. Its size is designed to hold a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will start playing after setting the tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>S</source>
+        <extracomment>Text displayed on the button for soloing an instrument strip in the mixer. Its size is designed for a single character.
+----------
+Text displayed on the button indicating that the Beat Counter will only set tempo. Its size is designed to hold one character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <extracomment>Text displayed on the button for muting an instrument strip in the mixer. Its size is designed for a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished">静音</translation>
+    </message>
+    <message>
+        <source>BYP</source>
+        <extracomment>Text displayed on the button for bypassing an element. Its size is designed for a three characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <extracomment>Text displayed on the button for editing an element. Its size is designed for a four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <extracomment>Text displayed on the button to clear all patterns in the SongEditor. Its size is designed to hold five characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>T</source>
+        <extracomment>Text displayed on the button to show the Timeline. Its size is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Timeline</source>
+        <extracomment>Text displayed on the button to activate the Timeline. Its size is designed to hold eight characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FX</source>
+        <extracomment>Text displayed on the button to enable the LADSPA effect strips. Its size is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <extracomment>Text displayed on the button to show the instrument peaks. Its size is designed to hold four characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold seven characters but is quite flexible.</extracomment>
+        <translation type="unfinished">常规</translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <extracomment>Text displayed on the button to show the Instrument Editor in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished">乐器</translation>
+    </message>
+    <message>
+        <source>Sound Library</source>
+        <extracomment>Text displayed on the button to show the Sound Library in the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Layers</source>
+        <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold six characters but is quite flexible.</extracomment>
+        <translation type="unfinished">层</translation>
+    </message>
+    <message>
+        <source>Load Layer</source>
+        <extracomment>Text displayed on the button to load a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Layer</source>
+        <extracomment>Text displayed on the button to delete a layer into an instrument. Its size is designed to hold twelve characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit Layer</source>
+        <extracomment>Text displayed on the button to edit a layer into an instrument. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B
+C</source>
+        <extracomment>Text displayed on the button to activate the Beat Counter. Its size is designed to hold two characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>R
+U
+B</source>
+        <extracomment>Text displayed on the button to activate the resampling using Rubberband. Its size is designed to hold three characters in two separate rows.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Trans</source>
+        <extracomment>Text displayed on the button to activate the JACK transport control. Its size is designed to hold seven characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>J.Master</source>
+        <extracomment>Text displayed on the button to activate the JACK Timebase master control. Its size is designed to hold eight characters and is moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mixer</source>
+        <extracomment>Text displayed on the button to show the Mixer window. Its size is designed to hold five characters and is flexible.</extracomment>
+        <translation type="unfinished">混音器</translation>
+    </message>
+    <message>
+        <source>Instrument Rack</source>
+        <extracomment>Text displayed on the button to show the Instrument Rack. Its size is designed to hold 15 characters and is flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <extracomment>Text displayed on the button activating Pattern Mode for playback. Its size is designed to hold seven characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song</source>
+        <extracomment>Text displayed on the button activating Song Mode for playback. Its size is designed to hold four characters and is slightly flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attack</source>
+        <extracomment>Text displayed below the rotary to adjust the attack of the ADSR in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished">起音</translation>
+    </message>
+    <message>
+        <source>Decay</source>
+        <extracomment>Text displayed below the rotary to adjust the decay of the ADSR in the Instrument Editor. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">衰减</translation>
+    </message>
+    <message>
+        <source>Sustain</source>
+        <extracomment>Text displayed below the rotary to adjust the sustain of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">延音</translation>
+    </message>
+    <message>
+        <source>Release</source>
+        <extracomment>Text displayed below the rotary to adjust the release of the ADSR in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">释音</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI channel in the Instrument Editor. Designed to hold seven characters but flexible.</extracomment>
+        <translation type="unfinished">通道</translation>
+    </message>
+    <message>
+        <source>Note</source>
+        <extracomment>Text displayed below the LCD to set the output MIDI note in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI Output</source>
+        <extracomment>Text displayed in the left part of the row of the Instrument Editor concerned with MIDI output parameters. Designed to hold eleven characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pitch</source>
+        <extracomment>Text displayed in the Instrument Editor in the row of the pitch widget. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Coarse</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch in front of decimal point in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fine</source>
+        <extracomment>Text displayed below the rotary to adjust the deterministic part of the instrument pitch after decimal point in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Random</source>
+        <extracomment>Text displayed below the rotary to adjust the random part of the instrument pitch in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the instrument gain in the Instrument Editor. Designed to hold four characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Group</source>
+        <extracomment>Text displayed below the LCD to set the mute group in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto-Stop Note</source>
+        <extracomment>Text displayed next to the checkbox to activate the auto stop note feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Apply Velocity</source>
+        <extracomment>Text displayed next to the checkbox to activate the apply velocity feature in the Instrument Editor. Designed to hold 14 characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HH Press. Grp</source>
+        <extracomment>Text displayed below the LCD to set the hihat pressure group in the Instrument Editor. Designed to hold 13 characters but is only moderately flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max Range</source>
+        <extracomment>Text displayed below the LCD to set the maximum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min Range</source>
+        <extracomment>Text displayed below the LCD to set the minimum range of the hihat pressure group in the Instrument Editor. Designed to hold nine characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cutoff</source>
+        <extracomment>Text displayed below the rotary to adjust the cutoff frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Resonance</source>
+        <extracomment>Text displayed below the rotary to adjust the resonance frequency of the lowpass filter applied to the instrument in the Instrument Editor. Designed to hold ten characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the layer gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C. Gain</source>
+        <extracomment>Text displayed below the rotary to adjust the component gain in the Instrument Editor. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample Sel.</source>
+        <extracomment>Text displayed left of the sample selection LCD combo in the Instrument Editor. Designed to hold eleven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Size</source>
+        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Res</source>
+        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hear</source>
+        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor. Designed to hold four characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quant</source>
+        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor. Designed to hold five characters but not that flexible.</extracomment>
+        <translation type="unfinished">输入</translation>
+    </message>
+    <message>
+        <source>MIDI-In</source>
+        <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CPU</source>
+        <extracomment>Text displayed in the Player Control to indicate the CPU load. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BPM</source>
+        <extracomment>Text displayed in the Player Control to indicate where the set the tempo of the song. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">BPM</translation>
+    </message>
+    <message>
+        <source>Hrs</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of hours passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Min</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of minutes passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sec</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of seconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1/1000</source>
+        <extracomment>Text displayed in the Player Control to indicate the number of milliseconds passed since playback started. Designed to hold three characters but not that flexible.</extracomment>
+        <translation type="unfinished">1/1000</translation>
+    </message>
+    <message>
+        <source>Humanize</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the humanization rotaries. Designed to hold eight characters but not that flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Swing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the swing humanization rotary. Designed to hold five characters but flexible.</extracomment>
+        <translation type="unfinished">摇摆</translation>
+    </message>
+    <message>
+        <source>Timing</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the timing humanization rotary. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Velocity</source>
+        <extracomment>Text displayed in the Master Mixer Strip as a heading for the velocity humanization rotary. Designed to hold eight characters flexible.</extracomment>
+        <translation type="unfinished">力度</translation>
+    </message>
+    <message>
+        <source>Master</source>
+        <extracomment>Text displayed as the title of the Master Mixer Strip. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Return</source>
+        <extracomment>Text displayed below the rotary in the FX Mixerline. Designed to hold six characters but flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Range</source>
+        <extracomment>Displayed in the tooltip of input widgets. Indicates the allowed values from minimum to maximum.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MIDI</source>
+        <extracomment>Displayed in the tooltip of input widgets. General heading of the part associating the Action of the widget with the MIDI event and parameter it is bound to.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>bound to</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part associating the Action of the widget with the MIDI event and parameter it is bound to. It&apos;s full context is &quot;ACTION bound to [EVENT : PARAMETER]&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>not bound</source>
+        <extracomment>Displayed in the tooltip of input widgets. Body of the part displaying the Action that is not associate to a MIDI event yet. It&apos;s full context is &quot;ACTION not bound&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>It&apos;s not possible to change the pattern size when playing.</source>
+        <extracomment>Displayed on both LCDSpinBoxes used for the pattern size while playback is rolling.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show drumkit editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show piano roll editor</source>
+        <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the PianoRollEditor.</extracomment>
+        <translation type="unfinished">显示钢琴卷帘编辑器</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please use the Preferences to select a different one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No audio driver set!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Register Hydrogen as JACK Timebase master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hydrogen is listening to tempo and position info. Press to register Hydrogen as JACK Timebase master instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK timebase support is disabled in the Preferences</source>
+        <translation type="unfinished">在首选项中禁用了 JACK Timebase 支持</translation>
+    </message>
+    <message>
+        <source>Waiting...</source>
+        <extracomment>Title of the window displayed when using the MIDI learning capabilities of Hydrogen.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Waiting for MIDI input...</source>
+        <extracomment>Text displayed when using the MIDI learning capabilities of Hydrogen. Only displayed if the widget has an associated action.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>This element is not MIDI operable.</source>
+        <extracomment>Displayed in the popup window when using the MIDI learning capabilities of Hydrogen. Indicating that there is not Action which could be associated to a MIDI event.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to load instrument</source>
+        <translation type="unfinished">无法加载乐器</translation>
+    </message>
+    <message>
+        <source>on</source>
+        <extracomment>Displayed within a status message when activating a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>off</source>
+        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
+        <translation type="unfinished">关</translation>
+    </message>
+    <message>
+        <source>enabled</source>
+        <extracomment>Displayed within a status message when enabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>disabled</source>
+        <extracomment>Displayed within a status message when disabling a widget.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable the Timeline for custom tempo changes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Timeline is only available in Song Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
+        <translation type="unfinished">使用外部 JACK Timebase Master 时，无法在 Hydrogen 中更改拍速</translation>
+    </message>
+    <message>
+        <source>Lock the Pattern Editor to only show and follow the pattern recorded notes will be inserted into while in Song Mode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not compiled</source>
+        <extracomment>Displayed in the Preferences dialog in the info section for a particular driver in case it is not properly supported on the system.</extracomment>
+        <translation type="unfinished">未编译</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <extracomment>Displayed in the Preferences dialog within a driver combobox in case no driver was selected.</extracomment>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <source>Both buffer size and sample rate can only be altered in the configuration of the JACK server itself.</source>
+        <extracomment>Displayed in the Preferences dialog as a tooltip for both the sample rate combobox and buffer size spinbox.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Ok</source>
+        <extracomment>Text displayed on a Ok button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">确定(&amp;O)</translation>
+    </message>
+    <message>
+        <source>&amp;Save</source>
+        <extracomment>Text displayed on a Save button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">保存(&amp;S)</translation>
+    </message>
+    <message>
+        <source>&amp;Cancel</source>
+        <extracomment>Text displayed on a Cancel button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">取消(&amp;C)</translation>
+    </message>
+    <message>
+        <source>&amp;Discard</source>
+        <extracomment>Text displayed on a Discard button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">丢弃(&amp;D)</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <extracomment>Text displayed on a Play button which will start playback. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished">播放(&amp;P)</translation>
+    </message>
+    <message>
+        <source>Play &amp;original sample</source>
+        <extracomment>Text displayed on a Play button in the SampleEditor which will start playback of the original file. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unsaved changes left. These changes will be lost. 
+Are you sure?</source>
+        <extracomment>Displayed in popup dialogs in case the user attempts to close a window which still contains unsaved changes. The &apos;
+&apos; character introduces a linebreak and must not be translated</extracomment>
+        <translation type="unfinished">有未保存的更改。这些更改将丢失。
+是否确定？</translation>
+    </message>
+    <message>
+        <source>Don&apos;t show this message again</source>
+        <translation type="unfinished">不再显示此消息</translation>
+    </message>
+    <message>
+        <source>License String</source>
+        <extracomment>Displayed in the Open dialog window if the selected song could not be loaded.Heading displayed in the info box asking the user to recover unsaved changes from an earlier session.Additional text displayed in the info box asking the user to recover unsaved changes from an earlier session.Label corresponding to the line edit in the drumkit and song properties dialog used to enter the license</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License parsed from License String. You can use this combo box to overwrite the current license with a predefined one</source>
+        <extracomment>Tool tip used for the combo boxes in both the drumkit and song property dialog to set a predefined license type.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License string written to disk. You can customize it to e.g. include an attribution other then the author. But be aware that it will be overwritten once you select a different license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You used drumkit samples holding a &lt;b&gt;copyleft license&lt;/b&gt;. Be aware that &lt;b&gt;you are legally obliged to make a copy publicly available and can not prevent its redistribution by others.&lt;/b&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All license containing the letters &apos;CC BY&apos; &lt;b&gt;require you to give an attribution&lt;/b&gt; by naming drumkit, author, as well as the license itself.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License Warning</source>
+        <extracomment>Shown as title in dialogs used to inform the user about license issues and information.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit registered in the current song can not be found on disk.
+Please load an existing drumkit first.
+Current kit:</source>
+        <translation type="unfinished">在磁盘上找不到在当前乐曲中注册的鼓组。
+请先加载现有鼓组。
+当前鼓组：</translation>
+    </message>
+    <message>
+        <source>system</source>
+        <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComponentMixerLine</name>
     <message>
         <source>Mute</source>
@@ -318,8 +889,16 @@
         <translation>组件名称</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>设置乐器音量 [%1]</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of component</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -355,10 +934,6 @@
     <message>
         <source>Cannot paste multi-pattern selection</source>
         <translation>无法粘贴多样式选择</translation>
-    </message>
-    <message>
-        <source>Unable to load instrument</source>
-        <translation>无法加载乐器</translation>
     </message>
 </context>
 <context>
@@ -464,6 +1039,22 @@ Overwrite the existing file?</source>
 Overwrite the existing file?</source>
         <translation>文件 %1 存在。
 覆盖现有文件？</translation>
+    </message>
+    <message>
+        <source>No sample in the current song uses Rubberband</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your song uses samples of the following license:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Be sure you satisfy all license conditions and give the required attribution.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -644,8 +1235,8 @@ Overwrite the existing file?</source>
 <context>
     <name>FileBrowser</name>
     <message>
-        <source>%1&lt;br>%2 KHz&lt;br>%3 %4</source>
-        <translation>%1&lt;br>%2 赫兹&lt;br>%3 %4</translation>
+        <source>%1&lt;br&gt;%2 KHz&lt;br&gt;%3 %4</source>
+        <translation>%1&lt;br&gt;%2 赫兹&lt;br&gt;%3 %4</translation>
     </message>
 </context>
 <context>
@@ -670,31 +1261,48 @@ Overwrite the existing file?</source>
         <source>User data directory</source>
         <translation>用户数据目录</translation>
     </message>
-</context>
-<context>
-    <name>FxMixerLine</name>
     <message>
-        <source>FX on/off</source>
-        <translation>打开/关闭音效</translation>
+        <source>Filesystem is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Master output</source>
-        <translation>主输出</translation>
+        <source>User data folder is not writable!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>H2Core::SongEditorPanelBpmWidget</name>
     <message>
-        <source>BPM</source>
-        <translation>BPM</translation>
-    </message>
-    <message>
         <source>Please enter a number within the range of </source>
         <translation>请输入在此范围内的数字 </translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
+        <source>Edit Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Create New Tempo Marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter tempo of selected tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set tempo of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move tempo marker to different column</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set column of new tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is already a tempo marker present at this Column. Please use left-click to edit it instead.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -719,26 +1327,44 @@ Overwrite the existing file?</source>
         <translation>图像文件（*.png *.jpg *.jpeg）</translation>
     </message>
     <message>
-        <source>This is not possible, you can only save changes inside instruments to the current loaded sound library</source>
-        <translation>无法实现，您只能将乐器内部的更改保存到当前加载的声音库中。</translation>
-    </message>
-    <message>
-        <source>Warning! Changing the drumkit name will result in creating a new drumkit with this name.
-Are you sure?</source>
-        <translation>警告！更改鼓组名称将导致使用该名称创建新的鼓组。
-是否确定？</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
-    </message>
-    <message>
         <source>Saving of this drumkit failed.</source>
         <translation>保存该鼓组失败。</translation>
+    </message>
+    <message>
+        <source>Altering the name of a drumkit would result in the creation of a new one. To do so, you need to load the drumkit (if you haven&apos;t done so already) using right click &gt; load and select Drumkits &gt; Save As in the main menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The current drumkit is read-only. Please use Drumkits &gt; Save As in the main menu to create a new one first.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Instrument</source>
+        <translation type="unfinished">乐器</translation>
+    </message>
+    <message>
+        <source>Component</source>
+        <translation type="unfinished">组件</translation>
+    </message>
+    <message>
+        <source>Sample</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation type="unfinished">许可协议</translation>
+    </message>
+    <message>
+        <source>Specified drumkit License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Specified image License String does not comply with the license selected in the combo box.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The name of the drumkit must not be left empty</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -760,14 +1386,6 @@ Are you sure?</source>
         <translation>已修改</translation>
     </message>
     <message>
-        <source>Drumkit loaded: [%1]</source>
-        <translation>鼓组已加载：[%1]</translation>
-    </message>
-    <message>
-        <source>Song saved.</source>
-        <translation>乐曲已保存</translation>
-    </message>
-    <message>
         <source>Error loading song.</source>
         <translation>加载乐曲时出错。</translation>
     </message>
@@ -785,20 +1403,36 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>只读乐曲。
 使用“另存为”作为自动保存选项。</translation>
     </message>
+    <message>
+        <source>There are unsaved changes.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Do you want to recover them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] loaded from [%2]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input Midi Note</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved as: </source>
+        <translation type="unfinished">乐曲另存为： </translation>
+    </message>
+    <message>
+        <source>Some sample licenses deviate from the one assigned to the overall drumkit [%1] and will be overwritten. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InstrumentEditor</name>
     <message>
-        <source>General</source>
-        <translation>常规</translation>
-    </message>
-    <message>
         <source>Show instrument properties</source>
         <translation>显示乐器属性</translation>
-    </message>
-    <message>
-        <source>Layers</source>
-        <translation>层</translation>
     </message>
     <message>
         <source>Show layers properties</source>
@@ -823,22 +1457,6 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>Filter resonance</source>
         <translation>谐振过滤器</translation>
-    </message>
-    <message>
-        <source>Attack</source>
-        <translation>起音</translation>
-    </message>
-    <message>
-        <source>Decay</source>
-        <translation>衰减</translation>
-    </message>
-    <message>
-        <source>Sustain</source>
-        <translation>延音</translation>
-    </message>
-    <message>
-        <source>Release</source>
-        <translation>释音</translation>
     </message>
     <message>
         <source>Instrument gain</source>
@@ -893,18 +1511,40 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>选择选择算法</translation>
     </message>
     <message>
-        <source>layer pitch: %1</source>
-        <translation>层音调：%1</translation>
+        <source>Length of Attack phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Decay phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sample volume in Sustain phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length of Release phase.
+
+Value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InstrumentLine</name>
     <message>
         <source>Mute instrument</source>
+        <extracomment>Text displayed on the button for muting an instrument. Its size is designed for a single character.</extracomment>
         <translation>静音乐器</translation>
     </message>
     <message>
         <source>Solo</source>
+        <extracomment>Text displayed on the button for soloing an instrument. Its size is designed for a single character.</extracomment>
         <translation>独奏</translation>
     </message>
     <message>
@@ -1007,16 +1647,8 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>显示乐器编辑器</translation>
     </message>
     <message>
-        <source>Instrument</source>
-        <translation>乐器</translation>
-    </message>
-    <message>
         <source>Show sound library</source>
         <translation>显示声音库</translation>
-    </message>
-    <message>
-        <source>Sound library</source>
-        <translation>声音库</translation>
     </message>
 </context>
 <context>
@@ -1067,6 +1699,14 @@ Use &apos;Save as&apos; to enable autosave.</source>
     <message>
         <source>No plugin</source>
         <translation>无插件</translation>
+    </message>
+    <message>
+        <source>Input control param. value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Output control param. value</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1131,16 +1771,16 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <translation>1</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Name:&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>d&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Name:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>d&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Name:&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Name:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>### fx name
@@ -1149,44 +1789,44 @@ p, li { white-space: pre-wrap; }
 1</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Label:&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Label:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Label:&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Label:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>### fx label</source>
         <translation>### fx label</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Type:&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Type:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Type:&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Type:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>ID:&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ID:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>ID:&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ID:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>### fx type</source>
@@ -1197,16 +1837,16 @@ p, li { white-space: pre-wrap; }
         <translation>### fx ID</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Maker:&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Maker:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Maker:&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Maker:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>### FX maker
@@ -1217,16 +1857,16 @@ p, li { white-space: pre-wrap; }
 2</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Copyright:&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Copyright:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-weight:600;&quot;>Copyright:&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Copyright:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>### copyright
@@ -1289,7 +1929,6 @@ MIDI = %2</translation>
     <message>
         <source>&amp;Undo</source>
         <translation>撤销(&amp;U)</translation>
-        <extra-FILE>menu</extra-FILE>
     </message>
     <message>
         <source>Drum&amp;kits</source>
@@ -1346,10 +1985,6 @@ Are you sure you want to save?</source>
         <translation>无法保存乐曲。</translation>
     </message>
     <message>
-        <source>Song saved.</source>
-        <translation>乐曲已保存</translation>
-    </message>
-    <message>
         <source>Save Pattern as ...</source>
         <translation>样式另存为...</translation>
     </message>
@@ -1378,10 +2013,6 @@ Are you sure you want to save?</source>
         <translation>清除所有乐器？</translation>
     </message>
     <message>
-        <source>Ok</source>
-        <translation>确定</translation>
-    </message>
-    <message>
         <source>Saving of this library failed.</source>
         <translation>保存该库失败。</translation>
     </message>
@@ -1408,10 +2039,6 @@ Are you sure you want to save?</source>
     <message>
         <source>Set default values</source>
         <translation>设定默认值</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
     </message>
     <message>
         <source>LilyPond file (*.ly)</source>
@@ -1458,12 +2085,8 @@ Are you sure you want to save?</source>
         <translation>播放列表：设置乐曲编号 %1</translation>
     </message>
     <message>
-        <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br>&lt;br>Thank you!</source>
-        <translation>您使用的是 Hydrogen 开发版本，请帮助我们在 Hydrogen 开发邮件列表中报告错误或给出建议。&lt;br>&lt;br>感谢！</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>不再显示此消息</translation>
+        <source>You&apos;re using a development version of Hydrogen, please help us reporting bugs or suggestions in the hydrogen-devel mailing list.&lt;br&gt;&lt;br&gt;Thank you!</source>
+        <translation>您使用的是 Hydrogen 开发版本，请帮助我们在 Hydrogen 开发邮件列表中报告错误或给出建议。&lt;br&gt;&lt;br&gt;感谢！</translation>
     </message>
     <message>
         <source>Playlist: Song No. %1</source>
@@ -1480,10 +2103,6 @@ Do you want to save the changes?
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>丢弃(&amp;D)</translation>
-    </message>
-    <message>
         <source>
 The current playlist contains unsaved changes.
 Do you want to discard the changes?
@@ -1495,18 +2114,22 @@ Do you want to discard the changes?
     </message>
     <message>
         <source>Replace With &amp;New Song</source>
+        <extracomment>When Hydrogen is under session management the path the song is stored to can not be changed by the user. This option allows to replace the current song with an empty one.</extracomment>
         <translation>替换为新乐曲(&amp;N)</translation>
     </message>
     <message>
         <source>Imp&amp;ort Into Session</source>
+        <extracomment>When Hydrogen is under session management the path the song is stored to can not be changed by the user. This option allows to replace the current song with one chosen by the user via a file browser widget.</extracomment>
         <translation>导入到会话(&amp;O)</translation>
     </message>
     <message>
         <source>Import &amp;Recent Into Session</source>
+        <extracomment>When Hydrogen is under session management the path the song is stored to can not be changed by the user. This option allows to replace the current song with one chosen recently used by the user.</extracomment>
         <translation>将最近导入到会话(&amp;R)</translation>
     </message>
     <message>
         <source>Export From Session &amp;As...</source>
+        <extracomment>When Hydrogen is under session management the path the song is stored to can not be changed by the user. This option allows the user store the current song in a .h2song anywhere on her system. The filepath of the current song won&apos;t be altered.</extracomment>
         <translation>从会话导出为(&amp;A)</translation>
     </message>
     <message>
@@ -1516,10 +2139,6 @@ Do you want to discard the changes?
     <message>
         <source>Save &amp;As...</source>
         <translation>另存为(&amp;A)</translation>
-    </message>
-    <message>
-        <source>Show &amp;Info</source>
-        <translation>显示信息(&amp;I)</translation>
     </message>
     <message>
         <source>E&amp;xport Pattern As...</source>
@@ -1711,6 +2330,49 @@ LilyPond 导出是一项实验性功能。
         <source>Playing.</source>
         <translation>正在播放。</translation>
     </message>
+    <message>
+        <source>Song Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replace current song with empty one?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You won&apos;t be able to undo this action after saving the new song! Please export the current song from the session first in order to keep it.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>
+There have been recent changes to the drumkit settings.
+The session needs to be saved before exporting will can be continued.
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit [%1] used in session could not found on your system. Please install it in to make the exported song work properly.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song saved into</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No pattern selected.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Demo Song</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Demo Song into Session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playback track couldn&apos;t be read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MasterMixerLine</name>
@@ -1723,35 +2385,32 @@ LilyPond 导出是一项实验性功能。
         <translation>人性化时间</translation>
     </message>
     <message>
-        <source>Swing</source>
-        <translation>摇摆</translation>
-    </message>
-    <message>
         <source>Set master volume [%1]</source>
         <translation>设置主音量 [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize time parameter [%1]</source>
-        <translation>设置人性化时间参数 [%1]</translation>
-    </message>
-    <message>
-        <source>Set humanize velocity parameter [%1]</source>
-        <translation>设置人性化力度参数 [%1]</translation>
     </message>
     <message>
         <source>Set swing factor [%1]</source>
         <translation>设置摇摆系数 [%1]</translation>
     </message>
-</context>
-<context>
-    <name>MidiSenseWidget</name>
     <message>
-        <source>This element is not midi operable.</source>
-        <translation>此元素不可以 MIDI 操作。</translation>
+        <source>Master volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Waiting for midi input...</source>
-        <translation>正在等待 MIDI 输入...</translation>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>16th-note Swing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize time param [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set humanize vel. param [%1]</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1761,16 +2420,28 @@ LilyPond 导出是一项实验性功能。
         <translation>按下按钮以记录 MIDI 事件</translation>
     </message>
     <message>
-        <source>Event</source>
-        <translation>事件</translation>
-    </message>
-    <message>
-        <source>Param.</source>
-        <translation>参数</translation>
-    </message>
-    <message>
         <source>Action</source>
         <translation>操作</translation>
+    </message>
+    <message>
+        <source>Incoming Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event Para.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Para. 3</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1788,10 +2459,6 @@ LilyPond 导出是一项实验性功能。
         <translation>显示乐器峰值</translation>
     </message>
     <message>
-        <source>Set FX %1 level </source>
-        <translation>设定音效 %1 级别 </translation>
-    </message>
-    <message>
         <source>Show instrument peaks = On</source>
         <translation>显示乐器峰值：开</translation>
     </message>
@@ -1804,12 +2471,16 @@ LilyPond 导出是一项实验性功能。
         <translation>LADSPA 效果在此版本的 Hydrogen 中不可用。</translation>
     </message>
     <message>
-        <source>Set LADSPA FX ( %1 ) volume</source>
-        <translation>设置 LADSPA 音效 (%1) 音量</translation>
-    </message>
-    <message>
         <source>Mixer Settings</source>
         <translation>混音器设置</translation>
+    </message>
+    <message>
+        <source>Set FX %1 level [%2] of instrument</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of FX</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1831,12 +2502,20 @@ LilyPond 导出是一项实验性功能。
         <translation>声相</translation>
     </message>
     <message>
-        <source>Set instrument volume [%1]</source>
-        <translation>设置乐器音量 [%1]</translation>
+        <source>FX %1 send</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Instrument name</source>
-        <translation>乐器名称</translation>
+        <source>Volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Peak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set volume [%1] of instrument</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1928,14 +2607,6 @@ LilyPond 导出是一项实验性功能。
         <translation>清除选择</translation>
     </message>
     <message>
-        <source>Set note velocity [%1]</source>
-        <translation>设定音符力度 [%1]</translation>
-    </message>
-    <message>
-        <source>Edit %1 property of %2 notes</source>
-        <translation>编辑 %2 音符的 %1 属性</translation>
-    </message>
-    <message>
         <source>B</source>
         <translation>B</translation>
     </message>
@@ -1983,6 +2654,10 @@ LilyPond 导出是一项实验性功能。
         <source>C</source>
         <translation>C</translation>
     </message>
+    <message>
+        <source>Edit [%1] property of [%2] notes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternEditor</name>
@@ -2015,8 +2690,52 @@ LilyPond 导出是一项实验性功能。
         <translation>将这些音符放在此处将覆盖 %1 个重复的音符。</translation>
     </message>
     <message>
-        <source>Don&apos;t show this message again</source>
-        <translation>不再显示此消息</translation>
+        <source>ticks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note velocity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the right by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note panned to the left by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note centered</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leading beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lagging beat by</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note on beat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set pitch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>octave</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set note probability to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2031,14 +2750,6 @@ LilyPond 导出是一项实验性功能。
     <message>
         <source>Loaded Soundlibrary</source>
         <translation>已加载的声音库</translation>
-    </message>
-    <message>
-        <source>Select pattern size</source>
-        <translation>选择样式大小</translation>
-    </message>
-    <message>
-        <source>Select grid resolution</source>
-        <translation>选择网格分辨率</translation>
     </message>
     <message>
         <source>Hear new notes</source>
@@ -2113,14 +2824,6 @@ LilyPond 导出是一项实验性功能。
         <translation>显示鼓编辑器</translation>
     </message>
     <message>
-        <source>Is not possible to change the pattern size when playing.</source>
-        <translation>播放时无法更改样式大小。</translation>
-    </message>
-    <message>
-        <source>Unsupported note denominator. Click for more information.</source>
-        <translation>不支持的音符分母。单击以获取更多信息。</translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation>四分</translation>
     </message>
@@ -2161,40 +2864,12 @@ LilyPond 导出是一项实验性功能。
         <translation>关</translation>
     </message>
     <message>
-        <source>Hydrogen can only represent notes as small as 1/%1 of a whole note, so note values must be multiple of this.
-Supported values are: 1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</source>
-        <translation>Hydrogen 最小只能显示到全音符的 1 / ％1，因此音符值必须是这个值的倍数。
-支持的值为：1/1, 1/2, 1/3, 1/4, 1/6, 1/8, 1/12, 1/16, 1/24, 1/32, 1/48, 1/64, 1/96, 1/192</translation>
+        <source>You can use the &apos;/&apos; inside the pattern size spin boxes to switch back and forth.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>New Pattern length (beats/note value)</source>
-        <translation>新样式长度（节拍/音符值）</translation>
-    </message>
-    <message>
-        <source>Denominator value rejected.
-Limits: (0, %1]</source>
-        <translation>分母值被拒绝。
-限制：(0, %1]</translation>
-    </message>
-    <message>
-        <source>Pattern size too big.
-Maximum = 16/4</source>
-        <translation>样式尺寸太大。
-最大值 = 16/4</translation>
-    </message>
-    <message>
-        <source>Pattern length in 1/%1 notes is not supported. Length may be approximated.</source>
-        <translation>不支持 1 / %1 音符中的样式长度。长度可以近似。</translation>
-    </message>
-    <message>
-        <source>Pattern size was approximated.
-(resolution = %1 ticks/quarter note)</source>
-        <translation>样式尺寸为近似值。
-（分辨率 = %1 TPQN)</translation>
-    </message>
-    <message>
-        <source>Text rejected</source>
-        <translation>文本被拒绝</translation>
+        <source>Pattern editor - No pattern selected</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2293,6 +2968,13 @@ Maximum = 16/4</source>
     </message>
 </context>
 <context>
+    <name>PlaybackTrackWaveDisplay</name>
+    <message>
+        <source>No playback track selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PlayerControl</name>
     <message>
         <source>Rewind</source>
@@ -2327,10 +3009,6 @@ Maximum = 16/4</source>
         <translation>乐曲模式</translation>
     </message>
     <message>
-        <source>BeatCounter Panel on</source>
-        <translation>打开节拍计数器面板</translation>
-    </message>
-    <message>
         <source>Set BPM / Set BPM and play</source>
         <translation>设置 BPM / 设置 BPM 并播放</translation>
     </message>
@@ -2347,16 +3025,8 @@ Maximum = 16/4</source>
         <translation>显示混音器</translation>
     </message>
     <message>
-        <source>Mixer</source>
-        <translation>混音器</translation>
-    </message>
-    <message>
         <source>Show Instrument Rack</source>
         <translation>显示乐器机架</translation>
-    </message>
-    <message>
-        <source>Instrument rack</source>
-        <translation>乐器机架</translation>
     </message>
     <message>
         <source>Record midi events = On</source>
@@ -2411,10 +3081,6 @@ Maximum = 16/4</source>
         <translation>使用 Rubberband 重新计算所有采样：关</translation>
     </message>
     <message>
-        <source>New BPM value</source>
-        <translation>新 BPM 值</translation>
-    </message>
-    <message>
         <source>Loop song = On</source>
         <translation>循环乐曲：开</translation>
     </message>
@@ -2424,19 +3090,8 @@ Maximum = 16/4</source>
     </message>
     <message>
         <source>JACK transport on/off</source>
+        <extracomment>Using the JACK the audio/midi input and output ports of any number of application can be connected.</extracomment>
         <translation>打开/关闭 JACK 传输</translation>
-    </message>
-    <message>
-        <source>JACK Timebase master on/off</source>
-        <translation>打开/关闭JACK Timebase Master</translation>
-    </message>
-    <message>
-        <source>JACK timebase support is disabled in the Preferences</source>
-        <translation>在首选项中禁用了 JACK Timebase 支持</translation>
-    </message>
-    <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation>使用外部 JACK Timebase Master 时，无法在 Hydrogen 中更改拍速</translation>
     </message>
     <message>
         <source>JACK transport will work only with JACK driver.</source>
@@ -2451,12 +3106,44 @@ Maximum = 16/4</source>
         <translation>JACK 传输模式：关</translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = On</source>
-        <translation>JACK Timebase Master 模式：开</translation>
+        <source>Toggle the BeatCounter Panel</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>JACK Timebase master mode = Off</source>
-        <translation>JACK Timebase Master 模式：关</translation>
+        <source>Please deactivate the Timeline first in order to use the BeatCounter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master the BeatCounter can not be used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alter the Playback Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>While the Timeline is active this widget is in read-only mode and just displays the tempo set using the current Timeline position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>In the presence of an external JACK Timebase master this widget just displays the tempo broadcasted by JACK</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK-transport will work only with JACK driver.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only be used after deactivating the Timeline and left of the first Tempo Marker when activating it again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK BBT transport or making Hydrogen the Timebase master.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>JACK Timebase mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2572,14 +3259,6 @@ Do you want to discard the changes?
 </translation>
     </message>
     <message>
-        <source>&amp;Discard</source>
-        <translation>丢弃(&amp;D)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
-    </message>
-    <message>
         <source>no Script</source>
         <translation>没有脚本</translation>
     </message>
@@ -2690,38 +3369,10 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>自动</translation>
     </message>
     <message>
-        <source>Steps</source>
-        <translation>步骤</translation>
-    </message>
-    <message>
-        <source>Fixed</source>
-        <translation>固定</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>缓慢</translation>
-    </message>
-    <message>
-        <source>Normal</source>
-        <translation>正常</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快速</translation>
-    </message>
-    <message>
         <source>Driver restart required.
  Restart driver?</source>
         <translation>需要重新启动驱动。
  重新启动驱动？</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
     </message>
     <message>
         <source>Automatic driver selection</source>
@@ -2730,14 +3381,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Please restart hydrogen to enable/disable LASH support</source>
         <translation>请重新启动 Hydrogen 以启用/禁用 LASH 支持</translation>
-    </message>
-    <message>
-        <source>Number of steps</source>
-        <translation>步骤数量</translation>
-    </message>
-    <message>
-        <source>Color (Hue value)</source>
-        <translation>颜色（色相值）</translation>
     </message>
     <message>
         <source>Hydrogen must be restarted for language change to take effect</source>
@@ -2752,16 +3395,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>选择您的 MIDI 驱动</translation>
     </message>
     <message>
-        <source>None</source>
-        <translation>无</translation>
-    </message>
-    <message>
         <source>The select port is unavailable. This instance uses the following temporary port instead:</source>
         <translation>所选端口不可用。该实例改为使用以下临时端口：</translation>
-    </message>
-    <message>
-        <source>selected</source>
-        <translation>已选择</translation>
     </message>
     <message>
         <source>Open Sound System</source>
@@ -2770,10 +3405,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Simple audio driver [/dev/dsp]</source>
         <translation>简单音频驱动 [/dev/dsp]</translation>
-    </message>
-    <message>
-        <source>Not compiled</source>
-        <translation>未编译</translation>
     </message>
     <message>
         <source>JACK Audio Connection Kit Driver</source>
@@ -2798,6 +3429,278 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>PulseAudio Driver</source>
         <translation>PulseAudio 驱动</translation>
+    </message>
+    <message>
+        <source>For changes of the interface layout to take effect Hydrogen must be restarted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>General</source>
+        <translation type="unfinished">常规</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Window Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Highlight Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selection Inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Base</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tool Tip Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button Red Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spin Box Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playhead</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cursor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Song Editor</source>
+        <translation type="unfinished">乐曲编辑器</translation>
+    </message>
+    <message>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Alternate Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected Row Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automation Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode On Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stacked Mode Off Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Octave Row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Full Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Default Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Half Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note (Zero Velocity)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Note Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Grid Line 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to proceed?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Currently connected to device: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error starting audio driver</source>
+        <translation type="unfinished">启动音频驱动时出错</translation>
+    </message>
+    <message>
+        <source>Unable to start audio driver</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme couldn&apos;t be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme imported from </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme can not be exported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme exported to </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Theme reset</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3019,8 +3922,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>传入端口</translation>
     </message>
     <message>
-        <source>&lt;html>&lt;head/>&lt;body>&lt;p>Port which will be used to receive incoming OSC messages&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;html>&lt;head/>&lt;body>&lt;p>端口将被用于接收传入的OSC消息&lt;/p>&lt;/body>&lt;/html></translation>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port which will be used to receive incoming OSC messages&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;端口将被用于接收传入的OSC消息&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>Enable OSC &amp;feedback</source>
@@ -3043,11 +3946,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>样式</translation>
     </message>
     <message>
-        <source>Select font</source>
-        <translation>选择字体</translation>
-    </message>
-    <message>
         <source>Meters falloff speed</source>
+        <extracomment>In case of a rapid sound lasting for just a milli second the meters in the Mixer would raise to peak value and fall of immediately without the user being able to see them. The falloff speed introduces a delay. The smaller the value, the longer the meter requires to reach 0dB again.</extracomment>
         <translation>测量衰减速度</translation>
     </message>
     <message>
@@ -3063,10 +3963,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>快速</translation>
     </message>
     <message>
-        <source>Mixer font</source>
-        <translation>混音器字体</translation>
-    </message>
-    <message>
         <source>Default interface layout</source>
         <translation>默认界面布局</translation>
     </message>
@@ -3079,16 +3975,8 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>标签式</translation>
     </message>
     <message>
-        <source>TextLabel</source>
-        <translation>文字标签</translation>
-    </message>
-    <message>
         <source>Coloring method for Song Editor elements</source>
         <translation>乐曲编辑器元素的着色模式</translation>
-    </message>
-    <message>
-        <source>&lt;html>&lt;head/>&lt;body>&lt;p>&lt;span style=&quot; font-style:italic;&quot;>After changing a font or the interface layout the application must be restarted.&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;html>&lt;head/>&lt;body>&lt;p>&lt;span style=&quot; font-style:italic;&quot;>更改字体或界面布局后，必须重启应用程序。&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
     </message>
     <message>
         <source>&amp;Cancel</source>
@@ -3128,6 +4016,7 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Use &amp;LASH</source>
+        <extracomment>LASH (acronym for LASH Audio Session Handler) is a protocol allowing for session management in Linux (recalling songs, preferences, and JACK port connections).</extracomment>
         <translation>使用 &amp;LASH</translation>
     </message>
     <message>
@@ -3206,17 +4095,133 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Prefer larger</source>
         <translation>偏好较大的</translation>
     </message>
+    <message>
+        <source>Numbers of autosaves per hour (set 0 to deactivated)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Host API</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Latency target</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Interface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Selected colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Icon color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Number of colors in Song Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Black</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>White</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Items</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <translation type="unfinished">B</translation>
+    </message>
+    <message>
+        <source>S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>H</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <source>R</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used within listings, like for the names of the available Pattern and Instruments.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Item font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for larger buttons.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Widget font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Font used for most of the GUI including menus, headings, and the grids of the Song and Pattern Editor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reset Appearance Tab</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QObject</name>
-    <message>
-        <source>Add Pattern ( %1, %2 )</source>
-        <translation>添加样式 ( %1, %2 )</translation>
-    </message>
-    <message>
-        <source>Delete Pattern ( %1, %2 )</source>
-        <translation>删除样式 ( %1, %2 )</translation>
-    </message>
     <message>
         <source>Move pattern list item ( %1, %2 )</source>
         <translation>移动样式列表项目 ( %1, %2 )</translation>
@@ -3248,14 +4253,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Fill/remove range of pattern</source>
         <translation>填充/删除样式范围</translation>
-    </message>
-    <message>
-        <source>Edit timeline tempo</source>
-        <translation>编辑时间轴拍速</translation>
-    </message>
-    <message>
-        <source>Delete timeline tempo</source>
-        <translation>删除时间轴拍速</translation>
     </message>
     <message>
         <source>Edit timeline tag</source>
@@ -3318,10 +4315,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>添加钢琴辊 NOTE_OFF 音符 ( %1, %2 )</translation>
     </message>
     <message>
-        <source>Change piano roll note length </source>
-        <translation>修改钢琴辊音符长度 </translation>
-    </message>
-    <message>
         <source>Change note properties piano roll</source>
         <translation>更改钢琴辊音符属性</translation>
     </message>
@@ -3341,40 +4334,47 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Move point</source>
         <translation>移动节点</translation>
     </message>
+    <message>
+        <source>Toggle Pattern ( %1, %2 )</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete tempo marker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Altering the length of the current pattern</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Reporter</name>
+    <message>
+        <source>Hydrogen exited abnormally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You can check the Hydrogen issue tracker on Github to see if this issue is already known about. If not, you can report it there to help the development team get you back on track and improve Hydrogen for the future.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open log file...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Github Issue tracker...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SampleEditor</name>
     <message>
-        <source>Unsaved changes left. These changes will be lost. 
-Are you sure?</source>
-        <translation>有未保存的更改。这些更改将丢失。
-是否确定？</translation>
-    </message>
-    <message>
-        <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
-    </message>
-    <message>
-        <source>Close dialog! maybe there is some unsaved work on sample.
-Are you sure?</source>
-        <translation>关闭对话框！也许有一些未保存的采样工作。
-是否确定？</translation>
-    </message>
-    <message>
         <source>SampleEditor </source>
         <translation>样本编辑器 </translation>
-    </message>
-    <message>
-        <source>&amp;Play</source>
-        <translation>播放(&amp;P)</translation>
-    </message>
-    <message>
-        <source>P&amp;lay original sample</source>
-        <translation>播放(&amp;L) 原采样</translation>
     </message>
     <message>
         <source>new sample length</source>
@@ -3416,18 +4416,18 @@ Are you sure?</source>
         <translation>调整采样循环的起始帧</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>Loop&lt;/span>&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>mode&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;Loop&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;mode&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>循环&lt;/span>&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>mode&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;循环&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;mode&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>set processing</source>
@@ -3446,18 +4446,18 @@ p, li { white-space: pre-wrap; }
         <translation>反复</translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>Loop&lt;/span>&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>Count&lt;/span>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;Loop&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;Count&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>循环&lt;/span>&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;span style=&quot; font-size:7pt;&quot;>Count&lt;/span>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans&apos;; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;循环&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;Count&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>loops</source>
@@ -3648,34 +4648,34 @@ p, li { white-space: pre-wrap; }
         <translation>清脆度： </translation>
     </message>
     <message>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&quot;Crispness&quot; levels:&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  0   equivalent to --no-transients --no-lamination --window-long&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  1   equivalent to --no-transients --no-lamination&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  2   equivalent to --no-transients&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  3   equivalent to --bl-transients&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  4   default processing options&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  5   equivalent to --no-lamination --window-short (may be good for drums)&lt;/p>
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>you can find more information here:&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;a href=&quot;http://www.breakfastquay.com/rubberband/ &quot;>&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;>http://www.breakfastquay.com/rubberband/ &lt;/span>&lt;/a>&lt;/p>&lt;/body>&lt;/html></source>
-        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;>
-&lt;html>&lt;head>&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; />&lt;style type=&quot;text/css&quot;>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&quot;Crispness&quot; levels:&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  0   equivalent to --no-transients --no-lamination --window-long&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  1   equivalent to --no-transients --no-lamination&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  2   equivalent to --no-transients&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  3   equivalent to --bl-transients&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  4   default processing options&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  5   equivalent to --no-lamination --window-short (may be good for drums)&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;you can find more information here:&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.breakfastquay.com/rubberband/ &quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://www.breakfastquay.com/rubberband/ &lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style>&lt;/head>&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&quot;Crispness&quot; levels:&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  0   equivalent to --no-transients --no-lamination --window-long&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  1   equivalent to --no-transients --no-lamination&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  2   equivalent to --no-transients&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  3   equivalent to --bl-transients&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  4   default processing options&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>  5   equivalent to --no-lamination --window-short (may be good for drums)&lt;/p>
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>you can find more information here:&lt;/p>
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;>&lt;a href=&quot;http://www.breakfastquay.com/rubberband/ &quot;>&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;>http://www.breakfastquay.com/rubberband/ &lt;/span>&lt;/a>&lt;/p>&lt;/body>&lt;/html></translation>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;DejaVu Sans&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&quot;Crispness&quot; levels:&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  0   equivalent to --no-transients --no-lamination --window-long&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  1   equivalent to --no-transients --no-lamination&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  2   equivalent to --no-transients&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  3   equivalent to --bl-transients&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  4   default processing options&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;  5   equivalent to --no-lamination --window-short (may be good for drums)&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;you can find more information here:&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;a href=&quot;http://www.breakfastquay.com/rubberband/ &quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;http://www.breakfastquay.com/rubberband/ &lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <source>0</source>
@@ -3708,29 +4708,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>panorama</source>
         <translation>全景</translation>
-    </message>
-</context>
-<context>
-    <name>SimpleHTMLBrowser</name>
-    <message>
-        <source>Manual</source>
-        <translation>用户手册</translation>
-    </message>
-    <message>
-        <source>Welcome to Hydrogen</source>
-        <translation>欢迎使用 Hydrogen</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show this message anymore</source>
-        <translation>不再显示此消息</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>确定</translation>
-    </message>
-    <message>
-        <source>Documentation index</source>
-        <translation>文档索引</translation>
     </message>
 </context>
 <context>
@@ -3783,14 +4760,6 @@ p, li { white-space: pre-wrap; }
         <translation>乐曲编辑器</translation>
     </message>
     <message>
-        <source>Enable time line edit</source>
-        <translation>启用时间轴编辑</translation>
-    </message>
-    <message>
-        <source>Timeline usage is disabled in the presence of an external JACK timebase master</source>
-        <translation>外部 JACK timebase master 存在时，禁用时间轴</translation>
-    </message>
-    <message>
         <source>Clear pattern sequence</source>
         <translation>清除样式序列</translation>
     </message>
@@ -3813,10 +4782,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Draw mode</source>
         <translation>绘图模式</translation>
-    </message>
-    <message>
-        <source>stacked mode</source>
-        <translation>堆叠模式</translation>
     </message>
     <message>
         <source>View playback track</source>
@@ -3853,32 +4818,20 @@ Are you sure?</source>
 是否确定？</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
-    </message>
-    <message>
         <source>stacked pattern mode</source>
         <translation>堆叠样式模式</translation>
     </message>
     <message>
-        <source>single pattern mode</source>
-        <translation>单一样式模式</translation>
+        <source>selected pattern mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>In the presence of an external JACK Timebase master the tempo can not be altered from within Hydrogen</source>
-        <translation>使用外部 JACK Timebase Master 时，无法在 Hydrogen 中更改拍速</translation>
+        <source>Playback track volume</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source> Timeline = Off</source>
-        <translation> 时间轴 = 关</translation>
-    </message>
-    <message>
-        <source> Timeline = On</source>
-        <translation> 时间轴 = 开</translation>
+        <source>Playback volume set to</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3886,22 +4839,6 @@ Are you sure?</source>
     <message>
         <source>Form</source>
         <translation>表单</translation>
-    </message>
-    <message>
-        <source>Edit the bpm value for current beat</source>
-        <translation>编辑当前节拍的BPM值</translation>
-    </message>
-    <message>
-        <source>500,55</source>
-        <translation>500.55</translation>
-    </message>
-    <message>
-        <source>Edit beat in timeline</source>
-        <translation>编辑时间轴中的节拍</translation>
-    </message>
-    <message>
-        <source>500</source>
-        <translation>500</translation>
     </message>
     <message>
         <source>Bar</source>
@@ -3974,10 +4911,6 @@ Are you sure?</source>
         <translation>虚拟样式</translation>
     </message>
     <message>
-        <source>Open Pattern</source>
-        <translation>打开样式</translation>
-    </message>
-    <message>
         <source>Could not export pattern.</source>
         <translation>无法导出样式。</translation>
     </message>
@@ -3992,24 +4925,8 @@ Overwrite the existing pattern?</source>
 覆盖现有样式？</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
-    </message>
-    <message>
         <source>Pattern saved.</source>
         <translation>样式已保存。</translation>
-    </message>
-    <message>
-        <source>Pattern 1</source>
-        <translation>样式 1</translation>
-    </message>
-    <message>
-        <source>not_categorized</source>
-        <translation>未分类</translation>
     </message>
     <message>
         <source>Duplicate</source>
@@ -4022,6 +4939,17 @@ Overwrite the existing pattern?</source>
     <message>
         <source>Could not save pattern to temporary directory.</source>
         <translation>无法将样式保存到临时目录。</translation>
+    </message>
+    <message>
+        <source>Open Pattern to Replace </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SongEditorPositionRuler</name>
+    <message>
+        <source>The tempo set in the BPM widget will be used as a default for the beginning of the song. Left-click to overwrite it.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4073,32 +5001,40 @@ Overwrite the existing pattern?</source>
 <context>
     <name>SoundLibraryExportDialog</name>
     <message>
-        <source>Export Sound Library</source>
-        <translation>导出声音库</translation>
-    </message>
-    <message>
         <source>Directory</source>
         <translation>目录</translation>
     </message>
     <message>
-        <source>Couldn&apos;t create archive</source>
-        <translation>无法创建存档</translation>
+        <source>&amp;Export</source>
+        <translation type="unfinished">导出(&amp;E)</translation>
     </message>
     <message>
-        <source>Drumkit exported.</source>
-        <translation>鼓组已导出</translation>
+        <source>Export Drumkit</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit not exported. Operation not supported.</source>
-        <translation>鼓组未导出不支持该操作。</translation>
+        <source>invalid drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The file [%1] does already exist and will be overwritten.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export drumkit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drumkit exported to</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All</source>
+        <translation type="unfinished">全部</translation>
     </message>
 </context>
 <context>
     <name>SoundLibraryExportDialog_UI</name>
-    <message>
-        <source>Drumkit</source>
-        <translation>鼓组</translation>
-    </message>
     <message>
         <source>Component</source>
         <translation>组件</translation>
@@ -4354,28 +5290,8 @@ Are you sure?</source>
 是否确定？</translation>
     </message>
     <message>
-        <source>&amp;Ok</source>
-        <translation>确定(&amp;O)</translation>
-    </message>
-    <message>
-        <source>&amp;Cancel</source>
-        <translation>取消(&amp;C)</translation>
-    </message>
-    <message>
-        <source>Drumkit registered in the current song can not be found on disk.
-Please load an existing drumkit first.
-Current kit:</source>
-        <translation>在磁盘上找不到在当前乐曲中注册的鼓组。
-请先加载现有鼓组。
-当前鼓组：</translation>
-    </message>
-    <message>
         <source>is a system drumkit and can&apos;t be deleted.</source>
         <translation>是一个系统鼓组，无法删除。</translation>
-    </message>
-    <message>
-        <source>Not implemented yet.</source>
-        <translation>尚未执行。</translation>
     </message>
 </context>
 <context>
@@ -4405,10 +5321,6 @@ Current kit:</source>
         <translation>取消</translation>
     </message>
     <message>
-        <source>Save changes made to instruments into sound library</source>
-        <translation>将对乐器所做的更改保存到声音库中</translation>
-    </message>
-    <message>
         <source>Image</source>
         <translation>图像</translation>
     </message>
@@ -4419,6 +5331,10 @@ Current kit:</source>
     <message>
         <source>Image License</source>
         <translation>图像许可协议</translation>
+    </message>
+    <message>
+        <source>Content</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4456,76 +5372,6 @@ Current kit:</source>
     </message>
 </context>
 <context>
-    <name>SoundLibrarySaveDialog</name>
-    <message>
-        <source>Save Sound Library</source>
-        <translation>保存声音库</translation>
-    </message>
-    <message>
-        <source>Open Image</source>
-        <translation>打开图像</translation>
-    </message>
-    <message>
-        <source>Image Files (*.png *.jpg *.jpeg)</source>
-        <translation>图像文件（*.png *.jpg *.jpeg）</translation>
-    </message>
-    <message>
-        <source>Please supply at least a valid name</source>
-        <translation>请至少提供一个有效的名称</translation>
-    </message>
-    <message>
-        <source>A library with the same name already exists. Do you want to overwrite the existing library?</source>
-        <translation>具有相同名称的库已经存在。您要覆盖现有库吗？</translation>
-    </message>
-    <message>
-        <source>Saving of this library failed.</source>
-        <translation>保存该库失败。</translation>
-    </message>
-</context>
-<context>
-    <name>SoundLibrarySaveDialog_UI</name>
-    <message>
-        <source>Dialog</source>
-        <translation>对话框</translation>
-    </message>
-    <message>
-        <source>Save </source>
-        <translation>保存 </translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>名称</translation>
-    </message>
-    <message>
-        <source>Author</source>
-        <translation>作者</translation>
-    </message>
-    <message>
-        <source>License</source>
-        <translation>许可协议</translation>
-    </message>
-    <message>
-        <source>Information</source>
-        <translation>信息</translation>
-    </message>
-    <message>
-        <source>Image</source>
-        <translation>图像</translation>
-    </message>
-    <message>
-        <source>Browse</source>
-        <translation>浏览</translation>
-    </message>
-    <message>
-        <source>Image License</source>
-        <translation>图像许可协议</translation>
-    </message>
-</context>
-<context>
     <name>SoundLibraryTree</name>
     <message>
         <source>Sound library</source>
@@ -4552,6 +5398,19 @@ Current kit:</source>
     <message>
         <source>Cancel</source>
         <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>WidgetWithLicenseProperty</name>
+    <message>
+        <source>Other</source>
+        <extracomment>Label used for all license not directly supported in Hydrogen&apos;s license combo box.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unspecified</source>
+        <extracomment>Label used if no license was specified.</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/data/i18n/updateTranslations.sh
+++ b/data/i18n/updateTranslations.sh
@@ -21,28 +21,7 @@ FILES="$UI $CPP $H"
 
 CMD="$LUPDATE -noobsolete ${FILES} -ts"
 
-
-
-$CMD ../../data/i18n/hydrogen_it.ts
-$CMD ../../data/i18n/hydrogen_es.ts
-$CMD ../../data/i18n/hydrogen_ru.ts
-$CMD ../../data/i18n/hydrogen_fr.ts
-$CMD ../../data/i18n/hydrogen_pt_BR.ts
-$CMD ../../data/i18n/hydrogen_hu_HU.ts
-$CMD ../../data/i18n/hydrogen_pl.ts
-$CMD ../../data/i18n/hydrogen_nl.ts
-$CMD ../../data/i18n/hydrogen_ja.ts
-$CMD ../../data/i18n/hydrogen_de.ts
-$CMD ../../data/i18n/hydrogen_sv.ts
-$CMD ../../data/i18n/hydrogen_hr.ts
-$CMD ../../data/i18n/hydrogen_cs.ts
-$CMD ../../data/i18n/hydrogen_el.ts
-$CMD ../../data/i18n/hydrogen_gl.ts
-$CMD ../../data/i18n/hydrogen_sr.ts
-$CMD ../../data/i18n/hydrogen_ca.ts
-$CMD ../../data/i18n/hydrogen_uk.ts
-$CMD ../../data/i18n/hydrogen_en.ts
-$CMD ../../data/i18n/hydrogen_en_GB.ts
+find ../../data/i18n/ -name "*.ts" -type f -exec $CMD {} \;
 
 echo "Creating *.qm files"
 cd ../../data/i18n

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1126,7 +1126,7 @@ bool Hydrogen::handleBeatCounter()
 	}
 	return true;
 }
-//~ m_nBeatCounter
+// ~ m_nBeatCounter
 
 void Hydrogen::offJackMaster()
 {

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -503,7 +503,7 @@ private:
 	timeval 		m_CurrentTime;		///< timeval
 	int			m_nCoutOffset;		///ms default 0
 	int			m_nStartOffset;		///ms default 0
-	//~ beatcounter
+	// ~ beatcounter
 
 
 	// used for song export

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -508,7 +508,7 @@ void Preferences::loadPreferences( bool bGlobal )
 									.arg( nBBTSync ) );
 						m_JackBBTSync = JackBBTSyncMethod::constMeasure;
 					}
-					//~ jack time master
+					// ~ jack time master
 
 					m_bJackTrackOuts = jackDriverNode.read_bool( "jack_track_outs", m_bJackTrackOuts, false, false );
 					m_bJackConnectDefaults = jackDriverNode.read_bool( "jack_connect_defaults", m_bJackConnectDefaults, false, false );
@@ -689,7 +689,7 @@ void Preferences::loadPreferences( bool bGlobal )
 				m_countOffset = guiNode.read_int( "countoffset", 0, false, false );
 				m_startOffset = guiNode.read_int( "playoffset", 0, false, false );
 
-				//~ beatcounter
+				// ~ beatcounter
 
 				m_nAutosavesPerHour = guiNode.read_int( "autosavesPerHour", 60, false, false );
 				
@@ -995,7 +995,7 @@ bool Preferences::savePreferences()
 			}
 			jackDriverNode.write_int( "jack_bbt_sync", nBBTSync );
 			
-			//~ jack time master
+			// ~ jack time master
 
 			// jack default connection
 			jackDriverNode.write_bool( "jack_connect_defaults", m_bJackConnectDefaults );
@@ -1126,7 +1126,7 @@ bool Preferences::savePreferences()
 
 		guiNode.write_int( "countoffset", m_countOffset );
 		guiNode.write_int( "playoffset", m_startOffset );
-		//~ beatcounter
+		// ~ beatcounter
 
 		guiNode.write_int( "autosavesPerHour", m_nAutosavesPerHour );
 

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -155,7 +155,7 @@ public:
 
 	int					m_countOffset;
 	int					m_startOffset;
-	//~ beatcounter
+	// ~ beatcounter
 
 	std::list<QString> 		sServerList;
 	std::list<QString> 		m_patternCategories;
@@ -363,7 +363,7 @@ public:
 	 * registered as time master.
 	 */
 	int					m_bJackMasterMode;
-	//~ jack driver properties
+	// ~ jack driver properties
 
 	///Default text editor (used by Playlisteditor)
 	QString				m_sDefaultEditor;
@@ -774,11 +774,11 @@ private:
 	int						m_nExportSampleRateIdx;
 	int						m_nExportSampleDepthIdx;
 	int						m_nExportTemplateIdx;
-	//~ Export dialog
+	// ~ Export dialog
 
     // Export midi dialog
     int						m_nMidiExportMode;
-    //~ Export midi dialog
+    // ~ Export midi dialog
 	
 	/** Full path to local preferences file.
 	 *

--- a/src/gui/src/AudioEngineInfoForm.h
+++ b/src/gui/src/AudioEngineInfoForm.h
@@ -48,7 +48,7 @@ class AudioEngineInfoForm :  public QWidget, public Ui_AudioEngineInfoForm_UI, p
 	virtual void stateChangedEvent( H2Core::AudioEngine::State state) override;
 	virtual void playingPatternsChangedEvent() override;
 	virtual void updateSongEvent(int) override;
-		//~ EventListener implementation
+		// ~ EventListener implementation
 
 	public:
 		explicit AudioEngineInfoForm(QWidget* parent);

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -49,10 +49,10 @@ CommonStrings::CommonStrings(){
 	  is designed to hold a single character.*/
 	m_sTimelineButton = tr( "T" );
 	/*: Text displayed on the button to activate the Timeline. Its size
-	  is designed to hold three characters.*/
+	  is designed to hold eight characters.*/
 	m_sTimelineBigButton = tr( "Timeline" );
 	/*: Text displayed on the button to enable the LADSPA effect strips. Its size
-	  is designed to hold eight characters.*/
+	  is designed to hold two characters.*/
 	m_sFXButton = tr( "FX" );
 	/*: Text displayed on the button to show the instrument peaks. Its size
 	  is designed to hold four characters.*/

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -198,7 +198,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 
 	m_pCutoffRotary->move( 109, 164 );
 	m_pResonanceRotary->move( 163, 164 );
-	//~ Filter
+	// ~ Filter
 
 	// ADSR
 	m_pAttackRotary = new Rotary( m_pInstrumentProp, Rotary::Type::Normal,
@@ -236,7 +236,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pReleaseLbl = new ClickableLabel( m_pInstrumentProp, QSize( 48, 10 ),
 										pCommonStrings->getReleaseLabel() );
 	m_pReleaseLbl->move( 199, 78 );
-	//~ ADSR
+	// ~ ADSR
 
 	// instrument gain
 	m_pInstrumentGainLCD = new LCDDisplay( m_pInstrumentProp, QSize( 43, 20 ), false, false );
@@ -316,7 +316,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pHihatMaxRangeLbl = new ClickableLabel( m_pInstrumentProp, QSize( 61, 10 ),
 											  pCommonStrings->getHihatMaxRangeLabel() );
 	m_pHihatMaxRangeLbl->move( 201, 327 );
-	//~ Instrument properties
+	// ~ Instrument properties
 
 	// LAYER properties
 	m_pLayerProp = new PixmapWidget( this );
@@ -451,7 +451,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 												pCommonStrings->getSampleSelectionLabel() );
 	m_pSampleSelectionLbl->move( 7, 436 );
 
-	//~ Layer properties
+	// ~ Layer properties
 
 	//component handling
 	QStringList itemsCompo;
@@ -474,7 +474,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	connect( popCompo, SIGNAL( triggered(QAction*) ),
 			 this, SLOT( compoChangeAddDelete(QAction*) ) );
 	update();
-	//~component handling
+	// ~ component handling
 
 	showLayers( false );
 
@@ -529,13 +529,13 @@ void InstrumentEditor::selectedInstrumentChangedEvent()
 			fTmp = 0.0;
 		}
 		m_pReleaseRotary->setValue( sqrtf(fTmp / 100000.0) );
-		//~ ADSR
+		// ~ ADSR
 
 		// filter
 		m_pFilterBypassBtn->setChecked( !m_pInstrument->is_filter_active() );
 		m_pCutoffRotary->setValue( m_pInstrument->get_filter_cutoff() );
 		m_pResonanceRotary->setValue( m_pInstrument->get_filter_resonance() );
-		//~ filter
+		// ~ filter
 
 		// pitch offset
 		char tmp[7];
@@ -674,7 +674,7 @@ void InstrumentEditor::instrumentParametersChangedEvent( int nInstrumentNumber )
 		m_pFilterBypassBtn->setChecked( !m_pInstrument->is_filter_active() );
 		m_pCutoffRotary->setValue( m_pInstrument->get_filter_cutoff() );
 		m_pResonanceRotary->setValue( m_pInstrument->get_filter_resonance() );
-		//~ filter
+		// ~ filter
 	}
 	else {
 		m_pNameLbl->setText( QString( "NULL Instrument..." ) );

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -69,7 +69,7 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 	virtual void drumkitLoadedEvent() override;
 	virtual void updateSongEvent( int ) override;
 	virtual void instrumentParametersChangedEvent( int ) override;
-		//~ implements EventListener interface
+		// ~ implements EventListener interface
 		void update();
 		static int findFreeDrumkitComponentId( int startingPoint = 0 );
 
@@ -178,7 +178,7 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 		LCDSpinBox *m_pHihatMaxRangeLCD;
 		ClickableLabel* m_pHihatMaxRangeLbl;
 
-		//~ Instrument properties
+		// ~ Instrument properties
 
 		// Layer properties
 		LayerPreview *m_pLayerPreview;
@@ -210,7 +210,7 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 		Button *m_pRemoveLayerBtn;
 		Button *m_pSampleEditorBtn;
 		QCheckBox *m_pIsStopNoteCheckBox;
-		//~ Layer properties
+		// ~ Layer properties
 
 
 		// Component
@@ -221,7 +221,7 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 
 		Rotary *m_pCompoGainRotary;
 		LCDDisplay *m_pCompoGainLCD;
-		//~ Component
+		// ~ Component
 
 		void setAutoVelocity();
 };

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -67,7 +67,7 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 
 	pTabButtonsPanel->setLayout( pTabHBox );
 
-//~ TAB buttons
+// ~ TAB buttons
 
 
 	InstrumentEditorPanel::get_instance()->setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -341,7 +341,7 @@ void MainForm::createMenuBar()
 
 	updateRecentUsedSongList();
 	connect( m_pRecentFilesMenu, SIGNAL( triggered(QAction*) ), this, SLOT( action_file_open_recent(QAction*) ) );
-	//~ FILE menu
+	// ~ FILE menu
 
 	// Undo menu
 	m_pUndoMenu = pMenubar->addMenu( tr( "&Undo" ) );
@@ -435,7 +435,7 @@ void MainForm::createMenuBar()
 
 	m_pOptionsMenu->addAction( tr("&Preferences"), this, SLOT( showPreferencesDialog() ), QKeySequence( "Alt+P" ) );
 
-	//~ Tools menu
+	// ~ Tools menu
 
 
 	Logger *pLogger = Logger::get_instance();
@@ -457,7 +457,7 @@ void MainForm::createMenuBar()
 		if(pLogger->bit_mask() == 8) { // hydrogen -V8 list object map in console 
 			m_pDebugMenu->addAction( tr( "&Print Objects" ), this, SLOT( action_debug_printObjects() ) );
 		}
-		//~ DEBUG menu
+		// ~ DEBUG menu
 	}
 
 	// INFO menu
@@ -467,7 +467,7 @@ void MainForm::createMenuBar()
 	m_pInfoMenu->addAction( tr("&About"), this, SLOT( action_help_about() ), QKeySequence( tr("", "Info|About") ) );
 	m_pInfoMenu->addAction( tr("&Report Bug"), this, SLOT( action_report_bug() ));
 	m_pInfoMenu->addAction( tr("&Donate"), this, SLOT( action_donate() ));
-	//~ INFO menu
+	// ~ INFO menu
 }
 
 void MainForm::startAutosaveTimer() {

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -76,7 +76,7 @@ Mixer::Mixer( QWidget* pParent )
 		m_pMixerLine[ i ] = nullptr;
 	}
 
-//~ fader panel
+// ~ fader panel
 
 
 // fX frame
@@ -110,7 +110,7 @@ Mixer::Mixer( QWidget* pParent )
 	else {
 		m_pFXFrame->hide();
 	}
-//~ fX frame
+// ~ fX frame
 
 
 // Master frame
@@ -141,7 +141,7 @@ Mixer::Mixer( QWidget* pParent )
 	m_pShowPeaksBtn->move( 63, 259 );
 	m_pShowPeaksBtn->setChecked( (Preferences::get_instance())->showInstrumentPeaks() );
 	connect( m_pShowPeaksBtn, SIGNAL( clicked() ), this, SLOT( showPeaksBtnClicked() ));
-//~ Master frame
+// ~ Master frame
 
 
 	// LAYOUT!

--- a/src/gui/src/Mixer/Mixer.h
+++ b/src/gui/src/Mixer/Mixer.h
@@ -105,7 +105,7 @@ class Mixer :  public QWidget, public EventListener,  public H2Core::Object<Mixe
 
 		// Implements EventListener interface
 		virtual void noteOnEvent( int nInstrument ) override;
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 
 };
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -2040,5 +2040,5 @@ void DrumPatternEditor::functionAddEmptyInstrumentRedo()
 	updateEditor();
 
 }
-///~undo / redo actions from pattern editor instrument list
+/// ~undo / redo actions from pattern editor instrument list
 ///==========================================================

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -57,7 +57,7 @@ class DrumPatternEditor : public PatternEditor, protected WidgetWithScalableFont
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;
 	virtual void songModeActivationEvent() override;
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 		void addOrDeleteNoteAction(		int nColumn,
 										int row,
 										int selectedPatternNumber,

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -124,7 +124,7 @@ class NotePropertiesRuler : public PatternEditor, protected WidgetWithScalableFo
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void songModeActivationEvent() override;
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 		
 		int m_nSelectedPatternNumber;
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -260,7 +260,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 			 m_pPatternEditorRuler, &PatternEditorRuler::onPreferencesChanged );
 
 
-//~ RULER
+// ~ RULER
 
 
 // EDITOR _____________________________________
@@ -312,7 +312,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	m_pPianoRollEditor->mergeSelectionGroups( m_pDrumPatternEditor );
 
-//~ EDITOR
+// ~ EDITOR
 
 
 
@@ -338,7 +338,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	connect( m_pInstrListScrollView->verticalScrollBar(), SIGNAL( valueChanged(int) ), this, SLOT( on_patternEditorVScroll(int) ) );
 	m_pInstrListScrollView->setFocusProxy( m_pInstrumentList );
 
-//~ INSTRUMENT LIST
+// ~ INSTRUMENT LIST
 
 
 
@@ -360,7 +360,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	m_pNoteVelocityEditor->mergeSelectionGroups( m_pDrumPatternEditor );
 
-//~ NOTE_VELOCITY EDITOR
+// ~ NOTE_VELOCITY EDITOR
 
 
 // NOTE_PAN EDITOR
@@ -382,7 +382,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	m_pNotePanEditor->mergeSelectionGroups( m_pDrumPatternEditor );
 
-//~ NOTE_PAN EDITOR
+// ~ NOTE_PAN EDITOR
 
 
 // NOTE_LEADLAG EDITOR
@@ -404,7 +404,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	m_pNoteLeadLagEditor->mergeSelectionGroups( m_pDrumPatternEditor );
 
-//~ NOTE_LEADLAG EDITOR
+// ~ NOTE_LEADLAG EDITOR
 
 
 // NOTE_NOTEKEY EDITOR
@@ -429,7 +429,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	
 	m_pNoteNoteKeyEditor->mergeSelectionGroups( m_pDrumPatternEditor );
 
-//~ NOTE_NOTEKEY EDITOR
+// ~ NOTE_NOTEKEY EDITOR
 
 // NOTE_PROBABILITY EDITOR
 	m_pNoteProbabilityScrollView = new WidgetScrollArea( nullptr );
@@ -449,7 +449,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	
 	m_pNoteProbabilityEditor->mergeSelectionGroups( m_pDrumPatternEditor );
 
-//~ NOTE_PROBABILITY EDITOR
+// ~ NOTE_PROBABILITY EDITOR
 
 
 
@@ -521,7 +521,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	pPropertiesVBox->addWidget( m_pPropertiesCombo );
 
-//~ NOTE_PROPERTIES BUTTONS
+// ~ NOTE_PROPERTIES BUTTONS
 
 
 // LAYOUT

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -95,7 +95,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 	virtual void updateSongEvent( int nValue ) override;
 	virtual void songModeActivationEvent() override;
 	virtual void stackedModeActivationEvent( int ) override;
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 
 		void ensureCursorVisible();
 		int getCursorPosition();
@@ -218,7 +218,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		// TOOLBAR
 		QLabel *			m_pPatternNameLbl;
 		Button *			m_pRandomVelocityBtn;
-		//~ TOOLBAR
+		// ~ TOOLBAR
 
 		Button *			sizeDropdownBtn;
 		Button *			resDropdownBtn;
@@ -228,7 +228,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		// Cursor positioning
 		int					m_nCursorPosition;
 		int					m_nCursorIncrement;
-		//~ Cursor
+		// ~ Cursor
 
 		virtual void dragEnterEvent(QDragEnterEvent *event) override;
 		virtual void dropEvent(QDropEvent *event) override;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.h
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.h
@@ -113,7 +113,7 @@ class PatternEditorRuler :  public QWidget, protected WidgetWithScalableFont<8, 
 	virtual void stateChangedEvent( H2Core::AudioEngine::State ) override;
 	virtual void songModeActivationEvent() override;
 	virtual void relocationEvent() override;
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 };
 
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -50,7 +50,7 @@ class PianoRollEditor: public PatternEditor, protected WidgetWithScalableFont<7,
 		virtual void selectedPatternChangedEvent() override;
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void songModeActivationEvent() override;
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 
 		void addOrDeleteNoteAction( int nColumn,
 									int pressedLine,

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -53,7 +53,7 @@ using namespace H2Core;
 
 //beatconter global
 int bcDisplaystatus = 0;
-//~ beatcounter
+// ~ beatcounter
 
 PlayerControl::PlayerControl(QWidget *parent)
  : QLabel(parent)
@@ -212,7 +212,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	
 
 
-//~ CONTROLS
+// ~ CONTROLS
 
 // BC on off
 	QWidget *pControlsBBTBConoffPanel = new QWidget( nullptr );
@@ -245,7 +245,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	connect(m_pBCOnOffBtn, SIGNAL( clicked(bool) ), this, SLOT( activateBeatCounter(bool) ));
 	pAction = std::make_shared<Action>("BEATCOUNTER");
 	m_pBCOnOffBtn->setAction( pAction );
-//~  BC on off
+// ~  BC on off
 
 //beatcounter
 	m_pControlsBCPanel = new PixmapWidget( nullptr );
@@ -312,7 +312,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pBCSetPlayBtn->setObjectName( "BeatCounterSetPlayButton" );
 	m_pBCSetPlayBtn->move( 64, 25 );
 	connect(m_pBCSetPlayBtn, SIGNAL( clicked() ), this, SLOT( bcSetPlayBtnClicked() ));
-//~ beatcounter
+// ~ beatcounter
 
 
 // BPM
@@ -375,7 +375,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pMetronomeBtn->setAction( pAction );
 	m_pMetronomeBtn->setChecked( pPref->m_bUseMetronome );
 
-//~ BPM
+// ~ BPM
 
 
 // JACK
@@ -449,7 +449,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	connect(m_pJackMasterBtn, SIGNAL( clicked() ), this, SLOT( jackMasterBtnClicked() ));
 	m_pJackMasterBtn->move( 56, 24 );
-	//~ jack time master
+	// ~ jack time master
 
 	// CPU load widget
 	m_pCpuLoadWidget = new CpuLoadWidget( pJackPanel );
@@ -470,7 +470,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	m_pMidiActivityLED->move( 11, 14 );
 	m_pCpuLoadWidget->move( 10, 3 );
-//~ JACK
+// ~ JACK
 
 
 	QWidget *pLcdBackGround = new QWidget( nullptr );
@@ -571,7 +571,7 @@ void PlayerControl::updatePlayerControl()
 			m_pBCSetPlayBtn->setChecked(true);
 		}
 	}
-	//~ beatcounter
+	// ~ beatcounter
 
 	// time
 	float fSeconds = m_pHydrogen->getAudioEngine()->getElapsedTime();
@@ -885,7 +885,7 @@ void PlayerControl::bctDownButtonClicked()
 	m_pBCDisplayT->setText( QString::number(tmp) );
 	m_pHydrogen->setNoteLength( (tmp) / 4 );
 }
-//~ beatcounter
+// ~ beatcounter
 
 
 
@@ -928,7 +928,7 @@ void PlayerControl::jackMasterBtnClicked()
 	}
 #endif
 }
-//~ jack time master
+// ~ jack time master
 
 void PlayerControl::fastForwardBtnClicked()
 {

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -84,7 +84,7 @@ private slots:
 	void updatePlayerControl();
 	void jackTransportBtnClicked();
 	//jack time master
-	void jackMasterBtnClicked();	//~ jack time master
+	void jackMasterBtnClicked();	// ~ jack time master
 	void bpmChanged( double );
 	void fastForwardBtnClicked();
 	void rewindBtnClicked();
@@ -99,7 +99,7 @@ private slots:
 	void bcbDownButtonClicked();
 	void bctUpButtonClicked();
 	void bctDownButtonClicked();
-	//~ beatcounter
+	// ~ beatcounter
 		
 	//rubberband
 	void rubberbandButtonToggle();
@@ -133,7 +133,7 @@ private:
 	Button *m_pBCTDownBtn;
 	Button *m_pBCBUpBtn;
 	Button *m_pBCBDownBtn;
-	//~ beatcounter
+	// ~ beatcounter
 
 	//rubberbandBPMChange
 	Button *m_pRubberBPMChange;
@@ -141,7 +141,7 @@ private:
 	Button *m_pJackTransportBtn;
 	//jack time master
 	Button *m_pJackMasterBtn;
-	//~ jack time master
+	// ~ jack time master
 
 	CpuLoadWidget *m_pCpuLoadWidget;
 	LED *m_pMidiActivityLED;
@@ -162,7 +162,7 @@ private:
 	QLabel *m_pBCDisplayZ;
 	QLabel *m_pBCDisplayB;
 	QLabel *m_pBCDisplayT;
-	//~ beatcounter
+	// ~ beatcounter
 
 	MetronomeLED *m_pMetronomeLED;
 	Button *m_pMetronomeBtn;

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -778,7 +778,7 @@ void PreferencesDialog::updateDriverPreferences() {
 	default:
 		ERRORLOG( QString( "Unexpected JACK BBT synchronization value" ) );
 	}
-	//~ JACK
+	// ~ JACK
 
 	if ( pPref->m_nBufferSize != bufferSizeSpinBox->value() ) {
 		pPref->m_nBufferSize = bufferSizeSpinBox->value();

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1169,7 +1169,7 @@ void SongEditor::createBackground()
 		p.drawLine( 0, y, (nMaxPatternSequence * m_nGridWidth), y );
 	}
 
-	//~ celle
+	// ~ celle
 	m_bSequenceChanged = true;
 
 }

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -285,7 +285,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	songModeActivationEvent();
 
-	//~ ZOOM
+	// ~ ZOOM
 
 	// PATTERN LIST
 	m_pPatternListScrollView = new WidgetScrollArea( nullptr );

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -77,7 +77,7 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		 */
 		void highlightPatternEditorLocked( bool bUseRedBackground );	
 		void restoreGroupVector( QString filename );
-		//~ Implements EventListener interface
+		// ~ Implements EventListener interface
 		/** Disables and deactivates the Timeline when an external
 		 * JACK timebase master is detected and enables it when it's
 		 * gone or Hydrogen itself becomes the timebase master.

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -353,7 +353,7 @@ private:
 	std::vector< QPoint > m_mergeCells;
 };
 
-//~song editor commands
+// ~song editor commands
 //=====================================================================================================================================
 //time line commands
 
@@ -456,7 +456,7 @@ private:
 	int m_nPosition;
 };
 
-//~time line commands
+// ~time line commands
 //=====================================================================================================================================
 //pattern editor commands
 
@@ -1147,7 +1147,7 @@ public:
 private:
 };
 
-//~pattern editor commands
+// ~pattern editor commands
 //=====================================================================================================================================
 //piano roll editor commands
 
@@ -1314,7 +1314,7 @@ class SE_moveNotePianoRollAction : public QUndoCommand
 
 };
 
-//~piano roll editor commands
+// ~piano roll editor commands
 //=====================================================================================================================================
 //Note Properties Ruler commands
 
@@ -1412,7 +1412,7 @@ private:
 	int __oldOctaveKeyVal;
 };
 
-//~Note Properties Ruler commands
+// ~Note Properties Ruler commands
 //=====================================================================================================================================
 
 


### PR DESCRIPTION
In addition, I updated all .ts files so translators do not work on old and incomplete versions (again).

- our `updateTranslations.py` script does not like "//~" comments and prints a warning message for _every_ translation file and comment occurrence. I changed those into "// ~" in order to make the scripts output readable
- the update of each and every .ts file in `updateTranslations.py` was hard-coded and the most recent one, zh_CN, was missing. The script does now run the update on all files in the i18n folder holding the suffix ".ts"

fixes https://github.com/hydrogen-music/hydrogen/issues/1694