### PR TITLE
SoundLibrary and log coverage tweaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -114,6 +114,11 @@
 		  different states: on, off, off next (pattern is played till the
 		  end and then turned off), and on next (pattern is played as soon
 		  as transport is looped again)
+		- In song mode the pattern editor can be locked meaning that
+		  always the bottom-most pattern of the current column the
+		  playhead resides in as well as all other playing notes are
+		  shown. Pattern selection is done automatically when moving into
+		  a different column.
 	* PatternEditor UX tweaks:
 		- Relocating transport by clicking the ruler is now supported
 		  (like in the SongEditor) and automatically switches transport
@@ -128,8 +133,9 @@
 		  both the drum pattern editor and the piano roll editor by
 		  right-clicking and dragging a note.
 		- All notes of the currently playing patterns will be hinted in
-		  stacked pattern mode. Even those exceeding the length of the
-		  current pattern.
+		  stacked pattern mode, when selecting a virtual pattern, or in
+		  case the pattern editor is locked in song mode. Even those notes
+		  exceeding the length of the current pattern are shown.
 	* OSC API
 		- Add command /Hydrogen/LOAD_DRUMKIT
 		- Add command /Hydrogen/UPGRADE_DRUMKIT

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -211,16 +211,6 @@ void Drumkit::load_samples()
 
 License Drumkit::loadLicenseFrom( const QString& sDrumkitDir, bool bSilent )
 {
-	// Try to retrieve the license from cache first.
-	auto pHydrogen = Hydrogen::get_instance();
-	if ( pHydrogen != nullptr ) {
-		auto pDrumkit =
-			pHydrogen->getSoundLibraryDatabase()->getDrumkit( sDrumkitDir );
-		if ( pDrumkit != nullptr ) {
-			return pDrumkit->get_license();
-		}
-	}
-
 	XMLDoc doc;
 	if ( Drumkit::loadDoc( sDrumkitDir, &doc, bSilent ) ) {
 		XMLNode root = doc.firstChildElement( "drumkit_info" );
@@ -239,29 +229,6 @@ License Drumkit::loadLicenseFrom( const QString& sDrumkitDir, bool bSilent )
 	}
 
 	return std::move( License() );
-}
-
-QString Drumkit::loadNameFrom( const QString& sDrumkitDir, bool bSilent ) {
-
-	// Try to retrieve the name from cache first.
-	auto pHydrogen = Hydrogen::get_instance();
-	if ( pHydrogen != nullptr ) {
-		auto pDrumkit =
-			pHydrogen->getSoundLibraryDatabase()->getDrumkit( sDrumkitDir );
-		if ( pDrumkit != nullptr ) {
-			return pDrumkit->get_name();
-		}
-	}
-
-	// No entry in cache found. Loading it from disk
-	XMLDoc doc;
-	if ( Drumkit::loadDoc( sDrumkitDir, &doc, bSilent ) ) {
-		XMLNode root = doc.firstChildElement( "drumkit_info" );
-
-		return( root.read_string( "name", "", true, true, bSilent ) );
-	}
-
-	return "";
 }
 
 bool Drumkit::loadDoc( const QString& sDrumkitDir, XMLDoc* pDoc, bool bSilent ) {

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -126,12 +126,6 @@ std::shared_ptr<Drumkit> Drumkit::load( const QString& sDrumkitPath, bool bUpgra
 	if ( ! bReadingSuccessful && bUpgrade ) {
 		upgrade_drumkit( pDrumkit, sDrumkitFile );
 	}
-
-	if ( ! bSilent ) {
-		INFOLOG( QString( "[%1] loaded from [%2]" )
-				 .arg( pDrumkit->get_name() )
-				 .arg( sDrumkitPath ) );
-	}
 	
 	return pDrumkit;
 }
@@ -149,7 +143,7 @@ std::shared_ptr<Drumkit> Drumkit::load_from( XMLNode* node, const QString& sDrum
 	pDrumkit->__path = sDrumkitPath;
 	pDrumkit->__name = sDrumkitName;
 	pDrumkit->__author = node->read_string( "author", "undefined author",
-											true, true, bSilent );
+											true, true, true );
 	pDrumkit->__info = node->read_string( "info", "No information available.",
 										  true, true, bSilent  );
 

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -85,18 +85,6 @@ class Drumkit : public H2Core::Object<Drumkit>
 	 * \param sDrumkitDir Directory containing a drumkit.xml file.
 	 */
 	static License loadLicenseFrom( const QString& sDrumkitDir, bool bSilent = false );
-
-	/**
-	 * Retrieve the name of a drumkit stored in @a sDrumkitDir.
-	 *
-	 * As the name of the drumkit can be set to arbitrary values, it
-	 * can not be assumed to be unique and does not qualify as unique
-	 * identifier of the kit. Instead, the location the drumkit is
-	 * loaded from/written to is used and this function maps it to the
-	 * corresponding drumkit name.
-	 */
-	static QString loadNameFrom( const QString& sDrumkitDir,
-								 bool bSilent = false );
 	
 	/**
 	 * Returns a version of #__name stripped of all whitespaces and

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -492,7 +492,8 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 		auto pCompo = Legacy::loadInstrumentComponent( pNode, pInstrument->get_drumkit_path(),
 													   instrumentLicense, bSilent );
 		if ( pCompo == nullptr ) {
-			ERRORLOG( "Unable to load component. Aborting." );
+			ERRORLOG( QString( "Unable to load component for instrument [%1]. Aborting." )
+					  .arg( pInstrument->get_name() ) );
 			return nullptr;
 		}
 

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -458,19 +458,20 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 		// directly.
 		auto pSoundLibraryDatabase = Hydrogen::get_instance()->getSoundLibraryDatabase();
 		if ( pSoundLibraryDatabase != nullptr ) {
-			auto pDrumkit = pSoundLibraryDatabase->getDrumkit( pInstrument->get_drumkit_path() );
-			if ( pDrumkit != nullptr ) {
+
+			// It is important to _not_ load the drumkit into the
+			// database as this code is part of the drumkit load
+			// itself. In case two drumkits contain an instrument from
+			// each other an infinite loop would be created.
+			auto pDrumkit = pSoundLibraryDatabase->getDrumkit(
+				pInstrument->get_drumkit_path(), false );
+			if ( pDrumkit == nullptr ) {
+				// Drumkit is not present in the database yet. Load
+				// its license from disk.
+				instrumentLicense = Drumkit::loadLicenseFrom( pInstrument->get_drumkit_path() );
+			} else {
 				instrumentLicense = pDrumkit->get_license();
 			}
-		}
-
-		if ( instrumentLicense == License() ) {
-			if ( ! bSilent ) {
-				WARNINGLOG( QString( "No license could be retrieved from drumkit [%1] in database. Loading directly." )
-							.arg( pInstrument->get_drumkit_path() ) );
-			}
-			
-			instrumentLicense = Drumkit::loadLicenseFrom( pInstrument->get_drumkit_path() );
 		}
 	} else {
 		instrumentLicense = license;

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -499,7 +499,7 @@ void Note::save_to( XMLNode* node )
 Note* Note::load_from( XMLNode* node, std::shared_ptr<InstrumentList> instruments, bool bSilent )
 {
 	bool bFound, bFound2;
-	float fPan = node->read_float( "pan", 0.f, &bFound, true, false, bSilent );
+	float fPan = node->read_float( "pan", 0.f, &bFound, true, false, true );
 	if ( !bFound ) {
 		// check if pan is expressed in the old fashion (version <=
 		// 1.1 ) with the pair (pan_L, pan_R)
@@ -507,6 +507,8 @@ Note* Note::load_from( XMLNode* node, std::shared_ptr<InstrumentList> instrument
 		float fPanR = node->read_float( "pan_R", 1.f, &bFound2, false, false, bSilent );
 		if ( bFound && bFound2 ) {
 			fPan = Sampler::getRatioPan( fPanL, fPanR );  // convert to single pan parameter
+		} else {
+			WARNINGLOG( QString( "Neither `pan` nor `pan_L` and `pan_R` were found. Falling back to `pan = 0`" ) );
 		}
 	}
 

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -160,7 +160,7 @@ bool Pattern::save_file( const QString& drumkit_name, const QString& author, con
 	XMLNode root = doc.set_root( "drumkit_pattern", "drumkit_pattern" );
 	root.write_string( "drumkit_name", drumkit_name );
 	root.write_string( "author", author );							// FIXME this is never loaded back
-	root.write_string( "license", license.toQString() );
+	root.write_string( "license", license.getLicenseString() );
 	// FIXME this is never loaded back
 	save_to( &root );
 	return doc.write( pattern_path );

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -123,7 +123,7 @@ Pattern* Pattern::load_from( XMLNode* node, std::shared_ptr<InstrumentList> pIns
 	Pattern* pPattern = new Pattern(
 	    node->read_string( "name", nullptr, false, false ),
 	    node->read_string( "info", "", false, true ),
-	    node->read_string( "category", "unknown", false, false ),
+	    node->read_string( "category", "unknown", false, true, true ),
 	    node->read_int( "size", -1, false, false ),
 	    node->read_int( "denominator", 4, false, false )
 	);

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -189,28 +189,6 @@ void Pattern::save_to( XMLNode* node, const std::shared_ptr<Instrument> pInstrum
 	}
 }
 
-QString Pattern::loadDrumkitNameFrom( const QString& sPatternPath ) {
-
-	XMLDoc doc;
-	// We don't check the return value in here since even if the
-	// validation against the pattern XSD schema fails the document
-	// will still be read and the drumkit name might still be
-	// contained.
-	loadDoc( sPatternPath, nullptr, &doc, false );
-
-	XMLNode rootNode = doc.firstChildElement( "drumkit_pattern" );
-	if ( ! rootNode.isNull() ) {
-
-		QString sDrumkitName = rootNode.read_string( "drumkit_name", "", false, false );
-		if ( sDrumkitName.isEmpty() ) {
-			sDrumkitName = rootNode.read_string( "pattern_for_drumkit", "" );
-		}
-
-		return sDrumkitName;
-	}
-	return QString();
-}
-
 Note* Pattern::find_note( int idx_a, int idx_b, std::shared_ptr<Instrument> instrument, Note::Key key, Note::Octave octave, bool strict ) const
 {
 	for( notes_cst_it_t it=__notes.lower_bound( idx_a ); it!=__notes.upper_bound( idx_a ); it++ ) {

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -104,12 +104,6 @@ class Pattern : public H2Core::Object<Pattern>
 		 */
 		bool save_file( const QString& drumkit_name, const QString& author, const License& license, const QString& pattern_path, bool overwrite=false ) const;
 
-	/**
-	 * Retrieves the name of the associated drumkit contained in the
-	 * pattern XML file residing at @a sPatternPath.
-	 */
-	static QString loadDrumkitNameFrom( const QString& sPatternPath );
-
 		///< set the name of the pattern
 		void set_name( const QString& name );
 		///< get the name of the pattern

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -438,12 +438,22 @@ std::shared_ptr<Song> Song::loadFrom( XMLNode* pRootNode, const QString& sFilena
 		sLastLoadedDrumkitPath = sMostCommonDrumkit;
 	}
 	pSong->setLastLoadedDrumkitPath( sLastLoadedDrumkitPath );
-	
+
 	if ( sLastLoadedDrumkitName.isEmpty() ) {
-		// Use the getter in here to support relative paths as well.
-		sLastLoadedDrumkitName =
-			Drumkit::loadNameFrom( pSong->getLastLoadedDrumkitPath(),
-								   bSilent );
+		// The initial song is loaded after Hydrogen was
+		// bootstrap. So, the SoundLibrary should be present and
+		// filled with all available drumkits.
+		auto pSoundLibraryDatabase = Hydrogen::get_instance()->getSoundLibraryDatabase();
+		if ( pSoundLibraryDatabase != nullptr ) {
+
+			// If it is not already present, we also load the last
+			// loaded drumkit into the database.
+			auto pDrumkit = pSoundLibraryDatabase->getDrumkit(
+				sLastLoadedDrumkitPath, true );
+			if ( pDrumkit != nullptr ) {
+				sLastLoadedDrumkitName = pDrumkit->get_name();
+			}
+		}
 	}
 	pSong->setLastLoadedDrumkitName( sLastLoadedDrumkitName );
 

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -299,12 +299,12 @@ std::shared_ptr<Song> Song::loadFrom( XMLNode* pRootNode, const QString& sFilena
 							 static_cast<int>( Song::ActionMode::selectMode ),
 							 false, false, bSilent ) ) );
 	pSong->setIsPatternEditorLocked( pRootNode->read_bool( "isPatternEditorLocked",
-														   false, false, false, bSilent ) );
+														   false, true, false, true ) );
 
 	bool bContainsIsTimelineActivated;
 	bool bIsTimelineActivated =
 		pRootNode->read_bool( "isTimelineActivated", false,
-							  &bContainsIsTimelineActivated, false, false, bSilent );
+							  &bContainsIsTimelineActivated, true, false, true );
 	if ( ! bContainsIsTimelineActivated ) {
 		// .h2song file was created in an older version of
 		// Hydrogen. Using the Timeline state in the

--- a/src/core/Helpers/Files.cpp
+++ b/src/core/Helpers/Files.cpp
@@ -52,7 +52,7 @@ namespace H2Core
 				break;
 		}
 
