### PR TITLE
MIDI: Common message type inference

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Support "START", "CONTINUE", and "STOP" type System Realtime
+		  MIDI messages in PortMidi and CoreMidi.
+		- Fix MIDI action binding to incoming MMC_DEFERRED_PLAY event.
 		- Fix missing MIDI driver restart when adjusting corresponding
 		  parameters in Preferences.
 		- Fix MIDI Machine Control (MMC) event type handling on Windows

--- a/src/core/IO/AlsaMidiDriver.cpp
+++ b/src/core/IO/AlsaMidiDriver.cpp
@@ -281,10 +281,30 @@ void AlsaMidiDriver::midi_action( snd_seq_t *seq_handle )
 				msg.m_nChannel = ev->data.control.channel;
 				break;
 
+			case SND_SEQ_EVENT_PGMCHANGE:
+				msg.m_type = MidiMessage::PROGRAM_CHANGE;
+				msg.m_nData1 = ev->data.control.value;
+				msg.m_nChannel = ev->data.control.channel;
+				break;
+
 			case SND_SEQ_EVENT_KEYPRESS:
 				msg.m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
 				msg.m_nData1 = ev->data.note.note;
 				msg.m_nData2 = ev->data.note.velocity;
+				msg.m_nChannel = ev->data.control.channel;
+				break;
+
+			case SND_SEQ_EVENT_CHANPRESS:
+				msg.m_type = MidiMessage::CHANNEL_PRESSURE;
+				msg.m_nData1 = ev->data.control.param;
+				msg.m_nData2 = ev->data.control.value;
+				msg.m_nChannel = ev->data.control.channel;
+				break;
+
+			case SND_SEQ_EVENT_PITCHBEND:
+				msg.m_type = MidiMessage::PITCH_WHEEL;
+				msg.m_nData1 = ev->data.control.param;
+				msg.m_nData2 = ev->data.control.value;
 				msg.m_nChannel = ev->data.control.channel;
 				break;
 
@@ -305,14 +325,30 @@ void AlsaMidiDriver::midi_action( snd_seq_t *seq_handle )
 
 			case SND_SEQ_EVENT_QFRAME:
 				msg.m_type = MidiMessage::QUARTER_FRAME;
-				break;
-
-			case SND_SEQ_EVENT_CLOCK:
-				//cout << "!!! Midi CLock" << endl;
+				msg.m_nData1 = ev->data.control.value;
+				msg.m_nData2 = ev->data.control.param;
 				break;
 
 			case SND_SEQ_EVENT_SONGPOS:
 				msg.m_type = MidiMessage::SONG_POS;
+				msg.m_nData1 = ev->data.control.value;
+				msg.m_nData2 = ev->data.control.param;
+				break;
+
+			case SND_SEQ_EVENT_SONGSEL:
+				msg.m_type = MidiMessage::SONG_SELECT;
+				msg.m_nData1 = ev->data.control.value;
+				msg.m_nData2 = ev->data.control.param;
+				break;
+
+			case SND_SEQ_EVENT_TUNE_REQUEST:
+				msg.m_type = MidiMessage::TUNE_REQUEST;
+				msg.m_nData1 = ev->data.control.value;
+				msg.m_nData2 = ev->data.control.param;
+				break;
+
+			case SND_SEQ_EVENT_CLOCK:
+				msg.m_type = MidiMessage::TIMING_CLOCK;
 				break;
 
 			case SND_SEQ_EVENT_START:
@@ -327,13 +363,12 @@ void AlsaMidiDriver::midi_action( snd_seq_t *seq_handle )
 				msg.m_type = MidiMessage::STOP;
 				break;
 
-			case SND_SEQ_EVENT_PITCHBEND:
+			case SND_SEQ_EVENT_SENSING:
+				msg.m_type = MidiMessage::ACTIVE_SENSING;
 				break;
 
-			case SND_SEQ_EVENT_PGMCHANGE:
-				msg.m_type = MidiMessage::PROGRAM_CHANGE;
-				msg.m_nData1 = ev->data.control.value;
-				msg.m_nChannel = ev->data.control.channel;
+			case SND_SEQ_EVENT_RESET:
+				msg.m_type = MidiMessage::RESET;
 				break;
 
 			case SND_SEQ_EVENT_CLIENT_EXIT:
