### PR TITLE
PortMidi: support virtual devices

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,10 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
+	* Release 1.3.0
+	* PortMidi driver does open a input/output port which can be
+		discovered and connected to by other applications when port was
+		set to "None" in the Preferences (not supported on Windows).
+
+XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1
 	* Update French translation
 	* Bugfixes

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -164,7 +164,6 @@ PortMidiDriver::~PortMidiDriver()
 void PortMidiDriver::handleOutgoingControlChange( int param, int value, int channel )
 {
 	if ( m_pMidiOut == nullptr ) {
-		ERRORLOG( "m_pMidiOut = nullptr " );
 		return;
 	}
 
@@ -367,7 +366,6 @@ std::vector<QString> PortMidiDriver::getOutputPortList()
 void PortMidiDriver::handleQueueNote(Note* pNote)
 {
 	if ( m_pMidiOut == nullptr ) {
-		ERRORLOG( "m_pMidiOut = nullptr " );
 		return;
 	}
 
@@ -402,7 +400,6 @@ void PortMidiDriver::handleQueueNote(Note* pNote)
 void PortMidiDriver::handleQueueNoteOff( int channel, int key, int velocity )
 {
 	if ( m_pMidiOut == nullptr ) {
-		ERRORLOG( "m_pMidiOut = nullptr " );
 		return;
 	}
 
@@ -425,7 +422,6 @@ void PortMidiDriver::handleQueueNoteOff( int channel, int key, int velocity )
 void PortMidiDriver::handleQueueAllNoteOff()
 {
 	if ( m_pMidiOut == nullptr ) {
-		ERRORLOG( "m_pMidiOut = nullptr " );
 		return;
 	}
 

--- a/src/core/IO/PortMidiDriver.h
+++ b/src/core/IO/PortMidiDriver.h
@@ -67,7 +67,8 @@ public:
 	static bool appendSysExData( MidiMessage* pMidiMessage, PmMessage msg );
 
 private:
-
+	int m_nVirtualInputDeviceId;
+	int m_nVirtualOutputDeviceId;
 };
 
 };


### PR DESCRIPTION
when setting "None" for MIDI input or output PortMidi does now create a virtual device instead of none at all. This means when started there is no MIDI connection established. But external applications will be able discover Hydrogens ports and to connect to them. This PortMidi feature is only available on macOS and Linux but not on Windows.

On Linux this still gives a different UX than using pure ALSA MIDI driver, but we are getting closer.