### PR TITLE
Checking write permissions when exporting or saving files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -170,7 +170,10 @@
 		- Hydrogen is now able to handle multiple drumkits featuring the
 		  same name in the SoundLibrary. The drumkit's absolute path will be
 		  used as unique handler from now on.
-		- Mixing instruments from different drumkit in one Song works again
+		- Mixing instruments from different drumkit in one Song works
+		  again
+		- Hydrogen shows a now a warning dialog when exporting/saving date
+		  to read-only folders
 	* Crash reporting
 		- Fatal errors will now show a GUI report including details to report
 		  and potential hints about the cause

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -871,6 +871,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -304,7 +304,7 @@
     </message>
     <message>
         <source>Set automatic velocity</source>
-    <translation>Setze Anschlaghärte (Velocity) automatisch</translation>
+        <translation>Setze Anschlaghärte (Velocity) automatisch</translation>
     </message>
 </context>
 <context>
@@ -866,7 +866,7 @@ Are you sure?</source>
         <source>Drumkit registered in the current song can not be found on disk.
 Please load an existing drumkit first.
 Current kit:</source>
-<translation>Schlagzeug des aktuellen Liedes konnte nicht auf der Festplatte gefunden werden
+        <translation>Schlagzeug des aktuellen Liedes konnte nicht auf der Festplatte gefunden werden
 Bitte laden Sie erst ein existierendes Schlagzeug.
 Aktuelles:</translation>
     </message>
@@ -874,6 +874,11 @@ Aktuelles:</translation>
         <source>system</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation>system</translation>
+    </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation>Der ausgewählte Ordner ist schreibgeschützt. Bitte wählen Sie einen anderen.</translation>
     </message>
 </context>
 <context>
@@ -1513,7 +1518,7 @@ Use &apos;Save as&apos; to enable autosave.</source>
         <source>Length of Attack phase.
 
 Value</source>
-<translation>Länge der Attack Phase.
+        <translation>Länge der Attack Phase.
 
 Wert</translation>
     </message>
@@ -1521,7 +1526,7 @@ Wert</translation>
         <source>Length of Decay phase.
 
 Value</source>
-<translation>Länge der Decay (Abkling-) Phase.
+        <translation>Länge der Decay (Abkling-) Phase.
 
 Wert</translation>
     </message>
@@ -1529,7 +1534,7 @@ Wert</translation>
         <source>Sample volume in Sustain phase.
 
 Value</source>
-<translation>Sample Lautstärke in der Sustain Phase.
+        <translation>Sample Lautstärke in der Sustain Phase.
 
 Wert</translation>
     </message>
@@ -1537,7 +1542,7 @@ Wert</translation>
         <source>Length of Release phase.
 
 Value</source>
-<translation>Länge der Release (Abkling-) Phase.
+        <translation>Länge der Release (Abkling-) Phase.
 
 Wert</translation>
     </message>
@@ -2353,7 +2358,7 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 There have been recent changes to the drumkit settings.
 The session needs to be saved before exporting will can be continued.
 </source>
-<translation>
+        <translation>
 Es gibt ungespeicherte Änderungen in den Schlagzeug Eigenschaften.
 Die Session muss gespeichert werden, ehe mit dem Export fortgefahren werden kann.</translation>
     </message>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -872,6 +872,11 @@ Kit actual:</translation>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -875,6 +875,11 @@ Kit actuel :</translation>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation>système</translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -872,6 +872,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -871,6 +871,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -870,6 +870,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -873,6 +873,11 @@ Current kit:</source>
         <extracomment>Suffix appended to a drumkit, song, or pattern name in case it * is found on system-level and is read-only.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You do not have permissions to write to the selected folder. Please select another one.</source>
