### PR TITLE
releases/1.2: fix compatibility with PortMidi 217

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -141,7 +141,7 @@ for:
       CPUS=$(nproc)
       echo "Building with $CPUS cpus"
       mkdir build && cd build && \
-        cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 .. \
+        cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_PORTMIDI=1 -DWANT_RUBBERBAND=1 .. \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           && \
         make -j $CPUS

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,10 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		  currently selected one.
 		- Do not start playback at cursor when cursor in Song Editor is
 		  beyond the current song length.
+		- Fixed compatibility with PortMidi version 217 (Hydrogen v1.2.1
+		  was incompatible) (#1795). All versions of Hydrogen >=1.3 will,
+		  however, require on a more recent PortMidi version (at least
+		  v2.0.1).
 
 2023-06-08 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -214,10 +214,9 @@ void PortMidiDriver::open()
 					nOutDeviceId = i;
 				}
 			}
-			INFOLOG( QString( "%1%2%3%4device called [%5] using [%6] MIDI API" )
+			INFOLOG( QString( "%1%2%3device called [%4] using [%5] MIDI API" )
 					 .arg( nDeviceId == i || nOutDeviceId == i ? "Using " :
 						   "Found available " )
-					 .arg( pInfo->is_virtual == TRUE ? "virtual " : "" )
 					 .arg( pInfo->input == TRUE ? "input " : "" )
 					 .arg( pInfo->output == TRUE ? "output " : "" )
 					 .arg( pInfo->name ).arg( pInfo->interf ) );


### PR DESCRIPTION
all code requiring a recent version of PortMidi have been removed from the releases/1.2 branch.

within the Linux build pipeline PortMidi development files are installed but, strangely, Hydrogen is not build with PortMidi support. Thats why the compilation failure in https://github.com/hydrogen-music/hydrogen/issues/1795 and https://github.com/hydrogen-music/hydrogen/issues/1798 slipped by unnoticed.