### PR TITLE
MidiCommon: merge SYSTEM_EXCLUSIVE into SYSEX

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix MIDI Machine Control (MMC) event type handling on Windows
+		  (#1773)
 		- Fix loading of legacy drumkits. All layers but the first one
 		  were dropped during drumkit upgrade (#1759)
 		- Fix MIDI input handling with "Discard MIDI messages after action

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -47,7 +47,6 @@ public:
 		PROGRAM_CHANGE,
 		CHANNEL_PRESSURE,
 		PITCH_WHEEL,
-		SYSTEM_EXCLUSIVE,
 		START,
 		CONTINUE,
 		STOP,
@@ -95,9 +94,6 @@ inline QString MidiMessage::TypeToQString( MidiMessageType type ) {
 		break;
 	case MidiMessageType::PITCH_WHEEL:
 		sType = "PITCH_WHEEL";
-		break;
-	case MidiMessageType::SYSTEM_EXCLUSIVE:
-		sType = "SYSTEM_EXCLUSIVE";
 		break;
 	case MidiMessageType::START:
 		sType = "START";

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -70,7 +70,6 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 		// exclude all midi channel filter independent messages
 		int type = msg.m_type;
 		if (  MidiMessage::SYSEX == type
-		   || MidiMessage::SYSTEM_EXCLUSIVE == type
 		   || MidiMessage::START == type
 		   || MidiMessage::CONTINUE == type
 		   || MidiMessage::STOP == type
@@ -138,7 +137,6 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 
 		case MidiMessage::CHANNEL_PRESSURE:
 		case MidiMessage::PITCH_WHEEL:
-		case MidiMessage::SYSTEM_EXCLUSIVE:
 		case MidiMessage::SONG_POS:
 		case MidiMessage::QUARTER_FRAME:
 			ERRORLOG( QString( "MIDI message of type [%1] is not supported by Hydrogen" )

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -87,7 +87,7 @@ void* PortMidiDriver_thread( void* param )
 					msg.m_type = MidiMessage::PITCH_WHEEL;
 				} else if ( ( nEventType >= 240 ) && ( nEventType < 256 ) ) {	// System Exclusive
 					msg.m_nChannel = nEventType - 240;
-					msg.m_type = MidiMessage::SYSTEM_EXCLUSIVE;
+					msg.m_type = MidiMessage::SYSEX;
 				} else {
 					__ERRORLOG( "Unhandled midi message type: " + QString::number( nEventType ) );
 					__INFOLOG( "MIDI msg: " );


### PR DESCRIPTION
After reading into both MIDI specs and doc as well as PortMidi API doc I came to the conclusion that the separate handling (and mere existence) of `SYSTEM_EXCLUSIVE` and `SYSEX` MIDI type must have been an accident.

This fix should enable MMC MIDI control using PortMidi (I have no hardware to test this).

Fixes #1773