### PR TITLE
pattern: length-sensitive iteration makros

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2325,8 +2325,9 @@ int AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 				// Loop over all notes at tick nPatternTickPosition
 				// (associated tick is determined by Note::__position
 				// at the time of insertion into the Pattern).
-				FOREACH_NOTE_CST_IT_BOUND(notes, it,
-										  m_pQueuingPosition->getPatternTickPosition()) {
+				FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes, it,
+												 m_pQueuingPosition->getPatternTickPosition(),
+												 pPattern ) {
 					Note *pNote = it->second;
 					if ( pNote != nullptr ) {
 						pNote->set_just_recorded( false );

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -953,7 +953,7 @@ void AudioEngineTests::testNoteEnqueuing() {
 	int nLoops = 5;
 	notesInSong.clear();
 	for ( int ii = 0; ii < nLoops; ++ii ) {
-		FOREACH_NOTE_CST_IT_BEGIN_END( pPattern->get_notes(), it ) {
+		FOREACH_NOTE_CST_IT_BEGIN_LENGTH( pPattern->get_notes(), it, pPattern ) {
 			if ( it->second != nullptr ) {
 				auto note = std::make_shared<Note>( it->second );
 				note->set_position( note->get_position() +

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -243,7 +243,17 @@ class Pattern : public H2Core::Object<Pattern>
 		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
-		int __length;                                           ///< the length of the pattern
+	/**
+	 * Determines the accessible range or notes within the
+	 * pattern.
+	 *
+	 * Notes are allow to be located at positions larger than
+	 * #__length. This can happen when programming a pattern and
+	 * decreasing its length later on. Those notes will be stored in
+	 * the associated .h2pattern and .h2song but won't be played back
+	 * or exported into a MIDI file. 
+	 */
+		int __length;
 		int __denominator;                                           ///< the meter denominator of the pattern used in meter (eg 4/4)
 		QString __name;                                         ///< the name of thepattern
 		QString __category;                                     ///< the category of the pattern
@@ -260,17 +270,41 @@ class Pattern : public H2Core::Object<Pattern>
 	static bool loadDoc( const QString& sPatternPath, std::shared_ptr<InstrumentList> pInstrumentList, XMLDoc* pDoc, bool bSilent = false );
 };
 
+/** Iterate over all provided notes in an immutable way. */
 #define FOREACH_NOTE_CST_IT_BEGIN_END(_notes,_it) \
 	for( Pattern::notes_cst_it_t _it=(_notes)->begin(); (_it)!=(_notes)->end(); (_it)++ )
 
-#define FOREACH_NOTE_CST_IT_BOUND(_notes,_it,_bound) \
+/** Iterate over all notes in column @a _bound in an immutable way. */
+#define FOREACH_NOTE_CST_IT_BOUND_END(_notes,_it,_bound) \
 	for( Pattern::notes_cst_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound); (_it)++ )
 
+/** Iterate over all provided notes in a mutable way. */
 #define FOREACH_NOTE_IT_BEGIN_END(_notes,_it) \
 	for( Pattern::notes_it_t _it=(_notes)->begin(); (_it)!=(_notes)->end(); (_it)++ )
 
-#define FOREACH_NOTE_IT_BOUND(_notes,_it,_bound) \
+/** Iterate over all notes in column @a _bound in a mutable way. */
+#define FOREACH_NOTE_IT_BOUND_END(_notes,_it,_bound)						\
 	for( Pattern::notes_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound); (_it)++ )
+
+/** Iterate over all accessible notes between position 0 and length of
+ * @a _pattern in an immutable way. */
+#define FOREACH_NOTE_CST_IT_BEGIN_LENGTH(_notes,_it,_pattern)			\
+	for( Pattern::notes_cst_it_t _it=(_notes)->begin(); (_it)!=(_notes)->end() && (_it)->first < (_pattern)->get_length(); (_it)++ )
+
+/** Iterate over all notes in column @a _bound in an immutable way if
+ * it is contained in @a _pattern. */
+#define FOREACH_NOTE_CST_IT_BOUND_LENGTH(_notes,_it,_bound,_pattern) \
+	for( Pattern::notes_cst_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound) && (_it)->first < (_pattern)->get_length(); (_it)++ )
+
+/** Iterate over all accessible notes between position 0 and length of
+ * @a _pattern in a mutable way. */
+#define FOREACH_NOTE_IT_BEGIN_LENGTH(_notes,_it,_pattern) \
+	for( Pattern::notes_it_t _it=(_notes)->begin(); (_it)!=(_notes)->end() && (_it)->first < (_pattern)->get_length(); (_it)++ )
+
+/** Iterate over all notes in column @a _bound in a mutable way if
+ * it is contained in @a _pattern. */
+#define FOREACH_NOTE_IT_BOUND_LENGTH(_notes,_it,_bound,_pattern) \
+	for( Pattern::notes_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound) && (_it)->first < (_pattern)->get_length(); (_it)++ )
 
 // DEFINITIONS
 

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1382,7 +1382,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 		else {
 			for ( const auto& ppattern : *pColumn ) {
 				if ( ppattern != nullptr ) {
-					FOREACH_NOTE_CST_IT_BEGIN_END( ppattern->get_notes(), it ) {
+					FOREACH_NOTE_CST_IT_BEGIN_LENGTH( ppattern->get_notes(), it, ppattern ) {
 						if ( it->second != nullptr ) {
 							// Use the copy constructor to not mess
 							// with the song itself.

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -535,7 +535,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 
 			for ( unsigned nNote = 0; nNote < nPatternSize; nNote++ ) {
 				const Pattern::notes_t* notes = pCurrentPattern->get_notes();
-				FOREACH_NOTE_CST_IT_BOUND( notes, it, nNote ) {
+				FOREACH_NOTE_CST_IT_BOUND_LENGTH( notes, it, nNote, pCurrentPattern ) {
 					Note *pNote = it->second;
 					if ( pNote != nullptr &&
 						 pNote->get_position() == m_nLastRecordedMIDINoteTick &&

--- a/src/core/Lilipond/Lilypond.cpp
+++ b/src/core/Lilipond/Lilypond.cpp
@@ -132,7 +132,7 @@ void H2Core::LilyPond::addPattern( const Pattern &pattern, notes_t &notes ) {
 		if ( !pPatternNotes ) {
 			continue;
 		}
-		FOREACH_NOTE_CST_IT_BOUND( pPatternNotes, it, nNote ) {
+		FOREACH_NOTE_CST_IT_BOUND_LENGTH( pPatternNotes, it, nNote, &pattern ) {
 			if ( Note *pNote = it->second ) {
 				int nId = pNote->get_instrument_id();
 				float fVelocity = pNote->get_velocity();

--- a/src/core/Smf/Smf.cpp
+++ b/src/core/Smf/Smf.cpp
@@ -254,7 +254,7 @@ void SMFWriter::save( const QString& sFilename, std::shared_ptr<Song> pSong )
 
 			for ( unsigned nNote = 0; nNote < pPattern->get_length(); nNote++ ) {
 				const Pattern::notes_t* notes = pPattern->get_notes();
-				FOREACH_NOTE_CST_IT_BOUND(notes,it,nNote) {
+				FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes,it,nNote,pPattern) {
 					Note *pNote = it->second;
 					if ( pNote ) {
 						float rnd = (float)rand()/(float)RAND_MAX;

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -451,7 +451,7 @@ bool ExportSongDialog::currentInstrumentHasNotes()
 	for ( unsigned i = 0; i < nPatterns; i++ ) {
 		Pattern *pPattern = pSong->getPatternList()->get( i );
 		const Pattern::notes_t* notes = pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
+		FOREACH_NOTE_CST_IT_BEGIN_LENGTH(notes,it,pPattern) {
 			Note *pNote = it->second;
 			assert( pNote );
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -422,7 +422,7 @@ void DrumPatternEditor::addOrDeleteNoteAction(	int nColumn,
 		// Find and delete an existing (matching) note.
 		Pattern::notes_t *notes = (Pattern::notes_t *)pPattern->get_notes();
 		bool bFound = false;
-		FOREACH_NOTE_IT_BOUND( notes, it, nColumn ) {
+		FOREACH_NOTE_IT_BOUND_END( notes, it, nColumn ) {
 			Note *pNote = it->second;
 			assert( pNote );
 			if ( ( isNoteOff && pNote->get_note_off() )
@@ -515,7 +515,7 @@ void DrumPatternEditor::moveNoteAction( int nColumn,
 	auto pFromInstrument = pInstrumentList->get( nRow );
 	auto pToInstrument = pInstrumentList->get( nNewRow );
 
-	FOREACH_NOTE_IT_BOUND((Pattern::notes_t *)pPattern->get_notes(), it, nColumn) {
+	FOREACH_NOTE_IT_BOUND_END((Pattern::notes_t *)pPattern->get_notes(), it, nColumn) {
 		Note *pCandidateNote = it->second;
 		if ( pCandidateNote->get_instrument() == pFromInstrument
 			 && pCandidateNote->get_key() == pNote->get_key()
@@ -891,7 +891,7 @@ void DrumPatternEditor::selectAll()
 	}
 	
 	m_selection.clearSelection();
-	FOREACH_NOTE_CST_IT_BEGIN_END(m_pPattern->get_notes(), it) {
+	FOREACH_NOTE_CST_IT_BEGIN_LENGTH(m_pPattern->get_notes(), it, m_pPattern) {
 		m_selection.addToSelection( it->second );
 	}
 	m_selection.updateWidgetGroup();
@@ -1415,7 +1415,7 @@ void DrumPatternEditor::undoRedoAction( int column,
 
 	if( pPattern != nullptr ) {
 		const Pattern::notes_t* notes = pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BOUND(notes,it,column) {
+		FOREACH_NOTE_CST_IT_BOUND_END(notes,it,column) {
 			Note *pNote = it->second;
 			assert( pNote );
 			assert( (int)pNote->get_position() == column );
@@ -1537,7 +1537,7 @@ void DrumPatternEditor::functionPasteNotesUndoAction(std::list<H2Core::Pattern*>
 
 				// Check if note is not present
 				Pattern::notes_t* notes = (Pattern::notes_t *)pat->get_notes();
-				FOREACH_NOTE_IT_BOUND(notes, it, pNote->get_position())
+				FOREACH_NOTE_IT_BOUND_END(notes, it, pNote->get_position())
 				{
 					Note *pFoundNote = it->second;
 					if (pFoundNote->get_instrument() == pNote->get_instrument())
@@ -1598,7 +1598,7 @@ void DrumPatternEditor::functionPasteNotesRedoAction(std::list<H2Core::Pattern*>
 				// Check if note is not present
 				bool noteExists = false;
 				const Pattern::notes_t* notes = pat->get_notes();
-				FOREACH_NOTE_CST_IT_BOUND(notes, it, pNote->get_position())
+				FOREACH_NOTE_CST_IT_BOUND_END(notes, it, pNote->get_position())
 				{
 					Note *pFoundNote = it->second;
 					if (pFoundNote->get_instrument() == pNote->get_instrument())
@@ -1654,7 +1654,7 @@ void DrumPatternEditor::functionFillNotesUndoAction( QStringList noteList, int n
 	for (int i = 0; i < noteList.size(); i++ ) {
 		int nColumn  = noteList.value(i).toInt();
 		Pattern::notes_t* notes = (Pattern::notes_t*)pPattern->get_notes();
-		FOREACH_NOTE_IT_BOUND(notes,it,nColumn) {
+		FOREACH_NOTE_IT_BOUND_END(notes,it,nColumn) {
 			Note *pNote = it->second;
 			assert( pNote );
 			if ( pNote->get_instrument() == pSelectedInstrument ) {
@@ -1731,7 +1731,7 @@ void DrumPatternEditor::functionRandomVelocityAction( QStringList noteVeloValue,
 	int positionCount = 0;
 	for (int i = 0; i < pPattern->get_length(); i += nResolution) {
 		const Pattern::notes_t* notes = pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {
+		FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes,it,i, pPattern) {
 			Note *pNote = it->second;
 			if ( pNote->get_instrument() ==  pSelectedInstrument) {
 				float velocity = noteVeloValue.value( positionCount ).toFloat();

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -140,7 +140,7 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 			notes.push_back( pNote );
 		}
 	} else {
-		FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, nColumn ) {
+		FOREACH_NOTE_CST_IT_BOUND_LENGTH( m_pPattern->get_notes(), it, nColumn, m_pPattern ) {
 			notes.push_back( it->second );
 		}
 	}
@@ -349,7 +349,7 @@ void NotePropertiesRuler::mouseMoveEvent( QMouseEvent *ev )
 	if ( ev->buttons() == Qt::NoButton ) {
 		int nColumn = getColumn( ev->x() );
 		bool bFound = false;
-		FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, nColumn ) {
+		FOREACH_NOTE_CST_IT_BOUND_LENGTH( m_pPattern->get_notes(), it, nColumn, m_pPattern ) {
 			bFound = true;
 			break;
 		}
@@ -401,7 +401,8 @@ void NotePropertiesRuler::prepareUndoAction( int x )
 	} else {
 		// No notes are selected. The target notes to adjust are all those at column given by 'x', so we preserve these.
 		int nColumn = getColumn( x );
-		FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, nColumn ) {
+		FOREACH_NOTE_CST_IT_BOUND_LENGTH( m_pPattern->get_notes(), it,
+										  nColumn, m_pPattern ) {
 			Note *pNote = it->second;
 			if ( pNote->get_instrument() == pSelectedInstrument ) {
 				m_oldNotes[ pNote ] = new Note( pNote );
@@ -452,7 +453,7 @@ void NotePropertiesRuler::propertyDragUpdate( QMouseEvent *ev )
 
 	bool bValueSet = false;
 
-	FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, nColumn ) {
+	FOREACH_NOTE_CST_IT_BOUND_LENGTH( m_pPattern->get_notes(), it, nColumn, m_pPattern ) {
 		Note *pNote = it->second;
 
 		if ( pNote->get_instrument() != pSelectedInstrument &&
@@ -722,7 +723,7 @@ void NotePropertiesRuler::keyPressEvent( QKeyEvent *ev )
 					notes.push_back( pNote );
 				}
 			} else {
-				FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, column ) {
+				FOREACH_NOTE_CST_IT_BOUND_LENGTH( m_pPattern->get_notes(), it, column, m_pPattern ) {
 					Note *pNote = it->second;
 					assert( pNote );
 					assert( pNote->get_position() == column );
@@ -1082,12 +1083,12 @@ void NotePropertiesRuler::createNormalizedBackground(QPixmap *pixmap)
 		selectedPen.setWidth( 2 );
 
 		const Pattern::notes_t* notes = m_pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
+		FOREACH_NOTE_CST_IT_BEGIN_LENGTH(notes,it, m_pPattern) {
 			Note *pposNote = it->second;
 			assert( pposNote );
 			uint pos = pposNote->get_position();
 			int xoffset = 0;
-			FOREACH_NOTE_CST_IT_BOUND(notes,coit,pos) {
+			FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes,coit,pos, m_pPattern) {
 				Note *pNote = coit->second;
 				assert( pNote );
 				if ( pNote->get_instrument() != pSelectedInstrument
@@ -1177,12 +1178,12 @@ void NotePropertiesRuler::createCenteredBackground(QPixmap *pixmap)
 		selectedPen.setWidth( 2 );
 
 		const Pattern::notes_t* notes = m_pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
+		FOREACH_NOTE_CST_IT_BEGIN_LENGTH(notes,it, m_pPattern) {
 			Note *pposNote = it->second;
 			assert( pposNote );
 			uint pos = pposNote->get_position();
 			int xoffset = 0;
-			FOREACH_NOTE_CST_IT_BOUND(notes,coit,pos) {
+			FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes,coit,pos, m_pPattern) {
 				Note *pNote = coit->second;
 				assert( pNote );
 				if ( pNote->get_note_off() || (pNote->get_instrument()
@@ -1331,7 +1332,7 @@ void NotePropertiesRuler::createNoteKeyBackground(QPixmap *pixmap)
 		selectedPen.setWidth( 2 );
 
 		const Pattern::notes_t* notes = m_pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
+		FOREACH_NOTE_CST_IT_BEGIN_LENGTH(notes,it, m_pPattern) {
 			Note *pNote = it->second;
 			assert( pNote );
 			if ( pNote->get_instrument() != pSelectedInstrument
@@ -1474,7 +1475,7 @@ std::vector<NotePropertiesRuler::SelectionIndex> NotePropertiesRuler::elementsIn
 	}
 	r += QMargins( 4, 4, 4, 4 );
 
-	FOREACH_NOTE_CST_IT_BEGIN_END(notes,it) {
+	FOREACH_NOTE_CST_IT_BEGIN_LENGTH(notes,it, m_pPattern) {
 		if ( it->second->get_instrument() != pSelectedInstrument
 			 && !m_selection.isSelected( it->second ) ) {
 			continue;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -401,7 +401,7 @@ void PatternEditor::selectInstrumentNotes( int nInstrument )
 	auto pInstrument = pInstrumentList->get( nInstrument );
 
 	m_selection.clearSelection();
-	FOREACH_NOTE_CST_IT_BEGIN_END(m_pPattern->get_notes(), it) {
+	FOREACH_NOTE_CST_IT_BEGIN_LENGTH(m_pPattern->get_notes(), it, m_pPattern) {
 		if ( it->second->get_instrument() == pInstrument ) {
 			m_selection.addToSelection( it->second );
 		}
@@ -488,7 +488,7 @@ bool PatternEditor::checkDeselectElements( std::vector<SelectionIndex> &elements
 			// Already marked pNote as a duplicate of some other pNote. Skip it.
 			continue;
 		}
-		FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, pNote->get_position() ) {
+		FOREACH_NOTE_CST_IT_BOUND_END( m_pPattern->get_notes(), it, pNote->get_position() ) {
 			// Duplicate note of a selected note is anything occupying the same position. Multiple notes
 			// sharing the same location might be selected; we count these as duplicates too. They will appear
 			// in both the duplicates and selection lists.
@@ -583,7 +583,7 @@ void PatternEditor::undoDeselectAndOverwriteNotes( std::vector< H2Core::Note *> 
 	}
 	// Select the previously-selected notes
 	for ( auto pNote : selected ) {
-		FOREACH_NOTE_CST_IT_BOUND( m_pPattern->get_notes(), it, pNote->get_position() ) {
+		FOREACH_NOTE_CST_IT_BOUND_END( m_pPattern->get_notes(), it, pNote->get_position() ) {
 			if ( notesMatchExactly( it->second, pNote ) ) {
 				m_selection.addToSelection( it->second );
 				break;

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -585,7 +585,7 @@ void InstrumentLine::functionFillNotes( int every )
 		for (int i = 0; i < nPatternSize; i += nResolution) {
 			bool noteAlreadyPresent = false;
 			const Pattern::notes_t* notes = pCurrentPattern->get_notes();
-			FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {
+			FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes,it,i,pCurrentPattern) {
 				Note *pNote = it->second;
 				if ( pNote->get_instrument() == pSelectedInstrument ) {
 					// note already exists
@@ -645,7 +645,7 @@ void InstrumentLine::functionRandomizeVelocity()
 
 		for (int i = 0; i < nPatternSize; i += nResolution) {
 			const Pattern::notes_t* notes = pCurrentPattern->get_notes();
-			FOREACH_NOTE_CST_IT_BOUND(notes,it,i) {
+			FOREACH_NOTE_CST_IT_BOUND_LENGTH(notes,it,i,pCurrentPattern) {
 				Note *pNote = it->second;
 				if ( pNote->get_instrument() == pSelectedInstrument ) {
 					float fVal = ( rand() % 100 ) / 100.0;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1034,53 +1034,15 @@ void PatternEditorPanel::patternSizeChanged( double fValue ){
 		return;
 	}
 
-	std::vector<Note*> excessiveNotes;
-	Pattern::notes_t* pNotes = (Pattern::notes_t *)m_pPattern->get_notes();
-	FOREACH_NOTE_IT_BEGIN_END( pNotes, it ) {
-		Note* pNote = it->second;
-		if ( pNote != nullptr &&
-			 pNote->get_position() >= nNewLength ) {
-			excessiveNotes.push_back( pNote );
-		}
-	}
-
-	// Delete all notes that are not accessible anymore.
 	QUndoStack* pUndoStack = HydrogenApp::get_instance()->m_pUndoStack;
-	if ( excessiveNotes.size() != 0 ) {
-		pUndoStack->beginMacro( QString( "Change pattern size to %1/%2 (trimming %3 notes)" )
-								.arg( fNewNumerator ).arg( fNewDenominator )
-								.arg( excessiveNotes.size() ) );
-	} else {
-		pUndoStack->beginMacro( QString( "Change pattern size to %1/%2" )
-								.arg( fNewNumerator ).arg( fNewDenominator ) );
-	}
+	pUndoStack->beginMacro( QString( "Change pattern size to %1/%2" )
+							.arg( fNewNumerator ).arg( fNewDenominator ) );
 
 	pUndoStack->push( new SE_patternSizeChangedAction( nNewLength,
 													   m_pPattern->get_length(),
 													   fNewDenominator,
 													   m_pPattern->get_denominator(),
 													   m_nSelectedPatternNumber ) );
-
-	for ( auto pNote : excessiveNotes ) {
-		// Note is exceeding the new pattern length. It has to be
-		// removed.
-		pUndoStack->push( new SE_addOrDeleteNoteAction( pNote->get_position(),
-														pInstrumentList->index( pNote->get_instrument() ),
-														m_nSelectedPatternNumber,
-														pNote->get_length(),
-														pNote->get_velocity(),
-														pNote->getPan(),
-														pNote->get_lead_lag(),
-														pNote->get_key(),
-														pNote->get_octave(),
-														pNote->get_probability(),
-														true,
-														false,
-														false,
-														false,
-														pNote->get_note_off() ) );
-	}
-	
 	pUndoStack->endMacro();
 }
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -361,7 +361,7 @@ void PianoRollEditor::drawPattern()
 	for ( Pattern *pPattern : getPatternsToShow() ) {
 		bool bIsForeground = ( pPattern == m_pPattern );
 		const Pattern::notes_t* notes = pPattern->get_notes();
-		FOREACH_NOTE_CST_IT_BEGIN_END( notes, it ) {
+		FOREACH_NOTE_CST_IT_BEGIN_LENGTH( notes, it, pPattern ) {
 			Note *note = it->second;
 			assert( note );
 			drawNote( note, &p, bIsForeground );
@@ -739,7 +739,7 @@ void PianoRollEditor::moveNoteAction( int nColumn,
 
 	Pattern *pPattern = pPatternList->get( nPattern );
 
-	FOREACH_NOTE_IT_BOUND((Pattern::notes_t *)pPattern->get_notes(), it, nColumn) {
+	FOREACH_NOTE_IT_BOUND_END((Pattern::notes_t *)pPattern->get_notes(), it, nColumn) {
 		Note *pCandidateNote = it->second;
 		if ( pCandidateNote->get_instrument() == pNote->get_instrument()
 			 && pCandidateNote->get_octave() == octave

--- a/src/tests/TestHelper.h
+++ b/src/tests/TestHelper.h
@@ -97,7 +97,7 @@ inline QString TestHelper::getTestDataDir() const
 
 inline QString TestHelper::getTestFile(const QString& file) const
 {
-	return m_sTestDataDir + "/" + file; 
+	return m_sTestDataDir + file; 
 }
 
 #define H2TEST_FILE(name) TestHelper::get_instance()->getTestFile(name)

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -183,7 +183,7 @@ void XmlTest::testDrumkit_UpgradeInvalidADSRValues()
 	std::shared_ptr<H2Core::Drumkit> pDrumkit = nullptr;
 
 	//1. Check, if the drumkit has been loaded
-	pDrumkit = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/invAdsrKit") );
+	pDrumkit = H2Core::Drumkit::load( H2TEST_FILE( "drumkits/invAdsrKit") );
 	CPPUNIT_ASSERT( pDrumkit != nullptr );
 	
 	//2. Make sure that the instruments of the drumkit have been loaded correctly (see GH issue #839)
@@ -201,15 +201,17 @@ void XmlTest::testDrumkit_UpgradeInvalidADSRValues()
 	
 	CPPUNIT_ASSERT( pSample->get_filename() == QString("snare.wav"));
 	
-	//3. Make sure that the original (invalid) file has been saved as
-	//a backup
-	QStringList backupFiles = pTestHelper->findDrumkitBackupFiles( "drumkits/invAdsrKit" );
-	CPPUNIT_ASSERT( backupFiles.size() == 1 );
-	CPPUNIT_ASSERT( H2Core::Filesystem::file_exists( backupFiles[ 0 ] ) );
+	// 3. Make sure that the original (invalid) file has been saved as
+	// a backup.
+	if ( H2Core::Filesystem::dir_writable( H2TEST_FILE( "drumkits/invAdsrKit" ), true ) ) {
+		QStringList backupFiles = pTestHelper->findDrumkitBackupFiles( "drumkits/invAdsrKit" );
+		CPPUNIT_ASSERT( backupFiles.size() == 1 );
+		CPPUNIT_ASSERT( H2Core::Filesystem::file_exists( backupFiles[ 0 ] ) );
+	}
 
 	//4. Load the drumkit again to assure updated file is valid
-	pDrumkit = H2Core::Drumkit::load( H2TEST_FILE( "/drumkits/invAdsrKit") );
-	backupFiles = pTestHelper->findDrumkitBackupFiles( "drumkits/invAdsrKit" );
+	pDrumkit = H2Core::Drumkit::load( H2TEST_FILE( "drumkits/invAdsrKit") );
+	QStringList backupFiles = pTestHelper->findDrumkitBackupFiles( "drumkits/invAdsrKit" );
 	CPPUNIT_ASSERT( pDrumkit != nullptr );
 	CPPUNIT_ASSERT( backupFiles.size() == 1 );
 	


### PR DESCRIPTION
Instead of discarding superfluous notes when shrinking a pattern - as introduced in #1562 - this approach tries to fix #1542 by introducing a second set of iteration macros for notes that take the length of the pattern into account.

This keeps it quite clean in the core and moves complexity of handling those notes into the GUI (in this particular case I think it is the place it belongs).

Use of the macros in the GUI is as follows:
- instrument list > right click > Delete notes -> affects all notes
- instrument list > right click > Edit all pattern -> delete/cut notes -> affects all notes
- instrument list > right click > Fill notes -> fills till length / not end
- instrument list > right click > Randomize velocity -> affects notes till length / not end
- PE > select all > affects notes till length / not end
- mouse & keyboard actions affect notes till length / not end
- pasting / moving is possible till the end
- undo of all of those actions above is allowed till the end of the pattern

The reason so switch from deleting to hiding superfluous notes is because there are already reports of people (developers) being annoyed by loosing notes while editing. Also, the removal of the notes only happened when altering the size of a pattern. In case of older songs with hidden notes #1542 would still occur. The tweaked iterators, however, also work for older songs.