### PR TITLE
DEBUG: add temp. debug output for pipeline

### DIFF
--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -293,12 +293,15 @@ void* diskWriterDriver_thread( void* param )
 		int nPercent = static_cast<int>( ( float )(patternPosition +1) /
 										 ( float )nColumns * 100.0 );
 		if ( nPercent < 100 ) {
+			qDebug() << "[diskWriterDriver_thread] nPrecent: " << nPercent;
 			EventQueue::get_instance()->push_event( EVENT_PROGRESS, nPercent );
 		}
 	}
 
 	// Explicitly mark export as finished.
 	EventQueue::get_instance()->push_event( EVENT_PROGRESS, 100 );
+	
+	qDebug() << "[diskWriterDriver_thread] done";
 	
 	delete[] pData;
 	pData = nullptr;

--- a/src/tests/TestHelper.cpp
+++ b/src/tests/TestHelper.cpp
@@ -252,13 +252,18 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 	while ( ! bDone ) {
 		H2Core::Event event = pQueue->pop_event();
 
-		if (event.type == H2Core::EVENT_PROGRESS && event.value == 100) {
-			bDone = true;
+		if (event.type == H2Core::EVENT_PROGRESS) {
+			qDebug() << "[TestHelper::exportSong] progress: " << event.value;
+			if ( event.value == 100 ) {
+				qDebug() << "[TestHelper::exportSong] done";
+				bDone = true;
+			}
 		}
 		else if ( event.type == H2Core::EVENT_NONE ) {
 			usleep(100 * 1000);
 		}
 	}
+	qDebug() << "[TestHelper::exportSong] stopping export";
 	pHydrogen->stopExportSession();
 
 	auto t1 = std::chrono::high_resolution_clock::now();

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -241,8 +241,11 @@ void TransportTest::testSampleConsistency() {
 
 	// Apply drumkit containing the long sample to be tested.
 	pCoreActionController->setDrumkit( sDrumkitDir, true );
-	
+
+	qDebug() << "[TransportTest::testSampleConsistency] start export";
 	TestHelper::exportSong( sOutFile );
+	qDebug() << "[TransportTest::testSampleConsistency] done exporting";
+	
 	H2TEST_ASSERT_AUDIO_FILES_DATA_EQUAL( sRefFile, sOutFile );
 	Filesystem::rm( sOutFile );
 	___INFOLOG( "passed" );


### PR DESCRIPTION
quite frequently, but not every time, our macOS pipeline gets stuck in `TransportTest::testSampleConsistency`. When looking at the code I do not see what could cause this issue (and I can not reproduce it locally). But we had a similar issue once were the thread of the `DiskWriterDriver` did not queued an event containing the final 100% progress. GUI itself does not care but unit test did fail because of it.

I added some temporary debug print statements that may point in the right direction once this problem shows itself within our pipeline again.

Will be reverted as soon as the pipeline failure is fixed.