### PR TITLE
Fix tooltips of MIDI-learnable widgets and MidiMap mapping

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix superfluous MIDI event - Action bindings. An incoming MIDI
+		  event can be mapped to an Action only once.
 		- Fix tool tips of MIDI-learnable widgets. All bounded MIDI events
 		  will be shown.
 		- Fix MIDI note output for channel 16 (previously only channel

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix tool tips of MIDI-learnable widgets. All bounded MIDI events
+		  will be shown.
 		- Fix MIDI note output for channel 16 (previously only channel
 		  1-15 were accessible in the InstrumentEditor).
 		- Fix spurious tempo changes to 120bpm when switching songs

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -174,7 +174,8 @@ enum EventType {
 	EVENT_DRIVER_CHANGED,
 	EVENT_PLAYBACK_TRACK_CHANGED,
 	EVENT_SOUND_LIBRARY_CHANGED,
-	EVENT_NEXT_SHOT
+	EVENT_NEXT_SHOT,
+	EVENT_MIDI_MAP_CHANGED
 };
 
 /** Basic building block for the communication between the core of

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -106,6 +106,7 @@ Hydrogen::Hydrogen() : m_nSelectedInstrumentNumber( 0 )
 					 , m_nSelectedPatternNumber( 0 )
 					 , m_bExportSessionIsActive( false )
 					 , m_GUIState( GUIState::unavailable )
+					 , m_lastMidiEvent( MidiMessage::Event::Null )
 					 , m_nLastMidiEventParameter( 0 )
 					 , m_CurrentTime( {0,0} )
 					 , m_oldEngineMode( Song::Mode::Song ) 
@@ -1741,7 +1742,8 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 		} else {
 			sOutput.append( QString( "nullptr\n" ) );
 		}
-		sOutput.append( QString( "%1%2lastMidiEvent: %3\n" ).arg( sPrefix ).arg( s ).arg( m_LastMidiEvent ) )
+		sOutput.append( QString( "%1%2lastMidiEvent: %3\n" ).arg( sPrefix ).arg( s )
+						.arg( MidiMessage::EventToQString( m_lastMidiEvent ) ) )
 			.append( QString( "%1%2lastMidiEventParameter: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nLastMidiEventParameter ) )
 			.append( QString( "%1%2m_nInstrumentLookupTable: [ %3 ... %4 ]\n" ).arg( sPrefix ).arg( s )
 					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS -1 ] ) );
@@ -1793,7 +1795,8 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 		} else {
 			sOutput.append( QString( " nullptr" ) );
 		}
-		sOutput.append( QString( ", lastMidiEvent: %1" ).arg( m_LastMidiEvent ) )
+		sOutput.append( QString( ", lastMidiEvent: %1" )
+						.arg( MidiMessage::EventToQString( m_lastMidiEvent ) ) )
 			.append( QString( ", lastMidiEventParameter: %1" ).arg( m_nLastMidiEventParameter ) )
 			.append( QString( ", m_nInstrumentLookupTable: [ %1 ... %2 ]" )
 					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS -1 ] ) );

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -29,6 +29,7 @@
 #include <core/Object.h>
 #include <core/Timeline.h>
 #include <core/IO/AudioOutput.h>
+#include <core/IO/MidiCommon.h>
 #include <core/IO/MidiInput.h>
 #include <core/IO/MidiOutput.h>
 #include <core/IO/JackAudioDriver.h>
@@ -104,8 +105,10 @@ public:
 	void			midi_noteOn( Note *note );
 
 	///Last received midi message
-	QString			m_LastMidiEvent;
-	int				m_nLastMidiEventParameter;
+	MidiMessage::Event	getLastMidiEvent() const;
+	void				setLastMidiEvent( MidiMessage::Event event );
+	int					getLastMidiEventParameter() const;
+	void				setLastMidiEventParameter( int nParam );
 
 	/** Wrapper around AudioEngine::toggleNextPattern().*/
 	void			toggleNextPattern( int nPatternNumber );
@@ -607,6 +610,12 @@ private:
 
 	void __kill_instruments();
 
+	/**
+	 * Cache last incoming MIDI event to be used in #MidiSenseWidget.
+	 */
+	MidiMessage::Event m_lastMidiEvent;
+	int					m_nLastMidiEventParameter;
+
 };
 
 
@@ -663,6 +672,18 @@ inline void Hydrogen::setSessionIsExported( bool bSessionIsExported ) {
 }
 inline bool Hydrogen::getSessionIsExported() const {
 	return m_bSessionIsExported;
+}
+inline MidiMessage::Event Hydrogen::getLastMidiEvent() const {
+	return m_lastMidiEvent;
+}
+inline void Hydrogen::setLastMidiEvent( MidiMessage::Event event ) {
+	m_lastMidiEvent = event;
+}
+inline int Hydrogen::getLastMidiEventParameter() const {
+	return m_nLastMidiEventParameter;
+}
+inline void	Hydrogen::setLastMidiEventParameter( int nParam ) {
+	m_nLastMidiEventParameter = nParam;
 }
 };
 

--- a/src/core/IO/MidiCommon.cpp
+++ b/src/core/IO/MidiCommon.cpp
@@ -204,5 +204,113 @@ QString MidiMessage::TypeToQString( MidiMessageType type ) {
 	return std::move( sType );
 }
 
