### PR TITLE
Fix spurious tempo changes to 120 bpm (#1779)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix spurious tempo changes to 120bpm when switching songs
+		  (#1779)
 		- Support "START", "CONTINUE", and "STOP" type System Realtime
 		  MIDI messages in PortMidi and CoreMidi.
 		- Fix MIDI action binding to incoming MMC_DEFERRED_PLAY event.

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -295,6 +295,9 @@ void AudioEngine::reset( bool bWithJackBroadcast ) {
 	m_fLastTickEnd = 0;
 	m_bLookaheadApplied = false;
 
+	m_fSongSizeInTicks = MAX_NOTES;
+	setNextBpm( 120 );
+
 	m_pTransportPosition->reset();
 	m_pQueuingPosition->reset();
 

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -96,6 +96,7 @@ void AudioEngineTests::testFrameToTickConversion() {
 
 void AudioEngineTests::testTransportProcessing() {
 	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 	auto pPref = Preferences::get_instance();
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 	auto pAE = pHydrogen->getAudioEngine();
@@ -115,6 +116,7 @@ void AudioEngineTests::testTransportProcessing() {
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames, ticks, and queuing
@@ -163,6 +165,7 @@ void AudioEngineTests::testTransportProcessing() {
 	}
 
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	resetVariables();
 
 	float fBpm;
@@ -275,6 +278,7 @@ void AudioEngineTests::testTransportProcessingTimeline() {
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames, ticks, and queuing
@@ -326,6 +330,7 @@ void AudioEngineTests::testTransportProcessingTimeline() {
 	// "classical" bpm change".
 
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	resetVariables();
 
 	float fBpm;
@@ -376,6 +381,7 @@ void AudioEngineTests::testTransportProcessingTimeline() {
 
 void AudioEngineTests::testLoopMode() {
 	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 	auto pPref = Preferences::get_instance();
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 	auto pAE = pHydrogen->getAudioEngine();
@@ -389,6 +395,7 @@ void AudioEngineTests::testLoopMode() {
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames, ticks, and queuing
@@ -578,6 +585,7 @@ int AudioEngineTests::processTransport( const QString& sContext,
 
 void AudioEngineTests::testTransportRelocation() {
 	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 	auto pPref = Preferences::get_instance();
 	auto pAE = pHydrogen->getAudioEngine();
@@ -593,6 +601,7 @@ void AudioEngineTests::testTransportRelocation() {
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames and ticks while relocating
@@ -649,6 +658,7 @@ void AudioEngineTests::testTransportRelocation() {
 	}
 
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Ready );
 	pAE->unlock();
 }
@@ -663,6 +673,7 @@ void AudioEngineTests::testSongSizeChange() {
 	
 	pAE->lock( RIGHT_HERE );
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Ready );
 	pAE->unlock();
 	
@@ -702,6 +713,7 @@ void AudioEngineTests::testSongSizeChange() {
 
 void AudioEngineTests::testSongSizeChangeInLoopMode() {
 	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 	auto pCoreActionController = pHydrogen->getCoreActionController();
 	auto pPref = Preferences::get_instance();
 	auto pAE = pHydrogen->getAudioEngine();
@@ -712,7 +724,7 @@ void AudioEngineTests::testSongSizeChangeInLoopMode() {
 
 	pAE->lock( RIGHT_HERE );
 
-	const int nColumns = pHydrogen->getSong()->getPatternGroupVector()->size();
+	const int nColumns = pSong->getPatternGroupVector()->size();
 
     std::random_device randomSeed;
     std::default_random_engine randomEngine( randomSeed() );
@@ -722,6 +734,7 @@ void AudioEngineTests::testSongSizeChangeInLoopMode() {
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	const uint32_t nFrames = 500;
@@ -806,6 +819,7 @@ void AudioEngineTests::testNoteEnqueuing() {
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames and ticks while using a
@@ -1015,6 +1029,7 @@ void AudioEngineTests::testNoteEnqueuing() {
 
 	pAE->lock( RIGHT_HERE );
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	nLoops = 1;
@@ -1086,6 +1101,7 @@ void AudioEngineTests::testNoteEnqueuingTimeline() {
 	// For reset() the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 	AudioEngineTests::resetSampler( __PRETTY_FUNCTION__ );
 
@@ -1190,6 +1206,7 @@ void AudioEngineTests::testHumanization() {
 	// For reset() the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Testing );
 
 	// Rolls playback from beginning to the end of the song and
@@ -1892,6 +1909,7 @@ void AudioEngineTests::toggleAndCheckConsistency( int nToggleColumn, int nToggle
 
 void AudioEngineTests::resetSampler( const QString& sContext ) {
 	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 	auto pAE = pHydrogen->getAudioEngine();
 	auto pSampler = pAE->getSampler();
 	auto pPref = Preferences::get_instance();
@@ -1930,6 +1948,7 @@ void AudioEngineTests::resetSampler( const QString& sContext ) {
 	}
 	
 	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 }
 
 void AudioEngineTests::throwException( const QString& sMsg ) {

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -58,6 +58,7 @@ int bcDisplaystatus = 0;
 PlayerControl::PlayerControl(QWidget *parent)
  : QLabel(parent)
  , m_midiActivityTimeout( 125 )
+ , m_bLCDBPMSpinboxIsArmed( true )
 {
 
 	m_pHydrogen = Hydrogen::get_instance();
@@ -548,7 +549,9 @@ void PlayerControl::updatePlayerControl()
 
 	if ( ! m_pLCDBPMSpinbox->hasFocus() &&
 		 ! m_pLCDBPMSpinbox->getIsHovered() ) {
+		m_bLCDBPMSpinboxIsArmed = false;
 		m_pLCDBPMSpinbox->setValue( m_pHydrogen->getAudioEngine()->getTransportPosition()->getBpm() );
+		m_bLCDBPMSpinboxIsArmed = true;
 	}
 
 	//beatcounter
@@ -767,7 +770,8 @@ void PlayerControl::activateSongMode( bool bActivate ) {
 
 void PlayerControl::bpmChanged( double fNewBpmValue ) {
 	auto pAudioEngine = m_pHydrogen->getAudioEngine();
-	if ( m_pLCDBPMSpinbox->getIsActive() ) {
+	if ( m_pLCDBPMSpinbox->getIsActive() &&
+		 m_bLCDBPMSpinboxIsArmed ) {
 		// Store it's value in the .h2song file.
 		m_pHydrogen->getSong()->setBpm( static_cast<float>( fNewBpmValue ) );
 		// Use tempo in the next process cycle of the audio engine.
@@ -1058,6 +1062,11 @@ void PlayerControl::updateBeatCounterToolTip() {
 
 void PlayerControl::tempoChangedEvent( int nValue )
 {
+	// When updating the tempo of the BPM spin box it is crucial to
+	// indicated that this was done due to a batch event and not due
+	// to user input.
+	m_bLCDBPMSpinboxIsArmed = false;
+
 	// Also update value if the BPM widget is disabled
 	bool bIsReadOnly = m_pLCDBPMSpinbox->isReadOnly();
 
@@ -1072,10 +1081,13 @@ void PlayerControl::tempoChangedEvent( int nValue )
 	 * of the song.
 	 */
 	m_pLCDBPMSpinbox->setValue( m_pHydrogen->getAudioEngine()->getTransportPosition()->getBpm() );
-	
+
 	if ( ! bIsReadOnly ) {
 		m_pLCDBPMSpinbox->setReadOnly( false );
 	}
+
+	// Re-enabling core Bpm alteration using BPM spinbox
+	m_bLCDBPMSpinboxIsArmed = true;
 
 	if ( nValue == -1 ) {
 		// Value was changed via API commands and not by the

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -191,6 +191,14 @@ private:
 	QString m_sLCDBPMSpinboxToolTip;
 	QString m_sLCDBPMSpinboxTimelineToolTip;
 	QString m_sLCDBPMSpinboxJackTimebaseToolTip;
+
+	/** When updating the tempo of the BPM spin box it is crucial to
+	 * indicated that this was done due to a batch event and not due
+	 * to user input. Else a batch update would trigger its
+	 * bpmChanged() slot, which in turn sets the core BPM again. When
+	 * changing a lot of tempo very quick (switch between songs of
+	 * different tempi) this spurious BPM setting will mess things up.*/
+	bool m_bLCDBPMSpinboxIsArmed;
 };
 
 


### PR DESCRIPTION
tempo changes applied without an explicit user action, like loading a song, did trigger the `PlayerControl::bpmChanged()` slot of the bpm lcd widget as well. This led to spurious and random tempo changes when switching between different tempi in batch assignment in short time, e.g. switching from a song using 140bpm to one with 180bpm (and resetting the audio engine to default 120bpm inbetween).

fixes https://github.com/hydrogen-music/hydrogen/issues/1779