-		if ( mode == SAVE_NEW && Filesystem::file_exists( fileInfo.absoluteFilePath(), false ) ) {
+		if ( mode == SAVE_NEW && Filesystem::file_exists( fileInfo.absoluteFilePath(), true ) ) {
 			return nullptr;
 		}
 

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -25,6 +25,7 @@
 #include <core/EventQueue.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Hydrogen.h>
+#include <core/SoundLibrary/SoundLibraryDatabase.h>
 
 #include <QtCore/QDir>
 #include <QtCore/QFile>
@@ -758,7 +759,15 @@ QString Filesystem::drumkit_path_search( const QString& dk_name, Lookup lookup, 
 		// drumkit (using its name).
 		QString sDrumkitXMLPath = QString( "%1/%2" )
 				.arg( sDrumkitPath ).arg( "drumkit.xml" );
-		QString sSessionDrumkitName = Drumkit::loadNameFrom( sDrumkitPath );
+
+		QString sSessionDrumkitName( "seemsLikeTheKitCouldNotBeRetrievedFromTheDatabase" );
+		auto pSoundLibraryDatabase = Hydrogen::get_instance()->getSoundLibraryDatabase();
+		if ( pSoundLibraryDatabase != nullptr ) {
+			auto pDrumkit = pSoundLibraryDatabase->getDrumkit( sDrumkitPath );
+			if ( pDrumkit != nullptr ) {
+				sSessionDrumkitName = pDrumkit->get_name();
+			}
+		}
 
 		if ( dk_name == sSessionDrumkitName ) {
 				// The local drumkit seems legit.	

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -252,7 +252,15 @@ void NsmClient::linkDrumkit( std::shared_ptr<H2Core::Song> pSong ) {
 		}
 	    
 		if ( H2Core::Filesystem::drumkit_valid( sLinkedDrumkitPath ) ) {
-			const QString sLinkedDrumkitName = H2Core::Drumkit::loadNameFrom( sLinkedDrumkitPath );
+
+			QString sLinkedDrumkitName( "seemsLikeTheKitCouldNotBeRetrievedFromTheDatabase" );
+			auto pSoundLibraryDatabase = pHydrogen->getSoundLibraryDatabase();
+			if ( pSoundLibraryDatabase != nullptr ) {
+				auto pDrumkit = pSoundLibraryDatabase->getDrumkit( sLinkedDrumkitPath );
+				if ( pDrumkit != nullptr ) {
+					sLinkedDrumkitName = pDrumkit->get_name();
+				}
+			}
 	
 			if ( sLinkedDrumkitName == sDrumkitName ) {
 				bRelinkDrumkit = false;

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -99,6 +99,11 @@ void SoundLibraryDatabase::updateDrumkits( bool bTriggerEvent ) {
 						  .arg( sDrumkitPath ) );
 				continue;
 			}
+			else {
+				INFOLOG( QString( "Drumkit [%1] loaded from [%2]" )
+						 .arg( pDrumkit->get_name() )
+						 .arg( sDrumkitPath ) );
+			}
 
 			m_drumkitDatabase[ sDrumkitPath ] = pDrumkit;
 		}

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -132,7 +132,7 @@ void SoundLibraryDatabase::updateDrumkit( const QString& sDrumkitPath, bool bTri
 	}
 }
 
-std::shared_ptr<Drumkit> SoundLibraryDatabase::getDrumkit( const QString& sDrumkit ) {
+std::shared_ptr<Drumkit> SoundLibraryDatabase::getDrumkit( const QString& sDrumkit, bool bLoad ) {
 
 	// Convert supplied path or drumkit name into absolute path used
 	// either as ID to retrieve the drumkit from cache or for loading
@@ -159,6 +159,9 @@ std::shared_ptr<Drumkit> SoundLibraryDatabase::getDrumkit( const QString& sDrumk
 
 	if ( m_drumkitDatabase.find( sDrumkitPath ) ==
 		 m_drumkitDatabase.end() ) {
+		if ( ! bLoad ) {
+			return nullptr;
+		}
 
 		// Drumkit is not present in database yet. We attempt to load
 		// and add it.

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -197,12 +197,19 @@ void SoundLibraryDatabase::loadPatternFromDirectory( const QString& sPatternDir 
 {
 	foreach ( const QString& sName, Filesystem::pattern_list( sPatternDir ) ) {
 		QString sFile = sPatternDir + sName;
-		std::shared_ptr<SoundLibraryInfo> pSoundLibraryInfo =
-			std::make_shared<SoundLibraryInfo>( sFile );
-		m_patternInfoVector.push_back( pSoundLibraryInfo );
+		std::shared_ptr<SoundLibraryInfo> pInfo =
+			std::make_shared<SoundLibraryInfo>();
+
+		if ( pInfo->load( sFile ) ) {
+			INFOLOG( QString( "Pattern [%1] of category [%2] loaded from [%3]" )
+					 .arg( pInfo->getName() ).arg( pInfo->getCategory() )
+					 .arg( sFile ) );
+			
+			m_patternInfoVector.push_back( pInfo );
 		
-		if ( ! m_patternCategories.contains( pSoundLibraryInfo->getCategory() ) ) {
-			m_patternCategories << pSoundLibraryInfo->getCategory();
+			if ( ! m_patternCategories.contains( pInfo->getCategory() ) ) {
+				m_patternCategories << pInfo->getCategory();
+			}
 		}
 	}
 }

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -62,7 +62,15 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 
 	void updateDrumkits( bool bTriggerEvent = true );
 	void updateDrumkit( const QString& sDrumkitPath, bool bTriggerEvent = true );
-	std::shared_ptr<Drumkit> getDrumkit( const QString& sDrumkitPath );
+	/**
+	 * Retrieve a drumkit from the database.
+	 *
+	 * @param sDrumkitPath Absolute path to the drumkit as unique
+	 * identifier
+	 * @param bLoad Whether the drumkit should be loaded into the
+	 * datebase in case it is not present yet.
+	 */
+	std::shared_ptr<Drumkit> getDrumkit( const QString& sDrumkitPath, bool bLoad = true );
 	const std::map<QString,std::shared_ptr<Drumkit>> getDrumkitDatabase() const {
 		return m_drumkitDatabase;
 	}

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -27,6 +27,7 @@
 #include <core/SoundLibrary/SoundLibraryInfo.h>
 #include <core/Object.h>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace H2Core
@@ -42,8 +43,6 @@ namespace H2Core
 *
 */
 
-typedef std::vector<SoundLibraryInfo*> soundLibraryInfoVector;
-
 /** \ingroup docGUI*/
 class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 {
@@ -52,10 +51,10 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 	SoundLibraryDatabase();
 	~SoundLibraryDatabase();
 
-	soundLibraryInfoVector* getAllPatternInfos() const {
+	std::vector<std::shared_ptr<SoundLibraryInfo>> getPatternInfoVector() const {
 		return m_patternInfoVector;
 	}
-	QStringList getAllPatternCategories() const {
+	QStringList getPatternCategories() const {
 		return m_patternCategories;
 	}
 
@@ -70,13 +69,13 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 	
 	void updatePatterns( bool bTriggerEvent = true );
 	void printPatterns() const;
-	void getPatternFromDirectory(const QString& path, soundLibraryInfoVector* );
-	bool isPatternInstalled( const QString& sPatternName) const;
+	void loadPatternFromDirectory( const QString& path );
+	bool isPatternInstalled( const QString& sPatternName ) const;
 
 private:
 	std::map<QString,std::shared_ptr<Drumkit>> m_drumkitDatabase;
 	
-	soundLibraryInfoVector* m_patternInfoVector;
+	std::vector<std::shared_ptr<SoundLibraryInfo>> m_patternInfoVector;
 	QStringList m_patternCategories;
 
 	/**

--- a/src/core/SoundLibrary/SoundLibraryInfo.cpp
+++ b/src/core/SoundLibrary/SoundLibraryInfo.cpp
@@ -33,21 +33,17 @@ SoundLibraryInfo::SoundLibraryInfo()
 	//default constructor
 }
 
-SoundLibraryInfo::SoundLibraryInfo( const QString& sPath )
-{
-	/*
-	 *Use the provided file instantiate this object with the corresponding meta
-	 *data from either a drumkit, a pattern or a song.
-	 */
-	
+bool SoundLibraryInfo::load( const QString& sPath ) {
 	setPath( sPath );
 
 	XMLDoc doc;
 	if ( ! doc.read( sPath, nullptr, true ) ) {
 		ERRORLOG( QString( "Unable to load SoundLibraryInfo from [%1]" )
 				  .arg( sPath ) );
-		return;
+		return false;
 	}
+
+	bool bLoadingWorked = false;
 
 	XMLNode rootNode =  doc.firstChildElement( "drumkit_pattern" );
 	if ( ! rootNode.isNull() )
@@ -58,13 +54,21 @@ SoundLibraryInfo::SoundLibraryInfo( const QString& sPath )
 
 		XMLNode patternNode = rootNode.firstChildElement( "pattern" );
 		// Try legacy format fist.
-		setName( patternNode.read_string( "pattern_name", "", false, false ) );
+		setName( patternNode.read_string( "pattern_name", "", true, true ) );
 		if ( getName().isEmpty() ) {
 			// Try current format.
 			setName( patternNode.read_string( "name", "", false, false ) );
 		}
-		setInfo( patternNode.read_string( "info", "No information available.", false, false ) );
-		setCategory( patternNode.read_string( "category", "", false, false ) );
+		setInfo( patternNode.read_string( "info", "No information available.", false, true, true ) );
+		setCategory( patternNode.read_string( "category", "", false, true ) );
+
+		QString sDrumkitName = rootNode.read_string( "drumkit_name", "", false, false );
+		if ( sDrumkitName.isEmpty() ) {
+			sDrumkitName = rootNode.read_string( "pattern_for_drumkit", "" );
+		}
+		setDrumkitName( sDrumkitName );
+		
+		bLoadingWorked = true;
 	}
 
 
@@ -79,8 +83,8 @@ SoundLibraryInfo::SoundLibraryInfo( const QString& sPath )
 		setInfo( rootNode.read_string( "info", "No information available.", false, false ) );
 		setImage( rootNode.read_string( "image", "", false, false ) );
 		setImageLicense( H2Core::License( rootNode.read_string( "imageLicense", "", false, false ) ) );
-
-		//setCategory( rootNode.read_string( "category", "" ) );
+		
+		bLoadingWorked = true;
 	}
 
 	//Songs
@@ -92,8 +96,17 @@ SoundLibraryInfo::SoundLibraryInfo( const QString& sPath )
 		setLicense( H2Core::License( rootNode.read_string( "license", "", false, false ) ) );
 		setName( rootNode.read_string( "name", "", false, false ) );
 		setInfo( rootNode.read_string( "info", "No information available.", false, false ) );
-		//setCategory( rootNode.read_string( "category", "" ) );
+
+		bLoadingWorked = true;
 	}
+
+	if ( ! bLoadingWorked ) {
+		ERRORLOG( QString( "[%1] could not be loaded as pattern, song, or drumkit" )
+				  .arg( sPath ) );
+		return false;
+	}
+
+	return true;
 }
 
 SoundLibraryInfo::~SoundLibraryInfo()

--- a/src/core/SoundLibrary/SoundLibraryInfo.h
+++ b/src/core/SoundLibrary/SoundLibraryInfo.h
@@ -48,8 +48,15 @@ class SoundLibraryInfo : public H2Core::Object<SoundLibraryInfo>
 	H2_OBJECT(SoundLibraryInfo)
 	public:
 		SoundLibraryInfo();
-		explicit SoundLibraryInfo( const QString& path);
 		~SoundLibraryInfo();
+
+	/**
+	 * Reads the content found in @a sPath.
+	 *
+	 * @param sPath Path to .h2pattern XML file
+	 * @return `true` on success
+	 */
+		bool load( const QString& sPath );
 
 		QString getName() const {
 			return m_sName;
@@ -130,6 +137,13 @@ class SoundLibraryInfo : public H2Core::Object<SoundLibraryInfo>
 		QString getPath(){
 			return m_sPath;
 		}
+	
+		void setDrumkitName( const QString& sDrumkitName ){
+			m_sDrumkitName = sDrumkitName;
+		}
+		QString getDrumkitName(){
+			return m_sDrumkitName;
+		}
 
 
 	private:
@@ -143,6 +157,9 @@ class SoundLibraryInfo : public H2Core::Object<SoundLibraryInfo>
 		QString m_sImage;
 		H2Core::License m_imageLicense;
 		QString m_sPath;
+
+	/** Drumkit the pattern was created with */
+	QString m_sDrumkitName;
 };
 }; // namespace H2Core
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -240,31 +240,28 @@ void SoundLibraryPanel::updateTree()
 			__pattern_item->setExpanded( __expand_pattern_list );
 			__pattern_item->setFont( 0, boldFont );
 		
-			soundLibraryInfoVector* allPatternDirList =
-				pSoundLibraryDatabase->getAllPatternInfos();
-			QStringList allCategoryNameList =
-				pSoundLibraryDatabase->getAllPatternCategories();
+			auto patternInfoVector = pSoundLibraryDatabase->getPatternInfoVector();
+			QStringList patternCategories =
+				pSoundLibraryDatabase->getPatternCategories();
 
 			//now sorting via category
 
-			for (uint i = 0; i < allCategoryNameList.size(); ++i) {
-				QString categoryName = allCategoryNameList[i];
+			for (uint i = 0; i < patternCategories.size(); ++i) {
+				QString categoryName = patternCategories[i];
 
 				QTreeWidgetItem* pCategoryItem = new QTreeWidgetItem( __pattern_item );
 				pCategoryItem->setText( 0, categoryName  );
 
-				soundLibraryInfoVector::iterator mapIterator;
-				for( mapIterator=allPatternDirList->begin(); mapIterator != allPatternDirList->end(); mapIterator++ )
-					{
-						QString patternCategory = (*mapIterator)->getCategory();
-						if ( (patternCategory == categoryName) || (patternCategory.isEmpty() && categoryName == "No category") ){
-							QTreeWidgetItem* pPatternItem = new QTreeWidgetItem( pCategoryItem );
-							pPatternItem->setText( 0, (*mapIterator)->getName());
-							pPatternItem->setText( 1, (*mapIterator)->getPath() );
-							pPatternItem->setToolTip( 0, Pattern::loadDrumkitNameFrom( (*mapIterator)->getPath() ));
-							INFOLOG( "Path" +  (*mapIterator)->getPath() );
-						}
+				for ( const auto& pInfo : patternInfoVector ) {
+					QString patternCategory = pInfo->getCategory();
+					if ( ( patternCategory == categoryName ) ||
+						 ( patternCategory.isEmpty() && categoryName == "No category" ) ){
+						QTreeWidgetItem* pPatternItem = new QTreeWidgetItem( pCategoryItem );
+						pPatternItem->setText( 0, pInfo->getName());
+						pPatternItem->setText( 1, pInfo->getPath() );
+						pPatternItem->setToolTip( 0, Pattern::loadDrumkitNameFrom( pInfo->getPath() ));
 					}
+				}
 			}
 		}
 	}

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -246,8 +246,11 @@ void SoundLibraryPanel::updateTree()
 
 			//now sorting via category
 
-			for (uint i = 0; i < patternCategories.size(); ++i) {
-				QString categoryName = patternCategories[i];
+			/*: Base tooltip displayed when hovering over a pattern in
+			  the Sound Library. It indicates which drumkit the
+			  pattern was created with*/
+			QString sPatternTooltip = tr( "Created for drumkit" );
+			for ( const auto& categoryName : patternCategories ) {
 
 				QTreeWidgetItem* pCategoryItem = new QTreeWidgetItem( __pattern_item );
 				pCategoryItem->setText( 0, categoryName  );
@@ -259,7 +262,9 @@ void SoundLibraryPanel::updateTree()
 						QTreeWidgetItem* pPatternItem = new QTreeWidgetItem( pCategoryItem );
 						pPatternItem->setText( 0, pInfo->getName());
 						pPatternItem->setText( 1, pInfo->getPath() );
-						pPatternItem->setToolTip( 0, Pattern::loadDrumkitNameFrom( pInfo->getPath() ));
+						pPatternItem->setToolTip( 0, QString( "%1 [%2]" )
+												  .arg( sPatternTooltip )
+												  .arg( pInfo->getDrumkitName() ) );
 					}
 				}
 			}


### PR DESCRIPTION
- Reviewing log verbosity when loading patterns, drumkits, and songs and removing some less important ones (which are likely to flood the log)
- fixing a small issue with storing the license string in a `.h2pattern`
- properly fail when loading invalid files from `.hydrogen/data/pattern`
-  previously, all `.h2pattern` files were loaded and a couple of their content was written into `SoundLibraryInfo` files. But not the name of the associated drumkit. Everytime `SoundLibraryPanel::updateTree()` was called all `.h2pattern` were opened _again_ to read just this property which is redundant and expensive. The drumkit name is now integrated in the `SoundLibraryInfo` class and loaded only once (and on `SoundLibraryDatabase` update)
- `SoundLibraryInfo` nodes representing patterns found on disk are now wrapped in shared pointers. In addition, some heritage code weirdness and naming fixed