### PR TITLE
EVENT_PROGRESS: -1 to indicate export failure

### DIFF
--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -948,6 +948,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1123,10 +1128,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -895,7 +895,7 @@ Aktuelles:</translation>
     <message>
         <source>Volume</source>
         <extracomment>Label shown in the input capture dialog for querying a new volume value.</extracomment>
-        <translation type="unfinished">Lautstärke</translation>
+        <translation>Lautstärke</translation>
     </message>
     <message>
         <source>Column Number</source>
@@ -940,17 +940,22 @@ Aktuelles:</translation>
     <message>
         <source>Pan</source>
         <extracomment>Label shown in the input capture dialog for querying a new pan value for a specified instrument.</extracomment>
-        <translation type="unfinished">Pan</translation>
+        <translation>Pan</translation>
     </message>
     <message>
         <source>Filter Cutoff</source>
         <extracomment>Label shown in the input capture dialog for querying a new filter cutoff value for a specified instrument.</extracomment>
-        <translation type="unfinished">Cutoff des Filters</translation>
+        <translation>Cutoff des Filters</translation>
     </message>
     <message>
         <source>Tag Text</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation>Lied konnte nicht exportiert werden</translation>
     </message>
 </context>
 <context>
@@ -1128,10 +1133,6 @@ Overwrite the existing file?</source>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
         <translation>Stellen Sie sicher, dass sie alle Lizenzvereinbarungen erfüllen und die notwenige Autorenschaft ausweisen.</translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
-        <translation>Lied konnte nicht exportiert werden</translation>
     </message>
 </context>
 <context>
@@ -4347,7 +4348,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>&amp;Clear</source>
-        <translation type="unfinished">&amp;Löschen</translation>
+        <translation>&amp;Löschen</translation>
     </message>
     <message>
         <source>&amp;Define</source>
@@ -4359,7 +4360,7 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished">Duplizieren</translation>
+        <translation>Duplizieren</translation>
     </message>
 </context>
 <context>
@@ -5200,7 +5201,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Show mixer</source>
-        <translation type="unfinished">Mixer anzeigen</translation>
+        <translation>Mixer anzeigen</translation>
     </message>
     <message>
         <source>Show instrument rack</source>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -941,17 +941,22 @@ Kit actual:</translation>
     <message>
         <source>Pan</source>
         <extracomment>Label shown in the input capture dialog for querying a new pan value for a specified instrument.</extracomment>
-        <translation type="unfinished">Balance</translation>
+        <translation>Balance</translation>
     </message>
     <message>
         <source>Filter Cutoff</source>
         <extracomment>Label shown in the input capture dialog for querying a new filter cutoff value for a specified instrument.</extracomment>
-        <translation type="unfinished">Filtro de Corte</translation>
+        <translation>Filtro de Corte</translation>
     </message>
     <message>
         <source>Tag Text</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation>No se puede exportar la canción</translation>
     </message>
 </context>
 <context>
@@ -1131,10 +1136,6 @@ Overwrite the existing file?</source>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
         <translation>Asegúrate de que cumples todas las condiciones de la licencia y que realizas la atribución oportuna.</translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
-        <translation>No se puede exportar la canción</translation>
     </message>
 </context>
 <context>
@@ -4364,7 +4365,7 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     </message>
     <message>
         <source>&amp;Clear</source>
-        <translation type="unfinished">&amp;Limpiar</translation>
+        <translation>&amp;Limpiar</translation>
     </message>
     <message>
         <source>&amp;Define</source>
@@ -4376,7 +4377,7 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished">Duplicar</translation>
+        <translation>Duplicar</translation>
     </message>
 </context>
 <context>
@@ -5217,7 +5218,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Show mixer</source>
-        <translation type="unfinished">Ver mezclador</translation>
+        <translation>Ver mezclador</translation>
     </message>
     <message>
         <source>Show instrument rack</source>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -952,6 +952,11 @@ Kit actuel :</translation>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation>Texte de l&apos;étiquette</translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation>Impossible d&apos;exporter le morceau</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1130,10 +1135,6 @@ Overwrite the existing file?</source>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
         <translation>Veillez à respecter toutes les conditions de la licence et à donner l&apos;attribution requise.</translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
