### PR TITLE
AudioEngine: fix false positives in humanization test

### DIFF
--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -433,6 +433,13 @@ public:
 	void flushAndAddNextPattern( int nPatternNumber );
 
 	void updateVirtualPatterns();
+
+	/**
+	 * Returns the size of #m_songNoteQueue.
+	 *
+	 * Required to not end unit tests prematurely.
+	 */
+	int getEnqueuedNotesNumber() const;
 	
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of
@@ -795,6 +802,9 @@ inline double AudioEngine::getSongSizeInTicks() const {
 }
 inline std::shared_ptr<Instrument> AudioEngine::getMetronomeInstrument() const {
 	return m_pMetronomeInstrument;
+}
+inline int AudioEngine::getEnqueuedNotesNumber() const {
+	return m_songNoteQueue.size();
 }
 };
 

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -1221,7 +1221,8 @@ void AudioEngineTests::testHumanization() {
 		
 		int nn = 0;
 		bool bEndOfSongReached = false;
-		while ( pTransportPos->getDoubleTick() < pAE->m_fSongSizeInTicks ) {
+		while ( pTransportPos->getDoubleTick() < pAE->m_fSongSizeInTicks ||
+				pAE->getEnqueuedNotesNumber() > 0 ) {
 
 			if ( ! bEndOfSongReached ) {
 				if ( pAE->updateNoteQueue( nFrames ) == -1 ) {
@@ -1265,8 +1266,6 @@ void AudioEngineTests::testHumanization() {
 	auto setSwing = [&]( double fValue ) {
 		fValue = std::clamp( fValue, 0.0, 1.0 );
 
-		pSong->setHumanizeTimeValue( fValue );
-		pSong->setHumanizeVelocityValue( fValue );
 		pSong->setSwingFactor( fValue );
 	};
 


### PR DESCRIPTION
occassionally the last note in the humanization test pattern was moved to the very end of pattern due to the humanization and was thus not picked up and counted. This lead to failure of the Ubuntu building pipeline. The unit test now waits till no more notes are enqueued in the song note queue.