### PR TITLE
Fix Widget issues and TempoMarker rendering

### DIFF
--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -272,6 +272,26 @@ QString Timeline::toQString( const QString& sPrefix, bool bShort ) const {
 	return sOutput;
 }
 
+QString Timeline::TempoMarker::getPrettyString() const {
+	QString sOut = QString( "%1" ).arg( fBpm, 0, 'f', 2 );
+
+	// Remove trailing zeros.
+	while ( sOut.size() > 0 ) {
+		if ( sOut.back() == "0" ) {
+			sOut.chop( 1 );
+		}
+		else if ( sOut.back() == "." ) {
+			sOut.chop( 1 );
+			break;
+		}
+		else {
+			break;
+		}
+	}
+
+	return std::move( sOut );
+}
+
 QString Timeline::TempoMarker::toQString( const QString& sPrefix, bool bShort ) const {
 	QString s = Base::sPrintIndention;
 	QString sOutput;

--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -272,22 +272,14 @@ QString Timeline::toQString( const QString& sPrefix, bool bShort ) const {
 	return sOutput;
 }
 
-QString Timeline::TempoMarker::getPrettyString() const {
-	QString sOut = QString( "%1" ).arg( fBpm, 0, 'f', 2 );
+QString Timeline::TempoMarker::getPrettyString( int nDecimals ) const {
 
-	// Remove trailing zeros.
-	while ( sOut.size() > 0 ) {
-		if ( sOut.back() == "0" ) {
-			sOut.chop( 1 );
-		}
-		else if ( sOut.back() == "." ) {
-			sOut.chop( 1 );
-			break;
-		}
-		else {
-			break;
-		}
+	int nPrec = 7;
+	if ( nDecimals >= 0 ) {
+		nPrec = std::min( nDecimals + ( fBpm >= 100 ? 3 : 2 ),
+						  7 );
 	}
+	QString sOut = QString::number( fBpm, 'g', nPrec );
 
 	return std::move( sOut );
 }

--- a/src/core/Timeline.h
+++ b/src/core/Timeline.h
@@ -81,6 +81,11 @@ public:
 		int		nColumn;		// beat position in timeline
 		float	fBpm;		// tempo in beats per minute
 
+		/**
+		 * @return A text representation of #fBpm limited to two
+		 *   decimals after point and trailing zeros removed.
+		 */
+		QString getPrettyString() const;
 		QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 	};
 

--- a/src/core/Timeline.h
+++ b/src/core/Timeline.h
@@ -82,10 +82,13 @@ public:
 		float	fBpm;		// tempo in beats per minute
 
 		/**
-		 * @return A text representation of #fBpm limited to two
-		 *   decimals after point and trailing zeros removed.
+		 * @param nDecimals Number of digits after point.
+		 *
+		 * @return A text representation of #fBpm limited to @a
+		 *   nDecimals decimals after point and trailing zeros
+		 *   removed.
 		 */
-		QString getPrettyString() const;
+		QString getPrettyString( int nDecimals = 2 ) const;
 		QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 	};
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -439,7 +439,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pLayerPitchFineLCD->move( 155, 393 );
 	m_pLayerPitchFineRotary->move( 191, 391 );
 
-	m_sampleSelectionAlg = new LCDCombo(m_pLayerProp, QSize( width() - 76 - 7, 18 ) );
+	m_sampleSelectionAlg = new LCDCombo(m_pLayerProp, QSize( width() - 76 - 7, 18 ), true );
 	m_sampleSelectionAlg->move( 76, 432 );
 	m_sampleSelectionAlg->setToolTip( tr( "Select selection algorithm" ) );
 	m_sampleSelectionAlg->addItem( QString( "First in Velocity" ) );

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -119,7 +119,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 
 	///
 	m_pMidiOutNoteLCD = new LCDSpinBox( m_pInstrumentProp, QSize( 59, 24 ),
-										LCDSpinBox::Type::Int, 0, 100 );
+										LCDSpinBox::Type::Int, 0, 100, true );
 	m_pMidiOutNoteLCD->move( 161, 257 );
 	m_pMidiOutNoteLCD->setToolTip(QString(tr("Midi out note")));
 	connect( m_pMidiOutNoteLCD, SIGNAL( valueChanged( double ) ),
@@ -300,7 +300,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pHihatGroupLbl->move( 22, 327 );
 
 	m_pHihatMinRangeLCD = new LCDSpinBox( m_pInstrumentProp, QSize( 59, 24 ),
-										  LCDSpinBox::Type::Int, 0, 127 );
+										  LCDSpinBox::Type::Int, 0, 127, true );
 	m_pHihatMinRangeLCD->move( 138, 303 );
 	connect( m_pHihatMinRangeLCD, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( hihatMinRangeChanged( double ) ) );
@@ -309,7 +309,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	m_pHihatMinRangeLbl->move( 136, 327 );
 
 	m_pHihatMaxRangeLCD = new LCDSpinBox( m_pInstrumentProp, QSize( 59, 24 ),
-										  LCDSpinBox::Type::Int, 0, 127 );
+										  LCDSpinBox::Type::Int, 0, 127, true );
 	m_pHihatMaxRangeLCD->move( 203, 303 );
 	connect( m_pHihatMaxRangeLCD, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( hihatMaxRangeChanged( double ) ) );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -118,14 +118,14 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	m_pEditorTop1_hbox_2->addWidget( m_pSizeResol );
 
 	// PATTERN size