@@ -346,9 +381,6 @@ void AlsaMidiDriver::midi_action( snd_seq_t *seq_handle )
 
 			case SND_SEQ_EVENT_PORT_UNSUBSCRIBED:
 				INFOLOG( "SND_SEQ_EVENT_PORT_UNSUBSCRIBED" );
-				break;
-
-			case SND_SEQ_EVENT_SENSING:
 				break;
 
 			default:

--- a/src/core/IO/CoreMidiDriver.cpp
+++ b/src/core/IO/CoreMidiDriver.cpp
@@ -48,47 +48,24 @@ static void midiProc ( const MIDIPacketList * pktlist,
 
 	MIDIPacket* packet = ( MIDIPacket * )pktlist->packet;
 
-		//_ERRORLOG( QString( "MIDIPROC packets # %1" ).arg( pktlist->numPackets ) );
-
 	CoreMidiDriver *instance = ( CoreMidiDriver * )readProcRefCon;
-	MidiMessage msg;
 	for ( uint i = 0; i < pktlist->numPackets; i++ ) {
+		MidiMessage msg;
 		int nEventType = packet->data[0];
-		if ( ( nEventType >= 128 ) && ( nEventType < 144 ) ) {	// note off
-			msg.m_nChannel = nEventType - 128;
-			msg.m_type = MidiMessage::NOTE_OFF;
-		} else if ( ( nEventType >= 144 ) && ( nEventType < 160 ) ) {	// note on
-			msg.m_nChannel = nEventType - 144;
-			msg.m_type = MidiMessage::NOTE_ON;
-		} else if ( ( nEventType >= 160 ) && ( nEventType < 176 ) ) {	// Polyphonic Key Pressure (After-touch)
-			msg.m_nChannel = nEventType - 160;
-			msg.m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
-		} else if ( ( nEventType >= 176 ) && ( nEventType < 192 ) ) {	// Control Change
-			msg.m_nChannel = nEventType - 176;
-			msg.m_type = MidiMessage::CONTROL_CHANGE;
-		} else if ( ( nEventType >= 192 ) && ( nEventType < 208 ) ) {	// Program Change
-			msg.m_nChannel = nEventType - 192;
-			msg.m_type = MidiMessage::PROGRAM_CHANGE;
-		} else if ( ( nEventType >= 208 ) && ( nEventType < 224 ) ) {	// Channel Pressure (After-touch)
-			msg.m_nChannel = nEventType - 208;
-			msg.m_type = MidiMessage::CHANNEL_PRESSURE;
-		} else if ( ( nEventType >= 224 ) && ( nEventType < 240 ) ) {	// Pitch Wheel Change
-			msg.m_nChannel = nEventType - 224;
-			msg.m_type = MidiMessage::PITCH_WHEEL;
-				} else if ( ( nEventType >= 240 ) && ( nEventType < 256 ) ) {	// System Exclusive
-					   msg.m_type = MidiMessage::SYSEX;
-					   for(int i = 0; i< packet->length;i++){
-							  msg.m_sysexData.push_back(packet->data[i]);
-					   }
-					   instance->handleMidiMessage( msg );
-					   packet = MIDIPacketNext( packet );
-					   return;
-		} else {
-			___ERRORLOG( QString( "Unhandled midi message type: %1" ).arg( nEventType ) );
+		msg.setType( nEventType );
+		
+		if ( nEventType == 240 ) {
+			// SysEx messages also contain arbitrary data which has to
+			// be copied manually.
+			for ( int i = 0; i < packet->length; i++ ) {
+				msg.m_sysexData.push_back( packet->data[ i ] );
+			}
+		}
+		else {
+			msg.m_nData1 = packet->data[1];
+			msg.m_nData2 = packet->data[2];
 		}
 
-		msg.m_nData1 = packet->data[1];
-		msg.m_nData2 = packet->data[2];
 		instance->handleMidiMessage( msg );
 		packet = MIDIPacketNext( packet );
 	}

--- a/src/core/IO/JackMidiDriver.cpp
+++ b/src/core/IO/JackMidiDriver.cpp
@@ -104,99 +104,25 @@ JackMidiDriver::JackMidiWrite(jack_nframes_t nframes)
 		memset(buffer, 0, sizeof(buffer));
 		memcpy(buffer, event.buffer, error);
 
-		switch (buffer[0] >> 4) {
-		case 0x8:	 /* note off */
-			msg.m_type = MidiMessage::NOTE_OFF;
-			msg.m_nData1 = buffer[1];
-			msg.m_nData2 = buffer[2];
-			msg.m_nChannel = buffer[0] & 0xF;
-			handleMidiMessage(msg);
-			break;
-		case 0x9:	 /* note on */
-			msg.m_type = MidiMessage::NOTE_ON;
-			msg.m_nData1 = buffer[1];
-			msg.m_nData2 = buffer[2];
-			msg.m_nChannel = buffer[0] & 0xF;
-			handleMidiMessage(msg);
-			break;
-		case 0xA:	 /* aftertouch */
-			msg.m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
-			msg.m_nData1 = buffer[1];
-			msg.m_nData2 = buffer[2];
-			msg.m_nChannel = buffer[0] & 0xF;
-			handleMidiMessage(msg);
-			break;
-		case 0xB:	 /* control change */
-			msg.m_type = MidiMessage::CONTROL_CHANGE;
-			msg.m_nData1 = buffer[1];
-			msg.m_nData2 = buffer[2];
-			msg.m_nChannel = buffer[0] & 0xF;
-			handleMidiMessage(msg);
-			break;
-		case 0xC:	 /* program change */
-			msg.m_type = MidiMessage::PROGRAM_CHANGE;
-			msg.m_nData1 = buffer[1];
-			msg.m_nData2 = buffer[2];
-			msg.m_nChannel = buffer[0] & 0xF;
-			handleMidiMessage(msg);
-			break;
-				case 0xF:
-					switch (buffer[0]) {
-						case 0xF0:	/* system exclusive */
-								msg.m_type = MidiMessage::SYSEX;
-								if(buffer[3] == 06 ){// MMC message
-									for ( int i = 0; i < sizeof(buffer) && i<6; i++ ) {
-											 msg.m_sysexData.push_back( buffer[i] );
-									}
-								}else
-								{
-									for ( int i = 0; i < sizeof(buffer); i++ ) {
-											 msg.m_sysexData.push_back( buffer[i] );
-									}
-								}
-								handleMidiMessage(msg);
-								break;
-			case 0xF1:
-				msg.m_type = MidiMessage::QUARTER_FRAME;
-				msg.m_nData1 = buffer[1];
-				msg.m_nData2 = buffer[2];
-				msg.m_nChannel = 0;
-				handleMidiMessage(msg);
-				break;
-			case 0xF2:
-				msg.m_type = MidiMessage::SONG_POS;
-				msg.m_nData1 = buffer[1];
-				msg.m_nData2 = buffer[2];
-				msg.m_nChannel = 0;
-				handleMidiMessage(msg);
-				break;
-			case 0xFA:
-				msg.m_type = MidiMessage::START;
-				msg.m_nData1 = buffer[1];
-				msg.m_nData2 = buffer[2];
-				msg.m_nChannel = 0;
-				handleMidiMessage(msg);
-				break;
-			case 0xFB:
-				msg.m_type = MidiMessage::CONTINUE;
-				msg.m_nData1 = buffer[1];
-				msg.m_nData2 = buffer[2];
-				msg.m_nChannel = 0;
-				handleMidiMessage(msg);
-				break;
-			case 0xFC:
-				msg.m_type = MidiMessage::STOP;
-				msg.m_nData1 = buffer[1];
-				msg.m_nData2 = buffer[2];
-				msg.m_nChannel = 0;
-				handleMidiMessage(msg);
-				break;
-			default:
-				break;
+		msg.setType( buffer[ 0 ] );
+		if ( msg.m_type == MidiMessage::SYSEX ) {
+			if ( buffer[ 3 ] == 06 ){// MMC message
+				for ( int i = 0; i < sizeof(buffer) && i<6; i++ ) {
+					msg.m_sysexData.push_back( buffer[ i ] );
+				}
 			}
-		default:
-			break;
+			else {
+				for ( int i = 0; i < sizeof(buffer); i++ ) {
+					msg.m_sysexData.push_back( buffer[ i ] );
+				}
+			}
 		}
+		else {
+			// All other MIDI messages
+			msg.m_nData1 = buffer[1];
+			msg.m_nData2 = buffer[2];
+		}
+		handleMidiMessage( msg );
 	}
 }
 

--- a/src/core/IO/MidiCommon.cpp
+++ b/src/core/IO/MidiCommon.cpp
@@ -32,6 +32,78 @@ void MidiMessage::clear() {
 	m_sysexData.clear();
 }
 
+void MidiMessage::setType( int nStatusByte ) {
+
+	if ( ( nStatusByte >= 128 ) && ( nStatusByte < 144 ) ) {
+		m_nChannel = nStatusByte - 128;
+		m_type = MidiMessage::NOTE_OFF;
+	}
+	else if ( ( nStatusByte >= 144 ) && ( nStatusByte < 160 ) ) {
+		m_nChannel = nStatusByte - 144;
+		m_type = MidiMessage::NOTE_ON;
+	}
+	else if ( ( nStatusByte >= 160 ) && ( nStatusByte < 176 ) ) {
+		m_nChannel = nStatusByte - 160;
+		m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
+	}
+	else if ( ( nStatusByte >= 176 ) && ( nStatusByte < 192 ) ) {
+		m_nChannel = nStatusByte - 176;
+		m_type = MidiMessage::CONTROL_CHANGE;
+	}
+	else if ( ( nStatusByte >= 192 ) && ( nStatusByte < 208 ) ) {
+		m_nChannel = nStatusByte - 192;
+		m_type = MidiMessage::PROGRAM_CHANGE;
+	}
+	else if ( ( nStatusByte >= 208 ) && ( nStatusByte < 224 ) ) {
+		m_nChannel = nStatusByte - 208;
+		m_type = MidiMessage::CHANNEL_PRESSURE;
+	}
+	else if ( ( nStatusByte >= 224 ) && ( nStatusByte < 240 ) ) {
+		m_nChannel = nStatusByte - 224;
+		m_type = MidiMessage::PITCH_WHEEL;
+	}
+	// System Common Messages
+	else if ( ( nStatusByte == 240 ) ) {
+		m_nChannel = nStatusByte - 224;
+		m_type = MidiMessage::SYSEX;
+	}
+	else if ( ( nStatusByte == 241 ) ) {
+		m_type = MidiMessage::QUARTER_FRAME;
+	}
+	else if ( ( nStatusByte == 242 ) ) {
+		m_type = MidiMessage::SONG_POS;
+	}
+	else if ( ( nStatusByte == 243 ) ) {
+		m_type = MidiMessage::SONG_SELECT;
+	}
+	// 244, 245 are undefined/reserved
+	else if ( ( nStatusByte == 246 ) ) {
+		m_type = MidiMessage::TUNE_REQUEST;
+	}
+	// 247 indicates the end of a SysEx (240) message
+	// System Realtime Messages
+	else if ( ( nStatusByte == 248 ) ) {
+		m_type = MidiMessage::TIMING_CLOCK;
+	}
+	// 249 is undefined/reserved
+	else if ( ( nStatusByte == 250 ) ) {
+		m_type = MidiMessage::START;
+	}
+	else if ( ( nStatusByte == 251 ) ) {
+		m_type = MidiMessage::CONTINUE;
+	}
+	else if ( ( nStatusByte == 252 ) ) {
+		m_type = MidiMessage::STOP;
+	}
+	// 253 is undefined/reserved
+	else if ( ( nStatusByte == 254 ) ) {
+		m_type = MidiMessage::ACTIVE_SENSING;
+	}
+	else if ( ( nStatusByte == 255 ) ) {
+		m_type = MidiMessage::RESET;
+	}
+}
+
 QString MidiMessage::toQString( const QString& sPrefix, bool bShort ) const {
 
 	QString s = Base::sPrintIndention;

--- a/src/core/IO/MidiCommon.cpp
+++ b/src/core/IO/MidiCommon.cpp
@@ -129,7 +129,7 @@ QString MidiMessage::toQString( const QString& sPrefix, bool bShort ) const {
 				sOutput.append( QString( " %1" ).arg( dd ) );
 			}
 		}
-		sOutput.append( "]\n" );
+		sOutput.append( "]" );
 	}
 	else {
 		sOutput = QString( "[MidiMessage] " )
@@ -148,7 +148,7 @@ QString MidiMessage::toQString( const QString& sPrefix, bool bShort ) const {
 				sOutput.append( QString( " %1" ).arg( dd ) );
 			}
 		}
-		sOutput.append( "]\n" );
+		sOutput.append( "]" );
 	}
 	
 	return sOutput;

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -51,7 +51,12 @@ public:
 		CONTINUE,
 		STOP,
 		SONG_POS,
