### PR TITLE
NSM: rename JACK port of drumkit load

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -969,7 +969,8 @@ void Hydrogen::renameJackPorts( std::shared_ptr<Song> pSong )
 			// When restarting the audio driver after loading a new song under
 			// Non session management all ports have to be registered _prior_
 			// to the activation of the client.
-			if ( isUnderSessionManagement() ) {
+			if ( isUnderSessionManagement() &&
+				 getGUIState() != Hydrogen::GUIState::ready ) {
 				return;
 			}
 			auto pAudioEngine = m_pAudioEngine;


### PR DESCRIPTION
JACK port renaming is suppressed on startup in order to not break them while being run in a NSM session. However, in case the user does manually load a drumkit, it has to be done