-        <translation>Impossible d&apos;exporter le morceau</translation>
     </message>
 </context>
 <context>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1124,10 +1129,6 @@ Sobrescribir o ficheiro existente?</translation>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -949,6 +949,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1126,10 +1131,6 @@ Sovrascrivere il file esistente?</translation>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -948,6 +948,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1125,10 +1130,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1124,10 +1129,6 @@ Sobrescrever o arquivo existente?</translation>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1124,10 +1129,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1124,10 +1129,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1122,10 +1127,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -947,6 +947,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1124,10 +1129,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -950,6 +950,11 @@ Current kit:</source>
         <extracomment>Label shown in the input capture dialog for querying text content for a new tag.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Unable to export song</source>
+        <extracomment>Shown in a dialog on export failure.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>
@@ -1127,10 +1132,6 @@ Overwrite the existing file?</source>
     </message>
     <message>
         <source>Be sure you satisfy all license conditions and give the required attribution.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unable to export song</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -491,10 +491,16 @@ int main(int argc, char *argv[])
 				switch ( event.type ) {
 				case EVENT_PROGRESS: /* event used only in export mode */
 					if ( ! ExportMode ) break;
-	
-					if ( event.value < 100 ) {
+
+					if ( event.value == -1 ) {
+						std::cout << "\rExport Progress ... FAILED!" << std::endl;
+						nReturnCode = 1;
+						quit = true;
+					}
+					else if ( event.value < 100 ) {
 						std::cout << "\rExport Progress ... " << event.value << "%";
-					} else {
+					}
+					else {
 						pHydrogen->stopExportSession();
 						std::cout << "\rExport Progress ... DONE" << std::endl;
 						quit = true;

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1269,15 +1269,17 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	 * The "try_lock" was introduced for Bug #164 (Deadlock after during
 	 * alsa driver shutdown). The try_lock *should* only fail in rare circumstances
 	 * (like shutting down drivers). In such cases, it seems to be ok to interrupt
-	 * audio processing. Returning the special return value "2" enables the disk 
-	 * writer driver to repeat the processing of the current data.
+	 * audio processing.
 	 */
 	if ( !pAudioEngine->tryLockFor( std::chrono::microseconds( (int)(1000.0*fSlackTime) ),
 							  RIGHT_HERE ) ) {
 		___ERRORLOG( QString( "Failed to lock audioEngine in allowed %1 ms, missed buffer" ).arg( fSlackTime ) );
 
 		if ( dynamic_cast<DiskWriterDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
-			return 2;	// inform the caller that we could not acquire the lock
+			// Returning the special return value "2" enables the disk 
+			// writer driver - which does not require running in
+			// realtime - to repeat the processing of the current data.
+			return 2;
 		}
 
 		return 0;

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -95,6 +95,12 @@ enum EventType {
 	 * Handled by EventListener::metronomeEvent().
 	 */
 	EVENT_METRONOME,
+	/**
+	 * Used by the thread of the `DiskWriterDriver` to indicate
+	 * progress of the ongoing audio export (from 0 to 100).
+	 *
+	 * The value `-1` is used to indicate exporting failed.
+	 */
 	EVENT_PROGRESS,
 	EVENT_JACK_SESSION,
 	EVENT_PLAYLIST_LOADSONG,

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -466,6 +466,9 @@ CommonStrings::CommonStrings(){
 	/*: Label shown in the input capture dialog for querying
 	  text content for a new tag. */
 	m_sInputCaptureTag = tr( "Tag Text" );
+	
+	/*: Shown in a dialog on export failure. */
+	m_sExportSongFailure = tr( "Unable to export song" );
 }
 
 CommonStrings::~CommonStrings(){

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -195,6 +195,8 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getInputCaptureFilterCutoff() const { return m_sInputCaptureFilterCutoff; }
 	const QString& getInputCaptureTag() const { return m_sInputCaptureTag; }
 	
+	const QString& getExportSongFailure() const { return m_sExportSongFailure; }
+	
 private:
 	QString m_sSmallSoloButton;
 	QString m_sSmallMuteButton;
@@ -348,5 +350,7 @@ private:
 	QString m_sInputCapturePan;
 	QString m_sInputCaptureFilterCutoff;
 	QString m_sInputCaptureTag;
+
+	QString m_sExportSongFailure;
 };
 #endif

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -425,7 +425,8 @@ void ExportSongDialog::on_okBtn_clicked()
 
 		if ( ! m_pHydrogen->startExportSession( sampleRateCombo->currentText().toInt(),
 												sampleDepthCombo->currentText().toInt()) ) {
-			QMessageBox::critical( this, "Hydrogen", tr( "Unable to export song" ) );
+			QMessageBox::critical( this, "Hydrogen",
+								   pCommonStrings->getExportSongFailure() );
 			return;
 		}
 		m_pHydrogen->startExportSong( filename );
@@ -732,7 +733,9 @@ void ExportSongDialog::on_exportNameTxt_textChanged( const QString& )
 
 void ExportSongDialog::progressEvent( int nValue )
 {
-	m_pProgressBar->setValue( nValue );
+	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	
+	m_pProgressBar->setValue( std::min( nValue, 0 ) );
 	if ( nValue == 100 ) {
 
 		m_bExporting = false;
@@ -746,13 +749,20 @@ void ExportSongDialog::progressEvent( int nValue )
 			exportTracks();
 		}
 	}
+	else if ( nValue == -1 ) {
+		m_bExporting = false;
+		QMessageBox::critical(
+			this, "Hydrogen",
+			pCommonStrings->getExportSongFailure());
+			
+	}
 
-	if ( nValue < 100 ) {
+	if ( nValue >= 0 && nValue < 100 ) {
 		closeBtn->setEnabled(false);
 		resampleComboBox->setEnabled(false);
 
-	}else
-	{
+	}
+	else {
 		closeBtn->setEnabled(true);
 		resampleComboBox->setEnabled(true);
 	}

--- a/src/tests/AudioBenchmark.cpp
+++ b/src/tests/AudioBenchmark.cpp
@@ -61,6 +61,9 @@ static long long exportCurrentSong( const QString &fileName, int nSampleRate )
 	bool done = false;
 	while ( ! done ) {
 		Event event = pQueue->pop_event();
+
+		// Ensure audio export does always work.
+		CPPUNIT_ASSERT( !(event.type == EVENT_PROGRESS && event.value == -1) );
 		
 		if (event.type == EVENT_PROGRESS && event.value == 100) {
 			done = true;

--- a/src/tests/TestHelper.cpp
+++ b/src/tests/TestHelper.cpp
@@ -253,6 +253,10 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 		H2Core::Event event = pQueue->pop_event();
 
 		if (event.type == H2Core::EVENT_PROGRESS) {
+
+			// Ensure audio export does work.
+			CPPUNIT_ASSERT( event.value != -1 );
+			
 			qDebug() << "[TestHelper::exportSong] progress: " << event.value;
 			if ( event.value == 100 ) {
 				qDebug() << "[TestHelper::exportSong] done";
@@ -290,6 +294,9 @@ void TestHelper::exportSong( const QString& sFileName )
 	bool bDone = false;
 	while ( ! bDone ) {
 		H2Core::Event event = pQueue->pop_event();
+
+		// Ensure audio export does work.
+		CPPUNIT_ASSERT( !(event.type == H2Core::EVENT_PROGRESS && event.value == -1) );
 
 		if (event.type == H2Core::EVENT_PROGRESS && event.value == 100) {
 			bDone = true;


### PR DESCRIPTION
the `DiskWriterDriver` thread is now able to indicate a failing export by sending the `EVENT_PROGRESS` with value `-1`.

There are a couple of places in the code and unit tests waiting for a `EVENT_PROGRESS` with value `100` in order to proceed. But in case the audio engine could not be locked, the sndfile format was not valid, or the audio file could not be created (e.g. read-only location), these parts of the code would wait indefinitely since the thread would never send the `100`.

A second thing fixed is that the attempts for the `DiskWriterDriver` thread to limit the  audio engine was limited to 30. Beforehand, it tried forever.

addresses #1820