### PR TITLE
Fix Director and EVENT_METRONOME bugs 

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -469,6 +469,25 @@ void AudioEngine::updateTransportPosition( double fTick, long long nFrame, std::
 	}
 
 	updateBpmAndTickSize( pPos );
+
+	// Beat - Bar (- Tick) information is a coarse grained position
+	// information and might not change on small position increments.
+	bool bBBTChanged = false;
+	if ( pPos->getColumn() + 1 != pPos->getBar() ) {
+		pPos->setBar( pPos->getColumn() + 1 );
+		bBBTChanged = true;
+	}
+
+	int nBeat = static_cast<int>(
+		std::floor(static_cast<float>(pPos->getPatternTickPosition()) /  48 )) + 1;
+	if ( pPos->getBeat() != nBeat ) {
+		pPos->setBeat( nBeat );
+		bBBTChanged = true;
+	}
+
+	if ( pPos == m_pTransportPosition && bBBTChanged ) {
+		EventQueue::get_instance()->push_event( EVENT_BBT_CHANGED, 0 );
+	}
 	
 	// WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, pos: %3, frame: %4" )
 	// 			.arg( fTick, 0, 'f' )
@@ -1163,6 +1182,11 @@ void AudioEngine::processPlayNotes( unsigned long nframes )
 				m_songNoteQueue.pop();
 				pNote->get_instrument()->dequeue();
 				continue;
+			}
+
+			if ( pNoteInstrument == m_pMetronomeInstrument ) {
+				m_pEventQueue->push_event( EVENT_METRONOME,
+										   pNote->get_pitch() == 0 ? 1 : 0 );
 			}
 
 			m_pSampler->noteOn( pNote );
@@ -2302,11 +2326,9 @@ int AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 			if ( nMetronomeTickPosition == 0 ) {
 				fPitch = 3;
 				fVelocity = 1.0;
-				EventQueue::get_instance()->push_event( EVENT_METRONOME, 1 );
 			} else {
 				fPitch = 0;
 				fVelocity = 0.8;
-				EventQueue::get_instance()->push_event( EVENT_METRONOME, 0 );
 			}
 			
 			// Only trigger the sounds if the user enabled the

--- a/src/core/AudioEngine/TransportPosition.cpp
+++ b/src/core/AudioEngine/TransportPosition.cpp
@@ -77,6 +77,8 @@ void TransportPosition::set( std::shared_ptr<TransportPosition> pOther ) {
 	}
 	m_nPatternSize = pOther->m_nPatternSize;
 	m_nLastLeadLagFactor = pOther->m_nLastLeadLagFactor;
