### PR TITLE
Properly handle session drumkits in SoundLibraryPanel

### DIFF
--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -546,16 +546,6 @@ bool Drumkit::remove( const QString& sDrumkitDir )
 	Hydrogen::get_instance()->getSoundLibraryDatabase()->updateDrumkits();
 	return true;
 }
-
-bool Drumkit::isUserDrumkit() const {
-	if ( __path.contains( Filesystem::sys_drumkits_dir() ) ) {
-		return false;
-	} else if ( ! Filesystem::dir_writable( __path ) ) {
-		return false;
-	}
-	
-	return true;
-}
 	
 bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath, bool bSilent )
 {

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -216,12 +216,6 @@ class Drumkit : public H2Core::Object<Drumkit>
 		/** return true if the samples are loaded */
 		const bool samples_loaded() const;
 
-		/**
-		 * \return Whether the associated files are located in the
-		 * user or the systems drumkit folder.
-		 */
-		bool isUserDrumkit() const;
-
 	std::shared_ptr<std::vector<std::shared_ptr<DrumkitComponent>>> get_components();
 	void set_components( std::shared_ptr<std::vector<std::shared_ptr<DrumkitComponent>>> components );
 

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -1018,6 +1018,23 @@ QString Filesystem::ensure_session_compatibility( const QString& sPath ) {
 
 	return sPath;
 }
+
+Filesystem::DrumkitType Filesystem::determineDrumkitType( const QString& sPath ) {
+	if ( sPath.contains( Filesystem::sys_drumkits_dir() ) ) {
+		return DrumkitType::System;
+	}
+	else if ( sPath.contains( Filesystem::usr_drumkits_dir() ) ) {
+		return DrumkitType::User;
+	}
+	else {
+		if ( dir_writable( sPath, true ) ) {
+			return DrumkitType::SessionReadWrite;
+		} else {
+			return DrumkitType::SessionReadOnly;
+		}
+	}
+}
+
 };
 
 /* vim: set softtabstop=4 noexpandtab: */

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -65,6 +65,25 @@ namespace H2Core
 		system = 2
 	};
 
+		/** Determines were to find a kit and whether it is writable
+		 *	by the current user.*/
+		enum class DrumkitType {
+			/** Kit was installed with Hydrogen, is automatically
+			 * loaded, and most probably readonly.*/
+			System = 0,
+			/** Kit was installed by the user, is automatically
+			 * loaded, and most probably writable.*/
+			User = 1,
+			/** Kit was loaded via a NSM session, OSC command, or CLI
+			 * option, only persist for the current Hydrogen session,
+			 * and is readonly.*/
+			SessionReadOnly = 2,
+			/** Kit was loaded via a NSM session, OSC command, or CLI
+			 * option, only persist for the current Hydrogen session,
+			 * and is writable.*/
+			SessionReadWrite = 3
+		};
+
 		static const QString songs_ext;
 		static const QString scripts_ext;
 		static const QString patterns_ext;
@@ -434,6 +453,12 @@ namespace H2Core
 		static const QString& getPreferencesOverwritePath();
 		/** \param sPath Sets m_sPreferencesOverwritePath*/
 		static void setPreferencesOverwritePath( const QString& sPath );
+
+		/**
+		 * @param sPath Absolute path to the drumkit folder containing
+		 *   a drumkit.xml file.
+		 */
+		static DrumkitType determineDrumkitType( const QString& sPath );
 
 	private:
 		static Logger* __logger;                    ///< a pointer to the logger

--- a/src/core/NsmClient.h
+++ b/src/core/NsmClient.h
@@ -122,6 +122,12 @@ class NsmClient : public H2Core::Object<NsmClient>
 		 *
 		 * Sets #bNsmShutdown to true.*/
 		void shutdown();
