### PR TITLE
Validate against former XSD drumkit definitions

### DIFF
--- a/data/xsd/legacy/v0_9_6/drumkit.xsd
+++ b/data/xsd/legacy/v0_9_6/drumkit.xsd
@@ -1,0 +1,95 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.hydrogen-music.org/drumkit"
+    xmlns:h2="http://www.hydrogen-music.org/drumkit"
+    elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+    <xsd:restriction base="xsd:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+    </xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0;1.0 ] -->
+<xsd:simpleType name='psfloat'>
+    <xsd:restriction base='xsd:float'>
+        <xsd:minInclusive value='0.0'/>
+        <xsd:maxInclusive value='1.0'/>
+    </xsd:restriction>
+</xsd:simpleType>
+
+<!-- LAYER -->
+<xsd:element name="layer">
+    <xsd:complexType>
+        <xsd:sequence>
+            <xsd:element name="filename"    type="xsd:string"/>
+            <xsd:element name="min"         type="xsd:float" default="0.0"/>
+            <xsd:element name="max"         type="xsd:float" default="1.0"/>
+            <xsd:element name="gain"        type="xsd:float" default="1.0"/>
+            <xsd:element name="pitch"       type="xsd:float" default="0.0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:element>
+
+<!-- INSTRUMENT -->
+<xsd:element name="instrument">
+    <xsd:complexType>
+        <!--
+        <xsd:all>
+            BUG libqt4-xml 4.6.3 and 4.7.1
+             http://bugreports.qt.nokia.com/browse/QTBUG-12534?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel#issue-tabs
+        -->
+        <xsd:sequence>
+            <xsd:element name="id"               type="xsd:integer"/>
+            <xsd:element name="name"             type="xsd:string"/>
+            <xsd:element name="volume"           type="xsd:decimal"     default="1.0"/>
+            <xsd:element name="isMuted"          type="h2:bool"         default="false"/>
+            <xsd:element name="pan_L"            type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="pan_R"            type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="randomPitchFactor" type="h2:psfloat"     default="0.0"/>
+            <xsd:element name="gain"             type="xsd:float"       default="1.0"/>
+            <xsd:element name="filterActive"     type="h2:bool"         default="false"/>
+            <xsd:element name="filterCutoff"     type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="filterResonance"  type="h2:psfloat"      default="0.0"/>
+            <xsd:element name="Attack"           type="h2:psfloat"      default="0.0"/>
+            <xsd:element name="Decay"            type="h2:psfloat"      default="0.0"/>
+            <xsd:element name="Sustain"          type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="Release"          type="xsd:nonNegativeInteger"  default="5800"/>
+            <xsd:element name="muteGroup"        type="xsd:integer"     default="-1"/>
+            <xsd:element name="midiOutChannel"   type="xsd:integer"     default="-1" minOccurs="0"/>
+            <xsd:element name="midiOutNote"      type="xsd:integer"     minOccurs="0"/>
+            <xsd:element name="isStopNote"       type="h2:bool"         default="false" minOccurs="0"/>
+            <xsd:element name="FX1Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:element name="FX2Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:element name="FX3Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:element name="FX4Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:sequence>
+                <xsd:element ref="h2:layer" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:sequence>
+        <!--</xsd:all>-->
+    </xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT -->
+<xsd:element name="drumkit_info">
+    <xsd:complexType>
+        <xsd:sequence>
+            <xsd:element name="name"     type="xsd:string"/>
+            <xsd:element name="author"   type="xsd:string"/>
+            <xsd:element name="info"     type="xsd:string"/>
+            <xsd:element name="license"  type="xsd:string"/>
+            <xsd:element name="instrumentList">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element ref="h2:instrument" maxOccurs="1000"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/data/xsd/legacy/v0_9_6/drumkit_pattern.xsd
+++ b/data/xsd/legacy/v0_9_6/drumkit_pattern.xsd
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.hydrogen-music.org/drumkit_pattern" elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xs:simpleType name="bool">
+    <xs:restriction base="xs:string">
+        <xs:enumeration value="true"/>
+        <xs:enumeration value="false"/>
+    </xs:restriction>
+</xs:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0;1.0 ] -->
+<xs:simpleType name='psfloat'>
+    <xs:restriction base='xs:float'>
+        <xs:minInclusive value='0.0'/>
+        <xs:maxInclusive value='1.0'/>
+    </xs:restriction>
+</xs:simpleType>
+
+<!-- NOTE -->
+<xs:element name="note">
+    <xs:complexType>
+        <!--
+        <xsd:all>
+            BUG libqt4-xml 4.6.3 and 4.7.1
+             http://bugreports.qt.nokia.com/browse/QTBUG-12534?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel#issue-tabs
+        -->
+        <xs:sequence>
+            <xs:element name="position"    type="xs:nonNegativeInteger"   default="0"/>
+            <xs:element name="leadlag"     type="xs:float"    default="0.0"/>
+            <xs:element name="velocity"    type="psfloat"   default="0.8"/>
+            <xs:element name="pan_L"       type="psfloat"   default="0.5"/>     <!-- maxINclusive="0.5" -->
+            <xs:element name="pan_R"       type="psfloat"   default="0.5"/>     <!-- maxInclusive="0.5" -->
+            <xs:element name="pitch"       type="xs:float"    default="0.0"/>
+            <xs:element name="key"         type="xs:string"   default="C0"/>
+            <xs:element name="length"      type="xs:integer"   default="-1"/>
+            <xs:element name="instrument"  type="xs:integer"/>
+            <xs:element name="note_off"    type="bool"      default="false"/>
+        </xs:sequence>
+        <!--</xsd:all>-->
+    </xs:complexType>
+</xs:element>
+
+<xs:element name="pattern">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="name"        type="xs:string"   default="unknown"/>
+            <xs:element name="info"        type="xs:string"/>
+            <xs:element name="category"    type="xs:string"   default="unknown"/>
+            <xs:element name="size"        type="xs:nonNegativeInteger"/>
+            <xs:element name="noteList">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element ref="note" maxOccurs="1000"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+
+<!-- DRUMKIT PATTERN -->
+<xs:element name="drumkit_pattern">
+    <xs:complexType>
+        <xs:sequence>
+            <xs:element name="drumkit_name"    type="xs:string"/>
+            <xs:element ref="pattern" minOccurs="1" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+
+</xs:schema>

