### PR TITLE
fix spurious modified flags on opened songs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix spurious marking of opened songs as modified.
 		- Fix MIDI (output) feedback for metronome toggling and pan
 		  setting.
 		- Fix superfluous MIDI event - Action bindings. An incoming MIDI

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -602,6 +602,9 @@ bool CoreActionController::setSong( std::shared_ptr<Song> pSong, bool bRelinking
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::unavailable ) {
 		EventQueue::get_instance()->push_event( EVENT_UPDATE_SONG, 0 );
 	}
+
+	// As we just set a fresh song, we can mark it not modified
+	pHydrogen->setIsModified( false );
 	
 	return true;
 }

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -501,6 +501,11 @@ void InstrumentEditor::updateSongEvent( int nValue ) {
 	// A new song got loaded
 	if ( nValue == 0 ) {
 		selectedInstrumentChangedEvent();
+
+		// The function call above sets some spurious isModified when
+		// updating the states of the widgets. This has to be reset
+		// for a freshly loaded song.
+		H2Core::Hydrogen::get_instance()->setIsModified( false );
 	}
 }
 
@@ -510,7 +515,6 @@ void InstrumentEditor::drumkitLoadedEvent() {
 
 void InstrumentEditor::selectedInstrumentChangedEvent()
 {
-	
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	


### PR DESCRIPTION
Opening the initial song during startup reset the modified flag properly. But when opening another song within a running Hydrogen instance the freshly opened song is marked modified.

`CoreActionController::setSong` is now properly resetting the modified flag when setting (opening) a different song. In addition, updating the widgets in the `InstrumentEditor` to the values of the opened song, also introduced a spurious modified flag. This is now reset explicitly too