### PR TITLE
DEBUG: more pipeline qDebug()s

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -711,6 +711,7 @@ bool Hydrogen::startExportSession( int nSampleRate, int nSampleDepth )
 /// Export a song to a wav file
 void Hydrogen::startExportSong( const QString& filename)
 {
+	qDebug() << "[Hydrogen::startExportSong] beginning";
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	getCoreActionController()->locateToTick( 0 );
 	pAudioEngine->play();
@@ -719,6 +720,7 @@ void Hydrogen::startExportSong( const QString& filename)
 	DiskWriterDriver* pDiskWriterDriver = static_cast<DiskWriterDriver*>(pAudioEngine->getAudioDriver());
 	pDiskWriterDriver->setFileName( filename );
 	pDiskWriterDriver->write();
+	qDebug() << "[Hydrogen::startExportSong] end";
 }
 
 void Hydrogen::stopExportSong()

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -61,6 +61,7 @@ void* diskWriterDriver_thread( void* param )
 	auto pAudioEngine = Hydrogen::get_instance()->getAudioEngine();
 	
 	__INFOLOG( "DiskWriterDriver thread start" );
+	qDebug() << "[diskWriterDriver_thread] started";
 
 	// always rolling, no user interaction
 	pAudioEngine->play();
@@ -142,16 +143,17 @@ void* diskWriterDriver_thread( void* param )
 		return nullptr;
 	}
 
-
+	qDebug() << "[diskWriterDriver_thread] setup";
 	SNDFILE* m_file = sf_open( pDriver->m_sFilename.toLocal8Bit(), SFM_WRITE, &soundInfo );
 	if ( m_file == nullptr ) {
 		__ERRORLOG( QString( "Unable to open file [%1] using libsndfile: %2" )
 					.arg( pDriver->m_sFilename )
 					.arg( sf_strerror( nullptr ) ) );
+		qDebug() << "[diskWriterDriver_thread] ERROR: unable to create file";
 		pthread_exit( nullptr );
 		return nullptr;
 	}
-	
+	qDebug() << "[diskWriterDriver_thread] file created";
 							  
 	float *pData = new float[ pDriver->m_nBufferSize * 2 ];	// always stereo
 


### PR DESCRIPTION
macOS pipeline build https://ci.appveyor.com/project/mauser/hydrogen/builds/47177927/job/2059c9uxwadkt9da shed some light on the failing macOS tests that caused the job to get stuck and timeout after an hour. It seems that this is not due to rounding errors in the PROGRESS event after all but either the `diskWriterDriver_thread` can not be created properly or it exits because the output file could not be created

related to #1766