+        <extracomment>Error message shown when attempt to export a song, pattern, drumkit, MIDI etc. into a read-only folder.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -334,6 +334,10 @@ CommonStrings::CommonStrings(){
 	m_sPatternLoadError = tr( "Unable to load pattern" );
 	m_sInstrumentLoadError = tr( "Unable to load instrument" );
 
+	/*: Error message shown when attempt to export a song, pattern,
+	  drumkit, MIDI etc. into a read-only folder.*/
+	m_sFileDialogMissingWritePermissions = tr( "You do not have permissions to write to the selected folder. Please select another one." );
+
 	/*: Displayed within a status message when activating a widget.*/
 	m_sStatusOn = tr( "on" );
 	/*: Displayed within a status message when deactivating a widget.*/

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -137,6 +137,8 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	
 	const QString& getPatternLoadError() const { return m_sPatternLoadError; }
 	const QString& getInstrumentLoadError() const { return m_sInstrumentLoadError; }
+	
+	const QString& getFileDialogMissingWritePermissions() const { return m_sFileDialogMissingWritePermissions; }
 
 	const QString& getStatusOn() const { return m_sStatusOn; }
 	const QString& getStatusOff() const { return m_sStatusOff; }
@@ -271,6 +273,8 @@ private:
 
 	QString m_sPatternLoadError;
 	QString m_sInstrumentLoadError;
+
+	QString m_sFileDialogMissingWritePermissions;
 	
 	QString m_sStatusOn;
 	QString m_sStatusOff;

--- a/src/gui/src/ExportMidiDialog.cpp
+++ b/src/gui/src/ExportMidiDialog.cpp
@@ -20,11 +20,12 @@
  *
  */
 
-#include <QFileDialog>
 #include <QLabel>
 
 #include "ExportMidiDialog.h"
+#include "CommonStrings.h"
 #include "HydrogenApp.h"
+#include "Widgets/FileDialog.h"
 
 #include <core/Basics/Song.h>
 #include <core/Hydrogen.h>
@@ -125,7 +126,7 @@ void ExportMidiDialog::on_browseBtn_clicked()
 		sPath = Filesystem::usr_data_path();
 	}
 	
-	QFileDialog fd( this );
+	FileDialog fd( this );
 
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( tr("Midi file (*%1)").arg( m_sExtension ) );
@@ -177,12 +178,21 @@ void ExportMidiDialog::on_okBtn_clicked()
 		return;
 	}
 	
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	
 	saveSettingsToPreferences();
 
 	std::shared_ptr<Song> pSong = m_pHydrogen->getSong();
 	
 	QString sFilename = exportNameTxt->text();
 	QFileInfo qFile( sFilename );
+	
+	if ( ! Filesystem::dir_writable( qFile.absoluteDir().absolutePath(), false ) ) {
+		QMessageBox::warning( this, "Hydrogen",
+							  pCommonStrings->getFileDialogMissingWritePermissions(),
+							  QMessageBox::Ok );
+		return;
+	}
 	
 	if ( qFile.exists() == true && m_bFileSelected == false ) {
 		int res = QMessageBox::information( this, "Hydrogen", tr( "The file %1 exists. \nOverwrite the existing file?").arg(sFilename), QMessageBox::Yes | QMessageBox::No );

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -52,6 +52,7 @@
 #include "SongPropertiesDialog.h"
 #include "UndoActions.h"
 #include "Widgets/InfoBar.h"
+#include "Widgets/FileDialog.h"
 
 #include "Director.h"
 #include "Mixer/Mixer.h"
@@ -694,7 +695,7 @@ void MainForm::action_file_save_as()
 	}
 
 	//std::auto_ptr<QFileDialog> fd( new QFileDialog );
-	QFileDialog fd(this);
+	FileDialog fd(this);
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::songs_filter_name );
 	fd.setAcceptMode( QFileDialog::AcceptSave );
@@ -936,7 +937,7 @@ void MainForm::action_file_export_pattern_as( int nPatternRow )
 	}
 
 	QString title = tr( "Save Pattern as ..." );
-	QFileDialog fd(this);
+	FileDialog fd(this);
 	fd.setWindowTitle( title );
 	fd.setDirectory( sPath );
 	fd.selectFile( pPattern->get_name() );
@@ -999,7 +1000,8 @@ void MainForm::action_file_openPattern()
 		sPath = Filesystem::patterns_dir();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setFileMode ( QFileDialog::ExistingFiles );
 	fd.setDirectory ( sPath );
 	fd.setNameFilter( Filesystem::patterns_filter_name );