-	m_pLCDSpinBoxNumerator = new LCDSpinBox( m_pSizeResol, QSize( 62, 20 ), LCDSpinBox::Type::Double, 0.1, 16.0 );
+	m_pLCDSpinBoxNumerator = new LCDSpinBox( m_pSizeResol, QSize( 62, 20 ), LCDSpinBox::Type::Double, 0.1, 16.0, true );
 	m_pLCDSpinBoxNumerator->setKind( LCDSpinBox::Kind::PatternSizeNumerator );
 	m_pLCDSpinBoxNumerator->move( 36, 0 );
 	connect( m_pLCDSpinBoxNumerator, &LCDSpinBox::slashKeyPressed, this, &PatternEditorPanel::switchPatternSizeFocus );
 	connect( m_pLCDSpinBoxNumerator, SIGNAL( valueChanged( double ) ), this, SLOT( patternSizeChanged( double ) ) );
 	m_pLCDSpinBoxNumerator->setKeyboardTracking( false );
 	
-	m_pLCDSpinBoxDenominator = new LCDSpinBox( m_pSizeResol, QSize( 48, 20 ), LCDSpinBox::Type::Int, 1, 192 );
+	m_pLCDSpinBoxDenominator = new LCDSpinBox( m_pSizeResol, QSize( 48, 20 ), LCDSpinBox::Type::Int, 1, 192, true );
 	m_pLCDSpinBoxDenominator->setKind( LCDSpinBox::Kind::PatternSizeDenominator );
 	m_pLCDSpinBoxDenominator->move( 106, 0 );
 	connect( m_pLCDSpinBoxDenominator, &LCDSpinBox::slashKeyPressed, this, &PatternEditorPanel::switchPatternSizeFocus );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -144,7 +144,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	m_pPatternSizeLbl->move( 2, 4 );
 	
 	// GRID resolution
-	m_pResolutionCombo = new LCDCombo( m_pSizeResol, QSize( 209, 19 ) );
+	m_pResolutionCombo = new LCDCombo( m_pSizeResol, QSize( 209, 19 ), true );
 	// m_pResolutionCombo->setToolTip(tr( "Select grid resolution" ));
 	m_pResolutionCombo->insertItem( 0, QString( "1/4 - " )
 								 .append( tr( "quarter" ) ) );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -120,7 +120,6 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	// PATTERN size
 	m_pLCDSpinBoxNumerator = new LCDSpinBox( m_pSizeResol, QSize( 62, 20 ), LCDSpinBox::Type::Double, 0.1, 16.0 );
 	m_pLCDSpinBoxNumerator->setKind( LCDSpinBox::Kind::PatternSizeNumerator );
