### PR TITLE
Audio engine-related tweaks

### DIFF
--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -458,6 +458,7 @@ public:
 	/** Uses handleTimelineChange() */
 	friend bool CoreActionController::deleteTempoMarker( int );
 	friend bool CoreActionController::locateToTick( long nTick, bool );
+	friend bool CoreActionController::activateSongMode( bool );
 	/** Is allowed to set m_state to State::Ready via setState()*/
 	friend int FakeDriver::connect();
 	friend void JackAudioDriver::updateTransportPosition();

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -924,17 +924,18 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 	}		
 	
 	pHydrogen->sequencer_stop();
+
+	pAudioEngine->lock( RIGHT_HERE );
+	pAudioEngine->reset( true );
+	
 	if ( bActivate && pHydrogen->getMode() != Song::Mode::Song ) {
 		pHydrogen->setMode( Song::Mode::Song );
 	} else if ( ! bActivate && pHydrogen->getMode() != Song::Mode::Pattern ) {
 		pHydrogen->setMode( Song::Mode::Pattern );
 	}
 
-	locateToColumn( 0 );
-
 	// Ensure the playing patterns are properly updated regardless of
 	// the state of transport before switching song modes.
-	pAudioEngine->lock( RIGHT_HERE );
 	pAudioEngine->updatePlayingPatterns();
 	pAudioEngine->unlock();
 	

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -625,9 +625,16 @@ bool Sampler::renderNote( Note* pNote, unsigned nBufferSize )
 		float fLayerPitch = pLayer->get_pitch();
 
 		if ( pSelectedLayer->SamplePosition >= pSample->get_frames() ) {
-			WARNINGLOG( QString( "sample position [%1] out of bounds [0,%2]. The layer has been resized during note play?" )
-						.arg( pSelectedLayer->SamplePosition )
-						.arg( pSample->get_frames() ) );
+			// Due to rounding errors in renderNoteResample() the
+			// sample position can occassionaly exceed the maximum
+			// frames of a sample. AFAICS this is not itself
+			// harmful. So, we just log a warning if the difference is
+			// larger, which might be caused by a different problem.
+			if ( pSelectedLayer->SamplePosition >= pSample->get_frames() + 3 ) {
+				WARNINGLOG( QString( "sample position [%1] out of bounds [0,%2]. The layer has been resized during note play?" )
+							.arg( pSelectedLayer->SamplePosition )
+							.arg( pSample->get_frames() ) );
+			}
 			nReturnValues[nReturnValueIndex] = true;
 			nReturnValueIndex++;
 			continue;

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -1134,6 +1134,25 @@ void PreferencesDialog::updateDriverInfo()
 	// Reset info text
 	updateDriverInfoLabel();
 
+	bufferSizeSpinBox->setValue( pPref->m_nBufferSize );
+	switch ( pPref->m_nSampleRate ) {
+	case 44100:
+		sampleRateComboBox->setCurrentIndex( 0 );
+		break;
+	case 48000:
+		sampleRateComboBox->setCurrentIndex( 1 );
+		break;
+	case 88200:
+		sampleRateComboBox->setCurrentIndex( 2 );
+		break;
+	case 96000:
+		sampleRateComboBox->setCurrentIndex( 3 );
+		break;
+	default:
+		ERRORLOG( QString("Wrong samplerate: %1").arg( pPref->m_nSampleRate ) );
+	}
+
+
 	if ( driverComboBox->currentText() == "Auto" ) {
 
 		if ( dynamic_cast<H2Core::JackAudioDriver*>(pAudioDriver) != nullptr ) {


### PR DESCRIPTION
- The state of the `AudioEngine` was not properly reset when switching from pattern mode to song mode or back. This caused small inconsistencies, like playhead glitches when switching from song or pattern mode and back while transport position was in a column other than 0 or error logs of invalid pattern start ticks when changing from song to pattern mode
- Due to rounding errors in `Sampler::renderNoteResample()` the sample position can occassionaly exceed the maximum frames of a sample. AFAICS this is not itself harmful. So, we just log a warning if the difference is larger, which might be caused by a different problem.
- In case of the JACK audio driver buffer size and sample rate are set by the server and not Hydrogen. When switching from a different driver to JACK, both values were previously not updated and might not represent the correct ones. Now, both sample rate and buffer size are updated when restarting the audio driver within the `PreferencesDialog`