### PR TITLE
AppVeyor: tweak artifacts upload strategy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -78,11 +78,6 @@ environment:
 build:
   verbosity: detailed
 
-matrix:
-  exclude:
-    - job_name: Windows32
-      branches: "master"
-
 # Upload artifacts in case either the branch is named *-artifacts or
 # HEAD is located on a tag (affects both Linux and Mac OS jobs).
 init:
@@ -290,8 +285,8 @@ for:
     before_build:
       cmd: |-
 
-          # Upload artifacts in case either the branch is named
-          # *-artifacts or HEAD is located on a tag.
+          REM *** Upload artifacts in case either the branch is named ***
+          REM *** *-artifacts or HEAD is located on a tag. ***
           if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
           if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,7 +43,7 @@
 
 environment:
   GENERATOR: "MinGW Makefiles"
-  ARTIFACT_BRANCH: master-artifacts
+  UPLOAD_ARTIFACTS: false
   TARGET_VERSION: '1.2.0'
   matrix:
 
@@ -82,6 +82,14 @@ matrix:
   exclude:
     - job_name: Windows32
       branches: "master"
+
+# Upload artifacts in case either the branch is named *-artifacts or
+# HEAD is located on a tag (affects both Linux and Mac OS jobs).
+init:
+  - sh: |-
+      if [[ "$APPVEYOR_REPO_TAG_NAME" || "$APPVEYOR_REPO_BRANCH" == *"-artifacts" ]]; then
+          UPLOAD_ARTIFACTS=true
+      fi
 
 for:
   - 
@@ -252,8 +260,7 @@ for:
         PATH="$(brew --prefix qt5)/bin:$PATH"
         ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg
 
-        # deploy dmg only on branch $ARTIFACT_BRANCH
-        if [ "$APPVEYOR_REPO_BRANCH" = "$ARTIFACT_BRANCH" ]; then
+        if [ "$UPLOAD_ARTIFACTS" == "true" ]; then
             appveyor PushArtifact Hydrogen*.dmg -DeploymentName Installer;
         fi
       ) || exit 1
@@ -283,7 +290,12 @@ for:
     before_build:
       cmd: |-
 
-          if not %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if %job_name%==Windows32 appveyor exit
+          # Upload artifacts in case either the branch is named
+          # *-artifacts or HEAD is located on a tag.
+          if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
+          if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
+
+          if not %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32 appveyor exit
 
           set QTDIR=%MSYS%
           set CMAKE_PREFIX_PATH=%QTDIR%
@@ -321,7 +333,7 @@ for:
 
     build_script:
       - cmd: |-
-          if not %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if %job_name%==Windows32 exit
+          if not %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32 exit
 
           REM *** Build ***
           set VERBOSE=1
@@ -340,7 +352,7 @@ for:
           IF %ERRORLEVEL% EQU 0 (del testOutput.log)
 
           7z a %APPVEYOR_BUILD_FOLDER%\testresults.zip %TEMP%\hydrogen || cmd /c "exit  /b 1"
-          if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
+          if %UPLOAD_ARTIFACTS%=="true" appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\testresults.zip
 
           mkdir %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
 
@@ -368,13 +380,13 @@ for:
           ccache -s
 
 on_finish:
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH%  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
+  - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
+  - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
+  - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
   - cmd: if EXIST %APPVEYOR_BUILD_FOLDER%\build\testOutput.log appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\testOutput.log
 
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win64.exe || cmd /c "exit /b 1"
-  - cmd: if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win32.exe || cmd /c "exit /b 1"
+  - cmd: if %UPLOAD_ARTIFACTS%=="true" if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win64.exe || cmd /c "exit /b 1"
+  - cmd: if %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win32.exe || cmd /c "exit /b 1"
 
   - cmd: |
-      if %APPVEYOR_REPO_BRANCH%==%ARTIFACT_BRANCH% curl -F file=@%APPVEYOR_BUILD_FOLDER%\build\test_installation.xml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%
+      if %UPLOAD_ARTIFACTS%=="true" curl -F file=@%APPVEYOR_BUILD_FOLDER%\build\test_installation.xml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%


### PR DESCRIPTION
I'm still not a 100% sure why but somehow I lost a couple of commits on the `releases/1.2` . In the end I managed to have the 1.2.0 tag at the HEAD of `releases/1.2-artifacts` but the `ARTIFACTS_BRANCH` in `.appveyor.yml` was reset to `master-artifacts`. That was a little bit frustrating as I have no idea how to put a commit altering the branch _in front_ of the tagged commit. In the end I put artifacts build with the some sources as the tag but from a different commit inside the release.

To ensure this will not happen again I did revise the artifact upload in the `.appveyor.yml`. (and I will try to reproduce what went wrong in another repo)

Instead of only building with artifacts in case the branch name matches a certain string specified in the `.appveyor.yml` file, artifact upload is now triggered whenever branch name has a "-artifacts" suffix or in case HEAD is at a tag. No editing of branch names in configs anymore and adding a tag on `master` does already trigger artifact generation. For the latter I'm not sure if it already works properly. I just simulated adding a tag by setting environmental variables according to the  AppVeyor Doc.

@cme As we only push sparsely to release branches we could also whitelist all branches with "releases/" prefix and offer rolling releases in addition to our regular ones.