### PR TITLE
AppVeyor: update openssl to version 3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,8 +62,8 @@ environment:
       BUILD_TYPE: "Release"
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
       appveyor_build_worker_image: Visual Studio 2019
-      LIBSSL: libssl-1_1-x64.dll
-      LIBCRYPTO: libcrypto-1_1-x64.dll
+      LIBSSL: libssl-3-x64.dll
+      LIBCRYPTO: libcrypto-3-x64.dll
 
     - job_name: 'Windows32'
       job_group: 'Windows'
@@ -72,8 +72,8 @@ environment:
       BUILD_TYPE: "Release"
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
       appveyor_build_worker_image: Visual Studio 2019
-      LIBSSL: libssl-1_1.dll
-      LIBCRYPTO: libcrypto-1_1.dll
+      LIBSSL: libssl-3.dll
+      LIBCRYPTO: libcrypto-3.dll
 
 build:
   verbosity: detailed


### PR DESCRIPTION
There seem to have been a couple of changes in the AppVeyor Windows image and its pacman cache during the last couple of days. `libssl-1_1` and `libcrypto-1_1` were dropped in favour for `libssl-3` and `libcrypto-3`. Manually pinning to `openssl-1.1.1-n` using `pacman` does not work https://ci.appveyor.com/project/mauser/hydrogen/builds/46402182 but just using version 3 seems to do https://ci.appveyor.com/project/mauser/hydrogen/builds/46397198. I also validated the latter using my local windows machine.

Nevertheless, it puzzles me. According to the Qt software configuration page https://wiki.qt.io/Qt_5.15_Tools_and_Versions\#Software_configurations_for_Qt_5.15.8 Qt 5.15.8, the one currently used in our AppVeyor image, should not run with this openssl version. I also made sure to upgrade systems one too.

But it seems to work and fixing the build pipeline has a higher priority as it a) just affects the online drumkit download and b) can easily fixed by putting the right libssl and libcrypto DLLs into the Hydrogen folder