--- a/data/xsd/legacy/v0_9_7/drumkit.xsd
+++ b/data/xsd/legacy/v0_9_7/drumkit.xsd
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://www.hydrogen-music.org/drumkit"
+    xmlns:h2="http://www.hydrogen-music.org/drumkit"
+    elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+    <xsd:restriction base="xsd:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+    </xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0;1.0 ] -->
+<xsd:simpleType name='psfloat'>
+    <xsd:restriction base='xsd:float'>
+        <xsd:minInclusive value='0.0'/>
+        <xsd:maxInclusive value='1.0'/>
+    </xsd:restriction>
+</xsd:simpleType>
+
+<!-- INSTRUMENT COMPONENT -->
+<xsd:element name="instrumentComponent">
+    <xsd:complexType>
+        <xsd:sequence>
+            <xsd:element name="component_id"    type="xsd:integer"/>
+            <xsd:element name="gain"  		type="xsd:float" default="1.0"/>
+    <xsd:sequence>
+                <xsd:element ref="h2:layer" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT COMPONENT -->
+<xsd:element name="drumkitComponent">
+    <xsd:complexType>
+        <xsd:sequence>
+            <xsd:element name="id"    	type="xsd:integer"/>
+            <xsd:element name="name"    type="xsd:string"/>
+            <xsd:element name="volume"  type="xsd:float" default="1.0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:element>
+
+<!-- LAYER -->
+<xsd:element name="layer">
+    <xsd:complexType>
+        <xsd:sequence>
+            <xsd:element name="filename"    type="xsd:string"/>
+            <xsd:element name="min"         type="xsd:float" default="0.0"/>
+            <xsd:element name="max"         type="xsd:float" default="1.0"/>
+            <xsd:element name="gain"        type="xsd:float" default="1.0"/>
+            <xsd:element name="pitch"       type="xsd:float" default="0.0"/>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:element>
+
+<!-- INSTRUMENT -->
+<xsd:element name="instrument">
+    <xsd:complexType>
+        <!--
+        <xsd:all>
+            BUG libqt4-xml 4.6.3 and 4.7.1
+             http://bugreports.qt.nokia.com/browse/QTBUG-12534?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel#issue-tabs
+        -->
+        <xsd:sequence>
+            <xsd:element name="id"               type="xsd:integer"/>
+            <xsd:element name="name"             type="xsd:string"/>
+            <xsd:element name="volume"           type="xsd:decimal"     default="1.0"/>
+            <xsd:element name="isMuted"          type="h2:bool"         default="false"/>
+            <xsd:element name="pan_L"            type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="pan_R"            type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="randomPitchFactor" type="h2:psfloat"     default="0.0"/>
+            <xsd:element name="gain"             type="xsd:float"       default="1.0"/>
+            <xsd:element name="applyVelocity"    type="h2:bool"         default="false"/>
+            <xsd:element name="filterActive"     type="h2:bool"         default="false"/>
+            <xsd:element name="filterCutoff"     type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="filterResonance"  type="h2:psfloat"      default="0.0"/>
+            <xsd:element name="Attack"           type="h2:psfloat"      default="0.0"/>
+            <xsd:element name="Decay"            type="h2:psfloat"      default="0.0"/>
+            <xsd:element name="Sustain"          type="h2:psfloat"      default="1.0"/>
+            <xsd:element name="Release"          type="xsd:nonNegativeInteger"  default="5800"/>
+            <xsd:element name="muteGroup"        type="xsd:integer"     default="-1"/>
+            <xsd:element name="midiOutChannel"   type="xsd:integer"     default="-1" minOccurs="0"/>
+            <xsd:element name="midiOutNote"      type="xsd:integer"     minOccurs="0"/>
+            <xsd:element name="isStopNote"       type="h2:bool"         default="false" minOccurs="0"/>
+            <xsd:element name="sampleSelectionAlgo" type="xsd:string"   default="VELOCITY"/>
+            <xsd:element name="isHihat"          type="xsd:integer"     default="-1"/>
+            <xsd:element name="lower_cc"         type="xsd:integer"     default="0"/>
+            <xsd:element name="higher_cc"        type="xsd:integer"     default="0"/>
+            <xsd:element name="FX1Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:element name="FX2Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:element name="FX3Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:element name="FX4Level"         type="xsd:decimal"     default="0.0" minOccurs="0"/>
+            <xsd:sequence>
+                <xsd:element ref="h2:instrumentComponent" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+        </xsd:sequence>
+        <!--</xsd:all>-->
+    </xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT -->
+<xsd:element name="drumkit_info">
+    <xsd:complexType>
+        <xsd:sequence>
+            <xsd:element name="name"     type="xsd:string"/>
+            <xsd:element name="author"   type="xsd:string"/>
+            <xsd:element name="info"     type="xsd:string"/>
+            <xsd:element name="license"  type="xsd:string"/>
+            <xsd:element name="image"	 type="xsd:string"/>
+	    <xsd:element name="imageLicense"    type="xsd:string"/>
+            <xsd:element name="componentList">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element ref="h2:drumkitComponent" maxOccurs="1000"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="instrumentList">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element ref="h2:instrument" maxOccurs="1000"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/data/xsd/legacy/v1_0_0/drumkit.xsd
+++ b/data/xsd/legacy/v1_0_0/drumkit.xsd
@@ -1,0 +1,127 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.hydrogen-music.org/drumkit"
+	xmlns:h2="http://www.hydrogen-music.org/drumkit"
+	elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+	<xsd:restriction base="xsd:string">
+		<xsd:enumeration value="true"/>
+		<xsd:enumeration value="false"/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0;1.0 ] -->
+<xsd:simpleType name='psfloat'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='0.0'/>
+		<xsd:maxInclusive value='1.0'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- INSTRUMENT COMPONENT -->
+<xsd:element name="instrumentComponent">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="component_id"	type="xsd:integer"/>
+			<xsd:element name="gain"			type="xsd:float"	default="1.0"/>
+			<xsd:sequence>
+				<xsd:element ref="h2:layer" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT COMPONENT -->
+<xsd:element name="drumkitComponent">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="id"		type="xsd:integer"/>
+			<xsd:element name="name"	type="xsd:string"/>
+			<xsd:element name="volume"	type="xsd:float"	default="1.0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- LAYER -->
+<xsd:element name="layer">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="filename"	type="xsd:string"/>
+			<xsd:element name="min"			type="xsd:float"	default="0.0"/>
+			<xsd:element name="max"			type="xsd:float"	default="1.0"/>
+			<xsd:element name="gain"		type="xsd:float"	default="1.0"/>
+			<xsd:element name="pitch"		type="xsd:float"	default="0.0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- INSTRUMENT -->
+<xsd:element name="instrument">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="id"					type="xsd:integer"/>
+			<xsd:element name="name"				type="xsd:string"/>
+			<xsd:element name="volume"				type="xsd:decimal"				default="1.0"/>
+			<xsd:element name="isMuted"				type="h2:bool"					default="false"/>
+			<xsd:element name="pan_L"				type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="pan_R"				type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="randomPitchFactor"	type="h2:psfloat"				default="0.0"/>
+			<xsd:element name="gain"				type="xsd:float"				default="1.0"/>
+			<xsd:element name="applyVelocity"		type="h2:bool"					default="false"/>
+			<xsd:element name="filterActive"		type="h2:bool"					default="false"/>
+			<xsd:element name="filterCutoff"		type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="filterResonance"		type="h2:psfloat"				default="0.0"/>
+			<xsd:element name="Attack"				type="xsd:nonNegativeInteger"	default="0"/>
+			<xsd:element name="Decay"				type="xsd:nonNegativeInteger"	default="0"/>
+			<xsd:element name="Sustain"				type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="Release"				type="xsd:nonNegativeInteger"	default="5800"/>
+			<xsd:element name="muteGroup"			type="xsd:integer"				default="-1"/>
+			<xsd:element name="midiOutChannel"		type="xsd:integer"				default="-1"	minOccurs="0"/>
+			<xsd:element name="midiOutNote"			type="xsd:integer"								minOccurs="0"/>
+			<xsd:element name="isStopNote"			type="h2:bool"					default="false"	minOccurs="0"/>
+			<xsd:element name="sampleSelectionAlgo"	type="xsd:string"				default="VELOCITY"/>
+			<xsd:element name="isHihat"				type="xsd:integer"				default="-1"/>
+			<xsd:element name="lower_cc"			type="xsd:integer"				default="0"/>
+			<xsd:element name="higher_cc"			type="xsd:integer"				default="0"/>
+			<xsd:element name="FX1Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="FX2Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="FX3Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="FX4Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:sequence>
+				<xsd:element ref="h2:instrumentComponent" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:sequence>
+</xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT -->
+<xsd:element name="drumkit_info">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="name"			type="xsd:string"/>
+			<xsd:element name="author"			type="xsd:string"/>
+			<xsd:element name="info"			type="xsd:string"/>
+			<xsd:element name="license"			type="xsd:string"/>
+			<xsd:element name="image"			type="xsd:string"/>
+			<xsd:element name="imageLicense"	type="xsd:string"/>
+			<xsd:element name="componentList">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:drumkitComponent" maxOccurs="1000"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="instrumentList">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:instrument" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/data/xsd/legacy/v1_0_0/drumkit_pattern.xsd
+++ b/data/xsd/legacy/v1_0_0/drumkit_pattern.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.hydrogen-music.org/drumkit_pattern"
+	xmlns:h2="http://www.hydrogen-music.org/drumkit_pattern"
+	elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+	<xsd:restriction base="xsd:string">
+		<xsd:enumeration value="true"/>
+		<xsd:enumeration value="false"/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0; 1.0] -->
+<xsd:simpleType name='psfloat'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='0.0'/>
+		<xsd:maxInclusive value='1.0'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0; 0.5] -->
+<xsd:simpleType name='psfloat5'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='0.0'/>
+		<xsd:maxInclusive value='0.5'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- NOTE -->
+<xsd:element name="note">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="position"	type="xsd:nonNegativeInteger"	default="0"/>
+			<xsd:element name="leadlag"		type="xsd:float"		default="0.0"/>
+			<xsd:element name="velocity"	type="h2:psfloat"		default="0.8"/>
+			<xsd:element name="pan_L"		type="h2:psfloat5"		default="0.5"/>
+			<xsd:element name="pan_R"		type="h2:psfloat5"		default="0.5"/>
+			<xsd:element name="pitch"		type="xsd:float"		default="0.0"/>
+			<xsd:element name="key"			type="xsd:string"		default="C0"/>
+			<xsd:element name="length"		type="xsd:integer"		default="-1"/>
+			<xsd:element name="instrument"	type="xsd:integer"/>
+			<xsd:element name="note_off"	type="h2:bool"			default="false"/>
+			<xsd:element name="probability"	type="xsd:float"		default="1.0"/>
+		</xsd:sequence>
+</xsd:complexType>
+</xsd:element>
+
+<xsd:element name="pattern">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="name"		type="xsd:string"		default="unknown"/>
+			<xsd:element name="info"		type="xsd:string"/>
+			<xsd:element name="category"	type="xsd:string"		default="unknown"/>
+			<xsd:element name="size"		type="xsd:nonNegativeInteger"/>
+			<xsd:element name="noteList">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:note" minOccurs="0" maxOccurs="1000"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT PATTERN -->
+<xsd:element name="drumkit_pattern">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="drumkit_name"	type="xsd:string"/>
+			<xsd:element name="author"			type="xsd:string"/>
+			<xsd:element name="license"			type="xsd:string"/>
+			<xsd:element ref="h2:pattern" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/data/xsd/legacy/v1_0_0/playlist.xsd
+++ b/data/xsd/legacy/v1_0_0/playlist.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.hydrogen-music.org/playlist"
+	xmlns:h2="http://www.hydrogen-music.org/playlist"
+	elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+	<xsd:restriction base="xsd:string">
+		<xsd:enumeration value="true"/>
+		<xsd:enumeration value="false"/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- NOTE -->
+<xsd:element name="song">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="path"			type="xsd:string"/>
+			<xsd:element name="scriptPath"		type="xsd:string"/>
+			<xsd:element name="scriptEnabled"	type="h2:bool"		default="false"/>
+		</xsd:sequence>
+</xsd:complexType>
+</xsd:element>
+
+<!-- PLAYLIST -->
+<xsd:element name="playlist">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="name"			type="xsd:string"/>
+			<xsd:element name="songs">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:song" maxOccurs="1000"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/data/xsd/legacy/v1_1_0/drumkit.xsd
+++ b/data/xsd/legacy/v1_1_0/drumkit.xsd
@@ -1,0 +1,129 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.hydrogen-music.org/drumkit"
+	xmlns:h2="http://www.hydrogen-music.org/drumkit"
+	elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+	<xsd:restriction base="xsd:string">
+		<xsd:enumeration value="true"/>
+		<xsd:enumeration value="false"/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0;1.0 ] -->
+<xsd:simpleType name='psfloat'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='0.0'/>
+		<xsd:maxInclusive value='1.0'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- INSTRUMENT COMPONENT -->
+<xsd:element name="instrumentComponent">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="component_id"	type="xsd:integer"/>
+			<xsd:element name="gain"			type="xsd:float"	default="1.0"/>
+			<xsd:sequence>
+				<xsd:element ref="h2:layer" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT COMPONENT -->
+<xsd:element name="drumkitComponent">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="id"		type="xsd:integer"/>
+			<xsd:element name="name"	type="xsd:string"/>
+			<xsd:element name="volume"	type="xsd:float"	default="1.0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- LAYER -->
+<xsd:element name="layer">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="filename"	type="xsd:string"/>
+			<xsd:element name="min"			type="xsd:float"	default="0.0"/>
+			<xsd:element name="max"			type="xsd:float"	default="1.0"/>
+			<xsd:element name="gain"		type="xsd:float"	default="1.0"/>
+			<xsd:element name="pitch"		type="xsd:float"	default="0.0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- INSTRUMENT -->
+<xsd:element name="instrument">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="id"					type="xsd:integer"/>
+			<xsd:element name="name"				type="xsd:string"/>
+			<xsd:element name="volume"				type="xsd:decimal"				default="1.0"/>
+			<xsd:element name="isMuted"				type="h2:bool"					default="false"/>
+			<xsd:element name="isSoloed"			type="h2:bool"					default="false"/>
+			<xsd:element name="pan_L"				type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="pan_R"				type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="pitchOffset"	type="h2:psfloat"				default="0.0"/>
+			<xsd:element name="randomPitchFactor"	type="h2:psfloat"				default="0.0"/>
+			<xsd:element name="gain"				type="xsd:float"				default="1.0"/>
+			<xsd:element name="applyVelocity"		type="h2:bool"					default="false"/>
+			<xsd:element name="filterActive"		type="h2:bool"					default="false"/>
+			<xsd:element name="filterCutoff"		type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="filterResonance"		type="h2:psfloat"				default="0.0"/>
+			<xsd:element name="Attack"				type="xsd:nonNegativeInteger"	default="0"/>
+			<xsd:element name="Decay"				type="xsd:nonNegativeInteger"	default="0"/>
+			<xsd:element name="Sustain"				type="h2:psfloat"				default="1.0"/>
+			<xsd:element name="Release"				type="xsd:nonNegativeInteger"	default="5800"/>
+			<xsd:element name="muteGroup"			type="xsd:integer"				default="-1"/>
+			<xsd:element name="midiOutChannel"		type="xsd:integer"				default="-1"	minOccurs="0"/>
+			<xsd:element name="midiOutNote"			type="xsd:integer"								minOccurs="0"/>
+			<xsd:element name="isStopNote"			type="h2:bool"					default="false"	minOccurs="0"/>
+			<xsd:element name="sampleSelectionAlgo"	type="xsd:string"				default="VELOCITY"/>
+			<xsd:element name="isHihat"				type="xsd:integer"				default="-1"/>
+			<xsd:element name="lower_cc"			type="xsd:integer"				default="0"/>
+			<xsd:element name="higher_cc"			type="xsd:integer"				default="0"/>
+			<xsd:element name="FX1Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="FX2Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="FX3Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:element name="FX4Level"			type="xsd:decimal"				default="0.0"	minOccurs="0"/>
+			<xsd:sequence>
+				<xsd:element ref="h2:instrumentComponent" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+		</xsd:sequence>
+</xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT -->
+<xsd:element name="drumkit_info">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="name"			type="xsd:string"/>
+			<xsd:element name="author"			type="xsd:string"/>
+			<xsd:element name="info"			type="xsd:string"/>
+			<xsd:element name="license"			type="xsd:string"/>
+			<xsd:element name="image"			type="xsd:string"/>
+			<xsd:element name="imageLicense"	type="xsd:string"/>
+			<xsd:element name="componentList">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:drumkitComponent" maxOccurs="1000"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+			<xsd:element name="instrumentList">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:instrument" maxOccurs="unbounded"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/data/xsd/legacy/v1_1_0/drumkit_pattern.xsd
+++ b/data/xsd/legacy/v1_1_0/drumkit_pattern.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.hydrogen-music.org/drumkit_pattern"
+	xmlns:h2="http://www.hydrogen-music.org/drumkit_pattern"
+	elementFormDefault="qualified">
+
+<!-- BOOL -->
+<xsd:simpleType name="bool">
+	<xsd:restriction base="xsd:string">
+		<xsd:enumeration value="true"/>
+		<xsd:enumeration value="false"/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0; 1.0] -->
+<xsd:simpleType name='psfloat'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='0.0'/>
+		<xsd:maxInclusive value='1.0'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- PSFLOAT - positive small float [0.0; 0.5] -->
+<xsd:simpleType name='psfloat5'>
+	<xsd:restriction base='xsd:float'>
+		<xsd:minInclusive value='0.0'/>
+		<xsd:maxInclusive value='0.5'/>
+	</xsd:restriction>
+</xsd:simpleType>
+
+<!-- NOTE -->
+<xsd:element name="note">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="position"	type="xsd:nonNegativeInteger"	default="0"/>
+			<xsd:element name="leadlag"		type="xsd:float"		default="0.0"/>
+			<xsd:element name="velocity"	type="h2:psfloat"		default="0.8"/>
+			<xsd:element name="pan_L"		type="h2:psfloat5"		default="0.5"/>
+			<xsd:element name="pan_R"		type="h2:psfloat5"		default="0.5"/>
+			<xsd:element name="pitch"		type="xsd:float"		default="0.0"/>
+			<xsd:element name="key"			type="xsd:string"		default="C0"/>
+			<xsd:element name="length"		type="xsd:integer"		default="-1"/>
+			<xsd:element name="instrument"	type="xsd:integer"/>
+			<xsd:element name="note_off"	type="h2:bool"			default="false"/>
+			<xsd:element name="probability"	type="xsd:float"		default="1.0"/>
+		</xsd:sequence>
+</xsd:complexType>
+</xsd:element>
+
+<xsd:element name="pattern">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="name"		type="xsd:string"		default="unknown"/>
+			<xsd:element name="info"		type="xsd:string"/>
+			<xsd:element name="category"	type="xsd:string"		default="unknown"/>
+			<xsd:element name="size"		type="xsd:nonNegativeInteger"/>
+			<xsd:element name="denominator"	type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="noteList">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:element ref="h2:note" minOccurs="0" maxOccurs="1000"/>
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- DRUMKIT PATTERN -->
+<xsd:element name="drumkit_pattern">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="drumkit_name"	type="xsd:string"/>
+			<xsd:element name="author"			type="xsd:string"/>
+			<xsd:element name="license"			type="xsd:string"/>
+			<xsd:element ref="h2:pattern" minOccurs="1" maxOccurs="1"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+</xsd:schema>

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -414,7 +414,7 @@ int main(int argc, char *argv[])
 		auto pCoreActionController = pHydrogen->getCoreActionController();
 
 		if ( bValidateDrumkit ) {
-			if ( ! pCoreActionController->validateDrumkit( sDrumkitToValidate ) ) {
+			if ( ! pCoreActionController->validateDrumkit( sDrumkitToValidate, true ) ) {
 				nReturnCode = -1;
 
 				std::cout << "Provided drumkit [" <<

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -72,6 +72,7 @@ static struct option long_opts[] = {
 	{"help", 0, nullptr, 'h'},
 	{"install", required_argument, nullptr, 'i'},
 	{"check", required_argument, nullptr, 'c'},
+	{"legacy-check", required_argument, nullptr, 'l'},
 	{"upgrade", required_argument, nullptr, 'u'},
 	{"extract", required_argument, nullptr, 'x'},
 	{"target", required_argument, nullptr, 't'},
@@ -170,6 +171,7 @@ int main(int argc, char *argv[])
 		QString drumkitToLoad;
 		QString sDrumkitToValidate;
 		bool bValidateDrumkit = false;
+		bool bValidateLegacyKits = false;
 		QString sDrumkitToUpgrade;
 		bool bUpgradeDrumkit = false;
 		QString sDrumkitToExtract;
@@ -204,6 +206,12 @@ int main(int argc, char *argv[])
 				//validate h2drumkit
 				sDrumkitToValidate = makePathAbsolute( optarg );
 				bValidateDrumkit = true;
+				break;
+			case 'l':
+				//validate h2drumkit including legacy XSD definitions
+				sDrumkitToValidate = makePathAbsolute( optarg );
+				bValidateDrumkit = true;
+				bValidateLegacyKits = true;
 				break;
 			case 'u':
 				//upgrade h2drumkit
@@ -414,8 +422,9 @@ int main(int argc, char *argv[])
 		auto pCoreActionController = pHydrogen->getCoreActionController();
 
 		if ( bValidateDrumkit ) {
-			if ( ! pCoreActionController->validateDrumkit( sDrumkitToValidate, true ) ) {
-				nReturnCode = -1;
+			if ( ! pCoreActionController->validateDrumkit( sDrumkitToValidate,
+					 bValidateLegacyKits ) ) {
+				nReturnCode = 1;
 
 				std::cout << "Provided drumkit [" <<
 					sDrumkitToValidate.toLocal8Bit().data() << "] is INVALID!" << std::endl;
@@ -428,7 +437,7 @@ int main(int argc, char *argv[])
 		} else if ( bExtractDrumkit ) {
 			if ( ! pCoreActionController->extractDrumkit( sDrumkitToExtract,
 														  sTarget ) ) {
-				nReturnCode = -1;
+				nReturnCode = 1;
 
 				if ( sTarget.isEmpty() ) {
 					std::cout << "Unable to install drumkit [" <<
@@ -455,7 +464,7 @@ int main(int argc, char *argv[])
 		} else if ( bUpgradeDrumkit ) {
 			if ( ! pCoreActionController->upgradeDrumkit( sDrumkitToUpgrade,
 														  sTarget ) ) {
-				nReturnCode = -1;
+				nReturnCode = 1;
 
 				std::cout << "Unable to upgrade provided drumkit [" <<
 					sDrumkitToUpgrade.toLocal8Bit().data() << "]!" << std::endl;
@@ -627,6 +636,10 @@ void showUsage()
 	std::cout << "Drumkit handling:" << std::endl;
 	std::cout << "   -i, --install FILE - install a drumkit (*.h2drumkit)" << std::endl;
 	std::cout << "   -c, --check FILE - validates a drumkit (*.h2drumkit)" << std::endl;
+	std::cout << "                      against current drumkit format" << std::endl;
+	std::cout << "   -l, --legcay-check FILE - validates a drumkit (*.h2drumkit)" << std::endl;
+	std::cout << "                             against current as well as legacy" << std::endl;
+	std::cout << "                             drumkit formats" << std::endl;
 	std::cout << "   -u, --upgrade FILE - upgrades a drumkit. FILE can be either" << std::endl;
 	std::cout << "                        an absolute path to a folder containing a" << std::endl;
 	std::cout << "                        drumkit, an absolute path to a drumkit file" << std::endl;

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -304,8 +304,15 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 	 * Checks whether the provided drumkit in @a sDrumkitPath can be
 	 * found, can be loaded, and does comply with the current XSD
 	 * definition.
+	 *
+	 * @param sDrumkitPath Can be either an absolute path to a folder
+	 *   containing a drumkit file (drumkit.xml), an absolute path to a
+	 *   drumkit file itself, or an absolute file to a compressed
+	 *   drumkit (.h2drumkit).
+	 * @param bCheckLegacyVersions Whether just the current XSD
+	 *   definition or also all previous versions should be checked.
 	 */
-	bool validateDrumkit( const QString& sDrumkitPath );
+	bool validateDrumkit( const QString& sDrumkitPath, bool bCheckLegacyVersions = false );
 	/**
 	 * Extracts the compressed .h2drumkit file in @a sDrumkitPath into
 	 * @a sTargetDir.

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -509,6 +509,10 @@ QString Filesystem::usr_click_file_path()
 	if( file_readable( __usr_data_path + CLICK_SAMPLE, true ) ) return __usr_data_path + CLICK_SAMPLE;
 	return click_file_path();
 }
+QString Filesystem::drumkit_xsd( )
+{
+	return DRUMKIT_XSD;
+}
 QString Filesystem::drumkit_xsd_path( )
 {
 	return xsd_dir() + DRUMKIT_XSD;
@@ -610,6 +614,10 @@ QString Filesystem::demos_dir()
 QString Filesystem::xsd_dir()
 {
 	return __sys_data_path + XSD;
+}
+QString Filesystem::xsd_legacy_dir()
+{
+	return xsd_dir() + "legacy";
 }
 QString Filesystem::tmp_dir()
 {
@@ -1033,6 +1041,25 @@ Filesystem::DrumkitType Filesystem::determineDrumkitType( const QString& sPath )
 			return DrumkitType::SessionReadOnly;
 		}
 	}
+}
+
+QStringList Filesystem::drumkit_xsd_legacy_paths() {
+	const QDir legacyDir( xsd_legacy_dir() );
+
+	const QStringList legacyDirSubfolders =
+		legacyDir.entryList( QDir::Dirs | QDir::NoDotAndDotDot,
+							 QDir::Name | QDir::Reversed );
+
+	QStringList drumkitXSDs;
+	for ( const auto& ffolder : legacyDirSubfolders ) {
+		const QDir folder( legacyDir.filePath( ffolder ) );
+		
+		if ( folder.exists( drumkit_xsd() ) ) {
+			drumkitXSDs << folder.filePath( drumkit_xsd() );
+		}
+	}
+
+	return std::move( drumkitXSDs );
 }
 
 };

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -156,8 +156,13 @@ namespace H2Core
 		static QString click_file_path();
 		/** returns click file path from user directory if exists, otherwise from system */
 		static QString usr_click_file_path();
+		/** returns the drumkit XSD (xml schema definition) name */
+		static QString drumkit_xsd( );
 		/** returns the path to the drumkit XSD (xml schema definition) file */
 		static QString drumkit_xsd_path( );
+		/** @return List of absolute paths to all formerly used
+			drumkit.xsd files.*/
+		static QStringList drumkit_xsd_legacy_paths( );
 		/** returns the path to the pattern XSD (xml schema definition) file */
 		static QString pattern_xsd_path( );
 		/** returns the path to the playlist pattern XSD (xml schema definition) file */
@@ -203,6 +208,7 @@ namespace H2Core
 		static QString demos_dir();
 		/** returns system xsd path */
 		static QString xsd_dir();
+		static QString xsd_legacy_dir();
 		/** returns temp path */
 		static QString tmp_dir();
 		static QString usr_theme_dir();

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -1041,7 +1041,7 @@ void OscServer::VALIDATE_DRUMKIT_Handler(lo_arg **argv, int argc) {
 	INFOLOG( "processing message" );
 	
 	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
-	pController->validateDrumkit( QString::fromUtf8( &argv[0]->s ) );
+	pController->validateDrumkit( QString::fromUtf8( &argv[0]->s ), true );
 }
 
 void OscServer::EXTRACT_DRUMKIT_Handler(lo_arg **argv, int argc) {

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -1039,9 +1039,15 @@ void OscServer::UPGRADE_DRUMKIT_Handler(lo_arg **argv, int argc) {
 
 void OscServer::VALIDATE_DRUMKIT_Handler(lo_arg **argv, int argc) {
 	INFOLOG( "processing message" );
+
+	bool bValidateLegacyKits = false;
+	if ( argc > 1 ) {
+		bValidateLegacyKits = argv[1]->f == 0 ? false : true;
+	}
 	
 	auto pController = H2Core::Hydrogen::get_instance()->getCoreActionController();
-	pController->validateDrumkit( QString::fromUtf8( &argv[0]->s ), true );
+	pController->validateDrumkit( QString::fromUtf8( &argv[0]->s ),
+								  bValidateLegacyKits );
 }
 
 void OscServer::EXTRACT_DRUMKIT_Handler(lo_arg **argv, int argc) {
@@ -1347,6 +1353,7 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/UPGRADE_DRUMKIT", "s", UPGRADE_DRUMKIT_Handler);
 	m_pServerThread->add_method("/Hydrogen/UPGRADE_DRUMKIT", "ss", UPGRADE_DRUMKIT_Handler);
 	m_pServerThread->add_method("/Hydrogen/VALIDATE_DRUMKIT", "s", VALIDATE_DRUMKIT_Handler);
+	m_pServerThread->add_method("/Hydrogen/VALIDATE_DRUMKIT", "sf", VALIDATE_DRUMKIT_Handler);
 	m_pServerThread->add_method("/Hydrogen/EXTRACT_DRUMKIT", "s", EXTRACT_DRUMKIT_Handler);
 	m_pServerThread->add_method("/Hydrogen/EXTRACT_DRUMKIT", "ss", EXTRACT_DRUMKIT_Handler);
 

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -241,7 +241,7 @@ void XmlTest::testDrumkitUpgrade() {
 
 		sDrumkitPath = H2TEST_FILE( "drumkits/legacyKits" ) + "/" + ssFile;
 
-		CPPUNIT_ASSERT( ! pCoreActionController->validateDrumkit( sDrumkitPath ) );
+		CPPUNIT_ASSERT( ! pCoreActionController->validateDrumkit( sDrumkitPath, false ) );
 
 		// The number of files within the drumkit has to be constant.
 		QTemporaryDir contentOriginal( H2Core::Filesystem::tmp_dir() + "-XXXXXX" );
@@ -268,7 +268,7 @@ void XmlTest::testDrumkitUpgrade() {
 		QString sUpgradedKit( firstUpgrade.path() + "/" +
 							  upgradeFolder.entryList( QDir::AllEntries |
 													   QDir::NoDotAndDotDot )[ 0 ] );
-		CPPUNIT_ASSERT( pCoreActionController->validateDrumkit( sUpgradedKit ) );
+		CPPUNIT_ASSERT( pCoreActionController->validateDrumkit( sUpgradedKit, false ) );
 		
 		QTemporaryDir contentUpgraded( H2Core::Filesystem::tmp_dir() + "-XXXXXX" );
 		contentUpgraded.setAutoRemove( false );


### PR DESCRIPTION
Using `h2cli` as well as an OSC command we can check the validity of a drumkit on the command line.

Previously, this only checked against the most recent drumkit.xsd definition. I think this is a bit too restrictive. We have a number functions dedicated to loading legacy kits and there were only minor tweaks in the most recent changes of the definition file. No need to deem those kits invalid.

With this patch both the CLI and OSC validation check against all previous drumkit files and reports valid in case one of them matches.

This also involves the promise to properly load all kits back to version 0.9.6. I am not sure whether we already do so but I think we should.

---
Edit: 

The default choice of checking legacy kits in https://github.com/theGreatWhiteShark/hydrogen/commit/b2b8659b5ec3d1a166b50a875ef91c7887e06edb has been reverted. The CLI validation was introduced in order to help the Debian maintainer with their packaging pipeline. In case the validation fails, all drumkits shipped need to be upgraded in order to prevent unnecessary log messages and upgrade of drumkit provided by Debian and installed on system-level.

Instead, a separate --legacy-check option in the CLI and an additional parameter in the OSC command VALIDATE_DRUMKIT for toggling the legcay check was introduced