@@ -1060,7 +1062,8 @@ void MainForm::openSongWithDialog( const QString& sWindowTitle, const QString& s
 	
 	auto pHydrogen = Hydrogen::get_instance();
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setFileMode( QFileDialog::ExistingFile );
 	fd.setDirectory( sPath );
 	fd.setNameFilter( Filesystem::songs_filter_name );
@@ -1996,7 +1999,7 @@ void MainForm::action_file_export_lilypond()
 		sPath = Filesystem::usr_data_path();
 	}
 
-	QFileDialog fd( this );
+	FileDialog fd( this );
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( tr( "LilyPond file (*.ly)" ) );
 	fd.setDirectory( sPath );

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -41,12 +41,12 @@
 #include <core/Basics/Playlist.h>
 
 #include "../Widgets/Button.h"
+#include "../Widgets/FileDialog.h"
 
 #include <QTreeWidget>
 #include <QDomDocument>
 #include <QMessageBox>
 #include <QHeaderView>
-#include <QFileDialog>
 #include <vector>
 #include <cstdlib>
 #include <iostream>
@@ -264,7 +264,8 @@ void PlaylistDialog::addSong()
 		sPath = Filesystem::songs_dir();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setWindowTitle( tr( "Add Song to PlayList" ) );
 	fd.setFileMode( QFileDialog::ExistingFiles );
 	fd.setNameFilter( Filesystem::songs_filter_name );
@@ -385,7 +386,8 @@ void PlaylistDialog::loadList()
 		sPath = Filesystem::playlists_dir();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setWindowTitle( tr( "Load Playlist" ) );
 	fd.setFileMode( QFileDialog::ExistingFile );
 	fd.setDirectory( sPath );
@@ -445,7 +447,7 @@ void PlaylistDialog::newScript()
 		sPath = Filesystem::scripts_dir();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
 	fd.setFileMode ( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::scripts_filter_name );
 	fd.setAcceptMode ( QFileDialog::AcceptSave );
@@ -489,7 +491,8 @@ void PlaylistDialog::newScript()
 
 		static QString lastUsedDir = "/usr/bin/";
 
-		QFileDialog fd(this);
+		FileDialog fd(this);
+		fd.setAcceptMode( QFileDialog::AcceptOpen );
 		fd.setFileMode ( QFileDialog::ExistingFile );
 		fd.setDirectory ( lastUsedDir );
 
@@ -516,7 +519,7 @@ void PlaylistDialog::saveListAs()
 		sPath = Filesystem::playlists_dir();
 	}
 	
-	QFileDialog fd(this);
+	FileDialog fd(this);
 	fd.setWindowTitle( tr( "Save Playlist" ) );
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::playlists_filter_name );
@@ -572,7 +575,8 @@ void PlaylistDialog::loadScript()
 		sPath = Filesystem::scripts_dir();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setFileMode ( QFileDialog::ExistingFile );
 	fd.setDirectory ( sPath );
 	fd.setNameFilter ( tr ( "Hydrogen Playlist (*.sh)" ) );
@@ -626,7 +630,8 @@ void PlaylistDialog::editScript()
 
 		static QString lastUsedDir = "/usr/bin/";
 
-		QFileDialog fd(this);
+		FileDialog fd(this);
+		fd.setAcceptMode( QFileDialog::AcceptOpen );
 		fd.setFileMode ( QFileDialog::ExistingFile );
 		fd.setDirectory ( lastUsedDir );
 

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -45,6 +45,7 @@
 #include "../SongEditor/SongEditor.h"
 #include "../SongEditor/SongEditorPanel.h"
 #include "../Widgets/LCDSpinBox.h"
+#include "../Widgets/FileDialog.h"
 
 #include <core/IO/PortAudioDriver.h>
 #include <core/IO/CoreAudioDriver.h>
@@ -2198,7 +2199,7 @@ void PreferencesDialog::importTheme() {
 	}
 	
 	QString sTitle = tr( "Import Theme" );
-	QFileDialog fd( this );
+	FileDialog fd( this );
 	fd.setWindowTitle( sTitle );
 	fd.setDirectory( sPath );
 	fd.setFileMode( QFileDialog::ExistingFile );
