### PR TITLE
InstrumentEditor: support 16 MIDI out channels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix MIDI note output for channel 16 (previously only channel
+		  1-15 were accessible in the InstrumentEditor).
 		- Fix spurious tempo changes to 120bpm when switching songs
 		  (#1779)
 		- Support "START", "CONTINUE", and "STOP" type System Realtime

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -107,7 +107,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 	pMidiOutLbl->move( 22, 281 );
 
 	m_pMidiOutChannelLCD = new LCDSpinBox( m_pInstrumentProp, QSize( 59, 24 ),
-										   LCDSpinBox::Type::Int, -1, 15,
+										   LCDSpinBox::Type::Int, -1, 16,
 										   true, true );
 	m_pMidiOutChannelLCD->move( 98, 257 );
 	m_pMidiOutChannelLCD->setToolTip(QString(tr("Midi out channel")));


### PR DESCRIPTION
since the channel value stored in `Instrument` is the one of the `InstrumentEditor` - 1, the maximum number of spinbox must be `16` not `15`.