### PR TITLE
Fix some drumkit-related issues

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1159,6 +1159,12 @@ void AudioEngine::processPlayNotes( unsigned long nframes )
 				delete pOffNote;
 			}
 
+			if ( ! pNote->get_instrument()->hasSamples() ) {
+				m_songNoteQueue.pop();
+				pNote->get_instrument()->dequeue();
+				continue;
+			}
+
 			m_pSampler->noteOn( pNote );
 			m_songNoteQueue.pop();
 			pNote->get_instrument()->dequeue();

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -157,7 +157,7 @@ std::shared_ptr<Drumkit> Drumkit::load_from( XMLNode* node, const QString& sDrum
 	pDrumkit->set_image( node->read_string( "image", "",
 											true, true, true ) );
 	License imageLicense( node->read_string( "imageLicense", "undefined license",
-											 true, true, bSilent  ),
+											 true, true, true  ),
 						  pDrumkit->__author );
 	pDrumkit->set_image_license( imageLicense );
 

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -661,6 +661,22 @@ QString Instrument::get_drumkit_path() const
 	return Filesystem::ensure_session_compatibility( __drumkit_path );
 }
 
+bool Instrument::hasSamples() const {
+	for ( const auto& pComponent : *__components ) {
+		if ( pComponent != nullptr ) {
+			for ( const auto& pLayer : *pComponent ) {
+				if ( pLayer != nullptr ) {
+					if ( pLayer->get_sample() != nullptr ) {
+						return true;
+					}
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
 QString Instrument::toQString( const QString& sPrefix, bool bShort ) const {
 	QString s = Base::sPrintIndention;
 	QString sOutput;

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -382,7 +382,7 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 	pInstrument->set_muted( pNode->read_bool( "isMuted", false,
 											 true, true, bSilent ) );
 	pInstrument->set_soloed( pNode->read_bool( "isSoloed", false,
-											  true, true, bSilent ) );
+											  true, false, true ) );
 	bool bFound, bFound2;
 	float fPan = pNode->read_float( "pan", 0.f, &bFound,
 								   true, true, true );
@@ -408,7 +408,7 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 	pInstrument->set_filter_resonance( pNode->read_float( "filterResonance", 0.0f,
 														 true, false, bSilent ) );
 	pInstrument->set_pitch_offset( pNode->read_float( "pitchOffset", 0.0f,
-													 true, false, bSilent ) );
+													 true, false, true ) );
 	pInstrument->set_random_pitch_factor( pNode->read_float( "randomPitchFactor", 0.0f,
 															true, false, bSilent ) );
 	pInstrument->set_gain( pNode->read_float( "gain", 1.0f,

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -307,6 +307,10 @@ class Instrument : public H2Core::Object<Instrument>
 
 		bool has_missing_samples() const { return m_bHasMissingSamples; }
 		void set_missing_samples( bool bHasMissingSamples ) { m_bHasMissingSamples = bHasMissingSamples; }
+
+	/** Whether the instrument contains at least one non-missing
+	 * sample */
+	bool hasSamples() const;
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of
 		 * every new line

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1316,7 +1316,9 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 bool CoreActionController::extractDrumkit( const QString& sDrumkitPath, const QString& sTargetDir ) {
 
 	QString sTarget;
+	bool bInstall = false;
 	if ( sTargetDir.isEmpty() ) {
+		bInstall = true;
 		INFOLOG( QString( "Installing drumkit [%1]" ).arg( sDrumkitPath ) );
 		sTarget = Filesystem::usr_drumkits_dir();
 	} else {
@@ -1343,6 +1345,10 @@ bool CoreActionController::extractDrumkit( const QString& sDrumkitPath, const QS
 		ERRORLOG( QString( "Unabled to extract provided drumkit [%1] into [%2]" )
 				  .arg( sDrumkitPath ).arg( sTarget ) );
 		return false;
+	}
+
+	if ( bInstall ) {
+		Hydrogen::get_instance()->getSoundLibraryDatabase()->updateDrumkits();
 	}
 
 	return true;

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -310,6 +310,12 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 	 * Extracts the compressed .h2drumkit file in @a sDrumkitPath into
 	 * @a sTargetDir.
 	 *
+	 * The function does not automatically load the extracted kit into
+	 * the current Hydrogen session in case a custom @a sTargetDir was
+	 * supplied. To do so, the name of the folder contained in the
+	 * tarball is required (might differ from the name of the tarball)
+	 * and it is not easily obtained.
+	 *
 	 * \param sDrumkitPath Tar-compressed drumkit with .h2drumkit
 	 * extension
 	 * \param sTargetDir Folder to extract the drumkit to. If the

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -585,8 +585,12 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 		}
 	}
 
-
 	// Play back the note.
+	if ( ! pInstr->hasSamples() ) {
+		pAudioEngine->unlock();
+		return;
+	}
+	
 	if ( bPlaySelectedInstrument ) {
 		if ( bNoteOff ) {
 			if ( pSampler->isInstrumentPlaying( pInstr ) ) {

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -193,6 +193,10 @@ bool Sampler::isRenderingNotes() const {
 void Sampler::noteOn(Note *pNote )
 {
 	assert( pNote );
+	if ( pNote == nullptr ) {
+		ERRORLOG( "Invalid note" );
+		return;
+	}
 
 	pNote->get_adsr()->attack();
 	auto pInstr = pNote->get_instrument();
@@ -1449,6 +1453,15 @@ void Sampler::stopPlayingNotes( std::shared_ptr<Instrument> pInstr )
 /// Preview, uses only the first layer
 void Sampler::preview_sample(std::shared_ptr<Sample> pSample, int nLength )
 {
+	if ( m_pPreviewInstrument == nullptr ) {
+		ERRORLOG( "Invalid preview instrument" );
+		return;
+	}
+
+	if ( ! m_pPreviewInstrument->hasSamples() ) {
+		return;
+	}
+	
 	Hydrogen::get_instance()->getAudioEngine()->lock( RIGHT_HERE );
 
 	for (const auto& pComponent: *m_pPreviewInstrument->get_components()) {
@@ -1470,6 +1483,15 @@ void Sampler::preview_sample(std::shared_ptr<Sample> pSample, int nLength )
 
 void Sampler::preview_instrument( std::shared_ptr<Instrument> pInstr )
 {
+	if ( pInstr == nullptr ) {
+		ERRORLOG( "Invalid instrument" );
+		return;
+	}
+
+	if ( ! pInstr->hasSamples() ) {
+		return;
+	}
+	
 	std::shared_ptr<Instrument> pOldPreview;
 	Hydrogen::get_instance()->getAudioEngine()->lock( RIGHT_HERE );
 

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -289,9 +289,11 @@ void LayerPreview::mousePressEvent(QMouseEvent *ev)
 	if ( ev->y() < 20 ) {
 		const float fVelocity = (float)ev->x() / (float)width();
 
-		Note * pNote = new Note( m_pInstrument, nPosition, fVelocity );
-		pNote->set_specific_compo_id( m_nSelectedComponent );
-		Hydrogen::get_instance()->getAudioEngine()->getSampler()->noteOn(pNote);
+		if ( m_pInstrument->hasSamples() ) {
+			Note * pNote = new Note( m_pInstrument, nPosition, fVelocity );
+			pNote->set_specific_compo_id( m_nSelectedComponent );
+			Hydrogen::get_instance()->getAudioEngine()->getSampler()->noteOn(pNote);
+		}
 		
 		for ( int i = 0; i < InstrumentComponent::getMaxLayers(); i++ ) {
 			auto pCompo = m_pInstrument->get_component(m_nSelectedComponent);

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -329,6 +329,12 @@ void Mixer::noteOnClicked( MixerLine* ref )
 		return;
 	}
 	
+	if ( ! pSelectedInstrument->hasSamples() ) {
+		INFOLOG( QString( "Instrument [%1] does not contain any samples. No preview available" )
+				 .arg( pSelectedInstrument->get_name() ) );
+		return;
+	}
+	
 	Note *pNote = new Note( pSelectedInstrument, 0, 1.0 );
 	pHydrogen->getAudioEngine()->getSampler()->noteOn(pNote);
 }

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -473,7 +473,7 @@ void DrumPatternEditor::addOrDeleteNoteAction(	int nColumn,
 			pNote->set_just_recorded(true);
 		}
 		// hear note
-		if ( listen && !isNoteOff ) {
+		if ( listen && !isNoteOff && pSelectedInstrument->hasSamples() ) {
 			Note *pNote2 = new Note( pSelectedInstrument, 0, fVelocity, fPan, nLength);
 			m_pAudioEngine->getSampler()->noteOn(pNote2);
 		}

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -363,18 +363,20 @@ void InstrumentLine::mousePressEvent(QMouseEvent *ev)
 	HydrogenApp::get_instance()->getPatternEditorPanel()->getDrumPatternEditor()->updateEditor();
 
 	if ( ev->button() == Qt::LeftButton ) {
-		const int nWidth = m_pMuteBtn->x() - 5; // clickable field width
-		const float fVelocity = std::min((float)ev->x()/(float)nWidth, 1.0f);
 
 		std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
-		auto pInstr = pSong->getInstrumentList()->get( m_nInstrumentNumber );
-		if ( pInstr == nullptr ) {
-			ERRORLOG( "No instrument selected" );
+		if ( pSong == nullptr ) {
+			ERRORLOG( "No song set yet" );
 			return;
 		}
+		auto pInstr = pSong->getInstrumentList()->get( m_nInstrumentNumber );
+		if ( pInstr != nullptr && pInstr->hasSamples() ) {
 
-		Note *pNote = new Note( pInstr, 0, fVelocity);
-		Hydrogen::get_instance()->getAudioEngine()->getSampler()->noteOn(pNote);
+			const int nWidth = m_pMuteBtn->x() - 5; // clickable field width
+			const float fVelocity = std::min((float)ev->x()/(float)nWidth, 1.0f);
+			Note *pNote = new Note( pInstr, 0, fVelocity);
+			Hydrogen::get_instance()->getAudioEngine()->getSampler()->noteOn(pNote);
+		}
 		
 	} else if (ev->button() == Qt::RightButton ) {
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -431,7 +431,7 @@ void PianoRollEditor::addOrRemoveNote( int nColumn, int nRealColumn, int nLine,
 	if ( pOldNote == nullptr ) {
 		// hear note
 		Preferences *pref = Preferences::get_instance();
-		if ( pref->getHearNewNotes() ) {
+		if ( pref->getHearNewNotes() && pSelectedInstrument->hasSamples() ) {
 			Note *pNote2 = new Note( pSelectedInstrument );
 			pNote2->set_key_octave( notekey, octave );
 			m_pAudioEngine->getSampler()->noteOn( pNote2 );


### PR DESCRIPTION
- do not render notes for instruments without samples

   In case a note is played back for an instrument without any samples, it passes till the rendering methods of the `Sampler` and is discarded there after logging some error messages. It does not really do any harm. On the other hand, it is not an error to click click the name of a freshly created instrument in the pattern editor (which will trigger a preview note).

  In this patch I prevent notes to be passed to the `Sampler` in case their associated instrument has no samples. It is a fast check but adds complexity as it was added at a lot of places. Ideally I would like to put it in just one place, namely `Sampler::noteOn`, but the lifecycle of `Note` is rather intricate. As soon as it enters `Sampler::noteOn` `Sampler` takes responsibility of deleting it as part of its process routines. Some functions, like `AudioEngine::processPlayNotes`, expect it to still exist after `Sampler::noteOn`. I do not want to check for the presence of samples in `Sampler::process` as it would be done not just one but many times per note. I also do not want to touch the lifecycle of `Note` right now was we are in between a beta and a release.

- Drumkit upgrade was broken since it provided the path to the drumkit.xml file instead of the path to the drumkit folder. This has been fixed and `Drumkit::save` has been done more resilent and does now work with both versions of the path
- `SoundLibraryDatabase` is updated as soon as a kit is installed via OSC command and the `SoundLibraryPanel` is immediately updated