+
+	/**
+	 * Checks whether there is a drumkit present in the session folder
+	 * and loads it into the #H2Core::SoundLibraryDatabase.
+	 */
+	static void loadDrumkit();
 	
 	/**
 	 * Responsible for linking a drumkit on user or system level into

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -175,6 +175,10 @@ std::shared_ptr<Drumkit> SoundLibraryDatabase::getDrumkit( const QString& sDrumk
 
 		m_customDrumkitPaths << sDrumkitPath;
 		m_drumkitDatabase[ sDrumkitPath ] = pDrumkit;
+		
+		INFOLOG( QString( "Session Drumkit [%1] loaded from [%2]" )
+				  .arg( pDrumkit->get_name() )
+				  .arg( sDrumkitPath ) );
 
 		EventQueue::get_instance()->push_event( EVENT_SOUND_LIBRARY_CHANGED, 0 );
 		

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -65,10 +65,10 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 	/**
 	 * Retrieve a drumkit from the database.
 	 *
-	 * @param sDrumkitPath Absolute path to the drumkit as unique
-	 * identifier
+	 * @param sDrumkitPath Absolute path to the drumkit directory
+	 *   (containing a drumkit.xml) file as unique identifier.
 	 * @param bLoad Whether the drumkit should be loaded into the
-	 * datebase in case it is not present yet.
+	 *   datebase in case it is not present yet.
 	 */
 	std::shared_ptr<Drumkit> getDrumkit( const QString& sDrumkitPath, bool bLoad = true );
 	const std::map<QString,std::shared_ptr<Drumkit>> getDrumkitDatabase() const {

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -425,6 +425,9 @@ CommonStrings::CommonStrings(){
 	/*: Suffix appended to a drumkit, song, or pattern name in case it
 	 * is found on system-level and is read-only. */
 	m_sSoundLibrarySystemSuffix = tr( "system" );
+	/*: Suffix appended to a drumkit that are loaded non-persistently
+	 *  into the current Hydrogen session. */
+	m_sSoundLibrarySessionSuffix = tr( "session" );
 }
 
 CommonStrings::~CommonStrings(){

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -178,6 +178,7 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 
 	const QString& getSoundLibraryFailedPreDrumkitLoad() const { return m_sSoundLibraryFailedPreDrumkitLoad; }
 	const QString& getSoundLibrarySystemSuffix() const { return m_sSoundLibrarySystemSuffix; }
+	const QString& getSoundLibrarySessionSuffix() const { return m_sSoundLibrarySessionSuffix; }
 	
 private:
 	QString m_sSmallSoloButton;
@@ -316,5 +317,6 @@ private:
 	
 	QString m_sSoundLibraryFailedPreDrumkitLoad;
 	QString m_sSoundLibrarySystemSuffix;
+	QString m_sSoundLibrarySessionSuffix;
 };
 #endif

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1361,14 +1361,17 @@ void MainForm::action_instruments_saveLibrary()
 	
 	auto pDrumkit = pHydrogen->getSoundLibraryDatabase()->
 		getDrumkit( pHydrogen->getLastLoadedDrumkitPath() );
+	auto drumkitType = Filesystem::determineDrumkitType(
+		pHydrogen->getLastLoadedDrumkitPath() );
 
 	// In case the user does not have write access to the folder of
 	// pDrumkit, the save as dialog will be opened.
-	if ( pDrumkit != nullptr && pDrumkit->isUserDrumkit() ) {
+	if ( pDrumkit != nullptr &&
+		 ( drumkitType == Filesystem::DrumkitType::User ||
+		   drumkitType == Filesystem::DrumkitType::SessionReadWrite ) ) {
 		auto pNewDrumkit = std::make_shared<Drumkit>(pDrumkit);
 		pNewDrumkit->set_instruments( pSong->getInstrumentList() );
 		pNewDrumkit->set_components( pSong->getComponents() );
-		
 		
 		if ( ! HydrogenApp::checkDrumkitLicense( pNewDrumkit ) ) {
 			ERRORLOG( "User cancelled dialog due to licensing issues." );

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -197,6 +197,7 @@ void SoundLibraryPanel::updateTree()
 			m_drumkitRegister[ sItemLabel ] = pDrumkitEntry.first;
 			
 			pDrumkitItem->setText( 0, sItemLabel );
+			pDrumkitItem->setToolTip( 0, pDrumkitEntry.first );
 			if ( ! m_bInItsOwnDialog ) {
 				auto pInstrList = pDrumkit->get_instruments();
 				for ( const auto& pInstrument : *pDrumkit->get_instruments() ) {

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -67,8 +67,9 @@ SoundLibraryPanel::SoundLibraryPanel( QWidget *pParent, bool bInItsOwnDialog )
  , __song_menu( nullptr )
  , __pattern_menu( nullptr )
  , __pattern_menu_list( nullptr )
- , __system_drumkits_item( nullptr )
- , __user_drumkits_item( nullptr )
+ , m_pTreeSystemDrumkitsItem( nullptr )
+ , m_pTreeUserDrumkitsItem( nullptr )
+ , m_pTreeSessionDrumkitsItem( nullptr )
  , __song_item( nullptr )
  , __pattern_item( nullptr )
  , __pattern_item_list( nullptr )
@@ -157,16 +158,13 @@ void SoundLibraryPanel::updateTree()
 
 	QFont childFont( pPref->getLevel2FontFamily(), getPointSize( pPref->getFontSize() ) );
 	setFont( childFont );
+	
+	m_pTreeSystemDrumkitsItem = nullptr;
+	m_pTreeUserDrumkitsItem = nullptr;
+	m_pTreeSessionDrumkitsItem = nullptr;
 
-	__system_drumkits_item = new QTreeWidgetItem( __sound_library_tree );
-	__system_drumkits_item->setText( 0, tr( "System drumkits" ) );
-	__system_drumkits_item->setExpanded( true );
-	__system_drumkits_item->setFont( 0, boldFont );
-
-	__user_drumkits_item = new QTreeWidgetItem( __sound_library_tree );
-	__user_drumkits_item->setText( 0, tr( "User drumkits" ) );
-	__user_drumkits_item->setExpanded( true );
-	__user_drumkits_item->setFont( 0, boldFont );
+	// top-level drumkit items found
+	QList<QTreeWidgetItem*> drumkitItems;
 
 	// drumkit list
 	m_drumkitRegister.clear();
@@ -180,12 +178,35 @@ void SoundLibraryPanel::updateTree()
 
 			QTreeWidgetItem* pDrumkitItem;
 			if ( drumkitType == Filesystem::DrumkitType::System ) {
-				pDrumkitItem = new QTreeWidgetItem( __system_drumkits_item );
+				if ( m_pTreeSystemDrumkitsItem == nullptr ) {
+					m_pTreeSystemDrumkitsItem = new QTreeWidgetItem();
+					m_pTreeSystemDrumkitsItem->setText( 0, tr( "System drumkits" ) );
+					m_pTreeSystemDrumkitsItem->setFont( 0, boldFont );
+				}
+
+				pDrumkitItem = new QTreeWidgetItem( m_pTreeSystemDrumkitsItem );
 				sItemLabel.append( QString( " (%1)" )
 								   .arg( pCommonStrings->getSoundLibrarySystemSuffix() ) );
-			} else {
-				pDrumkitItem = new QTreeWidgetItem( __user_drumkits_item );
 			}
+			else if ( drumkitType == Filesystem::DrumkitType::User ) {
+				if ( m_pTreeUserDrumkitsItem == nullptr ) {
+					m_pTreeUserDrumkitsItem = new QTreeWidgetItem();
+					m_pTreeUserDrumkitsItem->setText( 0, tr( "User drumkits" ) );
+					m_pTreeUserDrumkitsItem->setFont( 0, boldFont );
+				}
+
+				pDrumkitItem = new QTreeWidgetItem( m_pTreeUserDrumkitsItem );
+			} else {
+				if ( m_pTreeSessionDrumkitsItem == nullptr ) {
+					m_pTreeSessionDrumkitsItem = new QTreeWidgetItem();
+					m_pTreeSessionDrumkitsItem->setText( 0, tr( "Session drumkits" ) );
+					m_pTreeSessionDrumkitsItem->setFont( 0, boldFont );
+				}
+				pDrumkitItem = new QTreeWidgetItem( m_pTreeSessionDrumkitsItem );
+				sItemLabel.append( QString( " (%1)" )
+								   .arg( pCommonStrings->getSoundLibrarySessionSuffix() ) );
+			}
+
 
 			// Ensure uniqueness of the label.
 			int nCount = 1;
@@ -213,6 +234,31 @@ void SoundLibraryPanel::updateTree()
 				}
 			}
 		}
+	}
+
+	// Ensure the ordering of the top-level nodes is always
+	// system > user > session
+	if ( m_pTreeSystemDrumkitsItem != nullptr ) {
+		drumkitItems << m_pTreeSystemDrumkitsItem;
+	}
+	if ( m_pTreeUserDrumkitsItem != nullptr ) {
+		drumkitItems << m_pTreeUserDrumkitsItem;
+	}
+	if ( m_pTreeSessionDrumkitsItem != nullptr ) {
+		drumkitItems << m_pTreeSessionDrumkitsItem;
+	}
+	__sound_library_tree->addTopLevelItems( drumkitItems );
+
+	// Ensure drumkit nodes are expanded (necessary when added as
+	// above.)
+	if ( m_pTreeSystemDrumkitsItem != nullptr ) {
+		m_pTreeSystemDrumkitsItem->setExpanded( true );
+	}
+	if ( m_pTreeUserDrumkitsItem != nullptr ) {
+		m_pTreeUserDrumkitsItem->setExpanded( true );
+	}
+	if ( m_pTreeSessionDrumkitsItem != nullptr ) {
+		m_pTreeSessionDrumkitsItem->setExpanded( true );
 	}
 
 	if ( ! m_bInItsOwnDialog ) {
@@ -287,8 +333,9 @@ void SoundLibraryPanel::on_DrumkitList_ItemChanged( QTreeWidgetItem * current, Q
 		return;
 	}
 
-	if ( current->parent() == __system_drumkits_item ||
-		 current->parent() == __user_drumkits_item  ){
+	if ( current->parent() == m_pTreeSystemDrumkitsItem ||
+		 current->parent() == m_pTreeUserDrumkitsItem ||
+		 current->parent() == m_pTreeSessionDrumkitsItem ){
 			emit item_changed( true );
 	} else {
 		emit item_changed( false );
@@ -304,9 +351,15 @@ void SoundLibraryPanel::on_DrumkitList_itemActivated( QTreeWidgetItem * item, in
 	UNUSED( column );
 
 //	INFOLOG( "[on_DrumkitList_itemActivated]" );
-	if ( item == __system_drumkits_item ||
-		 item == __user_drumkits_item ||
-		 item == __system_drumkits_item->parent() ||
+	if ( item == m_pTreeSystemDrumkitsItem ||
+		 item == m_pTreeUserDrumkitsItem ||
+		 item == m_pTreeSessionDrumkitsItem ||
+		 ( ( m_pTreeSystemDrumkitsItem != nullptr &&
+			 item == m_pTreeSystemDrumkitsItem->parent() ) ||
+		   ( m_pTreeUserDrumkitsItem != nullptr &&
+			 item == m_pTreeUserDrumkitsItem->parent() ) ||
+		   ( m_pTreeSessionDrumkitsItem != nullptr &&
+			 item == m_pTreeSessionDrumkitsItem->parent() ) )||
 		 item->parent() == __song_item ||
 		 item == __song_item ||
 		 item == __pattern_item ||
@@ -318,8 +371,9 @@ void SoundLibraryPanel::on_DrumkitList_itemActivated( QTreeWidgetItem * item, in
 		return;
 	}
 
-	if ( item->parent() == __system_drumkits_item ||
-		 item->parent() == __user_drumkits_item  ) {
+	if ( item->parent() == m_pTreeSystemDrumkitsItem ||
+		 item->parent() == m_pTreeUserDrumkitsItem  ||
+		 item->parent() == m_pTreeSessionDrumkitsItem  ) {
 		// Double clicking a drumkit
 	}
 	else {
@@ -358,10 +412,10 @@ void SoundLibraryPanel::on_DrumkitList_rightClicked( QPoint pos )
 	}
 	
 	if (
-		( __sound_library_tree->currentItem()->parent() == nullptr ) ||
-		( __sound_library_tree->currentItem() == __user_drumkits_item ) ||
-		( __sound_library_tree->currentItem() == __system_drumkits_item )
-	) {
+		__sound_library_tree->currentItem()->parent() == nullptr ||
+		__sound_library_tree->currentItem() == m_pTreeUserDrumkitsItem ||
+		__sound_library_tree->currentItem() == m_pTreeSystemDrumkitsItem ||
+		__sound_library_tree->currentItem() == m_pTreeSessionDrumkitsItem ) {
 		return;
 	}
 
@@ -373,13 +427,28 @@ void SoundLibraryPanel::on_DrumkitList_rightClicked( QPoint pos )
 		__pattern_menu->popup( pos );
 	}
 
-	if ( __sound_library_tree->currentItem()->parent() == __user_drumkits_item ) {
+	if ( __sound_library_tree->currentItem()->parent() == m_pTreeUserDrumkitsItem ) {
 		__drumkit_menu->popup( pos );
 	}
 	
-
-	if ( __sound_library_tree->currentItem()->parent() == __system_drumkits_item ) {
+	if ( __sound_library_tree->currentItem()->parent() == m_pTreeSystemDrumkitsItem ) {
 		__drumkit_menu_system->popup( pos );
+	}
+	
+	// We do not provide distinct parent items for read-only and
+	// writable session drumkits as it would make the GUI unnecessary
+	// complex. Instead, the level of access for the current user is
+	// checked during runtime (which should be a very rare thing to do).
+	if ( __sound_library_tree->currentItem()->parent() == m_pTreeSessionDrumkitsItem ) {
+		const QString sDrumkitName = __sound_library_tree->currentItem()->text( 0 );
+		const QString sDrumkitPath = m_drumkitRegister[ sDrumkitName ];
+		const auto drumkitType = Filesystem::determineDrumkitType( sDrumkitPath );
+		
+		if ( drumkitType == Filesystem::DrumkitType::SessionReadOnly ) {
+			__drumkit_menu_system->popup( pos );
+		} else {
+			__drumkit_menu->popup( pos );
+		}
 	}
 
 }
@@ -407,10 +476,9 @@ void SoundLibraryPanel::on_DrumkitList_mouseMove( QMouseEvent *event)
 		return;
 	}
 
-	if (
-		( __sound_library_tree->currentItem()->parent() == __system_drumkits_item ) ||
-		( __sound_library_tree->currentItem()->parent() == __user_drumkits_item )
-	) {
+	if ( __sound_library_tree->currentItem()->parent() == m_pTreeSystemDrumkitsItem ||
+		 __sound_library_tree->currentItem()->parent() == m_pTreeUserDrumkitsItem ||
+		 __sound_library_tree->currentItem()->parent() == m_pTreeSessionDrumkitsItem ) {
  		// drumkit selection
 		//INFOLOG( "ho selezionato un drumkit (system)" );
 		return;
@@ -457,12 +525,12 @@ void SoundLibraryPanel::on_DrumkitList_mouseMove( QMouseEvent *event)
 			return;
 		}
 
-		QString sDrumkitName = __sound_library_tree->currentItem()->parent()->text(0);
-		QString sDrumkitPath = m_drumkitRegister[ sDrumkitName ];
-		QString sInstrumentName = ( __sound_library_tree->currentItem()->text(0) )
+		const QString sDrumkitName = __sound_library_tree->currentItem()->parent()->text(0);
+		const QString sDrumkitPath = m_drumkitRegister[ sDrumkitName ];
+		const QString sInstrumentName = ( __sound_library_tree->currentItem()->text(0) )
 			.remove( 0, __sound_library_tree->currentItem()->text(0).indexOf( "] " ) + 2 );
 
-		QString sText = "importInstrument:" + sDrumkitPath + "::" + sInstrumentName;
+		const QString sText = "importInstrument:" + sDrumkitPath + "::" + sInstrumentName;
 
 		QDrag *pDrag = new QDrag(this);
 		QMimeData *pMimeData = new QMimeData;
@@ -582,13 +650,24 @@ void SoundLibraryPanel::update_background_color()
 
 void SoundLibraryPanel::restore_background_color()
 {
-	for (int i = 0; i < __system_drumkits_item->childCount() ; i++){
-		( __system_drumkits_item->child( i ) )->setBackground( 0, QBrush() );		
+	if ( m_pTreeSystemDrumkitsItem != nullptr ) {
+		for (int i = 0; i < m_pTreeSystemDrumkitsItem->childCount() ; i++){
+			( m_pTreeSystemDrumkitsItem->child( i ) )->setBackground( 0, QBrush() );		
+		}
 	}
 
-	for (int i = 0; i < __user_drumkits_item->childCount() ; i++){
-		( __user_drumkits_item->child( i ) )->setBackground(0, QBrush() );
+	if ( m_pTreeUserDrumkitsItem != nullptr ) {
+		for (int i = 0; i < m_pTreeUserDrumkitsItem->childCount() ; i++){
+			( m_pTreeUserDrumkitsItem->child( i ) )->setBackground(0, QBrush() );
+		}
 	}
+
+	if ( m_pTreeSessionDrumkitsItem != nullptr ) {
+		for (int i = 0; i < m_pTreeSessionDrumkitsItem->childCount() ; i++){
+			( m_pTreeSessionDrumkitsItem->child( i ) )->setBackground( 0, QBrush() );		
+		}
+	}
+
 }
 
 QString SoundLibraryPanel::getDrumkitLabel( const QString& sDrumkitPath ) const {
@@ -619,32 +698,52 @@ void SoundLibraryPanel::change_background_color()
 				  .arg( sDrumkitPath ) );
 		return;
 	}
+
+	if ( m_pTreeSystemDrumkitsItem != nullptr ) {
+		for ( int i = 0; i < m_pTreeSystemDrumkitsItem->childCount() ; i++){
+			if ( ( m_pTreeSystemDrumkitsItem->child( i ) )->text( 0 ) == sDrumkitLabel ){
+				( m_pTreeSystemDrumkitsItem->child( i ) )->setBackground( 0, QColor( 50, 50, 50)  );
+				return;
+			}
+		}
+	}
+
+	if ( m_pTreeUserDrumkitsItem != nullptr ) {
+		for (int i = 0; i < m_pTreeUserDrumkitsItem->childCount() ; i++){
+			if ( ( m_pTreeUserDrumkitsItem->child( i ))->text( 0 ) == sDrumkitLabel ){
+				( m_pTreeUserDrumkitsItem->child( i ) )->setBackground( 0, QColor( 50, 50, 50)  );
+				break;
+			}
+		}
+	}
 	
-	for ( int i = 0; i < __system_drumkits_item->childCount() ; i++){
-		if ( ( __system_drumkits_item->child( i ) )->text( 0 ) == sDrumkitLabel ){
-			( __system_drumkits_item->child( i ) )->setBackground( 0, QColor( 50, 50, 50)  );
-			return;
+	if ( m_pTreeSessionDrumkitsItem != nullptr ) {
+		for ( int i = 0; i < m_pTreeSessionDrumkitsItem->childCount() ; i++){
+			if ( ( m_pTreeSessionDrumkitsItem->child( i ) )->text( 0 ) == sDrumkitLabel ){
+				( m_pTreeSessionDrumkitsItem->child( i ) )->setBackground( 0, QColor( 50, 50, 50)  );
+				return;
+			}
 		}
 	}
-	for (int i = 0; i < __user_drumkits_item->childCount() ; i++){
-		if ( ( __user_drumkits_item->child( i ))->text( 0 ) == sDrumkitLabel ){
-			( __user_drumkits_item->child( i ) )->setBackground( 0, QColor( 50, 50, 50)  );
-			break;
-		}
-	}
+
 }
 
 
 void SoundLibraryPanel::on_drumkitDeleteAction()
 {
 	QTreeWidgetItem* pItem = __sound_library_tree->currentItem();
-	QString sDrumkitName = pItem->text(0);
+	const QString sDrumkitName = pItem->text(0);
+	const QString sDrumkitPath = m_drumkitRegister[ sDrumkitName ];
+	const auto drumkitType = Filesystem::determineDrumkitType( sDrumkitPath );
+	
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
-	if ( pItem->parent() == __system_drumkits_item ) {
+	if ( pItem->parent() == m_pTreeSystemDrumkitsItem ||
+		 ( pItem->parent() == m_pTreeSessionDrumkitsItem &&
+		   drumkitType == Filesystem::DrumkitType::SessionReadOnly ) ) {
 		QMessageBox::warning( this, "Hydrogen", QString( "\"%1\" " )
 							  .arg(sDrumkitName)
-							  .append( tr( "is a system drumkit and can't be deleted.") ) );
+							  .append( tr( "is a read-only drumkit and can't be deleted.") ) );
 		return;
 	}
 
@@ -779,8 +878,7 @@ void SoundLibraryPanel::test_expandedItems()
 void SoundLibraryPanel::onPreferencesChanged( H2Core::Preferences::Changes changes ) {
 	auto pPref = H2Core::Preferences::get_instance();
 	
-	if ( __system_drumkits_item->child( 0 ) != nullptr &&
-		 ( changes & H2Core::Preferences::Changes::Font ) ) {
+	if ( changes & H2Core::Preferences::Changes::Font ) {
 		
 		QFont font( pPref->getLevel2FontFamily(), getPointSize( pPref->getFontSize() ) );
 		QFont boldFont( pPref->getApplicationFontFamily(), getPointSize( pPref->getFontSize() ) );
@@ -788,20 +886,36 @@ void SoundLibraryPanel::onPreferencesChanged( H2Core::Preferences::Changes chang
 
 		int ii, jj;
 		QTreeWidgetItem* childNode;
-		__system_drumkits_item->setFont( 0, boldFont );
-		for ( ii = 0; ii < __system_drumkits_item->childCount(); ii++ ){ 
-			childNode = __system_drumkits_item->child( ii );
-			childNode->setFont( 0, font );
-			for ( jj = 0; jj < childNode->childCount(); jj++ ) {
-				childNode->child( jj )->setFont( 0, font );
+		if ( m_pTreeSystemDrumkitsItem != nullptr ) {
+			m_pTreeSystemDrumkitsItem->setFont( 0, boldFont );
+			for ( ii = 0; ii < m_pTreeSystemDrumkitsItem->childCount(); ii++ ){ 
+				childNode = m_pTreeSystemDrumkitsItem->child( ii );
+				childNode->setFont( 0, font );
+				for ( jj = 0; jj < childNode->childCount(); jj++ ) {
+					childNode->child( jj )->setFont( 0, font );
+				}
 			}
 		}
-		__user_drumkits_item->setFont( 0, boldFont );
-		for ( ii = 0; ii < __user_drumkits_item->childCount(); ii++ ){ 
-			childNode = __user_drumkits_item->child( ii );
-			childNode->setFont( 0, font );
-			for ( jj = 0; jj < childNode->childCount(); jj++ ) {
-				childNode->child( jj )->setFont( 0, font );
+
+		if ( m_pTreeUserDrumkitsItem != nullptr ) {
+			m_pTreeUserDrumkitsItem->setFont( 0, boldFont );
+			for ( ii = 0; ii < m_pTreeUserDrumkitsItem->childCount(); ii++ ){ 
+				childNode = m_pTreeUserDrumkitsItem->child( ii );
+				childNode->setFont( 0, font );
+				for ( jj = 0; jj < childNode->childCount(); jj++ ) {
+					childNode->child( jj )->setFont( 0, font );
+				}
+			}
+		}
+		
+		if ( m_pTreeSessionDrumkitsItem != nullptr ) {
+			m_pTreeSessionDrumkitsItem->setFont( 0, boldFont );
+			for ( ii = 0; ii < m_pTreeSessionDrumkitsItem->childCount(); ii++ ){ 
+				childNode = m_pTreeSessionDrumkitsItem->child( ii );
+				childNode->setFont( 0, font );
+				for ( jj = 0; jj < childNode->childCount(); jj++ ) {
+					childNode->child( jj )->setFont( 0, font );
+				}
 			}
 		}
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -175,14 +175,16 @@ void SoundLibraryPanel::updateTree()
 		auto pDrumkit = pDrumkitEntry.second;
 		if ( pDrumkit != nullptr ) {
 			QString sItemLabel = pDrumkit->get_name();
+			auto drumkitType =
+				Filesystem::determineDrumkitType( pDrumkitEntry.first );
 
 			QTreeWidgetItem* pDrumkitItem;
-			if ( pDrumkit->isUserDrumkit() ) {
-				pDrumkitItem = new QTreeWidgetItem( __user_drumkits_item );
-			} else {
+			if ( drumkitType == Filesystem::DrumkitType::System ) {
 				pDrumkitItem = new QTreeWidgetItem( __system_drumkits_item );
 				sItemLabel.append( QString( " (%1)" )
 								   .arg( pCommonStrings->getSoundLibrarySystemSuffix() ) );
+			} else {
+				pDrumkitItem = new QTreeWidgetItem( __user_drumkits_item );
 			}
 
 			// Ensure uniqueness of the label.

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.h
@@ -89,8 +89,9 @@ private:
 	QMenu* __pattern_menu;
 	QMenu* __pattern_menu_list;
 
-	QTreeWidgetItem* __system_drumkits_item;
-	QTreeWidgetItem* __user_drumkits_item;
+	QTreeWidgetItem* m_pTreeSystemDrumkitsItem;
+	QTreeWidgetItem* m_pTreeUserDrumkitsItem;
+	QTreeWidgetItem* m_pTreeSessionDrumkitsItem;
 	QTreeWidgetItem* __song_item;
 	QTreeWidgetItem* __pattern_item;
 	QTreeWidgetItem* __pattern_item_list;

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
@@ -60,11 +60,16 @@ SoundLibraryPropertiesDialog::SoundLibraryPropertiesDialog( QWidget* pParent, st
 	connect( imageLicenseComboBox, SIGNAL( currentIndexChanged( int ) ),
 			 this, SLOT( imageLicenseComboBoxChanged( int ) ) );
 
-	bool bIsUserDrumkit = false;
+	bool bDrumkitWritable = false;
 	//display the current drumkit infos into the qlineedit
 	if ( pDrumkit != nullptr ){
 
-		bIsUserDrumkit = pDrumkit->isUserDrumkit();
+		auto drumkitType = Filesystem::determineDrumkitType(
+			pDrumkit->get_path() );
+		if ( drumkitType == Filesystem::DrumkitType::User ||
+			 drumkitType == Filesystem::DrumkitType::SessionReadWrite ) {
+			bDrumkitWritable = true;
+		}
 
 		nameTxt->setText( pDrumkit->get_name() );
 
@@ -105,7 +110,7 @@ SoundLibraryPropertiesDialog::SoundLibraryPropertiesDialog( QWidget* pParent, st
 
 	// In case the drumkit name is not locked/the dialog is used as
 	// "Save As" nothing needs to be disabled.
-	if ( ! bIsUserDrumkit && bDrumkitNameLocked ) {
+	if ( ! bDrumkitWritable && bDrumkitNameLocked ) {
 		QString sToolTip = tr( "The current drumkit is read-only. Please use Drumkits > Save As in the main menu to create a new one first." );
 		
 		// The drumkit is read-only. Thus we won't support altering


### PR DESCRIPTION
# Preface
Since recently we support loading a **session drumkit** into Hydrogen using the OSC command `LOAD_DRUMKIT`, the CLI option `-k`, or by loading a drumkit from a session folder when using NSM. These session kits can be located at arbitrary locations the user has read permissions for. They are not persistent and have to be loaded explicitly in every session. But once they are, they are registered in the `SoundLibraryDatabase` and can be handled like any other drumkit.

# Changes: 
- The session drumkit of the NSM session was not properly registered in the `SoundLibraryDatabase`
- When hovering a drumkit name in the `SoundLibraryPanel` its absolute path will be shown as tooltip. This is especially useful when dealing the session kits or multiple kits sharing the same name
- Instead of `Drumkit::isUserDrumkit()` - which was removed - a more fine-grained `Filesystem::determineDrumkitType()` in combination with the `Filesystem::DrumkitType` was introduced. Apart from system and user kit, it also encompasses session-level drumkits - non persistent ones loaded into a Hydrogen session - with both read-only and read-write access
- Next to "System drumkits" and "User drumkits" another top-level item called "Session drumkits" was introduced. Previously, all non-persistent session kits were listed amongst the user kits as well.
- The top-level "System drumkit" and "User drumkit" items are now suppressed in case no drumkit is found for this group