@@ -2253,7 +2254,7 @@ void PreferencesDialog::exportTheme() {
 		sPath = Filesystem::usr_theme_dir();
 	}
 	QString sTitle = tr( "Export Theme" );
-	QFileDialog fd( this );
+	FileDialog fd( this );
 	fd.setWindowTitle( sTitle );
 	fd.setDirectory( sPath );
 	fd.setFileMode( QFileDialog::AnyFile );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -54,6 +54,7 @@ using namespace H2Core;
 #include "../PatternPropertiesDialog.h"
 #include "../SongPropertiesDialog.h"
 #include "../Skin.h"
+#include "../Widgets/FileDialog.h"
 
 
 
@@ -1916,7 +1917,8 @@ void SongEditorPatternList::patternPopup_load()
 		sPath = Filesystem::patterns_dir();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setFileMode( QFileDialog::ExistingFile );
 	fd.setNameFilter( Filesystem::patterns_filter_name );
 	fd.setDirectory( sPath );

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
@@ -25,6 +25,7 @@
 #include "SoundLibraryPanel.h"
 
 #include "../Widgets/DownloadWidget.h"
+#include "../Widgets/FileDialog.h"
 #include "../HydrogenApp.h"
 #include "../InstrumentRack.h"
 
@@ -39,7 +40,6 @@
 #include <QDomDocument>
 #include <QMessageBox>
 #include <QHeaderView>
-#include <QFileDialog>
 #include <QCryptographicHash>
 
 #include <memory>
@@ -687,7 +687,8 @@ void SoundLibraryImportDialog::on_BrowseBtn_clicked()
 		sPath = QDir::homePath();
 	}
 
-	QFileDialog fd(this);
+	FileDialog fd(this);
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setFileMode(QFileDialog::ExistingFile);
 	fd.setNameFilter( "Hydrogen drumkit (*.h2drumkit)" );
 	fd.setDirectory( sPath );

--- a/src/gui/src/Widgets/FileDialog.cpp
+++ b/src/gui/src/Widgets/FileDialog.cpp
@@ -1,0 +1,50 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "FileDialog.h"
+#include "../CommonStrings.h"
+#include "../HydrogenApp.h"
+
+#include <core/Helpers/Filesystem.h>
+
+FileDialog::FileDialog( QWidget *pParent )
+ : QFileDialog( pParent ) {
+}
+
+FileDialog::~FileDialog() {
+}
+
+void FileDialog::accept() {
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	
+	QFileInfo fileInfo( selectedFiles().first() );
+	if ( acceptMode() == QFileDialog::AcceptSave &&
+		 ! H2Core::Filesystem::dir_writable(
+			 fileInfo.absoluteDir().absolutePath(), false ) ) {
+			QMessageBox::warning( this, "Hydrogen",
+								  pCommonStrings->getFileDialogMissingWritePermissions(),
+								  QMessageBox::Ok );
+			return;
+	}
+
+	QFileDialog::accept();
+}

--- a/src/gui/src/Widgets/FileDialog.h
+++ b/src/gui/src/Widgets/FileDialog.h
@@ -1,0 +1,44 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#ifndef FILEDIALOG_H
+#define FILEDIALOG_H
+
+#include <QDialog>
+#include <core/Object.h>
+
+/** Custom file dialog checking whether the user has write access to
+ * the selected folder before allowing to save a file.
+ */
+/** \ingroup docGUI docWidgets*/
+class FileDialog : public QFileDialog, public H2Core::Object<FileDialog>
+{
+    H2_OBJECT(FileDialog)
+	
+public:
+
+	FileDialog( QWidget* pParent );
+	~FileDialog();
+
+public slots:
+	void accept();
+};
+#endif


### PR DESCRIPTION
Whenever a song, drumkit, MIDI, audio file etc. is now saved or exported, the custom QFileDialog class will check whether the user has write permissions for the selected folder. This is done when pressing the "Export", "Save" etc. button and a warning dialog will popup asking the user to select a different folder without closing the overall file dialog

fixes https://github.com/hydrogen-music/hydrogen/issues/1711