-		QUARTER_FRAME
+		QUARTER_FRAME,
+		SONG_SELECT,
+		TUNE_REQUEST,
+		TIMING_CLOCK,
+		ACTIVE_SENSING,
+		RESET
 	};
 	static QString TypeToQString( MidiMessageType type );
 
@@ -69,6 +74,14 @@ public:
 
 	/** Reset message */
 	void clear();
+
+	/**
+	 * Derives and set #m_type (and if applicable #m_nChannel) using
+	 * the @a statusByte of an incoming MIDI message. The particular
+	 * values are defined by the MIDI standard and do not dependent on
+	 * the individual drivers.
+	 */
+	void setType( int nStatusByte );
 
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -87,7 +87,7 @@ void* PortMidiDriver_thread( void* param )
 					sysExMsg.clear();
 				}
 
-				if ( ( nEventType >= 240 ) && ( nEventType < 248 ) ) {
+				if ( nEventType == 240 ) {
 					// New SysEx message
 					sysExMsg.m_type = MidiMessage::SYSEX;
 					if ( PortMidiDriver::appendSysExData( &sysExMsg,
@@ -98,30 +98,7 @@ void* PortMidiDriver_thread( void* param )
 				else {
 					// Other MIDI message consisting only of a single PmEvent.
 					MidiMessage msg;
-
-					if ( ( nEventType >= 128 ) && ( nEventType < 144 ) ) {	// note off
-						msg.m_nChannel = nEventType - 128;
-						msg.m_type = MidiMessage::NOTE_OFF;
-					} else if ( ( nEventType >= 144 ) && ( nEventType < 160 ) ) {	// note on
-						msg.m_nChannel = nEventType - 144;
-						msg.m_type = MidiMessage::NOTE_ON;
-					} else if ( ( nEventType >= 160 ) && ( nEventType < 176 ) ) {	// Polyphonic Key Pressure (After-touch)
-						msg.m_nChannel = nEventType - 160;
-						msg.m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
-					} else if ( ( nEventType >= 176 ) && ( nEventType < 192 ) ) {	// Control Change
-						msg.m_nChannel = nEventType - 176;
-						msg.m_type = MidiMessage::CONTROL_CHANGE;
-					} else if ( ( nEventType >= 192 ) && ( nEventType < 208 ) ) {	// Program Change
-						msg.m_nChannel = nEventType - 192;
-						msg.m_type = MidiMessage::PROGRAM_CHANGE;
-					} else if ( ( nEventType >= 208 ) && ( nEventType < 224 ) ) {	// Channel Pressure (After-touch)
-						msg.m_nChannel = nEventType - 208;
-						msg.m_type = MidiMessage::CHANNEL_PRESSURE;
-					} else if ( ( nEventType >= 224 ) && ( nEventType < 240 ) ) {	// Pitch Wheel Change
-						msg.m_nChannel = nEventType - 224;
-						msg.m_type = MidiMessage::PITCH_WHEEL;
-					}
-
+					msg.setType( nEventType );
 					msg.m_nData1 = Pm_MessageData1( buffer[0].message );
 					msg.m_nData2 = Pm_MessageData2( buffer[0].message );
 					instance->handleMidiMessage( msg );


### PR DESCRIPTION
Using this patch incoming MIDI events should be handled the same regardless of which MIDI driver was selected, all drivers do now support all possible types of MIDI messages, and System Common and System Realtime events are not falsely handled as SysEx messages anymore.

The particular type of a MIDI message can be determined by looking at the first 8bit of the message. Which value corresponds to which type is defined by the standard itself and is not dependent on a particular driver. Thus, we can use common code for our drivers to infer the type.

Using this patch `AlsaMidiDriver`, `CoreMidiDriver`, `PortMidiDriver`, and `JackMidiDriver` do support all possible types of MIDI messages. Missing ones were added to the `MidiMessageType` enum. (But just for internal handling and Hydrogen does not act on more messages. UX did not change)

fixes https://github.com/hydrogen-music/hydrogen/issues/1776

I also found a tiny bug: the MIDI Machine Control (MMC) event type "MMC_DEFERRED_PLAY" was exposed in Preferences > MIDI System > MIDI table but incoming events of this type were falsely identified as "MMC_PLAY"