### PR TITLE
AudioEngine: fix mode change tempo glitches (#1785)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,8 +8,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		  will be shown.
 		- Fix MIDI note output for channel 16 (previously only channel
 		  1-15 were accessible in the InstrumentEditor).
-		- Fix spurious tempo changes to 120bpm when switching songs
-		  (#1779)
+		- Fix spurious tempo changes to 120bpm when switching songs or
+		  between pattern and song mode (#1779 and #1785)
 		- Support "START", "CONTINUE", and "STOP" type System Realtime
 		  MIDI messages in PortMidi and CoreMidi.
 		- Fix MIDI action binding to incoming MMC_DEFERRED_PLAY event.

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -586,6 +586,12 @@ private:
 	 */
 	void handleDriverChange();
 
+	/**
+	 * Called whenever Hydrogen switches from #Song::Mode::Song into
+	 * #Song::Mode::Pattern or the other way around.
+	 */
+	void switchMode();
+
 	Sampler* 			m_pSampler;
 	Synth* 				m_pSynth;
 	AudioOutput *		m_pAudioDriver;

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -911,8 +911,9 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
+	auto pSong = pHydrogen->getSong();
 
-	if ( pHydrogen->getSong() == nullptr ) {
+	if ( pSong == nullptr ) {
 		ERRORLOG( "no song set" );
 		return false;
 	}
@@ -926,17 +927,16 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 	pHydrogen->sequencer_stop();
 
 	pAudioEngine->lock( RIGHT_HERE );
-	pAudioEngine->reset( true );
-	
+
 	if ( bActivate && pHydrogen->getMode() != Song::Mode::Song ) {
 		pHydrogen->setMode( Song::Mode::Song );
-	} else if ( ! bActivate && pHydrogen->getMode() != Song::Mode::Pattern ) {
+	}
+	else if ( ! bActivate && pHydrogen->getMode() != Song::Mode::Pattern ) {
 		pHydrogen->setMode( Song::Mode::Pattern );
 	}
+	
+	pAudioEngine->switchMode();
 
-	// Ensure the playing patterns are properly updated regardless of
-	// the state of transport before switching song modes.
-	pAudioEngine->updatePlayingPatterns();
 	pAudioEngine->unlock();
 	
 	return true;


### PR DESCRIPTION
A dedicated method for handling switching between pattern and song mode was introduced. Previously, the `AudioEngine` was reset but the song tempo was not reintroduced.

Fixes #1785