### PR TITLE
cmake: remove HAVE_JACK_PORT_RENAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,6 @@ ELSE()
   #32bit Windows and all other OS
   FIND_HELPER(JACK jack jack/jack.h jack)
 ENDIF()
-CHECK_LIBRARY_EXISTS(jack jack_port_rename "" HAVE_JACK_PORT_RENAME)
 IF(APPLE)
     FIND_LIBRARY(AUDIOUNIT_LIBRARY AudioUnit)
     FIND_LIBRARY(CORESERVICES_LIBRARY CoreServices)

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -944,16 +944,11 @@ void JackAudioDriver::setTrackOutput( int n, std::shared_ptr<Instrument> pInstru
 	sComponentName = QString( "Track_%1_%2_%3_" ).arg( n + 1 )
 		.arg( pInstrument->get_name() ).arg( pDrumkitComponent->get_name() );
 
-#ifdef HAVE_JACK_PORT_RENAME
 	// This differs from jack_port_set_name() by triggering
 	// PortRename notifications to clients that have registered a
 	// port rename handler.
 	jack_port_rename( m_pClient, m_pTrackOutputPortsL[n], ( sComponentName + "L" ).toLocal8Bit() );
 	jack_port_rename( m_pClient, m_pTrackOutputPortsR[n], ( sComponentName + "R" ).toLocal8Bit() );
-#else
-	jack_port_set_name( m_pTrackOutputPortsL[n], ( sComponentName + "L" ).toLocal8Bit() );
-	jack_port_set_name( m_pTrackOutputPortsR[n], ( sComponentName + "R" ).toLocal8Bit() );
-#endif
 }
 
 void JackAudioDriver::startTransport()

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -421,21 +421,7 @@ private:
 	/**
 	 * Renames the @a n 'th port of JACK client and creates it if
 	 * it's not already present. 
-	 *
-	 * If the track number @a n is bigger than the number of ports
-	 * currently in usage #m_nTrackPortCount, @a n + 1 -
-	 * #m_nTrackPortCount new stereo ports will be created using
-	 * _jack_port_register()_ (jack/jack.h) and #m_nTrackPortCount
-	 * updated to @a n + 1.
-	 *
-	 * Afterwards, the @a n 'th port is renamed to a concatenation of
-	 * "Track_", DrumkitComponent::__name, "_", @a n + 1, "_",
-	 * Instrument::__name, and "_L", or "_R" using either
-	 * _jack_port_rename()_ (if HAVE_JACK_PORT_RENAME is defined) or
-	 * _jack_port_set_name()_ (both jack/jack.h). The former renaming
-	 * function triggers a _PortRename_ notifications to clients that
-	 * have registered a port rename handler.
-	 *
+  	 *
 	 * \param n Track number for which a port should be renamed
 	 *   (and created).
 	 * \param instr Pointer to the corresponding Instrument.

--- a/src/core/config.dox
+++ b/src/core/config.dox
@@ -94,10 +94,6 @@
  * Check whether the realtime clock _rtclock.c_ is present.
  */
 #define HAVE_RTCLOCK
-/**
- * Check whether a library called _jack_port_rename_ is present.
- */
-#define HAVE_JACK_PORT_RENAME
 
 /** Checks whether the user enabled debugging. Default: TRUE */
 #define H2CORE_HAVE_DEBUG

--- a/src/core/config.h.in
+++ b/src/core/config.h.in
@@ -32,7 +32,6 @@
 
 #cmakedefine HAVE_SSCANF
 #cmakedefine HAVE_RTCLOCK
-#cmakedefine HAVE_JACK_PORT_RENAME
 #cmakedefine HAVE_EXECINFO_H
 
 #ifndef H2CORE_HAVE_DEBUG


### PR DESCRIPTION
in macOS `cmake` seems to be unable to determine whether the `jack_port_rename` function is located in the installed library.

I removed this switch entirely as the `jack_port_rename` function was introduced into the JACK API 8 years ago and is present on all supported platforms by now.