+	m_nBar = pOther->m_nBar;
+	m_nBeat = pOther->m_nBeat;
 }
 
 void TransportPosition::reset() {
@@ -96,6 +98,8 @@ void TransportPosition::reset() {
 	m_pNextPatterns->clear();
 	m_nPatternSize = MAX_NOTES;
 	m_nLastLeadLagFactor = 0;
+	m_nBar = 1;
+	m_nBeat = 1;
 }
 
 void TransportPosition::setBpm( float fNewBpm ) {
@@ -185,6 +189,23 @@ void TransportPosition::setPatternSize( int nPatternSize ) {
 	}
 
 	m_nPatternSize = nPatternSize;
+}
+void TransportPosition::setBar( int nBar ) {
+	if ( nBar < 1 ) {
+		ERRORLOG( QString( "[%1] Provided bar [%2] it too small. Using [1] as a fallback instead." )
+				  .arg( m_sLabel ).arg( nBar ) );
+		nBar = 1;
+	}
+	m_nBar = nBar;
+}
+
+void TransportPosition::setBeat( int nBeat ) {
+	if ( nBeat < 1 ) {
+		ERRORLOG( QString( "[%1] Provided beat [%2] it too small. Using [1] as a fallback instead." )
+				  .arg( m_sLabel ).arg( nBeat ) );
+		nBeat = 1;
+	}
+	m_nBeat = nBeat;
 }
 				
 // This function uses the assumption that sample rate and resolution
@@ -635,7 +656,9 @@ QString TransportPosition::toQString( const QString& sPrefix, bool bShort ) cons
 			sOutput.append( QString( "%1%2m_pNextPatterns: %3\n" ).arg( sPrefix ).arg( s ).arg( m_pNextPatterns->toQString( sPrefix + s ), bShort ) );
 		}
 		sOutput.append( QString( "%1%2m_nPatternSize: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nPatternSize ) )
-			.append( QString( "%1%2m_nLastLeadLagFactor: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nLastLeadLagFactor ) );
+			.append( QString( "%1%2m_nLastLeadLagFactor: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nLastLeadLagFactor ) )
+			.append( QString( "%1%2m_nBar: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nBar ) )
+			.append( QString( "%1%2m_nBeat: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nBeat ) );
 	}
 	else {
 		sOutput = QString( "%1[TransportPosition]" ).arg( sPrefix )
@@ -659,7 +682,9 @@ QString TransportPosition::toQString( const QString& sPrefix, bool bShort ) cons
 			sOutput.append( QString( ", m_pNextPatterns: %1" ).arg( m_pNextPatterns->toQString( sPrefix + s ), bShort ) );
 		}
 		sOutput.append( QString( ", m_nPatternSize: %1" ).arg( m_nPatternSize ) )
-			.append( QString( ", m_nLastLeadLagFactor: %1" ).arg( m_nLastLeadLagFactor ) );
+			.append( QString( ", m_nLastLeadLagFactor: %1" ).arg( m_nLastLeadLagFactor ) )
+			.append( QString( ", m_nBar: %1" ).arg( m_nBar ) )
+			.append( QString( ", m_nBeat: %1" ).arg( m_nBeat ) );
 
 	}
 	

--- a/src/core/AudioEngine/TransportPosition.h
+++ b/src/core/AudioEngine/TransportPosition.h
@@ -76,6 +76,8 @@ public:
 	const PatternList* getNextPatterns() const;
 	int getPatternSize() const;
 	long long getLastLeadLagFactor() const;
+	int getBar() const;
+	int getBeat() const;
 
 	/**
 	 * Calculates tick equivalent of @a nFrame.
@@ -155,6 +157,8 @@ private:
 	void setNextPatterns( PatternList* pPatternList );
 	void setPatternSize( int nPatternSize );
 	void setLastLeadLagFactor( long long nValue );
+	void setBar( int nBar );
+	void setBeat( int nBeat );
 	
 	PatternList* getPlayingPatterns();
 	PatternList* getNextPatterns();
@@ -386,6 +390,19 @@ private:
 	 * #Song::Mode::Song).
 	 */
 	long long m_nLastLeadLagFactor;
+
+	/**
+	 * Last beat (column + 1) passed.
+	 *
+	 * Note that this variable starts at 1 not at 0.
+	 */
+	int m_nBar;
+	/**
+	 * Last bar passed since #m_nBar. A bar is composed of 48 ticks.
+	 *
+	 * Note that this variable starts at 1 not at 0.
+	 */
+	int m_nBeat;
 };
 
 inline const QString TransportPosition::getLabel() const {
@@ -456,6 +473,12 @@ inline long long TransportPosition::getLastLeadLagFactor() const {
 }
 inline void TransportPosition::setLastLeadLagFactor( long long nValue ) {
 	m_nLastLeadLagFactor = nValue;
+}
+inline int TransportPosition::getBar() const {
+	return m_nBar;
+}
+inline int TransportPosition::getBeat() const {
+	return m_nBeat;
 }
 };
 

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1402,8 +1402,6 @@ bool CoreActionController::locateToColumn( int nPatternGroup ) {
 		return false;
 	}
 	
-	EventQueue::get_instance()->push_event( EVENT_METRONOME, 1 );
-	
 	long nTotalTick = pHydrogen->getTickForColumn( nPatternGroup );
 	if ( nTotalTick < 0 ) {
 		if ( pHydrogen->getMode() == Song::Mode::Song ) {

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -85,29 +85,12 @@ enum EventType {
 	EVENT_XRUN,
 	EVENT_NOTEON,
 	EVENT_ERROR,
-	/** Event indicating the triggering of the
-	 * #H2Core::AudioEngine::m_pMetronomeInstrument.
+	/**
+	 * Triggered when a metronome note is passed to the
+	 * #H2Core::Sampler.
 	 *
-	 * In AudioEngine::updateNoteQueue() the pushing of this Event is
-	 * decoupled from the creation and queuing of the corresponding
-	 * Note itself.
-	 *
-	 * In Director it triggers a change in the displayed column
-	 * number, tempo, and tag.
-	 *
-	 * The associated values do correspond to the following actions:
-	 * - 0: Beat at the beginning of a Pattern in
-	 *      audioEngine_updateNoteQueue(). The corresponding Note will
-	 *      be created with a pitch of 3 and velocity of 1.0.
-	 *      Sets MetronomeWidget::m_state to
-	 *      MetronomeWidget::METRO_ON and triggers
-	 *      MetronomeWidget::updateWidget().
-	 * - 1: Beat in the remainder of a Pattern in
-	 *      audioEngine_updateNoteQueue(). The corresponding Note will
-	 *      be created with a pitch of 0 and velocity of 0.8.
-	 *      Sets MetronomeWidget::m_state to
-	 *      MetronomeWidget::METRO_FIRST and triggers
-	 *      MetronomeWidget::updateWidget().
+	 * - 0 - First bar requiring a distinct sound
+	 * - 1 - All the other bars
 	 *
 	 * Handled by EventListener::metronomeEvent().
 	 */
@@ -181,6 +164,12 @@ enum EventType {
 	 * or at the very end of the song in song mode.
 	 */
 	EVENT_RELOCATION,
+	/**
+	 * The coarse grained transport position in beats and bars did
+	 * change. (Tick - the "T" in BBT - resolution is not implemented
+	 * yet as no part of the application requires it).
+	 */
+	EVENT_BBT_CHANGED,
 	EVENT_SONG_SIZE_CHANGED,
 	EVENT_DRIVER_CHANGED,
 	EVENT_PLAYBACK_TRACK_CHANGED,

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -154,10 +154,30 @@ void Director::timelineUpdateEvent( int nValue ) {
 }
 
 bool Director::updateTags() {
-	auto pTimeline = Hydrogen::get_instance()->getTimeline();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pTimeline = pHydrogen->getTimeline();
+	auto pSong = pHydrogen->getSong();
+
+	if ( pSong == nullptr ) {
+		return false;
+	}
+	
+	const int nColumns = pSong->getPatternGroupVector()->size();
 
 	bool bRequiresUpdate = false;
-	if ( m_sTagNext != pTimeline->getTagAtColumn( m_nBar ) ) {
+	// Note that bar = column + 1
+	if ( m_nBar == nColumns ) {
+		if ( pSong->getLoopMode() == Song::LoopMode::Enabled &&
+			 m_sTagNext != pTimeline->getTagAtColumn( 0 ) ) {
+			// We are in the last column and transport will be looped back
+			// to the beginning. Show the tag in the first column as the
+			// next one.
+			m_sTagNext = pTimeline->getTagAtColumn( 0 );
+			updateFontSize( FontUpdate::TagNext );
+			bRequiresUpdate = true;
+		}
+	}
+	else if ( m_sTagNext != pTimeline->getTagAtColumn( m_nBar ) ) {
 		m_sTagNext = pTimeline->getTagAtColumn( m_nBar );
 		updateFontSize( FontUpdate::TagNext );
 		bRequiresUpdate = true;

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -55,11 +55,24 @@ public:
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
+	void resizeEvent( QResizeEvent *event ) override;
+
 private slots:
 	void updateMetronomBackground();
 
 
 private:
+	enum FontUpdate {
+		SongName = 0x001,
+		TagCurrent = 0x002,
+		TagNext = 0x004
+	};
+	/** @return true in case either #m_sTagCurrent or #m_sTagNext did
+	 * change.*/
+	bool updateTags();
+	void updateLabelContainers();
+	void updateFontSize( FontUpdate update );
+
 	QTimer				*m_pTimer;
 	QColor				m_Color;
 	QPalette			m_BlinkerPalette;
@@ -67,9 +80,15 @@ private:
 	float				m_fBpm;
 	int					m_nBar;
 	int					m_nFlashingArea;
-	QString				m_sTAG;
-	QString				m_sTAG2;
+	QString				m_sTagCurrent;
+	QString				m_sTagNext;
 	QString				m_sSongName;
+	QRect				m_rectSongName;
+	QRect				m_rectTagCurrent;
+	QRect				m_rectTagNext;
+	QFont				m_fontSongName;
+	QFont				m_fontTagCurrent;
+	QFont				m_fontTagNext;
 };
 
 

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -47,8 +47,8 @@ public:
 
 	virtual void updateSongEvent( int nValue ) override;
 	virtual void timelineUpdateEvent( int nValue ) override;
-	virtual void metronomeEvent( int nValue ) override;
-	virtual void relocationEvent() override;
+	virtual void bbtChangedEvent() override;
+	virtual void tempoChangedEvent( int nValue ) override;
 	
 	virtual void paintEvent( QPaintEvent*) override;
 	virtual void keyPressEvent( QKeyEvent* ev ) override;
@@ -78,7 +78,7 @@ private:
 	QTimer				*m_pTimer;
 	QColor				m_Color;
 	QPalette			m_BlinkerPalette;
-	int					m_nCounter;
+	int					m_nBeat;
 	float				m_fBpm;
 	int					m_nBar;
 	int					m_nFlashingArea;

--- a/src/gui/src/Director.h
+++ b/src/gui/src/Director.h
@@ -48,6 +48,8 @@ public:
 	virtual void updateSongEvent( int nValue ) override;
 	virtual void timelineUpdateEvent( int nValue ) override;
 	virtual void metronomeEvent( int nValue ) override;
+	virtual void relocationEvent() override;
+	
 	virtual void paintEvent( QPaintEvent*) override;
 	virtual void keyPressEvent( QKeyEvent* ev ) override;
 	virtual void closeEvent( QCloseEvent* ev ) override;

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -61,6 +61,7 @@ class EventListener
 	virtual void drumkitLoadedEvent(){}
 	virtual void patternEditorLockedEvent(){}
 	virtual void relocationEvent(){}
+	virtual void bbtChangedEvent(){}
 	virtual void songSizeChangedEvent(){}
 	virtual void driverChangedEvent(){}
 	virtual void playbackTrackChangedEvent(){}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -846,6 +846,10 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->relocationEvent();
 				break;
 				
+			case EVENT_BBT_CHANGED:
+				pListener->bbtChangedEvent();
+				break;
+
 			case EVENT_SONG_SIZE_CHANGED:
 				pListener->songSizeChangedEvent();
 				break;

--- a/src/gui/src/Widgets/LED.cpp
+++ b/src/gui/src/Widgets/LED.cpp
@@ -26,6 +26,8 @@
 #include "../HydrogenApp.h"
 #include <core/Globals.h>
 #include <core/Preferences/Preferences.h>
+#include <core/AudioEngine/AudioEngine.h>
+#include <core/AudioEngine/TransportPosition.h>
 
 LED::LED( QWidget *pParent, QSize size )
  : QWidget( pParent )
@@ -81,7 +83,7 @@ void LED::paintEvent( QPaintEvent* ev )
 
 MetronomeLED::MetronomeLED( QWidget *pParent, QSize size )
 	: LED( pParent, size )
-	, m_bFirstBeat( false )
+	, m_bFirstBar( false )
 	, m_activityTimeout( 250 )
 {
 	HydrogenApp::get_instance()->addEventListener( this );
@@ -114,16 +116,8 @@ void MetronomeLED::metronomeEvent( int nValue ) {
 		return;
 	}
 	
-	if ( nValue == 2 ) { // 2 = set pattern position is not needed here
-		return;
-	}
-
 	m_bActivated = true;
-	if ( nValue == 1 ) {
-		m_bFirstBeat = true;
-	} else {
-		m_bFirstBeat = false;
-	}
+	m_bFirstBar = nValue == 0;
 	
 	update();
 
@@ -143,7 +137,7 @@ void MetronomeLED::paintEvent( QPaintEvent* ev )
 	if ( m_background != nullptr ) {
 
 		if ( m_bActivated ) {
-			if ( m_bFirstBeat ) {
+			if ( m_bFirstBar ) {
 				m_background->render( &painter, "layer3" );
 			} else {
 				m_background->render( &painter, "layer2" );

--- a/src/gui/src/Widgets/LED.h
+++ b/src/gui/src/Widgets/LED.h
@@ -84,7 +84,7 @@ private slots:
 	void turnOff();
 	
 private:
-	bool m_bFirstBeat;
+	bool m_bFirstBar;
 	QTimer* m_pTimer;
 	std::chrono::milliseconds m_activityTimeout;
 	


### PR DESCRIPTION
Till now `EVENT_METRONOME` was triggered on relocations and when a metronome note (would be) queued in the `AudioEngine::m_songNoteQueue` at `AudioEngine::m_pQueuingPosition`. The signal is than used in two different ways: 1. to indicate a metronome note by flashing the `LED` below the metronome button, 2. to update the beat and bar information displayed in the `Director` (with the assumption that a metronome should sound on every bar).

Note that **beat** as discussed in here has a fixed length of 48 ticks.

This lead to a couple of issues
- metronome LED fires on relocations (even though no metronome note was played back)
- pausing transport at the right time could already trigger metronome LED while corresponding note was not played yet (as the lookahead between queuing and transport position has to be passed first)
- bar information in `Director` did lag behind. (as `EVENT_METRONOME` was fired at queuing position and Director shows position information at transport position))

I disentangled both use cases of the event and split it into `EVENT_METRONOME` and `EVENT_BBT_CHANGED`.

### `EVENT_METRONOME`

Is now fired in `AudioEngine::processPlayNotes()` every time a metronome note is passed to the `Sampler` and only evaluated by the metronome LED. -> LED only flashes if a metronome note is actually played.

### `EVENT_BBT`

`TransportPosition` class does now hold two more members `m_nBar` and `m_nBeat` - coarse grained versions of the transport position displayed in `Director`. The event is fired each time either or both of these variables do change in `AudioEngine::updateTransportPosition()` for the transport position. -> position displayed in `Director` is always in sync.

The **tick** part of BarBeatTick is not implemented yet as it is not used yet. But using these changes we could easy display this information in the `PlayerControl` instead of time (or in addition) at some point in the future).

## Director fixes

In addition, I found some bugs in `Director`

- fit text
   only small and concise song names and tag labels could be displayed whole in the previous implementation. All other did overflow to the left and right and were cut.

  Now, font size is set to a default value (the one used previously) whenever a label or song name changed and reduced until the font fits the window width.
- `Director` does now properly respond to all relevant events to ensure tag labels displayed are always correct