+QString MidiMessage::EventToQString( Event event ) {
+	QString sEvent;
+	
+	switch ( event ) {
+	case Event::Note:
+		sEvent = "NOTE";
+		break;
+	case Event::CC:
+		sEvent = "CC";
+		break;
+	case Event::PC:
+		sEvent = "PROGRAM_CHANGE";
+		break;
+	case Event::MmcStop:
+		sEvent = "MMC_STOP";
+		break;
+	case Event::MmcPlay:
+		sEvent = "MMC_PLAY";
+		break;
+	case Event::MmcPause:
+		sEvent = "MMC_PAUSE";
+		break;
+	case Event::MmcDeferredPlay:
+		sEvent = "MMC_DEFERRED_PLAY";
+		break;
+	case Event::MmcRewind:
+		sEvent = "MMC_REWIND";
+		break;
+	case Event::MmcFastForward:
+		sEvent = "MMC_FAST_FORWARD";
+		break;
+	case Event::MmcRecordStrobe:
+		sEvent = "MMC_RECORD_STROBE";
+		break;
+	case Event::MmcRecordExit:
+		sEvent = "MMC_RECORD_EXIT";
+		break;
+	case Event::MmcRecordReady:
+		sEvent = "MMC_RECORD_READY";
+		break;
+	case Event::Null:
+	default:
+		sEvent = "";
+	}
+
+	return std::move( sEvent );
+}
+
+MidiMessage::Event MidiMessage::QStringToEvent( const QString& sEvent ) {
+	if ( sEvent == "NOTE" ) {
+		return Event::Note;
+	}
+	else if ( sEvent == "CC" ) {
+		return Event::CC;
+	}
+	else if ( sEvent == "PROGRAM_CHANGE" ) {
+		return Event::PC;
+	}
+	else if ( sEvent == "MMC_STOP" ) {
+		return Event::MmcStop;
+	}
+	else if ( sEvent == "MMC_PLAY" ) {
+		return Event::MmcPlay;
+	}
+	else if ( sEvent == "MMC_PAUSE" ) {
+		return Event::MmcPause;
+	}
+	else if ( sEvent == "MMC_DEFERRED_PLAY" ) {
+		return Event::MmcDeferredPlay;
+	}
+	else if ( sEvent == "MMC_FAST_FORWARD" ) {
+		return Event::MmcFastForward;
+	}
+	else if ( sEvent == "MMC_REWIND" ) {
+		return Event::MmcRewind;
+	}
+	else if ( sEvent == "MMC_RECORD_STROBE" ) {
+		return Event::MmcRecordStrobe;
+	}
+	else if ( sEvent == "MMC_RECORD_EXIT" ) {
+		return Event::MmcRecordExit;
+	}
+	else if ( sEvent == "MMC_RECORD_READY" ) {
+		return Event::MmcRecordReady;
+	} 
+	else {
+		return Event::Null;
+	}
+}
+
+QStringList MidiMessage::getEventList() {
+	QStringList eventList;
+	eventList << EventToQString( Event::Null )
+			  << EventToQString( Event::MmcPlay )
+			  << EventToQString( Event::MmcDeferredPlay )
+			  << EventToQString( Event::MmcStop )
+			  << EventToQString( Event::MmcFastForward )
+			  << EventToQString( Event::MmcRewind )
+			  << EventToQString( Event::MmcRecordStrobe )
+			  << EventToQString( Event::MmcRecordExit )
+			  << EventToQString( Event::MmcRecordReady )
+			  << EventToQString( Event::MmcPause )
+			  << EventToQString( Event::Note )
+			  << EventToQString( Event::CC )
+			  << EventToQString( Event::PC );
+
+	return std::move( eventList );
+}
 };
 

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -37,6 +37,7 @@ namespace H2Core
 class MidiMessage
 {
 public:
+	/** All possible types of incoming MIDI messages.*/
 	enum MidiMessageType {
 		UNKNOWN,
 		SYSEX,
@@ -59,6 +60,29 @@ public:
 		RESET
 	};
 	static QString TypeToQString( MidiMessageType type );
+
+	/** Subset of incoming MIDI events that will be handled by
+		Hydrogen. */
+	enum class Event {
+		Null,
+		Note,
+		CC,
+		PC,
+		MmcStop,
+		MmcPlay,
+		MmcPause,
+		MmcDeferredPlay,
+		MmcFastForward,
+		MmcRewind,
+		MmcRecordStrobe,
+		MmcRecordExit,
+		MmcRecordReady
+	};
+	static QString EventToQString( Event event );
+	static Event QStringToEvent( const QString& sEvent );
+	/** Retrieve the string representation for all available
+	 * #Event. */
+	static QStringList getEventList();
 
 	MidiMessageType m_type;
 	int m_nData1;

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -187,7 +187,7 @@ void MidiInput::handleProgramChangeMessage( const MidiMessage& msg )
 	MidiMap *pMidiMap = MidiMap::get_instance();
 
 	for ( auto action : pMidiMap->getPCActions() ) {
-		if ( action->getType() != "NOTHING" ) {
+		if ( action->getType() != Action::getNullActionType() ) {
 			action->setValue( QString::number( msg.m_nData1 ) );
 			pMidiActionManager->handleAction( action );
 		}

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -76,6 +76,10 @@ Action::Action( QString sType ) {
 	m_sValue = "0";
 }
 
+bool Action::isNull() const {
+	return m_sType == Action::getNullActionType();
+}
+
 QString Action::toQString( const QString& sPrefix, bool bShort ) const {
 	QString s = Base::sPrintIndention;
 	QString sOutput;
@@ -88,11 +92,11 @@ QString Action::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2m_sParameter3: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sParameter3 ) );
 	} else {
 		sOutput = QString( "[Action]" )
-			.append( QString( "m_sType: %1\n" ).arg( m_sType ) )
-			.append( QString( "m_sValue: %1\n" ).arg( m_sValue ) )
-			.append( QString( "m_sParameter1: %1\n" ).arg( m_sParameter1 ) )
-			.append( QString( "m_sParameter2: %1\n" ).arg( m_sParameter2 ) )
-			.append( QString( "m_sParameter3: %1\n" ).arg( m_sParameter3 ) );
+			.append( QString( " m_sType: %1" ).arg( m_sType ) )
+			.append( QString( ", m_sValue: %1" ).arg( m_sValue ) )
+			.append( QString( ", m_sParameter1: %1" ).arg( m_sParameter1 ) )
+			.append( QString( ", m_sParameter2: %1" ).arg( m_sParameter2 ) )
+			.append( QString( ", m_sParameter3: %1" ).arg( m_sParameter3 ) );
 	}
 	
 	return sOutput;

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -88,6 +88,17 @@ bool Action::isNull() const {
 	return m_sType == Action::getNullActionType();
 }
 
+bool Action::isEquivalentTo( std::shared_ptr<Action> pOther ) {
+	if ( pOther == nullptr ) {
+		return false;
+	}
+	
+	return ( m_sType == pOther->m_sType &&
+			 m_sParameter1 == pOther->m_sParameter1 &&
+			 m_sParameter2 == pOther->m_sParameter2 &&
+			 m_sParameter3 == pOther->m_sParameter3 );
+}
+
 QString Action::toQString( const QString& sPrefix, bool bShort ) const {
 	QString s = Base::sPrintIndention;
 	QString sOutput;

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -76,6 +76,14 @@ Action::Action( QString sType ) {
 	m_sValue = "0";
 }
 
+Action::Action( std::shared_ptr<Action> pOther ) {
+	m_sType = pOther->m_sType;
+	m_sParameter1 = pOther->m_sParameter1;
+	m_sParameter2 = pOther->m_sParameter2;
+	m_sParameter3 = pOther->m_sParameter3;
+	m_sValue = pOther->m_sValue;
+}
+
 bool Action::isNull() const {
 	return m_sType == Action::getNullActionType();
 }

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -198,20 +198,6 @@ MidiActionManager::MidiActionManager() {
 	for ( const auto& ppAction : m_actionMap ) {
 		m_actionList << ppAction.first;
 	}
-
-	m_eventList << ""
-			  << "MMC_PLAY"
-			  << "MMC_DEFERRED_PLAY"
-			  << "MMC_STOP"
-			  << "MMC_FAST_FORWARD"
-			  << "MMC_REWIND"
-			  << "MMC_RECORD_STROBE"
-			  << "MMC_RECORD_EXIT"
-			  << "MMC_RECORD_READY"
-			  << "MMC_PAUSE"
-			  << "NOTE"
-			  << "CC"
-			  << "PROGRAM_CHANGE";
 }
 
 

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -36,6 +36,7 @@ class Action : public H2Core::Object<Action> {
 	}
 
 	Action( QString sType = getNullActionType() );
+	Action( std::shared_ptr<Action> pOther );
 
 	/** Checks whether m_sType is of getNullActionType() */
 	bool isNull() const;

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -77,6 +77,14 @@ class Action : public H2Core::Object<Action> {
 			return m_sType;
 		}
 
+	/**
+	 * @returns whether the current action and @a pOther identically
+	 *   in all member except of #m_sValue. If true, they are associated
+	 *   with the same widget. The value will differ depending on the
+	 *   incoming MIDI event.
+	 */
+	bool isEquivalentTo( std::shared_ptr<Action> pOther );
+
 	friend bool operator ==(const Action& lhs, const Action& rhs ) {
 		return ( lhs.m_sType == rhs.m_sType &&
 				 lhs.m_sParameter1 == rhs.m_sParameter1 &&

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -213,8 +213,6 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 		bool gain_level_absolute(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool pitch_level_absolute(std::shared_ptr<Action> , H2Core::Hydrogen * );
 
-		QStringList m_eventList;
-
 		int m_nLastBpmChangeCCParameter;
 
 	bool setSong( int nSongNumber, H2Core::Hydrogen* pHydrogen );
@@ -255,10 +253,6 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 
 		QStringList getActionList(){
 			return m_actionList;
-		}
-
-		QStringList getEventList(){
-			return m_eventList;
 		}
 	/**
 	 * \return -1 in case the @a couldn't be found.

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -31,7 +31,14 @@
 class Action : public H2Core::Object<Action> {
 	H2_OBJECT(Action)
 	public:
-	Action( QString sType = "NOTHING" );
+	static QString getNullActionType() {
+		return "NOTHING";
+	}
+
+	Action( QString sType = getNullActionType() );
+
+	/** Checks whether m_sType is of getNullActionType() */
+	bool isNull() const;
 
 		void setParameter1( QString text ){
 			m_sParameter1 = text;

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -76,6 +76,35 @@ class Action : public H2Core::Object<Action> {
 			return m_sType;
 		}
 
+	friend bool operator ==(const Action& lhs, const Action& rhs ) {
+		return ( lhs.m_sType == rhs.m_sType &&
+				 lhs.m_sParameter1 == rhs.m_sParameter1 &&
+				 lhs.m_sParameter2 == rhs.m_sParameter2 &&
+				 lhs.m_sParameter3 == rhs.m_sParameter3 &&
+				 lhs.m_sValue == rhs.m_sValue );
+	}
+	friend bool operator !=(const Action& lhs, const Action& rhs ) {
+		return ( lhs.m_sType != rhs.m_sType ||
+				 lhs.m_sParameter1 != rhs.m_sParameter1 ||
+				 lhs.m_sParameter2 != rhs.m_sParameter2 ||
+				 lhs.m_sParameter3 != rhs.m_sParameter3 ||
+				 lhs.m_sValue != rhs.m_sValue );
+	}
+	friend bool operator ==(std::shared_ptr<Action> lhs, std::shared_ptr<Action> rhs ) {
+		return ( lhs->m_sType == rhs->m_sType &&
+				 lhs->m_sParameter1 == rhs->m_sParameter1 &&
+				 lhs->m_sParameter2 == rhs->m_sParameter2 &&
+				 lhs->m_sParameter3 == rhs->m_sParameter3 &&
+				 lhs->m_sValue == rhs->m_sValue );
+	}
+	friend bool operator !=(std::shared_ptr<Action> lhs, std::shared_ptr<Action> rhs ) {
+		return ( lhs->m_sType != rhs->m_sType ||
+				 lhs->m_sParameter1 != rhs->m_sParameter1 ||
+				 lhs->m_sParameter2 != rhs->m_sParameter2 ||
+				 lhs->m_sParameter3 != rhs->m_sParameter3 ||
+				 lhs->m_sValue != rhs->m_sValue );
+	}
+
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of
 		 * every new line

--- a/src/core/MidiMap.cpp
+++ b/src/core/MidiMap.cpp
@@ -97,11 +97,19 @@ void MidiMap::registerMMCEvent( QString sEventString, std::shared_ptr<Action> pA
 {
 	QMutexLocker mx(&__mutex);
 
-	for ( const auto& it : m_mmcActionMap ) {
-		if ( it.first == sEventString &&
-			 it.second == pAction ) {
-			INFOLOG( QString( "MMC event [%1] for action [%2] was already registered" )
-					 .arg( sEventString ).arg( pAction->getType() ) );
+	if ( pAction == nullptr || pAction->isNull() ) {
+		ERRORLOG( "Invalid action" );
+		return;
+	}
+
+	for ( const auto& [ssType, ppAction] : m_mmcActionMap ) {
+		if ( ppAction != nullptr && ssType == sEventString &&
+			 ppAction->isEquivalentTo( pAction ) ) {
+			WARNINGLOG( QString( "MMC event [%1] for Action [%2: Param1: [%3], Param2: [%4], Param3: [%5]] was already registered" )
+						.arg( sEventString ).arg( pAction->getType() )
+						.arg( pAction->getParameter1() )
+						.arg( pAction->getParameter2() )
+						.arg( pAction->getParameter3() ) );
 			return;
 		}
 	}
@@ -112,19 +120,27 @@ void MidiMap::registerMMCEvent( QString sEventString, std::shared_ptr<Action> pA
 void MidiMap::registerNoteEvent( int nNote, std::shared_ptr<Action> pAction )
 {
 	QMutexLocker mx(&__mutex);
+
+	if ( pAction == nullptr || pAction->isNull() ) {
+		ERRORLOG( "Invalid action" );
+		return;
+	}
 	
 	if ( nNote < MIDI_OUT_NOTE_MIN || nNote > MIDI_OUT_NOTE_MAX ) {
-		ERRORLOG( QString( "Unable to register Note MIDI action [%1]: Provided note [%2] out of bound [%3,%4]" )
-				  .arg( pAction->getType() ).arg( nNote )
+		ERRORLOG( QString( "Unable to register Note MIDI [%1]: Provided note [%2] out of bound [%3,%4]" )
+				  .arg( pAction->toQString() ).arg( nNote )
 				  .arg( MIDI_OUT_NOTE_MIN ).arg( MIDI_OUT_NOTE_MAX ) );
 		return;
 	}
 
-	for ( const auto& it : m_noteActionMap ) {
-		if ( it.first == nNote &&
-			 it.second == pAction ) {
-			INFOLOG( QString( "Note event [%1] for action [%2] was already registered" )
-					 .arg( nNote ).arg( pAction->getType() ) );
+	for ( const auto& [nnPitch, ppAction] : m_noteActionMap ) {
+		if ( ppAction != nullptr && nnPitch == nNote &&
+			 ppAction->isEquivalentTo( pAction ) ) {
+			WARNINGLOG( QString( "NOTE event [%1] for Action [%2: Param1: [%3], Param2: [%4], Param3: [%5]] was already registered" )
+						.arg( nNote ).arg( pAction->getType() )
+						.arg( pAction->getParameter1() )
+						.arg( pAction->getParameter2() )
+						.arg( pAction->getParameter3() ) );
 			return;
 		}
 	}
@@ -134,33 +150,48 @@ void MidiMap::registerNoteEvent( int nNote, std::shared_ptr<Action> pAction )
 
 void MidiMap::registerCCEvent( int nParameter, std::shared_ptr<Action> pAction ){
 	QMutexLocker mx(&__mutex);
-	
-	if ( nParameter < 0 || nParameter > 127 ) {
-		ERRORLOG( QString( "Unable to register CC MIDI action [%1]: Provided parameter [%2] out of bound [0,127]" )
-				  .arg( pAction->getType() ).arg( nParameter ) );
+
+	if ( pAction == nullptr || pAction->isNull() ) {
+		ERRORLOG( "Invalid action" );
 		return;
 	}
 
-	for ( const auto& it : m_ccActionMap ) {
-		if ( it.first == nParameter &&
-			 it.second == pAction ) {
-			INFOLOG( QString( "CC event [%1] for action [%2] was already registered" )
-					 .arg( nParameter ).arg( pAction->getType() ) );
+	if ( nParameter < 0 || nParameter > 127 ) {
+		ERRORLOG( QString( "Unable to register CC MIDI [%1]: Provided parameter [%2] out of bound [0,127]" )
+				  .arg( pAction->toQString() ).arg( nParameter ) );
+		return;
+	}
+
+	for ( const auto& [nnParam, ppAction] : m_ccActionMap ) {
+		if ( ppAction != nullptr && nnParam == nParameter &&
+			 ppAction->isEquivalentTo( pAction ) ) {
+			WARNINGLOG( QString( "CC event [%1] for Action [%2: Param1: [%3], Param2: [%4], Param3: [%5]] was already registered" )
+						.arg( nParameter ).arg( pAction->getType() )
+						.arg( pAction->getParameter1() )
+						.arg( pAction->getParameter2() )
+						.arg( pAction->getParameter3() ) );
 			return;
 		}
 	}
 
 	m_ccActionMap.insert( { nParameter, pAction } );
-	
 }
 
 void MidiMap::registerPCEvent( std::shared_ptr<Action> pAction ){
 	QMutexLocker mx(&__mutex);
 
-	for ( const auto& action : m_pcActionVector ) {
-		if ( action == pAction ) {
-			INFOLOG( QString( "PC event for action [%1] was already registered" )
-					 .arg( pAction->getType() ) );
+	if ( pAction == nullptr || pAction->isNull() ) {
+		ERRORLOG( "Invalid action" );
+		return;
+	}
+
+	for ( const auto& ppAction : m_pcActionVector ) {
+		if ( ppAction != nullptr && ppAction->isEquivalentTo( pAction ) ) {
+			WARNINGLOG( QString( "PC event for Action [%2: Param1: [%3], Param2: [%4], Param3: [%5]] was already registered" )
+						.arg( pAction->getType() )
+						.arg( pAction->getParameter1() )
+						.arg( pAction->getParameter2() )
+						.arg( pAction->getParameter3() ) );
 			return;
 		}
 	}
@@ -177,7 +208,9 @@ std::vector<std::shared_ptr<Action>> MidiMap::getMMCActions( QString sEventStrin
 	auto range = m_mmcActionMap.equal_range( sEventString );
  
     for ( auto ii = range.first; ii != range.second; ++ii ) {
-		actions.push_back( ii->second );
+		if ( ii->second != nullptr ) {
+			actions.push_back( ii->second );
+		}
 	}
 
 	return std::move( actions );
@@ -192,7 +225,9 @@ std::vector<std::shared_ptr<Action>> MidiMap::getNoteActions( int nNote )
 	auto range = m_noteActionMap.equal_range( nNote );
  
     for ( auto ii = range.first; ii != range.second; ++ii ) {
-		actions.push_back( ii->second );
+		if ( ii->second != nullptr ) {
+			actions.push_back( ii->second );
+		}
 	}
 
 	return std::move( actions );
@@ -206,7 +241,9 @@ std::vector<std::shared_ptr<Action>> MidiMap::getCCActions( int nParameter ) {
 	auto range = m_ccActionMap.equal_range( nParameter );
  
     for ( auto ii = range.first; ii != range.second; ++ii ) {
-		actions.push_back( ii->second );
+		if ( ii->second != nullptr ) {
+			actions.push_back( ii->second );
+		}
 	}
 
 	return std::move( actions );
@@ -216,10 +253,10 @@ std::vector<int> MidiMap::findCCValuesByActionParam1( QString sActionType, QStri
 	QMutexLocker mx(&__mutex);
 	std::vector<int> values;
 
-	for ( const auto& it : m_ccActionMap ) {
-		if ( it.second->getType() == sActionType &&
-			it.second->getParameter1() == sParam1 ){
-			values.push_back( it.first );
+	for ( const auto& [nnParam, ppAction] : m_ccActionMap ) {
+		if ( ppAction != nullptr && ppAction->getType() == sActionType &&
+			 ppAction->getParameter1() == sParam1 ){
+			values.push_back( nnParam );
 		}
 	}
 	
@@ -230,9 +267,9 @@ std::vector<int> MidiMap::findCCValuesByActionType( QString sActionType ) {
 	QMutexLocker mx(&__mutex);
 	std::vector<int> values;
 
-	for ( const auto& it : m_ccActionMap ) {
-		if ( it.second->getType() == sActionType ){
-			values.push_back( it.first );
+	for ( const auto& [nnParam, ppAction] : m_ccActionMap ) {
+		if ( ppAction != nullptr && ppAction->getType() == sActionType ){
+			values.push_back( nnParam );
 		}
 	}
 	
@@ -244,24 +281,26 @@ std::vector<std::pair<QString,int>> MidiMap::getRegisteredMidiEvents( std::share
 
 	if ( pAction != nullptr && ! pAction->isNull() ) {
 		for ( const auto& [nParam, ppAction] : m_noteActionMap ) {
-			if ( ! ppAction->isNull() && ppAction == pAction ) {
+			if ( ppAction != nullptr &&
+				 ppAction->isEquivalentTo( pAction ) ) {
 				midiEvents.push_back( std::make_pair( "NOTE", nParam ) );
 			}
 		}
 		for ( const auto& [nParam, ppAction] : m_ccActionMap ) {
-			if ( ! ppAction->isNull() && ppAction == pAction ) {
+			if ( ppAction != nullptr &&
+				 ppAction->isEquivalentTo( pAction ) ) {
 				midiEvents.push_back( std::make_pair( "CC", nParam ) );
 			}
 		}
 		for ( const auto& [sType, ppAction] : m_mmcActionMap ) {
-			if ( ! ppAction->isNull() && ppAction == pAction ) {
+			if ( ppAction != nullptr &&
+				 ppAction->isEquivalentTo( pAction ) ) {
 				midiEvents.push_back( std::make_pair( sType, 0 ) );
 			}
 		}
 		for ( const auto& ppAction : m_pcActionVector ) {
-			INFOLOG( QString( "%1 vs %2" ).arg( pAction->toQString() ).arg( ppAction->toQString() ) );
-			if ( ! ppAction->isNull() && ppAction == pAction ) {
-				WARNINGLOG( "check" );
+			if ( ppAction != nullptr &&
+				 ppAction->isEquivalentTo( pAction ) ) {
 				midiEvents.push_back(
 					std::make_pair( "PROGRAM_CHANGE", 0 ) );
 			}
@@ -278,7 +317,7 @@ QString MidiMap::toQString( const QString& sPrefix, bool bShort ) const {
 		sOutput = QString( "%1[MidiMap]\n" ).arg( sPrefix )
 			.append( QString( "%1%2m_noteActionMap:\n" ).arg( sPrefix ).arg( s ) );
 		for ( const auto& [nParam, ppAction] : m_noteActionMap ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
 								.arg( nParam )
 								.arg( ppAction->toQString( "", true ) ) );
@@ -286,7 +325,7 @@ QString MidiMap::toQString( const QString& sPrefix, bool bShort ) const {
 		}
 		sOutput.append( QString( "%1%2m_ccActionMap:\n" ).arg( sPrefix ).arg( s ) );
 		for ( const auto& [nParam, ppAction] : m_ccActionMap ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
 								.arg( nParam )
 								.arg( ppAction->toQString( "", true ) ) );
@@ -294,7 +333,7 @@ QString MidiMap::toQString( const QString& sPrefix, bool bShort ) const {
 		}
 		sOutput.append( QString( "%1%2m_mmcActionMap:\n" ).arg( sPrefix ).arg( s ) );
 		for ( const auto& [nParam, ppAction] : m_mmcActionMap ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
 								.arg( nParam )
 								.arg( ppAction->toQString( "", true ) ) );
@@ -302,7 +341,7 @@ QString MidiMap::toQString( const QString& sPrefix, bool bShort ) const {
 		}
 		sOutput.append( QString( "%1%2m_pcActionVector:\n" ).arg( sPrefix ).arg( s ) );
 		for ( const auto& ppAction : m_pcActionVector ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
 								.arg( ppAction->toQString( "", true ) ) );
 			}
@@ -312,28 +351,28 @@ QString MidiMap::toQString( const QString& sPrefix, bool bShort ) const {
 
 		sOutput = QString( "[MidiMap] m_noteActionMap: [" );
 		for ( const auto& [nParam, ppAction] : m_noteActionMap ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1: %2, " ).arg( nParam )
 								.arg( ppAction->toQString( "", true ) ) );
 			}
 		}
 		sOutput.append( QString( "], m_ccActionMap: [" ) );
 		for ( const auto& [nParam, ppAction] : m_ccActionMap ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1: %2, " ).arg( nParam )
 								.arg( ppAction->toQString( "", true ) ) );
 			}
 		}
 		sOutput.append( QString( "], m_mmcActionMap: [" ) );
 		for ( const auto& [nParam, ppAction] : m_mmcActionMap ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1: %2, " ).arg( nParam )
 								.arg( ppAction->toQString( "", true ) ) );
 			}
 		}
 		sOutput.append( QString( ", m_pcActionVector: [" ) );
 		for ( const auto& ppAction : m_pcActionVector ) {
-			if ( ! ppAction->isNull() ) {
+			if ( ppAction != nullptr && ! ppAction->isNull() ) {
 				sOutput.append( QString( "%1, " ).arg( ppAction->toQString( "", true ) ) );
 			}
 		}

--- a/src/core/MidiMap.cpp
+++ b/src/core/MidiMap.cpp
@@ -50,7 +50,8 @@ MidiMap::MidiMap()
 
 	// Constructor
 	m_pcActionVector.resize( 1 );
-	m_pcActionVector[ 0 ] = std::make_shared<Action>("NOTHING");
+	m_pcActionVector[ 0 ] = std::make_shared<Action>(
+		Action::getNullActionType() );
 }
 
 MidiMap::~MidiMap()
@@ -88,7 +89,8 @@ void MidiMap::reset()
 	
 	m_pcActionVector.clear();
 	m_pcActionVector.resize( 1 );
-	m_pcActionVector[ 0 ] = std::make_shared<Action>("NOTHING");
+	m_pcActionVector[ 0 ] = std::make_shared<Action>(
+		Action::getNullActionType() );
 }
 
 void MidiMap::registerMMCEvent( QString sEventString, std::shared_ptr<Action> pAction )
@@ -234,4 +236,76 @@ std::vector<int> MidiMap::findCCValuesByActionType( QString sActionType ) {
 	}
 	
 	return std::move( values );
+}
+
+QString MidiMap::toQString( const QString& sPrefix, bool bShort ) const {
+	QString s = Base::sPrintIndention;
+	QString sOutput;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[MidiMap]\n" ).arg( sPrefix )
+			.append( QString( "%1%2m_noteActionMap:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& element : m_noteActionMap ) {
+			if ( ! element.second->isNull() ) {
+				sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
+								.arg( element.first )
+								.arg( element.second->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( QString( "%1%2m_ccActionMap:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& element : m_ccActionMap ) {
+			if ( ! element.second->isNull() ) {
+				sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
+								.arg( element.first )
+								.arg( element.second->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( QString( "%1%2m_mmcActionMap:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& element : m_mmcActionMap ) {
+			if ( ! element.second->isNull() ) {
+				sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
+								.arg( element.first )
+								.arg( element.second->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( QString( "%1%2m_pcActionVector:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& action : m_pcActionVector ) {
+			if ( ! action->isNull() ) {
+				sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
+								.arg( action->toQString( "", true ) ) );
+			}
+		}
+	}
+	else {
+
+		sOutput = QString( "[MidiMap] m_noteActionMap: [" );
+		for ( const auto& element : m_noteActionMap ) {
+			if ( ! element.second->isNull() ) {
+				sOutput.append( QString( "%1: %2, " ).arg( element.first )
+								.arg( element.second->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( QString( "], m_ccActionMap: [" ) );
+		for ( const auto& element : m_ccActionMap ) {
+			if ( ! element.second->isNull() ) {
+				sOutput.append( QString( "%1: %2, " ).arg( element.first )
+								.arg( element.second->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( QString( "], m_mmcActionMap: [" ) );
+		for ( const auto& element : m_mmcActionMap ) {
+			if ( ! element.second->isNull() ) {
+				sOutput.append( QString( "%1: %2, " ).arg( element.first )
+								.arg( element.second->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( QString( ", m_pcActionVector: [" ) );
+		for ( const auto& action : m_pcActionVector ) {
+			if ( ! action->isNull() ) {
+				sOutput.append( QString( "%1, " ).arg( action->toQString( "", true ) ) );
+			}
+		}
+		sOutput.append( "]" );
+	}
+		
+	return sOutput;
 }

--- a/src/core/MidiMap.h
+++ b/src/core/MidiMap.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <cassert>
 #include <core/Object.h>
+#include <core/IO/MidiCommon.h>
 
 #include <QtCore/QMutex>
 
@@ -95,7 +96,7 @@ public:
 	 *   @a pAction grouped in MIDI event type name and MIDI event
 	 *   parameter pairs.
 	 */
-	std::vector<std::pair<QString,int>> getRegisteredMidiEvents( std::shared_ptr<Action> pAction ) const;
+	std::vector<std::pair<H2Core::MidiMessage::Event,int>> getRegisteredMidiEvents( std::shared_ptr<Action> pAction ) const;
 	
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of

--- a/src/core/MidiMap.h
+++ b/src/core/MidiMap.h
@@ -89,6 +89,13 @@ public:
 		
 	std::vector<int> findCCValuesByActionParam1( QString sActionType, QString sParam1 );
 	std::vector<int> findCCValuesByActionType( QString sActionType );
+
+	/**
+	 * @returns a list of all MIDI events registered to a particular
+	 *   @a pAction grouped in MIDI event type name and MIDI event
+	 *   parameter pairs.
+	 */
+	std::vector<std::pair<QString,int>> getRegisteredMidiEvents( std::shared_ptr<Action> pAction ) const;
 	
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of

--- a/src/core/MidiMap.h
+++ b/src/core/MidiMap.h
@@ -89,6 +89,16 @@ public:
 		
 	std::vector<int> findCCValuesByActionParam1( QString sActionType, QString sParam1 );
 	std::vector<int> findCCValuesByActionType( QString sActionType );
+	
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 * every new line
+	 * \param bShort Instead of the whole content of all classes
+	 * stored as members just a single unique identifier will be
+	 * displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 private:
 	MidiMap();
 

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -1170,7 +1170,7 @@ bool Preferences::savePreferences()
 	for( const auto& it : mmcMap ){
 		QString event = it.first;
 		auto pAction = it.second;
-		if ( pAction->getType() != "NOTHING" ){
+		if ( pAction->getType() != Action::getNullActionType() ){
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
 			midiEventNode.write_string( "mmcEvent" , event );
@@ -1184,7 +1184,7 @@ bool Preferences::savePreferences()
 	for ( const auto& it : mM->getNoteActionMap() ){
 		int nNote = it.first;
 		auto pAction = it.second;
-		if( pAction != nullptr && pAction->getType() != "NOTHING") {
+		if( pAction != nullptr && pAction->getType() != Action::getNullActionType()) {
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
 			midiEventNode.write_string( "noteEvent" , QString("NOTE") );
@@ -1199,7 +1199,7 @@ bool Preferences::savePreferences()
 	for( const auto& it : mM->getCCActionMap() ){
 		int nParameter = it.first;
 		auto pAction = it.second;
-		if( pAction != nullptr && pAction->getType() != "NOTHING") {
+		if( pAction != nullptr && pAction->getType() != Action::getNullActionType()) {
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
 			midiEventNode.write_string( "ccEvent" , QString("CC") );
@@ -1212,7 +1212,7 @@ bool Preferences::savePreferences()
 	}
 
 	for ( const auto action : mM->getPCActions() ) {
-		if( action != nullptr && action->getType() != "NOTHING") {
+		if( action != nullptr && action->getType() != Action::getNullActionType()) {
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
 			midiEventNode.write_string( "pcEvent" , QString("PROGRAM_CHANGE") );

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -1162,64 +1162,60 @@ bool Preferences::savePreferences()
 	// MidiMap to be initialized.
 	MidiMap::create_instance();
 	MidiMap * mM = MidiMap::get_instance();
-	auto mmcMap = mM->getMMCActionMap();
 
 	//---- MidiMap ----
 	XMLNode midiEventMapNode = rootNode.createNode( "midiEventMap" );
 
-	for( const auto& it : mmcMap ){
-		QString event = it.first;
-		auto pAction = it.second;
-		if ( pAction->getType() != Action::getNullActionType() ){
+	for( const auto& [ssType, ppAction] : mM->getMMCActionMap() ){
+		if ( ppAction != nullptr && ! ppAction->isNull() ){
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
-			midiEventNode.write_string( "mmcEvent" , event );
-			midiEventNode.write_string( "action" , pAction->getType());
-			midiEventNode.write_string( "parameter" , pAction->getParameter1() );
-			midiEventNode.write_string( "parameter2" , pAction->getParameter2() );
-			midiEventNode.write_string( "parameter3" , pAction->getParameter3() );
+			midiEventNode.write_string( "mmcEvent" , ssType );
+			midiEventNode.write_string( "action" , ppAction->getType());
+			midiEventNode.write_string( "parameter" , ppAction->getParameter1() );
+			midiEventNode.write_string( "parameter2" , ppAction->getParameter2() );
+			midiEventNode.write_string( "parameter3" , ppAction->getParameter3() );
 		}
 	}
 
-	for ( const auto& it : mM->getNoteActionMap() ){
-		int nNote = it.first;
-		auto pAction = it.second;
-		if( pAction != nullptr && pAction->getType() != Action::getNullActionType()) {
+	for ( const auto& [nnPitch, ppAction] : mM->getNoteActionMap() ){
+		if ( ppAction != nullptr && ! ppAction->isNull() ){
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
-			midiEventNode.write_string( "noteEvent" , QString("NOTE") );
-			midiEventNode.write_int( "eventParameter" , nNote );
-			midiEventNode.write_string( "action" , pAction->getType() );
-			midiEventNode.write_string( "parameter" , pAction->getParameter1() );
-			midiEventNode.write_string( "parameter2" , pAction->getParameter2() );
-			midiEventNode.write_string( "parameter3" , pAction->getParameter3() );
+			midiEventNode.write_string(
+				"noteEvent", MidiMessage::EventToQString( MidiMessage::Event::Note ) );
+			midiEventNode.write_int( "eventParameter" , nnPitch );
+			midiEventNode.write_string( "action" , ppAction->getType() );
+			midiEventNode.write_string( "parameter" , ppAction->getParameter1() );
+			midiEventNode.write_string( "parameter2" , ppAction->getParameter2() );
+			midiEventNode.write_string( "parameter3" , ppAction->getParameter3() );
 		}
 	}
 
-	for( const auto& it : mM->getCCActionMap() ){
-		int nParameter = it.first;
-		auto pAction = it.second;
-		if( pAction != nullptr && pAction->getType() != Action::getNullActionType()) {
+	for ( const auto& [nnParam, ppAction] : mM->getCCActionMap() ){
+		if ( ppAction != nullptr && ! ppAction->isNull() ){
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
-			midiEventNode.write_string( "ccEvent" , QString("CC") );
-			midiEventNode.write_int( "eventParameter" , nParameter );
-			midiEventNode.write_string( "action" , pAction->getType() );
-			midiEventNode.write_string( "parameter" , pAction->getParameter1() );
-			midiEventNode.write_string( "parameter2" , pAction->getParameter2() );
-			midiEventNode.write_string( "parameter3" , pAction->getParameter3() );
+			midiEventNode.write_string(
+				"ccEvent", MidiMessage::EventToQString( MidiMessage::Event::CC ) );
+			midiEventNode.write_int( "eventParameter" , nnParam );
+			midiEventNode.write_string( "action" , ppAction->getType() );
+			midiEventNode.write_string( "parameter" , ppAction->getParameter1() );
+			midiEventNode.write_string( "parameter2" , ppAction->getParameter2() );
+			midiEventNode.write_string( "parameter3" , ppAction->getParameter3() );
 		}
 	}
 
-	for ( const auto action : mM->getPCActions() ) {
-		if( action != nullptr && action->getType() != Action::getNullActionType()) {
+	for ( const auto& ppAction : mM->getPCActions() ) {
+		if ( ppAction != nullptr && ! ppAction->isNull() ){
 			XMLNode midiEventNode = midiEventMapNode.createNode( "midiEvent" );
 
-			midiEventNode.write_string( "pcEvent" , QString("PROGRAM_CHANGE") );
-			midiEventNode.write_string( "action" , action->getType() );
-			midiEventNode.write_string( "parameter" , action->getParameter1() );
-			midiEventNode.write_string( "parameter2" , action->getParameter2() );
-			midiEventNode.write_string( "parameter3" , action->getParameter3() );
+			midiEventNode.write_string(
+				"pcEvent", MidiMessage::EventToQString( MidiMessage::Event::PC ) );
+			midiEventNode.write_string( "action" , ppAction->getType() );
+			midiEventNode.write_string( "parameter" , ppAction->getParameter1() );
+			midiEventNode.write_string( "parameter2" , ppAction->getParameter2() );
+			midiEventNode.write_string( "parameter3" , ppAction->getParameter3() );
 		}
 	}
 

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -67,6 +67,7 @@ class EventListener
 	virtual void playbackTrackChangedEvent(){}
 	virtual void soundLibraryChangedEvent(){}
 	virtual void nextShotEvent(){}
+	virtual void midiMapChangedEvent(){}
 
 		virtual ~EventListener() {}
 };

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -870,6 +870,10 @@ void HydrogenApp::onEventQueueTimer()
 				pListener->nextShotEvent();
 				break;
 
+			case EVENT_MIDI_MAP_CHANGED:
+				pListener->midiMapChangedEvent();
+				break;
+
 			default:
 				ERRORLOG( QString("[onEventQueueTimer] Unhandled event: %1").arg( event.type ) );
 			}

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -35,6 +35,7 @@
 #include <QTreeWidgetItemIterator>
 #include "../Widgets/MidiTable.h"
 
+#include <core/EventQueue.h>
 #include <core/MidiMap.h>
 #include <core/Hydrogen.h>
 #include <core/IO/MidiInput.h>
@@ -135,7 +136,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	: QDialog( parent )
 	, m_pCurrentColor( nullptr )
 	, m_nCurrentId( 0 )
-	, m_changes( H2Core::Preferences::Changes::None ) {
+	, m_changes( H2Core::Preferences::Changes::None )
+	, m_bMidiTableChanged( false ) {
 	
 	m_pCurrentTheme = std::make_shared<H2Core::Theme>( H2Core::Preferences::get_instance()->getTheme() );
 	m_pPreviousTheme = std::make_shared<H2Core::Theme>( H2Core::Preferences::get_instance()->getTheme() );
@@ -438,6 +440,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 				 m_changes =
 					 static_cast<H2Core::Preferences::Changes>(
 							m_changes | H2Core::Preferences::Changes::MidiTab );
+				 m_bMidiTableChanged = true;
 			 });
 
 	//////
@@ -906,6 +909,9 @@ void PreferencesDialog::on_okBtn_clicked()
 	mM->reset_instance();
 
 	midiTable->saveMidiTable();
+	if ( m_bMidiTableChanged ) {
+		H2Core::EventQueue::get_instance()->push_event( H2Core::EVENT_MIDI_MAP_CHANGED, 0 );
+	}
 
 	if ( m_pMidiDriverComboBox->currentText() == "ALSA" &&
 		 pPref->m_sMidiDriver != "ALSA" ) {

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.h
@@ -181,6 +181,8 @@ private:
 	QString m_sInitialLanguage;
 	std::vector<ColorSelectionButton*> m_colorSelectionButtons;
 
+	bool m_bMidiTableChanged;
+
 };
 
 

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -337,10 +337,20 @@ void Button::updateTooltip() {
 		sTip.append( QString( "\n%1: %2 " ).arg( pCommonStrings->getMidiTooltipHeading() )
 					 .arg( m_pAction->getType() ) );
 		if ( m_registeredMidiEvents.size() > 0 ) {
-			for ( const auto& event : m_registeredMidiEvents ) {
-				sTip.append( QString( "\n%1 [%2 : %3]" )
-							 .arg( pCommonStrings->getMidiTooltipBound() )
-							 .arg( event.first ).arg( event.second ) );
+			for ( const auto& [event, nnParam] : m_registeredMidiEvents ) {
+				if ( event == H2Core::MidiMessage::Event::Note ||
+					 event == H2Core::MidiMessage::Event::CC ) {
+					sTip.append( QString( "\n%1 [%2 : %3]" )
+								 .arg( pCommonStrings->getMidiTooltipBound() )
+								 .arg( H2Core::MidiMessage::EventToQString( event ) )
+								 .arg( nnParam ) );
+				}
+				else {
+					// PC and MMC_x do not have a parameter.
+					sTip.append( QString( "\n%1 [%2]" )
+								 .arg( pCommonStrings->getMidiTooltipBound() )
+								 .arg( H2Core::MidiMessage::EventToQString( event ) ) );
+				}
 			}
 		}
 		else {

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -40,8 +40,6 @@ Button::Button( QWidget *pParent, QSize size, Type type, const QString& sIcon, c
 	, m_type( type )
 	, m_iconSize( iconSize )
 	, m_sBaseTooltip( sBaseTooltip )
-	, m_sRegisteredMidiEvent( "" )
-	, m_nRegisteredMidiParameter( 0 )
 	, m_bColorful( bColorful )
 	, m_bLastCheckedState( false )
 	, m_sIcon( sIcon )
@@ -310,11 +308,6 @@ void Button::setBaseToolTip( const QString& sNewTip ) {
 	updateTooltip();
 }
 
-void Button::setAction( std::shared_ptr<Action> pAction ) {
-	m_pAction = pAction;
-	updateTooltip();
-}
-
 void Button::mousePressEvent(QMouseEvent*ev) {
 	if ( ev->button() == Qt::RightButton ) {
 		emit rightClicked();
@@ -327,16 +320,6 @@ void Button::mousePressEvent(QMouseEvent*ev) {
 	if ( ev->button() == Qt::LeftButton && ( ev->modifiers() & Qt::ShiftModifier ) ){
 		MidiSenseWidget midiSense( this, true, this->getAction() );
 		midiSense.exec();
-
-		// Store the registered MIDI event and parameter in order to
-		// show them in the tooltip. Looking them up in the MidiMap
-		// using the Action associated to the Widget might not yield a
-		// unique result since the Action can be registered from the
-		// PreferencesDialog as well.
-		m_sRegisteredMidiEvent = H2Core::Hydrogen::get_instance()->m_LastMidiEvent;
-		m_nRegisteredMidiParameter = H2Core::Hydrogen::get_instance()->m_nLastMidiEventParameter;
-		
-		updateTooltip();
 		return;
 	}
 
@@ -353,10 +336,14 @@ void Button::updateTooltip() {
 	if ( m_pAction != nullptr ) {
 		sTip.append( QString( "\n%1: %2 " ).arg( pCommonStrings->getMidiTooltipHeading() )
 					 .arg( m_pAction->getType() ) );
-		if ( ! m_sRegisteredMidiEvent.isEmpty() ) {
-			sTip.append( QString( "%1 [%2 : %3]" ).arg( pCommonStrings->getMidiTooltipBound() )
-						 .arg( m_sRegisteredMidiEvent ).arg( m_nRegisteredMidiParameter ) );
-		} else {
+		if ( m_registeredMidiEvents.size() > 0 ) {
+			for ( const auto& event : m_registeredMidiEvents ) {
+				sTip.append( QString( "\n%1 [%2 : %3]" )
+							 .arg( pCommonStrings->getMidiTooltipBound() )
+							 .arg( event.first ).arg( event.second ) );
+			}
+		}
+		else {
 			sTip.append( QString( "%1" ).arg( pCommonStrings->getMidiTooltipUnbound() ) );
 		}
 	}

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -118,7 +118,6 @@ public:
 	Button& operator=( const Button& rhs ) = delete;
 
 	void setBaseToolTip( const QString& sNewTip );
-	void setAction( std::shared_ptr<Action> pAction );
 	
 	bool getIsActive() const;
 	void setIsActive( bool bIsActive );
@@ -150,7 +149,7 @@ signals:
 private:
 	void updateStyleSheet();
 	void updateFont();
-	void updateTooltip();
+	void updateTooltip() override;
 	void updateIcon();
 
 	bool m_bUseRedBackground;
@@ -158,9 +157,7 @@ private:
 	QSize m_size;
 	QSize m_iconSize;
 	QString m_sBaseTooltip;
-	QString m_sRegisteredMidiEvent;
 	QString m_sIcon;
-	int m_nRegisteredMidiParameter;
 	int m_nFixedFontSize;
 
 	int m_nBorderRadius;

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -156,16 +156,7 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
 		MidiSenseWidget midiSense( this, true, this->getAction() );
 		midiSense.exec();
-
-		// Store the registered MIDI event and parameter in order to
-		// show them in the tooltip. Looking them up in the MidiMap
-		// using the Action associated to the Widget might not yield a
-		// unique result since the Action can be registered from the
-		// PreferencesDialog as well.
-		m_sRegisteredMidiEvent = H2Core::Hydrogen::get_instance()->m_LastMidiEvent;
-		m_nRegisteredMidiParameter = H2Core::Hydrogen::get_instance()->m_nLastMidiEventParameter;
 		m_bIgnoreMouseMove = true;
-		updateTooltip();
 	}
 	else {
 		setCursor( QCursor( Qt::SizeVerCursor ) );

--- a/src/gui/src/Widgets/MidiLearnable.cpp
+++ b/src/gui/src/Widgets/MidiLearnable.cpp
@@ -1,0 +1,51 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include "MidiLearnable.h"
+#include "../HydrogenApp.h"
+
+#include <core/MidiMap.h>
+
+MidiLearnable::MidiLearnable() : m_pAction( nullptr ) {
+	HydrogenApp::get_instance()->addEventListener( this );
+}
+
+MidiLearnable::~MidiLearnable() {
+	auto pHydrogenApp = HydrogenApp::get_instance();
+	if ( pHydrogenApp != nullptr ) {
+		pHydrogenApp->removeEventListener( this );
+	}
+}
+
+void MidiLearnable::setAction( std::shared_ptr<Action> pAction ){
+	m_pAction = pAction;
+
+	midiMapChangedEvent();
+}
+
+void MidiLearnable::midiMapChangedEvent() {
+	if ( m_pAction != nullptr ) {
+		m_registeredMidiEvents =
+			MidiMap::get_instance()->getRegisteredMidiEvents( m_pAction );
+		updateTooltip();
+	}
+}

--- a/src/gui/src/Widgets/MidiLearnable.h
+++ b/src/gui/src/Widgets/MidiLearnable.h
@@ -25,33 +25,58 @@
 #define MIDILEARNABLE_H
 
 #include <memory>
+#include <vector>
+#include <QString>
 #include <core/MidiAction.h>
 
+#include "../EventListener.h"
 
-
-/*
-  Every widget which supports MidiLearn should derive from this Class.
-*/
-
-/** \ingroup docGUI docWidgets docMIDI*/
-class MidiLearnable
+/**
+ * Every widget which supports MidiLearn should derive from this
+ * Class.
+ *
+ * MIDI-learnable widgets serve as a more convenient interface to the
+ * #MidiTable provided in the #PreferencesDialog. Instead of
+ * assigning a MIDI message type and parameter e.g. STRIP_SOLO_TOGGLE
+ * and specify the strip number to 2, one can also SHIFT - left click
+ * the solo button of the second strip and send the MIDI event.
+ *
+ * \ingroup docGUI docWidgets docMIDI
+ */
+class MidiLearnable : EventListener
 {
 public:
-    MidiLearnable(){
-		m_pAction = nullptr;
-	}
+    MidiLearnable();
+	~MidiLearnable();
 
-    void setAction( std::shared_ptr<Action> pAction ){
-		m_pAction = pAction;
-    }
+    void setAction( std::shared_ptr<Action> pAction );
 
     std::shared_ptr<Action> getAction() const {
 		return m_pAction;
     }
 
+	/**
+	 * Update #m_registeredMidiEvents since the underlying
+	 * #H2Core::MidiMap changed.
+	 */
+	void midiMapChangedEvent() override;
+
+	/**
+	 * Indicates child class to recalculate its tool tip in case
+	 * #m_registeredMidiEvents changed.
+	 */
+	virtual void updateTooltip(){};
 
 protected:
     std::shared_ptr<Action> m_pAction;
+
+	/**
+	 * Stores all MIDI events mapped to #m_pAction.
+	 *
+	 * It consists of pairs of MIDI event strings ("NOTE", "CC", "PC",
+	 * "MMC_x") and the associated MIDI parameter.
+	 */ 
+	std::vector<std::pair<QString,int>> m_registeredMidiEvents;
 };
 
 #endif // MIDILEARNABLE_H

--- a/src/gui/src/Widgets/MidiLearnable.h
+++ b/src/gui/src/Widgets/MidiLearnable.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <QString>
 #include <core/MidiAction.h>
+#include <core/IO/MidiCommon.h>
 
 #include "../EventListener.h"
 
@@ -73,10 +74,10 @@ protected:
 	/**
 	 * Stores all MIDI events mapped to #m_pAction.
 	 *
-	 * It consists of pairs of MIDI event strings ("NOTE", "CC", "PC",
-	 * "MMC_x") and the associated MIDI parameter.
+	 * It consists of pairs of MIDI events and the associated MIDI
+	 * parameter.
 	 */ 
-	std::vector<std::pair<QString,int>> m_registeredMidiEvents;
+	std::vector<std::pair<H2Core::MidiMessage::Event,int>> m_registeredMidiEvents;
 };
 
 #endif // MIDILEARNABLE_H

--- a/src/gui/src/Widgets/MidiSenseWidget.cpp
+++ b/src/gui/src/Widgets/MidiSenseWidget.cpp
@@ -28,7 +28,10 @@
 #include <core/Hydrogen.h>
 #include <core/EventQueue.h>
 
-MidiSenseWidget::MidiSenseWidget(QWidget* pParent, bool bDirectWrite, std::shared_ptr<Action> pAction): QDialog( pParent )
+MidiSenseWidget::MidiSenseWidget(QWidget* pParent, bool bDirectWrite, std::shared_ptr<Action> pAction)
+	: QDialog( pParent )
+	, m_lastMidiEvent( H2Core::MidiMessage::Event::Null )
+	, m_nLastMidiEventParameter( 0 )
 {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	m_bDirectWrite = bDirectWrite;
@@ -66,10 +69,8 @@ MidiSenseWidget::MidiSenseWidget(QWidget* pParent, bool bDirectWrite, std::share
 	setLayout( pVBox );
 	
 	H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
-	pHydrogen->m_LastMidiEvent = "";
-	pHydrogen->m_nLastMidiEventParameter = 0;
-
-	m_LastMidiEventParameter = 0;
+	pHydrogen->setLastMidiEvent( H2Core::MidiMessage::Event::Null );
+	pHydrogen->setLastMidiEventParameter( 0 );
 	
 	m_pUpdateTimer = new QTimer( this );
 
@@ -92,49 +93,47 @@ MidiSenseWidget::~MidiSenseWidget(){
 
 void MidiSenseWidget::updateMidi(){
 	H2Core::Hydrogen *pHydrogen = H2Core::Hydrogen::get_instance();
-	if(	!pHydrogen->m_LastMidiEvent.isEmpty() ){
-		m_sLastMidiEvent = pHydrogen->m_LastMidiEvent;
-		m_LastMidiEventParameter = pHydrogen->m_nLastMidiEventParameter;
+	if ( pHydrogen->getLastMidiEvent() != H2Core::MidiMessage::Event::Null ){
 
+		m_lastMidiEvent = pHydrogen->getLastMidiEvent();
+		m_nLastMidiEventParameter = pHydrogen->getLastMidiEventParameter();
 
-		if( m_bDirectWrite ){
-			//write the action / parameter combination to the midiMap
+		if ( m_bDirectWrite ) {
+			// write the action / parameter combination to the midiMap
 			MidiMap *pMidiMap = MidiMap::get_instance();
 
 			assert(m_pAction);
 
-			std::shared_ptr<Action> pAction = std::make_shared<Action>( m_pAction->getType() );
+			std::shared_ptr<Action> pAction = std::make_shared<Action>( m_pAction );
+			pAction->setValue( "0" );
 
-			pAction->setParameter1( m_pAction->getParameter1() );
-			pAction->setParameter2( m_pAction->getParameter2() );
-			pAction->setParameter3( m_pAction->getParameter3() );
+			switch( m_lastMidiEvent ) {
+			case H2Core::MidiMessage::Event::CC: 
+				pMidiMap->registerCCEvent( m_nLastMidiEventParameter, pAction );
+				break;
 
-			bool bEventRegistered = true;
+			case H2Core::MidiMessage::Event::Note:
+				pMidiMap->registerNoteEvent( m_nLastMidiEventParameter, pAction );
+				break;
 
-			if( m_sLastMidiEvent.left(2) == "CC" ){
-				pMidiMap->registerCCEvent( m_LastMidiEventParameter , pAction );
-			}
-			else if( m_sLastMidiEvent.left(3) == "MMC" ){
-				pMidiMap->registerMMCEvent( m_sLastMidiEvent , pAction );
-			}
-			else if( m_sLastMidiEvent.left(4) == "NOTE" ){
-				pMidiMap->registerNoteEvent( m_LastMidiEventParameter , pAction );
-			}
-			else if (m_sLastMidiEvent.left(14) == "PROGRAM_CHANGE" ){
+			case H2Core::MidiMessage::Event::PC:
 				pMidiMap->registerPCEvent( pAction );
-			}
-			else {
-				bEventRegistered = false;
-				/* In all other cases, the midiMap cares for deleting the pointer */
-			}
-			if ( bEventRegistered ) {
-				H2Core::EventQueue::get_instance()->push_event( H2Core::EVENT_MIDI_MAP_CHANGED, 0 );
+				break;
+
+			case H2Core::MidiMessage::Event::Null:
+				return;
+
+			default:
+				// MMC event
+				pMidiMap->registerMMCEvent(
+					H2Core::MidiMessage::EventToQString( m_lastMidiEvent ),
+					pAction );
 			}
 
+			H2Core::EventQueue::get_instance()->push_event( H2Core::EVENT_MIDI_MAP_CHANGED, 0 );
 		}
 
 		close();
 	}
-
 }
 

--- a/src/gui/src/Widgets/MidiSenseWidget.h
+++ b/src/gui/src/Widgets/MidiSenseWidget.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <core/Object.h>
 #include <core/MidiAction.h>
+#include <core/IO/MidiCommon.h>
 
 /** \ingroup docGUI docWidgets docMIDI*/
 class MidiSenseWidget :  public QDialog , public H2Core::Object<MidiSenseWidget>
@@ -40,17 +41,25 @@ class MidiSenseWidget :  public QDialog , public H2Core::Object<MidiSenseWidget>
 		explicit MidiSenseWidget(QWidget*,bool bDirectWrite = false , std::shared_ptr<Action> pAction = nullptr);
 		~MidiSenseWidget();
 
-		QString		m_sLastMidiEvent;
-		int			m_LastMidiEventParameter;
-	
+		H2Core::MidiMessage::Event getLastMidiEvent() const;
+		int getLastMidiEventParameter() const;
+
 	private slots:
 		void		updateMidi();
 
 	private:
-		QTimer*		m_pUpdateTimer;
-		QLabel*		m_pURLLabel;
-		std::shared_ptr<Action>		m_pAction;
-		bool		m_bDirectWrite;
+		H2Core::MidiMessage::Event 		m_lastMidiEvent;
+		int								m_nLastMidiEventParameter;
+		QTimer*							m_pUpdateTimer;
+		QLabel*							m_pURLLabel;
+		std::shared_ptr<Action>			m_pAction;
+		bool							m_bDirectWrite;
 };
 
+inline H2Core::MidiMessage::Event MidiSenseWidget::getLastMidiEvent() const {
+	return m_lastMidiEvent;
+}
+inline int MidiSenseWidget::getLastMidiEventParameter() const {
+	return m_nLastMidiEventParameter;
+}
 #endif

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -240,7 +240,7 @@ void MidiTable::setupMidiTable()
 	}
 
 	for ( const auto& action : pMidiMap->getPCActions() ) {
-		if ( action->getType() != "NOTHING" ) {
+		if ( action->getType() != Action::getNullActionType() ) {
 			insertNewRow( action, "PROGRAM_CHANGE", 0 );
 		}
 	}
@@ -342,7 +342,7 @@ void MidiTable::updateRow( int nRow ) {
 	LCDSpinBox* pActionSpinner1 = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 4 ) );
 	LCDSpinBox* pActionSpinner2 = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 5 ) );
 	LCDSpinBox* pActionSpinner3 = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 6 ) );
-	if ( sActionType == "NOTHING" || sActionType.isEmpty() ) {
+	if ( sActionType == Action::getNullActionType() || sActionType.isEmpty() ) {
 		pActionSpinner1->hide();
 		pActionSpinner2->hide();
 		pActionSpinner3->hide();

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -27,6 +27,7 @@
 #include "MidiTable.h"
 
 #include <core/MidiMap.h>
+#include <core/IO/MidiCommon.h>
 #include <core/Preferences/Preferences.h>
 #include <core/Globals.h>
 #include <core/Hydrogen.h>
@@ -76,8 +77,10 @@ void MidiTable::midiSensePressed( int row ){
 	LCDSpinBox * eventSpinner = dynamic_cast <LCDSpinBox *> ( cellWidget( row, 2 ) );
 
 
-	eventCombo->setCurrentIndex( eventCombo->findText( midiSenseWidget.m_sLastMidiEvent ) );
-	eventSpinner->setValue( midiSenseWidget.m_LastMidiEventParameter );
+	eventCombo->setCurrentIndex( eventCombo->findText(
+									 H2Core::MidiMessage::EventToQString(
+										 midiSenseWidget.getLastMidiEvent() ) ) );
+	eventSpinner->setValue( midiSenseWidget.getLastMidiEventParameter() );
 
 	m_pUpdateTimer->start( 100 );
 
@@ -148,7 +151,7 @@ void MidiTable::insertNewRow(std::shared_ptr<Action> pAction, QString eventStrin
 
 	LCDCombo *eventBox = new LCDCombo(this);
 	eventBox->setSize( QSize( m_nColumn1Width, m_nRowHeight ) );
-	eventBox->insertItems( oldRowCount , pActionHandler->getEventList() );
+	eventBox->insertItems( oldRowCount , H2Core::MidiMessage::getEventList() );
 	eventBox->setCurrentIndex( eventBox->findText(eventString) );
 	connect( eventBox , SIGNAL( currentIndexChanged( int ) ) , this , SLOT( updateTable() ) );
 	connect( eventBox , SIGNAL( currentIndexChanged( int ) ),
@@ -227,21 +230,35 @@ void MidiTable::setupMidiTable()
 	setColumnWidth( 5 , m_nColumn5Width );
 	setColumnWidth( 6 , m_nColumn6Width );
 
-	for ( const auto& it : pMidiMap->getMMCActionMap() ) {
-		insertNewRow( it.second, it.first, 0 );
+	for ( const auto& [ssMmcType, ppAction] : pMidiMap->getMMCActionMap() ) {
+		if ( ppAction != nullptr && ! ppAction->isNull() ) {
+			insertNewRow( ppAction, ssMmcType, 0 );
+		}
 	}
 
-	for ( const auto& it : pMidiMap->getNoteActionMap() ) {
-		insertNewRow( it.second, "NOTE", it.first );
+	for ( const auto& [nnPitch, ppAction] : pMidiMap->getNoteActionMap() ) {
+		if ( ppAction != nullptr && ! ppAction->isNull() ) {
+			insertNewRow( ppAction,
+						  H2Core::MidiMessage::EventToQString(
+							  H2Core::MidiMessage::Event::Note ),
+						  nnPitch );
+		}
 	}
 
-	for ( const auto& it : pMidiMap->getCCActionMap() ) {
-		insertNewRow( it.second, "CC", it.first );
+	for ( const auto& [nnParam, ppAction] : pMidiMap->getCCActionMap() ) {
+		if ( ppAction != nullptr && ! ppAction->isNull() ) {
+			insertNewRow( ppAction,
+						  H2Core::MidiMessage::EventToQString(
+							  H2Core::MidiMessage::Event::CC ),
+						  nnParam );
+		}
 	}
 
-	for ( const auto& action : pMidiMap->getPCActions() ) {
-		if ( action->getType() != Action::getNullActionType() ) {
-			insertNewRow( action, "PROGRAM_CHANGE", 0 );
+	for ( const auto& ppAction : pMidiMap->getPCActions() ) {
+		if ( ppAction != nullptr && ! ppAction->isNull() ) {
+			insertNewRow( ppAction,
+						  H2Core::MidiMessage::EventToQString(
+							  H2Core::MidiMessage::Event::PC ), 0 );
 		}
 	}
 
@@ -263,13 +280,11 @@ void MidiTable::saveMidiTable()
 		LCDSpinBox * actionSpinner2 = dynamic_cast <LCDSpinBox *> ( cellWidget( row, 5 ) );
 		LCDSpinBox * actionSpinner3 = dynamic_cast <LCDSpinBox *> ( cellWidget( row, 6 ) );
 
-		QString eventString;
-		QString actionString;
-
 		if( !eventCombo->currentText().isEmpty() && !actionCombo->currentText().isEmpty() ){
-			eventString = eventCombo->currentText();
+			const QString sEventString = eventCombo->currentText();
+			const auto event = H2Core::MidiMessage::QStringToEvent( sEventString );
 
-			actionString = actionCombo->currentText();
+			const QString actionString = actionCombo->currentText();
 		
 			std::shared_ptr<Action> pAction = std::make_shared<Action>( actionString );
 
@@ -283,14 +298,27 @@ void MidiTable::saveMidiTable()
 				pAction->setParameter3( actionSpinner3->cleanText() );
 			}
 
-			if( eventString.left(2) == "CC" ){
+			switch ( event ) {
+			case H2Core::MidiMessage::Event::CC:
 				mM->registerCCEvent( eventSpinner->cleanText().toInt() , pAction );
-			} else if( eventString.left(3) == "MMC" ){
-				mM->registerMMCEvent( eventString , pAction );
-			} else if( eventString.left(4) == "NOTE" ){
+				break;
+				
+			case H2Core::MidiMessage::Event::Note:
 				mM->registerNoteEvent( eventSpinner->cleanText().toInt() , pAction );
-			} else if( eventString.left(14) == "PROGRAM_CHANGE" ){
+				break;
+				
+			case H2Core::MidiMessage::Event::PC:
 				mM->registerPCEvent( pAction );
+				break;
+				
+			case H2Core::MidiMessage::Event::Null:
+				// Event not recognized
+				continue;
+				
+			default:
+				// All remaining events should be different trades of
+				// MMC events. If not, registerMMCEvent will handle it.
+				mM->registerMMCEvent( sEventString , pAction );
 			}
 		}
 	}
@@ -315,28 +343,28 @@ void MidiTable::updateRow( int nRow ) {
 	// Adjust the event parameter spin box to fit the need of the
 	// particular event.
 	LCDSpinBox* pEventParameterSpinner = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 2 ) );
-	QString sEventString = pEventCombo->currentText();
-	
-	if ( sEventString.left(2) == "CC" ) {
+	const QString sEventString = pEventCombo->currentText();
+	const auto event = H2Core::MidiMessage::QStringToEvent( sEventString );
+
+	switch ( event ) {
+	case H2Core::MidiMessage::Event::CC:
 		pEventParameterSpinner->show();
 		pEventParameterSpinner->setMinimum( 0 );
 		pEventParameterSpinner->setMaximum( 127 );
-	}
-	else if ( sEventString.left(3) == "MMC" ) {
-		pEventParameterSpinner->hide();
-	}
-	else if ( sEventString.left(4) == "NOTE" ) {
+		break;
+		
+	case H2Core::MidiMessage::Event::Note:
 		pEventParameterSpinner->show();
 		pEventParameterSpinner->setMinimum( MIDI_OUT_NOTE_MIN );
 		pEventParameterSpinner->setMaximum( MIDI_OUT_NOTE_MAX );
-	}
-	else if ( sEventString.left(14) == "PROGRAM_CHANGE" ) {
-		pEventParameterSpinner->hide();
-	}
-	else {
-		pEventParameterSpinner->hide();
-	}
+		break;
 		
+	case H2Core::MidiMessage::Event::PC:
+	case H2Core::MidiMessage::Event::Null:
+	default:
+		// Includes all MMC events
+		pEventParameterSpinner->hide();
+	}
 
 	QString sActionType = pActionCombo->currentText();
 	LCDSpinBox* pActionSpinner1 = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 4 ) );

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -25,6 +25,7 @@
 #include "MidiSenseWidget.h"
 
 #include <core/Hydrogen.h>
+#include <core/MidiMap.h>
 
 #ifdef WIN32
 #    include "core/Timehelper.h"
@@ -52,8 +53,6 @@ WidgetWithInput::WidgetWithInput( QWidget* parent, bool bUseIntSteps, QString sB
 	, m_nWidgetWidth( 20 )
 	, m_sInputBuffer( "" )
 	, m_inputBufferTimeout( 2.0 )
-	, m_sRegisteredMidiEvent( "" )
-	, m_nRegisteredMidiParameter( 0 )
 	, m_bModifyOnChange( bModifyOnChange ) {
 	
 	setAttribute( Qt::WA_Hover );
@@ -77,10 +76,15 @@ void WidgetWithInput::updateTooltip() {
 	if ( m_pAction != nullptr ) {
 		sTip.append( QString( "\n%1: %2 " ).arg( pCommonStrings->getMidiTooltipHeading() )
 					 .arg( m_pAction->getType() ) );
-		if ( ! m_sRegisteredMidiEvent.isEmpty() ) {
-			sTip.append( QString( "%1 [%2 : %3]" ).arg( pCommonStrings->getMidiTooltipBound() )
-						 .arg( m_sRegisteredMidiEvent ).arg( m_nRegisteredMidiParameter ) );
-		} else {
+		if ( m_registeredMidiEvents.size() > 0 ) {
+			for ( const auto& event : m_registeredMidiEvents ) {
+				sTip.append( QString( "\n%1 [%2 : %3]" )
+							 .arg( pCommonStrings->getMidiTooltipBound() )
+							 .arg( event.first ).arg( event.second ) );
+			}
+
+		}
+		else {
 			sTip.append( QString( "%1" ).arg( pCommonStrings->getMidiTooltipUnbound() ) );
 		}
 	}
@@ -150,17 +154,8 @@ void WidgetWithInput::mousePressEvent(QMouseEvent *ev)
 	else if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ShiftModifier ) {
 		MidiSenseWidget midiSense( this, true, this->m_pAction );
 		midiSense.exec();
-
-		// Store the registered MIDI event and parameter in order to
-		// show them in the tooltip. Looking them up in the MidiMap
-		// using the Action associated to the Widget might not yield a
-		// unique result since the Action can be registered from the
-		// PreferencesDialog as well.
-		m_sRegisteredMidiEvent = H2Core::Hydrogen::get_instance()->m_LastMidiEvent;
-		m_nRegisteredMidiParameter = H2Core::Hydrogen::get_instance()->m_nLastMidiEventParameter;
 	
 		m_bIgnoreMouseMove = true;
-		updateTooltip();
 	}
 	else {
 		setCursor( QCursor( Qt::SizeVerCursor ) );
@@ -424,9 +419,4 @@ void WidgetWithInput::setDefaultValue( float fDefaultValue )
 void WidgetWithInput::resetValueToDefault()
 {
 	setValue( m_fDefaultValue, true );
-}
-
-void WidgetWithInput::setAction( std::shared_ptr<Action> pAction ) {
-	m_pAction = pAction;
-	updateTooltip();
 }

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -77,10 +77,20 @@ void WidgetWithInput::updateTooltip() {
 		sTip.append( QString( "\n%1: %2 " ).arg( pCommonStrings->getMidiTooltipHeading() )
 					 .arg( m_pAction->getType() ) );
 		if ( m_registeredMidiEvents.size() > 0 ) {
-			for ( const auto& event : m_registeredMidiEvents ) {
-				sTip.append( QString( "\n%1 [%2 : %3]" )
-							 .arg( pCommonStrings->getMidiTooltipBound() )
-							 .arg( event.first ).arg( event.second ) );
+			for ( const auto& [event, nnParam] : m_registeredMidiEvents ) {
+				if ( event == H2Core::MidiMessage::Event::Note ||
+					 event == H2Core::MidiMessage::Event::CC ) {
+					sTip.append( QString( "\n%1 [%2 : %3]" )
+								 .arg( pCommonStrings->getMidiTooltipBound() )
+								 .arg( H2Core::MidiMessage::EventToQString( event ) )
+								 .arg( nnParam ) );
+				}
+				else {
+					// PC and MMC_x do not have a parameter.
+					sTip.append( QString( "\n%1 [%2]" )
+								 .arg( pCommonStrings->getMidiTooltipBound() )
+								 .arg( H2Core::MidiMessage::EventToQString( event ) ) );
+				}
 			}
 
 		}

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -91,8 +91,6 @@ public:
 	int getScrollSpeedFast() const;
 	void setScrollSpeedFast( int nScrollSpeedFast ) const;
 
-	void setAction( std::shared_ptr<Action> pAction );
-
 signals:
 	void valueChanged(WidgetWithInput *ref);	
 
@@ -105,7 +103,7 @@ protected:
 	virtual void leaveEvent( QEvent *ev );
 	virtual void keyPressEvent( QKeyEvent *ev );
 
-	void updateTooltip();
+	void updateTooltip() override;
 	
 	bool m_bUseIntSteps;
 	QString m_sBaseTooltip;
@@ -135,9 +133,6 @@ protected:
 	/** Number of seconds before #m_sInputBuffer will be flushed
 		(happens asynchronically whenever the next key input occurs.)*/
 	double m_inputBufferTimeout;
-
-	QString m_sRegisteredMidiEvent;
-	int m_nRegisteredMidiParameter;
 
 	/** Whether Hydrogen::setIsModified() is invoked with `true` as
 		soon as the value of the widget does change.*/


### PR DESCRIPTION
In 1.2 I introduced a tool tip for all `MidiLearnable` widgets showing what `Action` they do represent and which MIDI event they are mapped to.

But it was not the whole story yet. An Action can be mapped to several MIDI Events which all have to be listed in the tool tip. In addition, those MIDI-learnable are just a more convenient way to add rows to the `MidiTable` in the `PreferencesDialog`. All mappings done their and all changes applied have to be represented in the tool tips as well. Previously, just those mappings done using `MidiSenseWidget` were used.

Also, since 1.2 an incoming MIDI event can be mapped to several Actions (the UX also suggest this to be possible previously. But only the last Action took precedence and all other were discarded).

But the check determining whether the MIDI event was already mapped to this Action was flawed and multiple instances of the same incoming message could be mapped to the same Action (causing it to be triggered multiple times).