### PR TITLE
TagWidget: fix dropped tag input

### DIFF
--- a/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
+++ b/src/gui/src/SongEditor/SongEditorPanelTagWidget.h
@@ -27,6 +27,8 @@
 #include "ui_SongEditorPanelTagWidget_UI.h"
 #include <core/Object.h>
 
+#include <memory>
+
 ///
 ///
 namespace H2Core
@@ -52,12 +54,12 @@ class SongEditorPanelTagWidget :  public QDialog, public Ui_SongEditorPanelTagWi
 		void on_CancelBtn_clicked();
 		void on_okBtn_clicked();
 		void on_tagTableWidget_currentItemChanged( QTableWidgetItem * current, QTableWidgetItem * previous );
-		void  a_itemIsChanged(QTableWidgetItem *item);
 		
 	private:
-		int m_stimelineposition;
+		int m_nMaxRows;
+		int m_nTimelinePosition;
 		void createTheTagTableWidget();
-		QStringList __theChangedItems;
+		std::vector<QString> m_oldTags;
 };
 
 }


### PR DESCRIPTION
When opening a `SongEditorPanelTagWidget`, entering some text, and pressing RETURN right away (without hitting the arrow keys beforehand or clicking somewhere using the mouse) the input is discarded and no `Tag` is created.

This happened because when editing an item of the `QTableWidget` in the tag dialog a persistent editor is opened for the item. RETURN triggers `SongEditorPanelTagWidget::on_okBtn_clicked()` _before_ closing the persistent editor. This caused the previous implementation, which was more efficient since it just checked those items of the table for which `itemChanged` events were triggered, to miss the item edited last (closing the editor and emitting `itemChanged` happened after the okBtn routine). To circumvent this problem, we now manually close the persistent editor for the current item in the okBtn routine and compare all item texts with their original state.