### PR TITLE
Fix PlaylistDialog layout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		  currently selected one.
 		- Do not start playback at cursor when cursor in Song Editor is
 		  beyond the current song length.
+		- Playlist dialog can now be resized and remembers geometry,
+		  position, as well as visibility.
 
 2023-06-08 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -4368,7 +4368,7 @@ Le chemin vers le script et le nom du script doivent être sans espaces.</transl
     </message>
     <message>
         <source>&amp;Define</source>
-        <source>&amp;Définir</source>
+        <translation>&amp;Définir</translation>
     </message>
     <message>
         <source>Add additional rows for the select actions to allow them to be bound to further shortcuts</source>

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -113,7 +113,7 @@ HydrogenApp::HydrogenApp( MainForm *pMainForm )
 
 	m_pPlaylistDialog = new PlaylistDialog( nullptr );
 	WindowProperties playlistDialogProp = pPref->getPlaylistDialogProperties();
-	setWindowProperties( m_pPlaylistDialog, playlistDialogProp, SetX + SetY );
+	setWindowProperties( m_pPlaylistDialog, playlistDialogProp, SetAll );
 
 	m_pDirector = new Director( nullptr );
 	WindowProperties directorProp = pPref->getDirectorProperties();
@@ -1025,7 +1025,7 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 		m_pMixer->updateMixer();
 
 		WindowProperties playlistDialogProp = pPref->getPlaylistDialogProperties();
-		setWindowProperties( m_pPlaylistDialog, playlistDialogProp );
+		setWindowProperties( m_pPlaylistDialog, playlistDialogProp, SetAll );
 
 		WindowProperties directorProp = pPref->getDirectorProperties();
 		setWindowProperties( m_pDirector, directorProp, SetAll );

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -75,18 +75,21 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 	m_pPlaylistTree->setFont( font );
 	
 	setWindowTitle ( tr ( "Playlist Browser" ) + QString(" - ") + Playlist::get_instance()->getFilename() );
-	setFixedSize ( width(), height() );
 
 	installEventFilter( this );
 
 	m_pMenubar = new QMenuBar( this );
 	populateMenuBar();
-	
+
+	QHBoxLayout* pMenuBarLayout = new QHBoxLayout( menuBarWidget );
+	pMenuBarLayout->setSpacing(0);
+	pMenuBarLayout->setContentsMargins( 0, 0, 0, 0 );
+	pMenuBarLayout->addWidget( m_pMenubar );
+
 	// CONTROLS
-	PixmapWidget *pControlsPanel = new PixmapWidget( nullptr );
+	PixmapWidget *pControlsPanel = new PixmapWidget( controlWidget );
 	pControlsPanel->setFixedSize( 119, 32 );
 	pControlsPanel->setPixmap( "/playerControlPanel/playlist_background_Control.png" );
-	vboxLayout->addWidget( pControlsPanel );
 
 	// Rewind button
 	m_pRwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "rewind.svg", "", false, QSize( 13, 13 ), tr("Rewind") );
@@ -139,27 +142,30 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 	newScriptBTN->hide();
 		clearPlBTN->setEnabled ( false );*/
 
-	QVBoxLayout *pSideBarLayout = new QVBoxLayout(sideBarWidget);
-	pSideBarLayout->setSpacing(0);
-	pSideBarLayout->setMargin(0);
-
 #else
 	QStringList headers;
 	headers << tr ( "Song list" ) << tr ( "Script" ) << tr ( "exec Script" );
 	QTreeWidgetItem* header = new QTreeWidgetItem ( headers );
 	m_pPlaylistTree->setHeaderItem ( header );
-	m_pPlaylistTree->header()->resizeSection ( 0, 405 );
-	m_pPlaylistTree->header()->resizeSection ( 1, 405 );
-	m_pPlaylistTree->header()->resizeSection ( 2, 15 );
+
+	m_pPlaylistTree->setColumnWidth( 0, 405 );
+	m_pPlaylistTree->setColumnWidth( 1, 405 );
+	m_pPlaylistTree->setColumnWidth( 2, 105 );
+
+	m_pPlaylistTree->header()->setStretchLastSection( false );
+	m_pPlaylistTree->header()->setSectionResizeMode( 0, QHeaderView::Stretch );
+	m_pPlaylistTree->header()->setSectionResizeMode( 1, QHeaderView::Stretch );
+	m_pPlaylistTree->header()->setSectionResizeMode( 2, QHeaderView::Fixed );
+
 	m_pPlaylistTree->setAlternatingRowColors( true );
 	for ( int ii = 0; ii < m_pPlaylistTree->headerItem()->columnCount(); ii++ ) {
 		m_pPlaylistTree->headerItem()->setFont( ii, font );
 	}
