### PR TITLE
Fix CC MIDI feedback

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix MIDI (output) feedback for metronome toggling and pan
+		  setting.
 		- Fix superfluous MIDI event - Action bindings. An incoming MIDI
 		  event can be mapped to an Action only once.
 		- Fix tool tips of MIDI-learnable widgets. All bounded MIDI events

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -210,7 +210,7 @@ bool CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelec
 			pHydrogen->setSelectedInstrumentNumber( nStrip );
 		}
 
-		return sendStripPanSymFeedback( nStrip );
+		return sendStripPanFeedback( nStrip );
 	}
 
 	return false;
@@ -399,33 +399,6 @@ bool CoreActionController::sendStripPanFeedback( int nStrip ) {
 
 		return handleOutgoingControlChanges( ccParamValues,
 											 pInstr->getPanWithRangeFrom0To1() * 127 );
-	}
-
-	return false;
-}
-
-bool CoreActionController::sendStripPanSymFeedback( int nStrip ) {
-	auto pInstr = getStrip( nStrip );
-	if ( pInstr != nullptr ) {
-
-#ifdef H2CORE_HAVE_OSC
-		if ( Preferences::get_instance()->getOscFeedbackEnabled() ) {
-			std::shared_ptr<Action> pFeedbackAction =
-				std::make_shared<Action>( "PAN_ABSOLUTE_SYM" );
-		
-			pFeedbackAction->setParameter1( QString("%1").arg( nStrip + 1 ) );
-			pFeedbackAction->setValue( QString("%1")
-									   .arg( pInstr->getPan() ) );
-			OscServer::get_instance()->handleAction( pFeedbackAction );
-		}
-#endif
-	
-		MidiMap* pMidiMap = MidiMap::get_instance();
-		auto ccParamValues = pMidiMap->findCCValuesByActionParam1( QString("PAN_ABSOLUTE_SYM"),
-																   QString("%1").arg( nStrip ) );
-
-		return handleOutgoingControlChanges( ccParamValues,
-											 pInstr->getPan() * 127 );
 	}
 
 	return false;

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1209,8 +1209,12 @@ bool MidiActionManager::toggle_metronome( std::shared_ptr<Action> , Hydrogen* pH
 		ERRORLOG( "No song set yet" );
 		return false;
 	}
+
+	// Use the wrapper in CAC over a plain setting of the parameter in
+	// order to send MIDI feedback
+	pHydrogen->getCoreActionController()->setMetronomeIsActive( 
+		! Preferences::get_instance()->m_bUseMetronome );
 	
-	Preferences::get_instance()->m_bUseMetronome = !Preferences::get_instance()->m_bUseMetronome;
 	return true;
 }
 


### PR DESCRIPTION
`MidiAction::toggle_metronome` was not properly wired to send MIDI feedback and `CoreActionController::sendMetronomeIsActiveFeedback()` was only triggered in case a CC MIDI event was mapped to `TOGGLE_METRONOME` and the metronome button in the `PlayerControl` was pressed.

There is no use at all to have a MIDI feedback function sending pan values in the range of [-127,127] as MIDI supports just values between [0,127]. The `CoreActionController::setStripPanSym()` and `CoreActionController::setStripPan()` functions do now send the same feedback.

Fixes #1636 