### PR TITLE
rtclock: fix implicit sleep declaration

### DIFF
--- a/cmake/rtclock/rtclock.c
+++ b/cmake/rtclock/rtclock.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <time.h>
 #include <stdint.h>
+#include <unistd.h>
 int main( int argc, char** argv, char** env ) {
     uint64_t dt;
     struct timespec t0,t1;


### PR DESCRIPTION
otherwise clang16 fails to compile this code, and detects this as false