### PR TITLE
Fix playlist restoring

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,10 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes
+		- Fix reopening of last used Playlist. In addition, in case the
+		  PlaylistDialog was opened at the end of the last session - when
+		  "Reopen last used playlist" is checked in the Preferences - the
+		  dialog will be reopened too at the same position.
 		- Fix spurious marking of opened songs as modified.
 		- Fix MIDI (output) feedback for metronome toggling and pan
 		  setting.

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -255,6 +255,7 @@ Preferences::Preferences()
 	songEditorProperties.set(10, 10, 600, 250, true);
 	instrumentRackProperties.set(500, 20, 526, 437, true);
 	audioEngineInfoProperties.set(720, 120, 0, 0, false);
+	m_playlistDialogProperties.set(200, 300, 961, 397, false);
 	m_ladspaProperties[0].set(2, 20, 0, 0, false);
 	m_ladspaProperties[1].set(2, 20, 0, 0, false);
 	m_ladspaProperties[2].set(2, 20, 0, 0, false);
@@ -629,6 +630,7 @@ void Preferences::loadPreferences( bool bGlobal )
 				setSongEditorProperties( readWindowProperties( guiNode, "songEditor_properties", songEditorProperties ) );
 				setInstrumentRackProperties( readWindowProperties( guiNode, "instrumentRack_properties", instrumentRackProperties ) );
 				setAudioEngineInfoProperties( readWindowProperties( guiNode, "audioEngineInfo_properties", audioEngineInfoProperties ) );
+				setPlaylistDialogProperties( readWindowProperties( guiNode, "playlistDialog_properties", m_playlistDialogProperties ) );
 
 				// last used file dialog folders
 				m_sLastExportPatternAsDirectory = guiNode.read_string( "lastExportPatternAsDirectory", QDir::homePath(), true, false, true );
@@ -1070,6 +1072,7 @@ bool Preferences::savePreferences()
 		writeWindowProperties( guiNode, "songEditor_properties", songEditorProperties );
 		writeWindowProperties( guiNode, "instrumentRack_properties", instrumentRackProperties );
 		writeWindowProperties( guiNode, "audioEngineInfo_properties", audioEngineInfoProperties );
+		writeWindowProperties( guiNode, "playlistDialog_properties", m_playlistDialogProperties );
 		for ( unsigned nFX = 0; nFX < MAX_FX; nFX++ ) {
 			QString sNode = QString("ladspaFX_properties%1").arg( nFX );
 			writeWindowProperties( guiNode, sNode, m_ladspaProperties[nFX] );

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -541,6 +541,9 @@ public:
 	WindowProperties	getLadspaProperties( unsigned nFX );
 	void			setLadspaProperties( unsigned nFX, const WindowProperties& prop );
 
+	WindowProperties	getPlaylistDialogProperties();
+	void				setPlaylistDialogProperties( const WindowProperties& prop );
+
 	const std::shared_ptr<ColorTheme>	getColorTheme() const;
 	void			setColorTheme( const std::shared_ptr<ColorTheme> pNewColorTheme );
 
@@ -760,6 +763,7 @@ private:
 	WindowProperties		instrumentRackProperties;
 	WindowProperties		audioEngineInfoProperties;
 	WindowProperties		m_ladspaProperties[MAX_FX];
+	WindowProperties		m_playlistDialogProperties;
 
 	QString					m_sPreferredLanguage;
 
@@ -1320,6 +1324,13 @@ inline WindowProperties Preferences::getLadspaProperties( unsigned nFX ) {
 }
 inline void Preferences::setLadspaProperties( unsigned nFX, const WindowProperties& prop ) {
 	m_ladspaProperties[nFX] = prop;
+}
+
+inline WindowProperties Preferences::getPlaylistDialogProperties() {
+	return m_playlistDialogProperties;
+}
+inline void Preferences::setPlaylistDialogProperties( const WindowProperties& prop ) {
+	m_playlistDialogProperties = prop;
 }
 
 inline const std::shared_ptr<ColorTheme> Preferences::getColorTheme() const {

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -112,6 +112,9 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm )
 	m_pFilesystemInfoForm = new FilesystemInfoForm( nullptr );
 
 	m_pPlaylistDialog = new PlaylistDialog( nullptr );
+	WindowProperties playlistDialogProp = pPref->getPlaylistDialogProperties();
+	setWindowProperties( m_pPlaylistDialog, playlistDialogProp, SetX + SetY );
+
 	m_pDirector = new Director( nullptr );
 
 	// Initially keyboard cursor is hidden.

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -202,11 +202,21 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 	m_pUndoView->setWindowTitle(tr("Undo history"));
 
 	//restore last playlist
-	if(	pPref->isRestoreLastPlaylistEnabled()
-		&& ! pPref->getLastPlaylistFilename().isEmpty() ){
-		bool loadlist = h2app->getPlayListDialog()->loadListByFileName( pPref->getLastPlaylistFilename() );
-		if( !loadlist ){
-			_ERRORLOG ( "Error loading the playlist" );
+	if ( pPref->isRestoreLastPlaylistEnabled() &&
+		 ! pPref->getLastPlaylistFilename().isEmpty() ) {
+		bool bLoadSuccessful = h2app->getPlayListDialog()->loadListByFileName(
+			pPref->getLastPlaylistFilename() );
+		if ( bLoadSuccessful ) {
+			if ( pPref->getPlaylistDialogProperties().visible ){
+				// If there was a playlist used during the last
+				// session and it was still visible/shown when closing
+				// Hydrogen, bring it up again.
+				action_window_showPlaylistDialog();
+			}
+		}
+		else {
+			_ERRORLOG( QString( "Unable to load last playlist [%1]" )
+					   .arg( pPref->getLastPlaylistFilename() ) );
 		}
 	}
 
@@ -1479,6 +1489,9 @@ void MainForm::savePreferences() {
 	pPreferences->setInstrumentRackProperties( h2app->getWindowProperties( h2app->getInstrumentRack() ) );
 	// save audio engine info properties
 	pPreferences->setAudioEngineInfoProperties( h2app->getWindowProperties( h2app->getAudioEngineInfoForm() ) );
+
+	pPreferences->setPlaylistDialogProperties(
+		h2app->getWindowProperties( h2app->getPlayListDialog() ) );
 
 #ifdef H2CORE_HAVE_LADSPA
 	// save LADSPA FX window properties

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -237,9 +237,6 @@ MainForm::~MainForm()
 		file.remove();
 	}
 
-	//if a playlist is used, we save the last playlist-path to hydrogen.conf
-	Preferences::get_instance()->setLastPlaylistFilename( Playlist::get_instance()->getFilename() );
-
 	if ( (Hydrogen::get_instance()->getAudioEngine()->getState() == H2Core::AudioEngine::State::Playing) ) {
 		Hydrogen::get_instance()->sequencer_stop();
 	}
@@ -1492,6 +1489,11 @@ void MainForm::savePreferences() {
 }
 
 void MainForm::closeAll(){
+	// Store the last playlist in the Preferences in order to allow to
+	// reopen it at startup.
+	Preferences::get_instance()->setLastPlaylistFilename(
+		Playlist::get_instance()->getFilename() );
+
 	savePreferences();
 	m_pQApp->quit();
 }


### PR DESCRIPTION
The path to the last `Playlist` used was written to the Preferences _after_ the Preferences were written to disk.

In addition, the window properties of the `PlaylistDialog` including its visibility (but only in case "Reopen last used playlist" was checked in the Preferences)