### PR TITLE
CMake and DiskWriterDriver patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,11 +290,11 @@ FOREACH( _pkg ${STATUS_LIST})
 ENDFOREACH()
 
 # LIBSNDFILE CHECKS
-STRING( COMPARE GREATER "${LIBSNDFILE_VERSION}" "${LIBSNDFILE_VERSION_PREV}" LIBSNDFILE_VERSION_OK)
+STRING( COMPARE GREATER "${PC_LIBSNDFILE_VERSION}" "${LIBSNDFILE_VERSION_PREV}" LIBSNDFILE_VERSION_OK)
 IF(LIBSNDFILE_VERSION_OK)
-    SET(LIBSNDFILE_MSG "libsndfile supports FLAC and OGG sound file formats")
+    SET(LIBSNDFILE_MSG "${PC_LIBSNDFILE_VERSION}: libsndfile supports FLAC and OGG sound file formats")
 ELSE()
-	SET(LIBSNDFILE_MSG "libsndfile version must be greater than ${LIBSNDFILE_VERSION_PREV} to support FLAC and OGG sound file formats. Found version: ${LIBSNDFILE_VERSION}")
+	SET(LIBSNDFILE_MSG "libsndfile version must be greater than ${LIBSNDFILE_VERSION_PREV} to support FLAC and OGG sound file formats. Found version: ${PC_LIBSNDFILE_VERSION}")
 ENDIF()
 
 # RUBBERBAND information

--- a/cmake/FindHelper.cmake
+++ b/cmake/FindHelper.cmake
@@ -26,7 +26,7 @@ macro(FIND_HELPER prefix pkg_name header lib)
         if(PKG_CONFIG_FOUND)
             pkg_check_modules(PC_${prefix} ${pkg_name})
         else()
-            MESSAGE(STATUS "Checking for module '${pkg_name}'")
+            MESSAGE(STATUS "Checking for module '${pkg_name}' without pkgconfig")
         endif()
         # find_path
         find_path(${prefix}_INCLUDE_DIRS


### PR DESCRIPTION
- cmake: fix reported libsndfile version
    seems like the particular version of libsndfile found was determined differently at some point and was not adapted when switching to pkgconfig. The current variant required and additional "PC_" prefix
- cmake: tweak FindHelper
   In case the FindHelper.cmake attempts to file without the help of pkgconfig it echos a status message identical to the one used by pkgconfig itself. That is quite confusing during debugging.
- DiskWriterDriver: additional error checking
   the DiskWriterDriver does not check whether it was able to create a file using libsndfile and prints an error and exits in case it failed

addresses #1709 