### PR TITLE
PortMidi: love and SysEx

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix missing MIDI driver restart when adjusting corresponding
+		  parameters in Preferences.
 		- Fix MIDI Machine Control (MMC) event type handling on Windows
 		  (#1773)
 		- Fix loading of legacy drumkits. All layers but the first one

--- a/src/core/IO/AlsaMidiDriver.cpp
+++ b/src/core/IO/AlsaMidiDriver.cpp
@@ -466,7 +466,7 @@ void AlsaMidiDriver::getPortInfo( const QString& sPortName, int& nClient, int& n
 		return;
 	}
 
-	if ( sPortName == "None" ) {
+	if ( sPortName == Preferences::getNullMidiPort() ) {
 		nClient = -1;
 		nPort = -1;
 		return;

--- a/src/core/IO/CoreMidiDriver.cpp
+++ b/src/core/IO/CoreMidiDriver.cpp
@@ -101,8 +101,6 @@ CoreMidiDriver::CoreMidiDriver()
 {
 	
 	OSStatus err = noErr;
-
-	QString sMidiPortName = Preferences::get_instance()->m_sMidiPortName;
 	err = MIDIClientCreate ( CFSTR( "h2MIDIClient" ), NULL, NULL, &h2MIDIClient );
 	if ( err != noErr ) {
 		ERRORLOG( QString( "Cannot create CoreMIDI client: %1" ).arg( err ));
@@ -156,7 +154,8 @@ void CoreMidiDriver::open()
 			char cmName[64];
 			err = CFStringGetCString( H2MidiNames, cmName, 64, kCFStringEncodingASCII );
 			QString h2MidiPortName = cmName;
-			if ( h2MidiPortName == sMidiPortName ) {
+			if ( h2MidiPortName == sMidiPortName &&
+				 sMidiPortName != Preferences::getNullMidiPort() ) {
 				MIDIPortConnectSource ( h2InputRef, cmH2Src, NULL );
 				m_bRunning = true;
 			}

--- a/src/core/IO/JackMidiDriver.cpp
+++ b/src/core/IO/JackMidiDriver.cpp
@@ -444,7 +444,7 @@ JackMidiDriver::getOutputPortList()
 void
 JackMidiDriver::getPortInfo(const QString& sPortName, int& nClient, int& nPort)
 {
-	if (sPortName == "None") {
+	if ( sPortName == Preferences::getNullMidiPort() ) {
 		nClient = -1;
 		nPort = -1;
 		return;

--- a/src/core/IO/MidiCommon.cpp
+++ b/src/core/IO/MidiCommon.cpp
@@ -1,0 +1,136 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2023-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include <core/IO/MidiCommon.h>
+
+namespace H2Core
+{
+
+void MidiMessage::clear() {
+	m_type = UNKNOWN;
+	m_nData1 = -1;
+	m_nData2 = -1;
+	m_nChannel = -1;
+	m_sysexData.clear();
+}
+
+QString MidiMessage::toQString( const QString& sPrefix, bool bShort ) const {
+
+	QString s = Base::sPrintIndention;
+	QString sOutput;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[MidiMessage]\n" ).arg( sPrefix )
+			.append( QString( "%1%2m_type: %3\n" )
+					 .arg( MidiMessage::TypeToQString( m_type ) ) )
+			.append( QString( "%1%2m_nData1: %3\n" )
+					 .arg( m_nData1 ) )
+			.append( QString( "%1%2m_nData2: %3\n" )
+					 .arg( m_nData2 ) )
+			.append( QString( "%1%2m_nChannel: %3\n" )
+					 .arg( m_nChannel ) )
+			.append( QString( "%1%2m_sysexData: [" ) );
+		bool bIsFirst = true;
+		for ( const auto& dd : m_sysexData ) {
+			if ( bIsFirst ) {
+				sOutput.append( QString( "%1" ).arg( dd ) );
+				bIsFirst = false;
+			}
+			else {
+				sOutput.append( QString( " %1" ).arg( dd ) );
+			}
+		}
+		sOutput.append( "]\n" );
+	}
+	else {
+		sOutput = QString( "[MidiMessage] " )
+			.append( QString( "m_type: %1" ).arg( MidiMessage::TypeToQString( m_type ) ) )
+			.append( QString( ", m_nData1: %1" ).arg( m_nData1 ) )
+			.append( QString( ", m_nData2: %1" ).arg( m_nData2 ) )
+			.append( QString( ", m_nChannel: %1" ).arg( m_nChannel ) )
+			.append( QString( ", m_sysexData: [" ) );
+		bool bIsFirst = true;
+		for ( const auto& dd : m_sysexData ) {
+			if ( bIsFirst ) {
+				sOutput.append( QString( "%1" ).arg( dd ) );
+				bIsFirst = false;
+			}
+			else {
+				sOutput.append( QString( " %1" ).arg( dd ) );
+			}
+		}
+		sOutput.append( "]\n" );
+	}
+	
+	return sOutput;
+}
+
+QString MidiMessage::TypeToQString( MidiMessageType type ) {
+	QString sType;
+	switch( type ) {
+	case MidiMessageType::SYSEX:
+		sType = "SYSEX";
+		break;
+	case MidiMessageType::NOTE_ON:
+		sType = "NOTE_ON";
+		break;
+	case MidiMessageType::NOTE_OFF:
+		sType = "NOTE_OFF";
+		break;
+	case MidiMessageType::POLYPHONIC_KEY_PRESSURE:
+		sType = "POLYPHONIC_KEY_PRESSURE";
+		break;
+	case MidiMessageType::CONTROL_CHANGE:
+		sType = "CONTROL_CHANGE";
+		break;
+	case MidiMessageType::PROGRAM_CHANGE:
+		sType = "PROGRAM_CHANGE";
+		break;
+	case MidiMessageType::CHANNEL_PRESSURE:
+		sType = "CHANNEL_PRESSURE";
+		break;
+	case MidiMessageType::PITCH_WHEEL:
+		sType = "PITCH_WHEEL";
+		break;
+	case MidiMessageType::START:
+		sType = "START";
+		break;
+	case MidiMessageType::CONTINUE:
+		sType = "CONTINUE";
+		break;
+	case MidiMessageType::STOP:
+		sType = "STOP";
+		break;
+	case MidiMessageType::SONG_POS:
+		sType = "SONG_POS";
+		break;
+	case MidiMessageType::QUARTER_FRAME:
+		sType = "QUARTER_FRAME";
+		break;
+	case MidiMessageType::UNKNOWN:
+	default:
+		sType = "Unknown MIDI message type";
+	}
+
+	return std::move( sType );
+}
+
+};
+

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -118,17 +118,6 @@ inline QString MidiMessage::TypeToQString( MidiMessageType type ) {
 	return std::move( sType );
 }
 
-
-/** \ingroup docCore docMIDI */
-class MidiPortInfo
-{
-public:
-	QString m_sName;
-	int m_nClient;
-	int m_nPort;
-};
-
-
 };
 
 #endif

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -66,58 +66,20 @@ public:
 			, m_nData1( -1 )
 			, m_nData2( -1 )
 			, m_nChannel( -1 ) {}
+
+	/** Reset message */
+	void clear();
+
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 *   every new line
+	 * \param bShort Instead of the whole content of all classes
+	 *   stored as members just a single unique identifier will be
+	 *   displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 };
-
-inline QString MidiMessage::TypeToQString( MidiMessageType type ) {
-	QString sType;
-	switch( type ) {
-	case MidiMessageType::SYSEX:
-		sType = "SYSEX";
-		break;
-	case MidiMessageType::NOTE_ON:
-		sType = "NOTE_ON";
-		break;
-	case MidiMessageType::NOTE_OFF:
-		sType = "NOTE_OFF";
-		break;
-	case MidiMessageType::POLYPHONIC_KEY_PRESSURE:
-		sType = "POLYPHONIC_KEY_PRESSURE";
-		break;
-	case MidiMessageType::CONTROL_CHANGE:
-		sType = "CONTROL_CHANGE";
-		break;
-	case MidiMessageType::PROGRAM_CHANGE:
-		sType = "PROGRAM_CHANGE";
-		break;
-	case MidiMessageType::CHANNEL_PRESSURE:
-		sType = "CHANNEL_PRESSURE";
-		break;
-	case MidiMessageType::PITCH_WHEEL:
-		sType = "PITCH_WHEEL";
-		break;
-	case MidiMessageType::START:
-		sType = "START";
-		break;
-	case MidiMessageType::CONTINUE:
-		sType = "CONTINUE";
-		break;
-	case MidiMessageType::STOP:
-		sType = "STOP";
-		break;
-	case MidiMessageType::SONG_POS:
-		sType = "SONG_POS";
-		break;
-	case MidiMessageType::QUARTER_FRAME:
-		sType = "QUARTER_FRAME";
-		break;
-	case MidiMessageType::UNKNOWN:
-	default:
-		sType = "Unknown MIDI message type";
-	}
-
-	return std::move( sType );
-}
-
 };
 
 #endif

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -53,10 +53,7 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 {
 		EventQueue::get_instance()->push_event( EVENT_MIDI_ACTIVITY, -1 );
 
-		INFOLOG( QString( "Incoming message of channel: %1, val1: %2, val2: %3, type: %4" )
-				 .arg( msg.m_nChannel ).arg( msg.m_nData1 )
-				 .arg( msg.m_nData2 )
-				 .arg( MidiMessage::TypeToQString( msg.m_type ) ) );
+		INFOLOG( QString( "Incoming message: [%1]" ).arg( msg.toQString() ) );
 
 		// midi channel filter for all messages
 		bool bIsChannelValid = true;
@@ -154,10 +151,7 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 		}
 
 		// Two spaces after "msg." in a row to align message parameters
-		INFOLOG( QString( "DONE handling msg.  channel: %1, val1: %2, val2: %3, type: %4" )
-				 .arg( msg.m_nChannel ).arg( msg.m_nData1 )
-				 .arg( msg.m_nData2 )
-				 .arg( MidiMessage::TypeToQString( msg.m_type ) ) );
+		INFOLOG( QString( "DONE handling msg:  [%1]" ).arg( msg.toQString() ) );
 }
 
 void MidiInput::handleControlChangeMessage( const MidiMessage& msg )

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -55,50 +55,89 @@ void* PortMidiDriver_thread( void* param )
 	PmError status;
 	int length;
 	PmEvent buffer[1];
+
+	// SysEx messages in PortMidi spread across multiple PmEvents and
+	// it is our responsibility to put them together.
+	MidiMessage sysExMsg;
 	while ( instance->m_bRunning ) {
 		length = Pm_Read( instance->m_pMidiIn, buffer, 1 );
 		if ( length > 0 ) {
-			// New MIDI data available
-			MidiMessage msg;
 
 			int nEventType = Pm_MessageStatus( buffer[0].message );
-			if ( ( nEventType >= 128 ) && ( nEventType < 144 ) ) {	// note off
-				msg.m_nChannel = nEventType - 128;
-				msg.m_type = MidiMessage::NOTE_OFF;
-			} else if ( ( nEventType >= 144 ) && ( nEventType < 160 ) ) {	// note on
-				msg.m_nChannel = nEventType - 144;
-				msg.m_type = MidiMessage::NOTE_ON;
-			} else if ( ( nEventType >= 160 ) && ( nEventType < 176 ) ) {	// Polyphonic Key Pressure (After-touch)
-				msg.m_nChannel = nEventType - 160;
-				msg.m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
-			} else if ( ( nEventType >= 176 ) && ( nEventType < 192 ) ) {	// Control Change
-				msg.m_nChannel = nEventType - 176;
-				msg.m_type = MidiMessage::CONTROL_CHANGE;
-			} else if ( ( nEventType >= 192 ) && ( nEventType < 208 ) ) {	// Program Change
-				msg.m_nChannel = nEventType - 192;
-				msg.m_type = MidiMessage::PROGRAM_CHANGE;
-			} else if ( ( nEventType >= 208 ) && ( nEventType < 224 ) ) {	// Channel Pressure (After-touch)
-				msg.m_nChannel = nEventType - 208;
-				msg.m_type = MidiMessage::CHANNEL_PRESSURE;
-			} else if ( ( nEventType >= 224 ) && ( nEventType < 240 ) ) {	// Pitch Wheel Change
-				msg.m_nChannel = nEventType - 224;
-				msg.m_type = MidiMessage::PITCH_WHEEL;
-			} else if ( ( nEventType >= 240 ) && ( nEventType < 256 ) ) {	// System Exclusive
-				msg.m_nChannel = nEventType - 240;
-				msg.m_type = MidiMessage::SYSEX;
-			} else {
-				__ERRORLOG( "Unhandled midi message type: " + QString::number( nEventType ) );
-				__INFOLOG( "MIDI msg: " );
-				__INFOLOG( QString::number( buffer[0].timestamp ) );
-				__INFOLOG( QString::number( Pm_MessageStatus( buffer[0].message ) ) );
-				__INFOLOG( QString::number( Pm_MessageData1( buffer[0].message ) ) );
-				__INFOLOG( QString::number( Pm_MessageData2( buffer[0].message ) ) );
+
+			if ( nEventType > 127 && nEventType != 247 && nEventType < 256 ) {
+				// New MIDI message received.
+				//
+				// In case of a SysEx message spanning multiple
+				// PmEvents only the first one will have SysEx status
+				// byte. In all remaining events it is omit and the
+				// first byte is an actual data byte [0,127]. The
+				// termination of such an SysEx message is indicated
+				// using 247 which by itself must not be interpreted
+				// as the beginning of a new message.
+				//
+				// 'System Realtime' messages are allowed to occur in
+				// between events corresponding to one and the same
+				// SysEx message but all other event types indicated
+				// that either the previous SysEx message was
+				// completed or that it was truncated (e.g. MIDI cable
+				// removed).
+				if ( nEventType < 248 ) {
+					// No System Realtime event
+					sysExMsg.clear();
+				}
+
+				if ( ( nEventType >= 240 ) && ( nEventType < 248 ) ) {
+					// New SysEx message
+					sysExMsg.m_type = MidiMessage::SYSEX;
+					if ( PortMidiDriver::appendSysExData( &sysExMsg,
+														  buffer[0].message ) ) {
+						instance->handleMidiMessage( sysExMsg );
+					}
+				}
+				else {
+					// Other MIDI message consisting only of a single PmEvent.
+					MidiMessage msg;
+
+					if ( ( nEventType >= 128 ) && ( nEventType < 144 ) ) {	// note off
+						msg.m_nChannel = nEventType - 128;
+						msg.m_type = MidiMessage::NOTE_OFF;
+					} else if ( ( nEventType >= 144 ) && ( nEventType < 160 ) ) {	// note on
+						msg.m_nChannel = nEventType - 144;
+						msg.m_type = MidiMessage::NOTE_ON;
+					} else if ( ( nEventType >= 160 ) && ( nEventType < 176 ) ) {	// Polyphonic Key Pressure (After-touch)
+						msg.m_nChannel = nEventType - 160;
+						msg.m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
+					} else if ( ( nEventType >= 176 ) && ( nEventType < 192 ) ) {	// Control Change
+						msg.m_nChannel = nEventType - 176;
+						msg.m_type = MidiMessage::CONTROL_CHANGE;
+					} else if ( ( nEventType >= 192 ) && ( nEventType < 208 ) ) {	// Program Change
+						msg.m_nChannel = nEventType - 192;
+						msg.m_type = MidiMessage::PROGRAM_CHANGE;
+					} else if ( ( nEventType >= 208 ) && ( nEventType < 224 ) ) {	// Channel Pressure (After-touch)
+						msg.m_nChannel = nEventType - 208;
+						msg.m_type = MidiMessage::CHANNEL_PRESSURE;
+					} else if ( ( nEventType >= 224 ) && ( nEventType < 240 ) ) {	// Pitch Wheel Change
+						msg.m_nChannel = nEventType - 224;
+						msg.m_type = MidiMessage::PITCH_WHEEL;
+					}
+
+					msg.m_nData1 = Pm_MessageData1( buffer[0].message );
+					msg.m_nData2 = Pm_MessageData2( buffer[0].message );
+					instance->handleMidiMessage( msg );
+				}
 			}
-
-			msg.m_nData1 = Pm_MessageData1( buffer[0].message );
-			msg.m_nData2 = Pm_MessageData2( buffer[0].message );
-
-			instance->handleMidiMessage( msg );
+			else if ( nEventType >= 256 ) {
+				__ERRORLOG( QString( "Unsupported midi message type: [%1]" )
+							.arg( nEventType ) );
+			}
+			else {
+				// Continuation of a SysEx message.
+				if ( PortMidiDriver::appendSysExData( &sysExMsg,
+													  buffer[0].message ) ) {
+					instance->handleMidiMessage( sysExMsg );
+				}
+			}
 		}
 		else if ( length == 0 ) {
 			// No data available
@@ -437,6 +476,36 @@ void PortMidiDriver::handleQueueAllNoteOff()
 					  .arg( PortMidiDriver::translatePmError( err ) ) );
 		}
 	}
+}
+
+bool PortMidiDriver::appendSysExData( MidiMessage* pMidiMessage, PmMessage msg ) {
+	// End of exception byte indicating the end of a SysEx message.
+	unsigned char eox = 247;
+	unsigned char c = msg & 0x000000ffUL;
+	pMidiMessage->m_sysexData.push_back( c );
+	if ( c == eox ) {
+		return true;
+	}
+
+    c = (msg & 0x0000ff00UL) >>  8;
+	pMidiMessage->m_sysexData.push_back( c );
+	if ( c == eox ) {
+		return true;
+	}
+
+	c = (msg & 0x00ff0000UL) >> 16;
+	pMidiMessage->m_sysexData.push_back( c );
+	if ( c == eox ) {
+		return true;
+	}
+
+	c = (msg & 0xff000000UL) >> 24;
+	pMidiMessage->m_sysexData.push_back( c );
+	if ( c == eox ) {
+		return true;
+	}
+
+	return false;
 }
 
 QString PortMidiDriver::translatePmError( PmError err ) {

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -187,13 +187,15 @@ void PortMidiDriver::open()
 		}
 		else {
 			if ( pInfo->input == TRUE ) {
-				if ( strcmp( pInfo->name, sMidiPortName.toLocal8Bit().constData() ) == 0 ) {
+				if ( strcmp( pInfo->name, sMidiPortName.toLocal8Bit().constData() ) == 0 &&
+					 sMidiPortName != Preferences::getNullMidiPort() ) {
 					nDeviceId = i;
 				}
 			}
 	
 			if ( pInfo->output == TRUE ) {
-				if ( strcmp( pInfo->name, sMidiOutputPortName.toLocal8Bit().constData() ) == 0 ) {
+				if ( strcmp( pInfo->name, sMidiOutputPortName.toLocal8Bit().constData() ) == 0 &&
+					 sMidiOutputPortName != Preferences::getNullMidiPort() ) {
 					nOutDeviceId = i;
 				}
 			}
@@ -252,7 +254,7 @@ void PortMidiDriver::open()
 	}
 	else {
 		// If no input device was selected, there is no error in here.
-		if ( ! sMidiPortName.isEmpty() ) {
+		if ( sMidiPortName != Preferences::getNullMidiPort() ) {
 			WARNINGLOG( QString( "MIDI input device [%1] not found." )
 					  .arg( sMidiPortName ) );
 		}
@@ -279,7 +281,7 @@ void PortMidiDriver::open()
 	}
 	else {
 		// If no output device was selected, there is no error in here.
-		if ( ! sMidiOutputPortName.isEmpty() ) {
+		if ( sMidiOutputPortName != Preferences::getNullMidiPort() ) {
 			WARNINGLOG( QString( "MIDI output device [%1] not found." )
 						.arg( sMidiOutputPortName ) );
 		}

--- a/src/core/IO/PortMidiDriver.h
+++ b/src/core/IO/PortMidiDriver.h
@@ -55,6 +55,16 @@ public:
 	virtual void handleOutgoingControlChange( int param, int value, int channel ) override;
 
 	static QString translatePmError( PmError err );
+	/**
+	 * Appends the content of @a msg to #MidiMessage::m_sysexData of
+	 * @a pMidiMessage till 247 (EOX - end of exclusion) is
+	 * encountered.
+	 *
+	 * @returns `true` - in case all SysEx data is gathered and @a
+	 *   pMidiMessage can be considered complete or `false` if there
+	 *   is still pending data.
+	 */
+	static bool appendSysExData( MidiMessage* pMidiMessage, PmMessage msg );
 
 private:
 

--- a/src/core/IO/PortMidiDriver.h
+++ b/src/core/IO/PortMidiDriver.h
@@ -54,6 +54,8 @@ public:
 	virtual void handleQueueAllNoteOff() override;
 	virtual void handleOutgoingControlChange( int param, int value, int channel ) override;
 
+	static QString translatePmError( PmError err );
+
 private:
 
 };

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -167,8 +167,8 @@ Preferences::Preferences()
 	// (although MIDI won't work in this case).
 	m_sMidiDriver = QString( "ALSA" );
 #endif
-	m_sMidiPortName = QString("None");
-	m_sMidiOutputPortName = QString("None");
+	m_sMidiPortName = QString( Preferences::getNullMidiPort() );
+	m_sMidiOutputPortName = QString( Preferences::getNullMidiPort() );
 	m_nMidiChannelFilter = -1;
 	m_bMidiNoteOffIgnore = false;
 	m_bMidiFixedMapping = false;
@@ -554,8 +554,10 @@ void Preferences::loadPreferences( bool bGlobal )
 					} else if ( m_sAudioDriver == "CoreMidi" ) {
 						m_sAudioDriver = "CoreMIDI";
 					}
-					m_sMidiPortName = midiDriverNode.read_string( "port_name", "None", false, false );
-					m_sMidiOutputPortName = midiDriverNode.read_string( "output_port_name", "None", false, false );
+					m_sMidiPortName = midiDriverNode.read_string(
+						"port_name", Preferences::getNullMidiPort(), false, false );
+					m_sMidiOutputPortName = midiDriverNode.read_string(
+						"output_port_name", Preferences::getNullMidiPort(), false, false );
 					m_nMidiChannelFilter = midiDriverNode.read_int( "channel_filter", -1, false, false );
 					m_bMidiNoteOffIgnore = midiDriverNode.read_bool( "ignore_note_off", true, false, false );
 					m_bMidiDiscardNoteAfterAction = midiDriverNode.read_bool( "discard_note_after_action", true, false, false );

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -221,6 +221,18 @@ public:
 	QString				m_sMidiDriver;
 	QString				m_sMidiPortName;
 	QString				m_sMidiOutputPortName;
+	/**
+	 * Choice of #m_sMidiPortName and #m_sMidiOutputPortName in case
+	 * no port/device was selected.
+	 *
+	 * Pinning its value to "None" will prevent Hydrogen to connect to
+	 * ports/devices using this exact name but is still done for
+	 * backward compatibility.
+	 */
+	static QString getNullMidiPort() {
+		return "None";
+	}
+	
 	int					m_nMidiChannelFilter;
 	bool				m_bMidiNoteOffIgnore;
 	bool				m_bMidiFixedMapping;

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -952,7 +952,7 @@ void PreferencesDialog::on_okBtn_clicked()
 
 	QString sNewMidiPortName = midiPortComboBox->currentText();
 	if ( midiPortComboBox->currentIndex() == 0 ) {
-		sNewMidiPortName = "None";
+		sNewMidiPortName = Preferences::getNullMidiPort();
 	}
 	if ( pPref->m_sMidiPortName != sNewMidiPortName ) {
 		pPref->m_sMidiPortName = sNewMidiPortName;
@@ -962,7 +962,7 @@ void PreferencesDialog::on_okBtn_clicked()
 	
 	QString sNewMidiOutputPortName = midiOutportComboBox->currentText();
 	if ( midiOutportComboBox->currentIndex() == 0 ) {
-		sNewMidiOutputPortName = "None";
+		sNewMidiOutputPortName = Preferences::getNullMidiPort();
 	}
 	if ( pPref->m_sMidiOutputPortName != sNewMidiOutputPortName ) {
 		pPref->m_sMidiOutputPortName = sNewMidiOutputPortName;

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -836,11 +836,7 @@ void PreferencesDialog::on_okBtn_clicked()
 											pCommonStrings->getButtonOk(),
 											pCommonStrings->getButtonCancel(),
 											nullptr, 1 );
-		if ( res == 0 ) {
-			QApplication::setOverrideCursor( Qt::WaitCursor );
-			pHydrogen->restartDrivers();
-			QApplication::restoreOverrideCursor();			
-		} else {
+		if ( res != 0 ) {
 			// Don't save the Preferences and don't close the PreferencesDialog
 			return;
 		}
@@ -1104,6 +1100,14 @@ void PreferencesDialog::on_okBtn_clicked()
 	//////////////////////////////////////////////////////////////////
 
 	pPref->setTheme( m_pCurrentTheme );
+
+	if ( m_bNeedDriverRestart ) {
+		// Restart audio and MIDI drivers now that we updated all
+		// values in Preferences.
+		QApplication::setOverrideCursor( Qt::WaitCursor );
+		pHydrogen->restartDrivers();
+		QApplication::restoreOverrideCursor();
+	}
 
 	pH2App->changePreferences( m_changes );
 	


### PR DESCRIPTION
Our PortMidi driver needed some love. I added missing error handling and a number of log messages which will ease debugging of related issues. Upon starting the driver does now log which devices are available and to which it is connected to.

It features the missing pieces to fix #1773. Our PortMidi driver is now able to accept and process SysEx - and thus MMC - messages. The implementation was previously lacking since the message needs to be put together piece by piece by the developer herself.

I also found a bug in the `PreferencesDialog`: audio and MIDI drivers are both restarted using `Hydrogen::restartDrivers()`. But previously this was done _before_ storing changes of the MIDI driver to `Preferences`. As a result it felt like a restart of Hydrogen was required to apply the changes.

And I introduced one tiny UX change: In case no output and/or input port was chosen in Preferences > MIDI System both `CoreMidiDriver` and `PortMidiDriver` attempted to connect to a port called "None". This behavior is now suppressed and a port featuring this particular name can not be connected to anymore.