### PR TITLE
Debug: more debug messages in DiskWriterDriver

### DIFF
--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -219,11 +219,13 @@ void* diskWriterDriver_thread( void* param )
 				nLastRun = nPatternLengthInFrames - nFrameNumber;
 				nUsedBuffer = nLastRun;
 			};
-
+			
+			qDebug() << "[diskWriterDriver_thread] while loop pre processCallback";
 			int ret = pDriver->m_processCallback( nUsedBuffer, nullptr );
 			
 			// In case the DiskWriter couldn't acquire the lock of the AudioEngine.
 			while( ret == 2 ) {
+				qDebug() << "[diskWriterDriver_thread] while loop could not acquire mutex";
 				ret = pDriver->m_processCallback( nUsedBuffer, nullptr );
 			}
 
@@ -281,6 +283,7 @@ void* diskWriterDriver_thread( void* param )
 					pData[ ii * 2 + 1 ] = pData_R[ ii ];
 				}
 			}
+			qDebug() << "[diskWriterDriver_thread] writing data";
 			
 			const int res = sf_writef_float( m_file, pData, nBufferWriteLength );
 			qDebug() << "[diskWriterDriver_thread] data written: " << res;
@@ -297,13 +300,14 @@ void* diskWriterDriver_thread( void* param )
 			if ( nSuccessiveZeros == nMaxNumberOfSilentFrames ) {
 				break;
 			}
+			qDebug() << "[diskWriterDriver_thread] while loop done" << res;
 		}
 		
 		// this progress bar method is not exact but ok enough to give users a usable visible progress feedback
 		int nPercent = static_cast<int>( ( float )(patternPosition +1) /
 										 ( float )nColumns * 100.0 );
+		qDebug() << "[diskWriterDriver_thread] nPrecent: " << nPercent;
 		if ( nPercent < 100 ) {
-			qDebug() << "[diskWriterDriver_thread] nPrecent: " << nPercent;
 			EventQueue::get_instance()->push_event( EVENT_PROGRESS, nPercent );
 		}
 	}


### PR DESCRIPTION
in https://ci.appveyor.com/project/mauser/hydrogen/builds/47546760/job/7wr7cciduryo86ij it seems Hydrogen stopped while processing the song and writing data.

It is not evident what is going wrong yet but currently I do see two possible causes: 1) for some reason the process callback is not able anymore to acquire the mutex of the audio engine (which would be really bad) or 2) the pthread started by the `DiskWriterDriver` suddenly dies. 2) is we should take care of regardless of whether it is the cause of the sporadic failures of the macOS pipeline or not.