### PR TITLE
AppVeyor/win: pin qttools to 5.15.9-1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -312,7 +312,7 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
-
+          c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
           ccache -M 256M
           ccache -s
 


### PR DESCRIPTION
as `windeployqt.exe` makes the Windows pipeline fail in the most recent Qt5 version. (Something that seems to happen only on AppVeyor. I can not reproduce it on my local Windows machine)