### PR TITLE
MidiAction: fix handleActions (#1751)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix loading of legacy drumkits. All layers but the first one
+		  were dropped during drumkit upgrade (#1759)
+		- Fix MIDI input handling with "Discard MIDI messages after action
+		  has been triggered" checked. Incoming NOTEON message were
+		  dropped without triggering a sound (#1751)
 		- Fix beat and bar calculation in pattern mode (#1741)
 		- Fix compilation in GCC with -Werror=format-security (#1739)
 		- Explicit usage of Python3 in stats.py script

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1228,12 +1228,12 @@ int MidiActionManager::getParameterNumber( const QString& sActionType ) const {
 
 bool MidiActionManager::handleActions( std::vector<std::shared_ptr<Action>> actions ) {
 
-	bool bResult = true;
+	bool bResult = false;
 	
 	for ( const auto& action : actions ) {
 		if ( action != nullptr ) {
-			if ( ! handleAction( action ) ) {
-				bResult = false;
+			if ( handleAction( action ) ) {
+				bResult = true;
 			}
 		}
 	}

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -182,15 +182,19 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 		 * Handles multiple actions at once and calls handleAction()
 		 * on them.
 		 *
-		 * \return true - in case all actions were successful, false - otherwise.
+		 * \return true - if at least one Action was handled
+		 *   successfully. Calling functions should treat the event
+		 *   resulting in @a actions as consumed.
 		 */
-	bool handleActions( std::vector<std::shared_ptr<Action>> );
+	bool handleActions( std::vector<std::shared_ptr<Action>> actions );
 		/**
 		 * The handleAction method is the heart of the
 		 * MidiActionManager class. It executes the operations that
 		 * are needed to carry the desired action.
+		 *
+		 * @return true - if @a action was handled successfully.
 		 */
-		bool handleAction( std::shared_ptr<Action> );
+		bool handleAction( std::shared_ptr<Action> action );
 		/**
 		 * If #__instance equals 0, a new MidiActionManager
 		 * singleton will be created and stored in it.


### PR DESCRIPTION
While adding a handler function allowing to process multiple actions at once I seem to misinterpreted the intention of `handleAction`s return value.

The value returned by `handleActions` does now indicate whether an action was successfully processed and thus the event triggering the action should be consumed.