+#endif
 
 	QVBoxLayout *pSideBarLayout = new QVBoxLayout(sideBarWidget);
 	pSideBarLayout->setSpacing(0);
 	pSideBarLayout->setMargin(0);
-#endif
 
 	// zoom-in btn
 	Button *pUpBtn = new Button( nullptr, QSize( 16, 16 ), Button::Type::Push, "up.svg", "", false, QSize( 9, 9 ), tr( "sort" ) );

--- a/src/gui/src/PlaylistEditor/PlaylistDialog_UI.ui
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog_UI.ui
@@ -6,94 +6,142 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>961</width>
-    <height>397</height>
+    <width>943</width>
+    <height>747</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>PlayList Browser</string>
   </property>
-  <widget class="QTreeWidget" name="m_pPlaylistTree">
-   <property name="geometry">
-    <rect>
-     <x>12</x>
-     <y>29</y>
-     <width>921</width>
-     <height>321</height>
-    </rect>
+  <layout class="QVBoxLayout" name="overallLayout">
+   <property name="spacing">
+    <number>0</number>
    </property>
-   <property name="minimumSize">
-    <size>
-     <width>0</width>
-     <height>271</height>
-    </size>
+   <property name="leftMargin">
+    <number>0</number>
    </property>
-   <property name="acceptDrops">
-    <bool>false</bool>
+   <property name="topMargin">
+    <number>0</number>
    </property>
-   <property name="verticalScrollBarPolicy">
-    <enum>Qt::ScrollBarAsNeeded</enum>
+   <property name="rightMargin">
+    <number>0</number>
    </property>
-   <property name="horizontalScrollBarPolicy">
-    <enum>Qt::ScrollBarAsNeeded</enum>
+   <property name="bottomMargin">
+    <number>0</number>
    </property>
-   <property name="tabKeyNavigation">
-    <bool>true</bool>
-   </property>
-   <property name="showDropIndicator" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="dragEnabled">
-    <bool>false</bool>
-   </property>
-   <property name="dragDropOverwriteMode">
-    <bool>false</bool>
-   </property>
-   <property name="dragDropMode">
-    <enum>QAbstractItemView::NoDragDrop</enum>
-   </property>
-   <property name="rootIsDecorated">
-    <bool>true</bool>
-   </property>
-   <property name="uniformRowHeights">
-    <bool>true</bool>
-   </property>
-   <property name="itemsExpandable">
-    <bool>false</bool>
-   </property>
-   <property name="sortingEnabled">
-    <bool>false</bool>
-   </property>
-   <property name="move" stdset="0">
-    <stringlist/>
-   </property>
-   <column>
-    <property name="text">
-     <string>Song list</string>
-    </property>
-   </column>
-  </widget>
-  <widget class="QWidget" name="sideBarWidget" native="true">
-   <property name="geometry">
-    <rect>
-     <x>940</x>
-     <y>30</y>
-     <width>16</width>
-     <height>311</height>
-    </rect>
-   </property>
-  </widget>
-  <widget class="QWidget" name="verticalLayout">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>350</y>
-     <width>181</width>
-     <height>41</height>
-    </rect>
-   </property>
-   <layout class="QVBoxLayout"/>
-  </widget>
+   <item>
+    <widget class="QWidget" name="menuBarWidget" native="true"/>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="spacing">
+      <number>2</number>
+     </property>
+     <property name="leftMargin">
+      <number>9</number>
+     </property>
+     <property name="topMargin">
+      <number>1</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>7</number>
+     </property>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QTreeWidget" name="m_pPlaylistTree">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>271</height>
+          </size>
+         </property>
+         <property name="acceptDrops">
+          <bool>false</bool>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAsNeeded</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAsNeeded</enum>
+         </property>
+         <property name="tabKeyNavigation">
+          <bool>true</bool>
+         </property>
+         <property name="showDropIndicator" stdset="0">
+          <bool>false</bool>
+         </property>
+         <property name="dragEnabled">
+          <bool>false</bool>
+         </property>
+         <property name="dragDropOverwriteMode">
+          <bool>false</bool>
+         </property>
+         <property name="dragDropMode">
+          <enum>QAbstractItemView::NoDragDrop</enum>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>true</bool>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <property name="itemsExpandable">
+          <bool>false</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>false</bool>
+         </property>
+         <property name="move" stdset="0">
+          <stringlist/>
+         </property>
+         <column>
+          <property name="text">
+           <string>Song list</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="sideBarWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QWidget" name="controlWidget" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>119</width>
+         <height>32</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
the Playlist dialog can now be resized and all components expand as I would expect them to do. Geometry, position, and visibility of the dialog will be restored as well.

Addresses #1818 