-	m_pLCDSpinBoxNumerator->setDecimals( 16 );
 	m_pLCDSpinBoxNumerator->move( 36, 0 );
 	connect( m_pLCDSpinBoxNumerator, &LCDSpinBox::slashKeyPressed, this, &PatternEditorPanel::switchPatternSizeFocus );
 	connect( m_pLCDSpinBoxNumerator, SIGNAL( valueChanged( double ) ), this, SLOT( patternSizeChanged( double ) ) );

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -332,7 +332,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 	// LCD BPM SpinBox
 	m_pLCDBPMSpinbox = new LCDSpinBox( pBPMPanel, QSize( 95, 30), LCDSpinBox::Type::Double,
 									   static_cast<double>( MIN_BPM ),
-									   static_cast<double>( MAX_BPM ) );
+									   static_cast<double>( MAX_BPM ), true );
 	m_pLCDBPMSpinbox->move( 36, 1 );
 	m_pLCDBPMSpinbox->setStyleSheet( m_pLCDBPMSpinbox->styleSheet().
 									 append( " QAbstractSpinBox {font-size: 16px;}" ) );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -976,9 +976,7 @@ void SongEditor::updatePosition( float fTick ) {
 	if ( fTick != m_fTick ) {
 		float fDiff = static_cast<float>(m_nGridWidth) * (fTick - m_fTick);
 		m_fTick = fTick;
-		int nX = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
-								   m_fTick * static_cast<float>(m_nGridWidth) -
-								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nX = SongEditorPositionRuler::tickToColumn( m_fTick, m_nGridWidth );
 		int nOffset = Skin::getPlayheadShaftOffset();
 		QRect updateRect( nX + nOffset -2, 0, 4, height() );
 		update( updateRect );
@@ -1043,9 +1041,7 @@ void SongEditor::paintEvent( QPaintEvent *ev )
 	}
 	// Draw playhead
 	if ( m_fTick != -1 ) {
-		int nX = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
-								   m_fTick * static_cast<float>(m_nGridWidth) -
-								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nX = SongEditorPositionRuler::tickToColumn( m_fTick, m_nGridWidth );
 		int nOffset = Skin::getPlayheadShaftOffset();
 		Skin::setPlayheadPen( &painter, false );
 		painter.drawLine( nX + nOffset, 0, nX + nOffset, height() );
@@ -2985,8 +2981,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 
 	// Draw playhead
 	if ( m_fTick != -1 ) {
-		int nX = 1 + columnToX( m_fTick ) -
-			static_cast<int>(static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nX = tickToColumn( m_fTick, m_nGridWidth );
 		int nShaftOffset = Skin::getPlayheadShaftOffset();
 		Skin::drawPlayhead( &painter, nX, height() / 2 + 2, false );
 		painter.drawLine( nX + nShaftOffset, 0, nX + nShaftOffset, height() );
@@ -3161,8 +3156,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		 m_hoveredRow == HoveredRow::Ruler &&
 		 m_nHoveredColumn <= m_nActiveColumns ) {
 
-		int x = 1 + columnToX( m_nHoveredColumn ) -
-			static_cast<int>(static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int x = tickToColumn( m_nHoveredColumn, m_nGridWidth );
 		int nShaftOffset = Skin::getPlayheadShaftOffset();
 		Skin::drawPlayhead( &painter, x, height() / 2 + 2, true );
 		painter.drawLine( x + nShaftOffset, 0, x + nShaftOffset, height() / 2 + 1 );
@@ -3313,8 +3307,7 @@ void SongEditorPositionRuler::updatePosition()
 		float fDiff = static_cast<float>(m_nGridWidth) * (fTick - m_fTick);
 
 		m_fTick = fTick;
-		int nX = 1 + columnToX( m_fTick ) -
-			static_cast<int>(static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nX = tickToColumn( m_fTick, m_nGridWidth );
 
 		QRect updateRect( nX -2, 0, 4 + Skin::nPlayheadWidth, height() );
 		update( updateRect );
@@ -3342,6 +3335,12 @@ int SongEditorPositionRuler::xToColumn( int nX ) const {
 		( static_cast<float>(nX) - static_cast<float>(SongEditor::nMargin)) /
 		static_cast<float>(m_nGridWidth));
 }
+int SongEditorPositionRuler::tickToColumn( float fTick, uint nGridWidth ) {
+	return static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
+								   fTick * static_cast<float>(nGridWidth) -
+							 static_cast<float>(Skin::nPlayheadWidth) / 2 );
+}
+
 
 void SongEditorPositionRuler::timelineUpdateEvent( int nValue )
 {

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -3175,8 +3175,8 @@ QRect SongEditorPositionRuler::calcTempoMarkerRect( std::shared_ptr<const Timeli
 					  getPointSize( pPref->getFontSize() ), weight );
 
 	const int x = columnToX( pTempoMarker->nColumn );
-	const QString sText = QString( "%1" ).arg( pTempoMarker->fBpm, 0, 'f', 2 );
-	int nWidth = QFontMetrics( font ).size( Qt::TextSingleLine, sText ).width();
+	int nWidth = QFontMetrics( font ).size(
+		Qt::TextSingleLine, pTempoMarker->getPrettyString() ).width();
 
 	// Check whether the full width would overlap with an adjacent
 	// tempo marker and trim it if necessary
@@ -3246,7 +3246,7 @@ void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::T
 	}
 	painter.setFont( font );
 	painter.drawText( rect, Qt::AlignLeft | Qt::AlignVCenter,
-					  QString( "%1" ).arg( pTempoMarker->fBpm, 0, 'f', 2 ) );
+					  pTempoMarker->getPrettyString() );
 
 	if ( bEmphasize ) {
 		font.setBold( false );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2552,8 +2552,7 @@ void SongEditorPositionRuler::setGridWidth( uint width )
 	if ( SONG_EDITOR_MIN_GRID_WIDTH <= width && SONG_EDITOR_MAX_GRID_WIDTH >= width )
 	{
 		m_nGridWidth = width;
-		resize( SongEditor::nMargin +
-				Preferences::get_instance()->getMaxBars() * m_nGridWidth, height() );
+		resize( columnToX( Preferences::get_instance()->getMaxBars() ), height() );
 		invalidateBackground();
 		update();
 	}
@@ -2589,7 +2588,7 @@ void SongEditorPositionRuler::createBackground()
 	qreal pixelRatio = devicePixelRatio();
 	if ( m_pBackgroundPixmap->devicePixelRatio() != pixelRatio ||
 		 m_pBackgroundPixmap->width() != width() ||
-		 m_pBackgroundPixmap->height() != height()  ) {
+		 m_pBackgroundPixmap->height() != height() ) {
 		delete m_pBackgroundPixmap;
 		m_pBackgroundPixmap = new QPixmap( width()  * pixelRatio , height() * pixelRatio );
 		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
@@ -2600,9 +2599,7 @@ void SongEditorPositionRuler::createBackground()
 	QPainter p( m_pBackgroundPixmap );
 	p.setFont( font );
 
-	int nActiveWidth = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
-										 static_cast<float>(m_nActiveColumns) *
-										 static_cast<float>(m_nGridWidth) );
+	int nActiveWidth = columnToX( m_nActiveColumns ) + 1;
 	p.fillRect( 0, 0, width(), height(), backgroundColorTempoMarkers );
 	p.fillRect( 0, 25, nActiveWidth, height() - 25, backgroundColor );
 	p.fillRect( nActiveWidth, 25, width() - nActiveWidth, height() - 25,
@@ -2615,7 +2612,7 @@ void SongEditorPositionRuler::createBackground()
 	textColorGrid.setAlpha( 200 );
 	p.setPen( QPen( textColorGrid, 1, Qt::SolidLine ) );
 	for ( int ii = 0; ii < nMaxPatternSequence + 1; ii++) {
-		int x = SongEditor::nMargin + ii * m_nGridWidth;
+		int x = columnToX( ii );
 
 		if ( ( ii % 4 ) == 0 ) {
 			p.drawLine( x, height() - 14, x, height() - 1);
@@ -2628,7 +2625,7 @@ void SongEditorPositionRuler::createBackground()
 	// Add every 4th number to the grid
 	p.setPen( textColor );
 	for (uint i = 0; i < nMaxPatternSequence + 1; i += 4) {
-		uint x = SongEditor::nMargin + i * m_nGridWidth;
+		uint x = columnToX( i );
 
 		sprintf( tmp, "%d", i + 1 );
 		if ( i < 10 ) {
@@ -2647,7 +2644,7 @@ void SongEditorPositionRuler::createBackground()
 	p.setFont( font2 );
 		
 	for ( const auto& ttag : tagVector ){
-		int x = SongEditor::nMargin + ttag->nColumn * m_nGridWidth + 4;
+		int x = columnToX( ttag->nColumn ) + 4;
 		QRect rect( x, height() / 2 - 1 - m_nTagHeight,
 					m_nGridWidth - 6, m_nTagHeight );
 
@@ -2667,7 +2664,7 @@ void SongEditorPositionRuler::createBackground()
 		p.setPen( tempoMarkerGridColor );
 	}
 	for (uint ii = 0; ii < nMaxPatternSequence + 1; ii++) {
-		uint x = SongEditor::nMargin + ii * m_nGridWidth;
+		uint x = columnToX( ii );
 
 		p.drawLine( x, 1, x, 4 );
 		p.drawLine( x, height() / 2 - 5, x, height() / 2 );
@@ -2728,7 +2725,7 @@ void SongEditorPositionRuler::mouseMoveEvent(QMouseEvent *ev)
 {
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	int nColumn = ( std::max( ev->x() - SongEditor::nMargin, 0 ) ) / m_nGridWidth;
+	int nColumn = std::max( xToColumn( ev->x() ), 0 );
 
 	HoveredRow row;
 	if ( ev->y() > 22 ) {
@@ -2813,7 +2810,7 @@ void SongEditorPositionRuler::showToolTip( QHelpEvent* ev ) {
 		
 	} else if ( m_hoveredRow == HoveredRow::Tag ) {
 		// Row containing the tags
-		int nColumn = std::max( ev->x() - SongEditor::nMargin, 0 ) / m_nGridWidth;
+		int nColumn = std::max( xToColumn( ev->x() ), 0 );
 		if ( pTimeline->hasColumnTag( nColumn ) ) {
 			QToolTip::showText( ev->globalPos(),
 								pTimeline->getTagAtColumn( nColumn ), this );
@@ -2847,7 +2844,7 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 		
-	int nColumn = ( std::max( ev->x() - SongEditor::nMargin, 0 ) / m_nGridWidth);
+	int nColumn = std::max( xToColumn( ev->x() ), 0 );
 	
 	if (ev->button() == Qt::LeftButton ) {
 		if ( ev->y() > 22 ) {
@@ -2865,15 +2862,18 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 
 			m_pHydrogen->getCoreActionController()->locateToColumn( nColumn );
 			update();
-		} else if ( ev->y() > 22 - 1 - m_nTagHeight ) {
+		}
+		else if ( ev->y() > 22 - 1 - m_nTagHeight ) {
 			showTagWidget( nColumn );
-			
-		} else if ( m_pHydrogen->isTimelineEnabled() ){
+		}	
+		else if ( m_pHydrogen->isTimelineEnabled() ){
 			showBpmWidget( nColumn );
 		}
-	} else if ( ev->button() == Qt::MiddleButton ) {
+	}
+	else if ( ev->button() == Qt::MiddleButton ) {
 		showTagWidget( nColumn );
-	} else if (ev->button() == Qt::RightButton && ev->y() >= 26) {
+	}
+	else if (ev->button() == Qt::RightButton && ev->y() >= 26) {
 		Preferences* pPref = Preferences::get_instance();
 		if ( nColumn >= (int) m_pHydrogen->getSong()->getPatternGroupVector()->size() ) {
 			pPref->unsetPunchArea();
@@ -2926,8 +2926,8 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	QColor backgroundColor = pPref->getColorTheme()->m_songEditor_alternateRowColor.darker( 115 );
 	QColor backgroundColorTempoMarkers = backgroundColor.darker( 120 );
 
-	int pIPos = Preferences::get_instance()->getPunchInPos();
-	int pOPos = Preferences::get_instance()->getPunchOutPos();
+	int nPunchInPos = Preferences::get_instance()->getPunchInPos();
+	int nPunchOutPos = Preferences::get_instance()->getPunchOutPos();
 
 	QPainter painter(this);
 	QFont font( pPref->getApplicationFontFamily(), getPointSize( pPref->getFontSize() ) );
@@ -2961,15 +2961,18 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	if ( nCurrentTempoMarkerColumn != -1 ) {
 		auto pTempoMarker = pTimeline->getTempoMarkerAtColumn( nCurrentTempoMarkerColumn );
 		if ( pTempoMarker != nullptr ) {
+			// Reset the region and overwrite the marker's versio
+			// using normal weight.
+			const QRect rect = calcTempoMarkerRect( pTempoMarker, true );
+			painter.fillRect( rect, backgroundColorTempoMarkers );
 			drawTempoMarker( pTempoMarker, true, painter );
 		}
 	}
 
 	// Draw playhead
 	if ( m_fTick != -1 ) {
-		int nX = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
-								   m_fTick * static_cast<float>(m_nGridWidth) -
-								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nX = 1 + columnToX( m_fTick ) -
+			static_cast<int>(static_cast<float>(Skin::nPlayheadWidth) / 2 );
 		int nShaftOffset = Skin::getPlayheadShaftOffset();
 		Skin::drawPlayhead( &painter, nX, height() / 2 + 2, false );
 		painter.drawLine( nX + nShaftOffset, 0, nX + nShaftOffset, height() );
@@ -2987,7 +2990,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		} else {
 			nColumn = m_nHoveredColumn;
 		}
-		const int x = SongEditor::nMargin + nColumn * m_nGridWidth;
+		const int x = columnToX( nColumn );
 
 		// Erase background tick lines to not get any interference.
 		painter.fillRect( x, 1, 1, 4,
@@ -3013,7 +3016,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	if ( m_hoveredRow == HoveredRow::Tag &&
 		 pTimeline->hasColumnTag( m_nHoveredColumn ) ) {
 
-		int x = SongEditor::nMargin + m_nHoveredColumn * m_nGridWidth + 4;
+		int x = columnToX( m_nHoveredColumn ) + 4;
 		QRect rect( x, height() / 2 - 1 - m_nTagHeight,
 					m_nGridWidth - 6, m_nTagHeight );
 	
@@ -3048,30 +3051,27 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		if ( pTimeline->hasColumnTempoMarker( nColumn ) ||
 			 ( pTimeline->isFirstTempoMarkerSpecial() &&
 			   nColumn == 0 ) ) {
-		
-			QRect rect( SongEditor::nMargin - SONG_EDITOR_MAX_GRID_WIDTH +
-						nColumn * m_nGridWidth + m_nGridWidth / 2,
-						6, 2 * SONG_EDITOR_MAX_GRID_WIDTH, 12 );
-			painter.fillRect( rect, backgroundColorTempoMarkers );
 
 			auto pTempoMarker = pTimeline->getTempoMarkerAtColumn( nColumn );
 			if ( pTempoMarker != nullptr ) {
-				drawTempoMarker( pTempoMarker,
-								 pTempoMarker->nColumn == nCurrentTempoMarkerColumn, // emphasize
-								 painter );
-			}
+
+				const bool bEmphasize = pTempoMarker->nColumn == nCurrentTempoMarkerColumn;
+				const QRect rect = calcTempoMarkerRect( pTempoMarker, bEmphasize );
+		
+				painter.fillRect( rect, backgroundColorTempoMarkers );
+				drawTempoMarker( pTempoMarker, bEmphasize, painter );
 				
-			if ( m_nActiveBpmWidgetColumn == -1 ) {
-				painter.setPen( QPen( colorHovered, 1 ) );
-			} else {
-				painter.setPen( QPen( highlightColor, 1 ) );
+				if ( m_nActiveBpmWidgetColumn == -1 ) {
+					painter.setPen( QPen( colorHovered, 1 ) );
+				} else {
+					painter.setPen( QPen( highlightColor, 1 ) );
+				}
+				painter.drawRect( rect );
+
+				painter.drawLine( rect.x(), 2, rect.x() + m_nGridWidth / 2, 2 );
+
+				bTempoMarkerPresent = true;
 			}
-			painter.drawRect( rect );
-
-			painter.drawLine( rect.x() + m_nGridWidth - m_nGridWidth / 2 + 1, 2,
-							  rect.x() + m_nGridWidth + m_nGridWidth / 2 - 6, 2 );
-
-			bTempoMarkerPresent = true;
 		}
 	}
 
@@ -3096,11 +3096,9 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 
 		int nCursorX;
 		if ( m_nActiveBpmWidgetColumn != -1 ) {
-			nCursorX = SongEditor::nMargin +
-				m_nActiveBpmWidgetColumn * m_nGridWidth + 3;
+			nCursorX = columnToX( m_nActiveBpmWidgetColumn ) + 3;
 		} else {
-			nCursorX = SongEditor::nMargin +
-				m_nHoveredColumn * m_nGridWidth + 3;
+			nCursorX = columnToX( m_nHoveredColumn ) + 3;
 		}
 
 		if ( m_hoveredRow == HoveredRow::TempoMarker ||
@@ -3114,8 +3112,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 
 	// Draw cursor
 	if ( ! pHydrogenApp->hideKeyboardCursor() && pSongEditor->hasFocus() ) {
-		int nCursorX = SongEditor::nMargin +
-			pSongEditor->getCursorColumn() * m_nGridWidth + 2;
+		int nCursorX = columnToX( pSongEditor->getCursorColumn() ) + 2;
 
 		QColor cursorColor = pPref->getColorTheme()->m_cursorColor;
 
@@ -3145,10 +3142,8 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		 m_hoveredRow == HoveredRow::Ruler &&
 		 m_nHoveredColumn <= m_nActiveColumns ) {
 
-		int x = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
-								  static_cast<float>(m_nHoveredColumn) *
-								  static_cast<float>(m_nGridWidth) -
-								  static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int x = 1 + columnToX( m_nHoveredColumn ) -
+			static_cast<int>(static_cast<float>(Skin::nPlayheadWidth) / 2 );
 		int nShaftOffset = Skin::getPlayheadShaftOffset();
 		Skin::drawPlayhead( &painter, x, height() / 2 + 2, true );
 		painter.drawLine( x + nShaftOffset, 0, x + nShaftOffset, height() / 2 + 1 );
@@ -3156,18 +3151,38 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 						  x + nShaftOffset, height() );
 	}
 
-	if ( pIPos <= pOPos ) {
-		int xIn = (int)( SongEditor::nMargin + pIPos * m_nGridWidth );
-		int xOut = (int)( 9 + (pOPos+1) * m_nGridWidth );
+	if ( nPunchInPos <= nPunchOutPos ) {
+		const int xIn = columnToX( nPunchInPos );
+		const int xOut = columnToX( nPunchOutPos + 1 );
 		painter.fillRect( xIn, 30, xOut-xIn+1, 12, QColor(200, 100, 100, 100) );
 		QPen pen(QColor(200, 100, 100));
 		painter.setPen(pen);
 		painter.drawRect( xIn, 30, xOut-xIn+1, 12 );
 	}
-
 }
 
-void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::TempoMarker> tempoMarker, bool bEmphasize, QPainter& painter ) {
+QRect SongEditorPositionRuler::calcTempoMarkerRect( std::shared_ptr<const Timeline::TempoMarker> pTempoMarker, bool bEmphasize ) const {
+	assert( pTempoMarker );
+
+	auto pPref = Preferences::get_instance();
+	auto weight = QFont::Normal;
+	if ( bEmphasize ) {
+		weight = QFont::Bold;
+	}
+	
+	const QFont font( pPref->getApplicationFontFamily(),
+					  getPointSize( pPref->getFontSize() ), weight );
+
+	const int x = columnToX( pTempoMarker->nColumn );
+	const QString sText = QString( "%1" ).arg( pTempoMarker->fBpm, 0, 'f', 2 );
+	const int nWidth = QFontMetrics( font ).size( Qt::TextSingleLine, sText ).width();
+	QRect rect( x, 6, nWidth, 12 );
+
+	return std::move( rect );
+}
+
+void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::TempoMarker> pTempoMarker, bool bEmphasize, QPainter& painter ) {
+	assert( pTempoMarker );
 
 	auto pPref = Preferences::get_instance();
 	auto pHydrogen = Hydrogen::get_instance();
@@ -3176,23 +3191,21 @@ void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::T
 
 	// Only paint the special tempo marker in case Timeline is
 	// activated.
-	if ( tempoMarker->nColumn == 0 && pTimeline->isFirstTempoMarkerSpecial() &&
+	if ( pTempoMarker->nColumn == 0 && pTimeline->isFirstTempoMarkerSpecial() &&
 		 ! pHydrogen->isTimelineEnabled() ) {
 		return;
 	}
 		
 	QFont font( pPref->getApplicationFontFamily(), getPointSize( pPref->getFontSize() ) );
 		
-	QRect rect( SongEditor::nMargin - SONG_EDITOR_MAX_GRID_WIDTH +
-				tempoMarker->nColumn * m_nGridWidth + m_nGridWidth / 2,
-				6, 2 * SONG_EDITOR_MAX_GRID_WIDTH, 12 );
+	QRect rect = calcTempoMarkerRect( pTempoMarker, bEmphasize );
 
 	// Draw an additional small horizontal line at the top of the
 	// current column to better indicate the position of the tempo
 	// marker (for larger float values e.g. 130.67).
 	QColor textColor( pPref->getColorTheme()->m_songEditor_textColor );
 
-	if ( tempoMarker->nColumn == 0 && pTimeline->isFirstTempoMarkerSpecial() ) {
+	if ( pTempoMarker->nColumn == 0 && pTimeline->isFirstTempoMarkerSpecial() ) {
 		textColor = textColor.darker( 150 );
 	}
 			
@@ -3206,8 +3219,7 @@ void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::T
 		painter.setPen( tempoMarkerGridColor );
 	}
 
-	painter.drawLine( rect.x() + m_nGridWidth - m_nGridWidth / 2 + 1, 2,
-					  rect.x() + m_nGridWidth + m_nGridWidth / 2 - 6, 2 );
+	painter.drawLine( rect.x(), 2, rect.x() + m_nGridWidth / 2, 2 );
 
 	QColor tempoMarkerColor( textColor );
 	if ( ! pHydrogen->isTimelineEnabled() ) {
@@ -3219,10 +3231,8 @@ void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::T
 		font.setBold( true );
 	}
 	painter.setFont( font );
-				
-	char tempo[10];
-	sprintf( tempo, "%d",  static_cast<int>( tempoMarker->fBpm ) );
-	painter.drawText( rect, Qt::AlignCenter, tempo );
+	painter.drawText( rect, Qt::AlignCenter,
+					  QString( "%1" ).arg( pTempoMarker->fBpm, 0, 'f', 2 ) );
 
 	if ( bEmphasize ) {
 		font.setBold( false );
@@ -3270,9 +3280,8 @@ void SongEditorPositionRuler::updatePosition()
 		float fDiff = static_cast<float>(m_nGridWidth) * (fTick - m_fTick);
 
 		m_fTick = fTick;
-		int nX = static_cast<int>( static_cast<float>(SongEditor::nMargin) + 1 +
-								   m_fTick * static_cast<float>(m_nGridWidth) -
-								   static_cast<float>(Skin::nPlayheadWidth) / 2 );
+		int nX = 1 + columnToX( m_fTick ) -
+			static_cast<int>(static_cast<float>(Skin::nPlayheadWidth) / 2 );
 
 		QRect updateRect( nX -2, 0, 4 + Skin::nPlayheadWidth, height() );
 		update( updateRect );
@@ -3290,6 +3299,15 @@ void SongEditorPositionRuler::updatePosition()
 			pSongEditorPanel->getAutomationPathView()->updatePosition( fTick );
 		}
 	}
+}
+
+int SongEditorPositionRuler::columnToX( int nColumn ) const {
+	return SongEditor::nMargin + nColumn * static_cast<int>(m_nGridWidth);
+}
+int SongEditorPositionRuler::xToColumn( int nX ) const {
+	return static_cast<int>(
+		( static_cast<float>(nX) - static_cast<float>(SongEditor::nMargin)) /
+		static_cast<float>(m_nGridWidth));
 }
 
 void SongEditorPositionRuler::timelineUpdateEvent( int nValue )

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -3103,7 +3103,12 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 
 		if ( m_hoveredRow == HoveredRow::TempoMarker ||
 			 m_nActiveBpmWidgetColumn != -1 ) {
-			painter.drawRect( nCursorX, 6, m_nGridWidth - 5, 12 );
+			// Reset the background during highlight in order to
+			// indicate that no tempo marker is present in this
+			// column.
+			QRect hoveringRect( nCursorX, 6, m_nGridWidth - 5, 12 );
+			painter.fillRect( hoveringRect, backgroundColorTempoMarkers );
+			painter.drawRect( hoveringRect );
 		} else {
 			painter.drawRect( nCursorX, height() / 2 - 1 - m_nTagHeight,
 							  m_nGridWidth - 5, m_nTagHeight - 1 );

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -449,7 +449,7 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 	int columnToX( int nColumn ) const;
 	int xToColumn( int nX ) const;
 
-	void showToolTip( QHelpEvent* ev );
+	void showToolTip( const QPoint& pos, const QPoint& globalPos );
 
 	void drawTempoMarker( std::shared_ptr<const H2Core::Timeline::TempoMarker> pTempoMarker,
 						  bool bEmphasize, QPainter& painter );

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -382,7 +382,8 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 	virtual void timelineActivationEvent() override;
 	virtual void timelineUpdateEvent( int nValue ) override;
 	virtual void jackTimebaseStateChangedEvent() override;
-													   
+
+	static int tickToColumn( float fTick, uint nGridWidth );
 
 	public slots:
 		void updatePosition();

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -440,10 +440,26 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 	virtual void leaveEvent( QEvent* ev ) override;
 	virtual bool event( QEvent* ev ) override;
 
+	/** Calculates the position in pixel required to the painter for a
+	 * particular @a nColumn of the grid.
+	 *
+	 * TODO: There needs to be some refactoring / common basis for
+	 * song (and pattern) editor classes.
+ 	 */
+	int columnToX( int nColumn ) const;
+	int xToColumn( int nX ) const;
+
 	void showToolTip( QHelpEvent* ev );
 
-	void drawTempoMarker( std::shared_ptr<const H2Core::Timeline::TempoMarker> tempoMarker,
+	void drawTempoMarker( std::shared_ptr<const H2Core::Timeline::TempoMarker> pTempoMarker,
 						  bool bEmphasize, QPainter& painter );
+	/**
+	 * @param pTempoMarker Associated #TempoMarker
+	 * @param bEmphasize Whether the text of @a pTempoMarker will be
+	 *   printed with bold font.
+	 */
+	QRect calcTempoMarkerRect( std::shared_ptr<const H2Core::Timeline::TempoMarker> pTempoMarker,
+		bool bEmphasize = false ) const;
 
 };
 

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -363,7 +363,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	connect( m_pAutomationPathView, SIGNAL( pointRemoved(float, float) ), this, SLOT( automationPathPointRemoved(float,float) ) );
 	connect( m_pAutomationPathView, SIGNAL( pointMoved(float, float, float, float) ), this, SLOT( automationPathPointMoved(float,float, float, float) ) );
 
-	m_pAutomationCombo = new LCDCombo( nullptr, QSize( m_nPatternListWidth, 18 ) );
+	m_pAutomationCombo = new LCDCombo( nullptr, QSize( m_nPatternListWidth, 18 ), true );
 	m_pAutomationCombo->setToolTip( tr("Adjust parameter values in time") );
 	m_pAutomationCombo->addItem( tr("Velocity") );
 	m_pAutomationCombo->setCurrentIndex( 0 );

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -37,7 +37,7 @@
 namespace H2Core
 {
 
-	SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int nColumn, bool bTempoMarkerPresent )
+SongEditorPanelBpmWidget::SongEditorPanelBpmWidget( QWidget* pParent, int nColumn, bool bTempoMarkerPresent )
 	: QDialog( pParent )
 	, m_nColumn( nColumn )
 	, m_bTempoMarkerPresent( bTempoMarkerPresent )
@@ -50,6 +50,7 @@ namespace H2Core
 
 	auto pHydrogen = Hydrogen::get_instance();
 
+	bpmSpinBox->setType( LCDSpinBox::Type::Double );
 	bpmSpinBox->setMinimum( MIN_BPM );
 	bpmSpinBox->setMaximum( MAX_BPM );
 	bpmSpinBox->setValue( pHydrogen->getTimeline()->getTempoAtColumn( m_nColumn ) );
@@ -59,7 +60,8 @@ namespace H2Core
 	// Required for correct focus highlighting.
 	bpmSpinBox->setSize( QSize( 146, 23 ) );
 	bpmSpinBox->setFocus();
-	
+
+	columnSpinBox->setType( LCDSpinBox::Type::Int );
 	columnSpinBox->setMinimum( 1 );
 	columnSpinBox->setMaximum( Preferences::get_instance()->getMaxBars() );
 	columnSpinBox->setValue( m_nColumn + 1 );
@@ -119,7 +121,7 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 	
 	float fOldBpm = pTimeline->getTempoAtColumn( m_nColumn );
 
-	SE_editTimelineAction *action = new SE_editTimelineAction( m_nColumn, nNewColumn, fOldBpm, QString( bpmSpinBox->text() ).toFloat(), m_bTempoMarkerPresent );
+	SE_editTimelineAction *action = new SE_editTimelineAction( m_nColumn, nNewColumn, fOldBpm, bpmSpinBox->value(), m_bTempoMarkerPresent );
 	HydrogenApp::get_instance()->m_pUndoStack->push( action );
 	accept();
 }

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -38,10 +38,12 @@ class LCDCombo : public QComboBox, protected WidgetWithScalableFont<6, 8, 9>, pu
 	Q_OBJECT
 
 public:
-	explicit LCDCombo( QWidget *pParent, QSize size = QSize( 0, 0 ), bool bModifyOnChange = true );
+	explicit LCDCombo( QWidget *pParent, QSize size = QSize( 0, 0 ), bool bModifyOnChange = false );
 	~LCDCombo();
 
 	void setSize( QSize size );
+	void setModifyOnChange( bool bModifyOnChange );
+	
 	virtual void showPopup() override;
 	void addItem(const QString &text, const QVariant &userData = QVariant());
 	
@@ -71,6 +73,9 @@ private:
 	virtual void enterEvent( QEvent *ev ) override;
 	virtual void leaveEvent( QEvent *ev ) override;
 };
+inline void LCDCombo::setModifyOnChange( bool bModifyOnChange ) {
+	m_bModifyOnChange = bModifyOnChange;
+}
 inline bool LCDCombo::getIsActive() const {
 	return m_bIsActive;
 }

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -31,7 +31,6 @@
 LCDSpinBox::LCDSpinBox( QWidget *pParent, QSize size, Type type, double fMin, double fMax, bool bModifyOnChange, bool bMinusOneAsOff )
  : QDoubleSpinBox( pParent )
  , m_size( size )
- , m_type( type )
  , m_bEntered( false )
  , m_kind( Kind::Default )
  , m_bIsActive( true )
@@ -47,19 +46,32 @@ LCDSpinBox::LCDSpinBox( QWidget *pParent, QSize size, Type type, double fMin, do
 	adjustSize();
 	setFixedSize( m_size );
 
+	setType( type );
+	
 	updateStyleSheet();
 
 	connect( this, SIGNAL(valueChanged(double)), this,
                         SLOT(valueChanged(double)));
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
 			 this, &LCDSpinBox::onPreferencesChanged );
-		
+
 	setMaximum( fMax );
 	setMinimum( fMin );
 	setValue( fMin );
 }
 
 LCDSpinBox::~LCDSpinBox() {
+}
+
+void LCDSpinBox::setType( Type type ) {
+	m_type = type;
+
+	if ( type == Type::Int ) {
+		setDecimals( 0 );
+	}
+	else {
+		setDecimals( std::numeric_limits<double>::max_exponent );
+	}
 }
 
 void LCDSpinBox::setSize( QSize size ) {
@@ -82,7 +94,7 @@ void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 	static float fCumulatedDelta;
 
 	double fOldValue = value();
-	
+
 	if ( m_kind == Kind::PatternSizeDenominator ) {
 
 		// Cumulate scroll positions to provide a native feeling for
@@ -218,14 +230,9 @@ QString LCDSpinBox::textFromValue( double fValue ) const {
 	} else {
 		if ( m_type == Type::Int ) {
 			result = QString( "%1" ).arg( fValue, 0, 'f', 0 );
-		} else {
-			// Only show a larger precision than 2 digits after point
-			// if there are more than 2 non-zero digits after point.
-			if ( std::fmod( fValue * 100, 1 ) > 0 ) {
-				result = QString( "%1" ).arg( fValue, 0, 'f', 16 ) ;
-			} else {
-				result = QString( "%1" ).arg( fValue, 0, 'f', 2 ) ;
-			}
+		}
+		else {
+			result = QString( "%1" ).arg( fValue ) ;
 		}
 	}
 

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -70,12 +70,13 @@ public:
 		PatternSizeDenominator
 	};
 
-	LCDSpinBox( QWidget *pParent, QSize size = QSize(), Type type = Type::Int, double fMin = 0.0, double fMax = 1.0, bool bModifyOnChange = true, bool bMinusOneAsOff = false );
+	LCDSpinBox( QWidget *pParent, QSize size = QSize(), Type type = Type::Int, double fMin = 0.0, double fMax = 1.0, bool bModifyOnChange = false, bool bMinusOneAsOff = false );
 	~LCDSpinBox();
 
 	void setType( Type type );
 	void setKind( Kind kind );
 	void setSize( QSize size );
+	void setModifyOnChange( bool bModifyOnChange );
 	
 	virtual QValidator::State validate( QString &text, int &pos ) const override;
 	
@@ -130,6 +131,9 @@ private:
 
 inline void LCDSpinBox::setKind( Kind kind ) {
 	m_kind = kind;
+}
+inline void LCDSpinBox::setModifyOnChange( bool bModifyOnChange ) {
+	m_bModifyOnChange = bModifyOnChange;
 }
 inline bool LCDSpinBox::getIsActive() const {
 	return m_bIsActive;

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -73,13 +73,14 @@ public:
 	LCDSpinBox( QWidget *pParent, QSize size = QSize(), Type type = Type::Int, double fMin = 0.0, double fMax = 1.0, bool bModifyOnChange = true, bool bMinusOneAsOff = false );
 	~LCDSpinBox();
 
+	void setType( Type type );
 	void setKind( Kind kind );
+	void setSize( QSize size );
+	
 	virtual QValidator::State validate( QString &text, int &pos ) const override;
 	
 	bool getIsActive() const;
 	void setIsActive( bool bIsActive );
-
-	void setSize( QSize size );
 
 	bool getIsHovered() const;
 


### PR DESCRIPTION
# `TempoMarker` rendering fixes

- **Float precision** `TempoMarker`s can now be set and rendered (rounded to two decimals after point). 
- Marker's BPM text is now left aligned with the column it is associated with. Previously it was centered at the middle of the column. But figuring which column the mark belongs to was quite hard by just looking at it. Especially for float precision values. In addition, the left-most tempo marker did overflow when entering float values.
- BPM texts do not overlap anymore but are truncated with the right-most marker taking precedence.
- A horizontal line covering the first half of the column is introduced at the top of the ruler in case a column holds a tempo marker. This way one can distinguish between neighboring markers with the left one being truncated and fully displayed since ones.
- Hovering a tempo marker displays its full float value as a tool tip.
- Hovering a tempo marker displays the full label without truncation.
- Hovering an empty column displays an empty rectangle even if some text of a neighboring tempo marker is flowing in. This way one can more easily distinguish columns with and without markers in situations when a lot of them are present

## Old
On full zoom out:
![fullSize_old](https://user-images.githubusercontent.com/14164547/223060658-846516ae-bf77-497b-9bf4-37c8df682ff3.png)

On full zoom in:
![minimalSize_old](https://user-images.githubusercontent.com/14164547/223060660-bc2371b9-4701-4e3b-b888-3546db15a253.png)

## New
On full zoom out:
![fullSize_new](https://user-images.githubusercontent.com/14164547/223060665-3230d8ba-6552-496d-af58-ef7b9f9599f8.png)

On full zoom in:
![minimalSize_new](https://user-images.githubusercontent.com/14164547/223060663-d8fbd643-57a8-49d6-9878-0b0ca97b034e.png)

Still not ideal but a lot better.

# Widget fixes

- `LCDSpinBox` and `LCDCombo`: fix is modified behavior

  Previously, if not set otherwise in the constructor, a value change in a `LCDSpinBox` or `LCDCombo` caused the current song in Hydrogen to be marked "modified". While this was good for the spin boxes in the main window it also applied for those constructed as part of an .ui file. But marking it modified by altering a value in the `PreferencesDialog` of BPM widget was never intended. Instead, the is modified feature needs now to be explicitly activated and is only set for the main window boxes

- `LCDSpinBox` type exposure
  `LCDSpinBox` instances instantiated as part of a .ui file did all get the default `LCDSpinBox::Type::Int` type. A `setType` method was introduce to cope for it. Setting the spinbox type to `LCDSpinBox::Type::Int` does now also set the number of allowed decimals to `0`. This prevents the user from inputing digits after point what is exactly waht I would expect from a integer spinbox.