### PR TITLE
MIDI logging and handling refactoring

### DIFF
--- a/src/core/IO/CoreMidiDriver.cpp
+++ b/src/core/IO/CoreMidiDriver.cpp
@@ -85,9 +85,6 @@ static void midiProc ( const MIDIPacketList * pktlist,
 					   return;
 		} else {
 			___ERRORLOG( QString( "Unhandled midi message type: %1" ).arg( nEventType ) );
-			___INFOLOG( "MIDI msg: " );
-			// instance->errorLog( "Unhandled midi message type: " + to_string( nEventType ) );
-			// instance->infoLog( "MIDI msg: " );
 		}
 
 		msg.m_nData1 = packet->data[1];

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include <QString>
+
 namespace H2Core
 {
 
@@ -52,6 +54,7 @@ public:
 		SONG_POS,
 		QUARTER_FRAME
 	};
+	static QString TypeToQString( MidiMessageType type );
 
 	MidiMessageType m_type;
 	int m_nData1;
@@ -65,6 +68,59 @@ public:
 			, m_nData2( -1 )
 			, m_nChannel( -1 ) {}
 };
+
+inline QString MidiMessage::TypeToQString( MidiMessageType type ) {
+	QString sType;
+	switch( type ) {
+	case MidiMessageType::SYSEX:
+		sType = "SYSEX";
+		break;
+	case MidiMessageType::NOTE_ON:
+		sType = "NOTE_ON";
+		break;
+	case MidiMessageType::NOTE_OFF:
+		sType = "NOTE_OFF";
+		break;
+	case MidiMessageType::POLYPHONIC_KEY_PRESSURE:
+		sType = "POLYPHONIC_KEY_PRESSURE";
+		break;
+	case MidiMessageType::CONTROL_CHANGE:
+		sType = "CONTROL_CHANGE";
+		break;
+	case MidiMessageType::PROGRAM_CHANGE:
+		sType = "PROGRAM_CHANGE";
+		break;
+	case MidiMessageType::CHANNEL_PRESSURE:
+		sType = "CHANNEL_PRESSURE";
+		break;
+	case MidiMessageType::PITCH_WHEEL:
+		sType = "PITCH_WHEEL";
+		break;
+	case MidiMessageType::SYSTEM_EXCLUSIVE:
+		sType = "SYSTEM_EXCLUSIVE";
+		break;
+	case MidiMessageType::START:
+		sType = "START";
+		break;
+	case MidiMessageType::CONTINUE:
+		sType = "CONTINUE";
+		break;
+	case MidiMessageType::STOP:
+		sType = "STOP";
+		break;
+	case MidiMessageType::SONG_POS:
+		sType = "SONG_POS";
+		break;
+	case MidiMessageType::QUARTER_FRAME:
+		sType = "QUARTER_FRAME";
+		break;
+	case MidiMessageType::UNKNOWN:
+	default:
+		sType = "Unknown MIDI message type";
+	}
+
+	return std::move( sType );
+}
 
 
 /** \ingroup docCore docMIDI */

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -117,23 +117,24 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 				break;
 
 		case MidiMessage::START: /* Start from position 0 */
-				if ( pAudioEngine->getState() != AudioEngine::State::Playing ) {
-					pHydrogen->getCoreActionController()->locateToColumn( 0 );
-					pHydrogen->sequencer_play();
-				}
-				break;
+			if ( pAudioEngine->getState() != AudioEngine::State::Playing ) {
+				pHydrogen->getCoreActionController()->locateToColumn( 0 );
+				auto pAction = std::make_shared<Action>("PLAY");
+				MidiActionManager::get_instance()->handleAction( pAction );
+			}
+			break;
 
-		case MidiMessage::CONTINUE: /* Just start */
-				if ( pAudioEngine->getState() != AudioEngine::State::Playing ) {
-					pHydrogen->sequencer_play();
-				}
-				break;
+		case MidiMessage::CONTINUE: /* Just start */ {
+			auto pAction = std::make_shared<Action>("PLAY");
+			MidiActionManager::get_instance()->handleAction( pAction );
+			break;
+		}
 
-		case MidiMessage::STOP: /* Stop in current position i.e. Pause */
-				if ( pAudioEngine->getState() == AudioEngine::State::Playing ) {
-					pHydrogen->sequencer_stop();
-				}
-				break;
+		case MidiMessage::STOP: /* Stop in current position i.e. Pause */ {
+			auto pAction = std::make_shared<Action>("PAUSE");
+			MidiActionManager::get_instance()->handleAction( pAction );
+			break;
+		}
 
 		case MidiMessage::CHANNEL_PRESSURE:
 		case MidiMessage::PITCH_WHEEL:


### PR DESCRIPTION
instead of calling `Hydrogen::sequencer_start` and `Hydrogen::sequencer_stop` directly when encountering MIDI messages of type **START**, **CONTINUE**, and **STOP** in `MidiInput::handleMidiMessage()` the corresponding MIDI actions are triggered. Code is almost identical but it should help to keep things consistent