### PR TITLE
AppVeyor: port to CMake 3.26.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -376,8 +376,7 @@ for:
 
 on_finish:
   - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeCache.txt
-  - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeOutput.log
-  - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeError.log
+  - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeConfigureLog.yaml
   - cmd: if EXIST %APPVEYOR_BUILD_FOLDER%\build\testOutput.log appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\testOutput.log
 
   - cmd: if %UPLOAD_ARTIFACTS%=="true" if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win64.exe || cmd /c "exit /b 1"


### PR DESCRIPTION
AppVeyor updated `cmake` version of their build pipeline recently which caused both Windows pipelines to fail.

With version 3.26 CMake deprecated both `CMakeFiles/CMakeOutput.log` and `CMakeFiles/CMakeError.log` and replaced them by `CMakeFiles/CMakeConfigureLog.yaml` (see https://cmake.org/cmake/help/v3.26/release/3.26.html\#id14).