### PR TITLE
AudioEngine: tweaks m_pLocker

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2608,16 +2608,29 @@ QString AudioEngine::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2m_nRealtimeFrame: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nRealtimeFrame ) )
 			.append( QString( "%1%2m_AudioProcessCallback: stringification not implemented\n" ).arg( sPrefix ).arg( s ) )
 			.append( QString( "%1%2m_songNoteQueue: length = %3\n" ).arg( sPrefix ).arg( s ).arg( m_songNoteQueue.size() ) );
-		sOutput.append( QString( "%1%2m_midiNoteQueue: [\n" ).arg( sPrefix ).arg( s ) );
+		sOutput.append( QString( "%1%2m_midiNoteQueue: [" ).arg( sPrefix ).arg( s ) );
 		for ( const auto& nn : m_midiNoteQueue ) {
-			sOutput.append( nn->toQString( sPrefix + s, bShort ) );
+			sOutput.append( nn->toQString( sPrefix + s, bShort ) ).append( "\n" );
 		}
 		sOutput.append( QString( "]\n%1%2m_pMetronomeInstrument: %3\n" ).arg( sPrefix ).arg( s ).arg( m_pMetronomeInstrument->toQString( sPrefix + s, bShort ) ) )
 			.append( QString( "%1%2nMaxTimeHumanize: %3\n" ).arg( sPrefix ).arg( s ).arg( AudioEngine::nMaxTimeHumanize ) )
 			.append( QString( "%1%2fHumanizeVelocitySD: %3\n" ).arg( sPrefix ).arg( s ).arg( AudioEngine::fHumanizeVelocitySD ) )
 			.append( QString( "%1%2fHumanizePitchSD: %3\n" ).arg( sPrefix ).arg( s ).arg( AudioEngine::fHumanizePitchSD ) )
 			.append( QString( "%1%2fHumanizeTimingSD: %3\n" ).arg( sPrefix ).arg( s ).arg( AudioEngine::fHumanizeTimingSD ) );
-		
+		sOutput.append( QString( "%1%2m_pLocker: " ).arg( sPrefix ).arg( s ) );
+		if ( m_pLocker.file == nullptr || m_pLocker.function == nullptr ){
+			sOutput.append( "was not locked yet\n" );
+		}
+		else {
+			if ( m_pLocker.isLocked ) {
+				sOutput.append( "is currently locked by: " );
+			} else {
+				sOutput.append( "was last locked by: " );
+			}
+			sOutput.append( QString( "[function: %1, line: %2, file: %3]\n" )
+							.arg( m_pLocker.function ).arg( m_pLocker.line )
+							.arg( m_pLocker.file ) );
+		}
 	}
 	else {
 		sOutput = QString( "%1[AudioEngine]" ).arg( sPrefix )
@@ -2675,6 +2688,20 @@ QString AudioEngine::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", fHumanizeVelocitySD: id %1" ).arg( AudioEngine::fHumanizeVelocitySD ) )
 			.append( QString( ", fHumanizePitchSD: id %1" ).arg( AudioEngine::fHumanizePitchSD ) )
 			.append( QString( ", fHumanizeTimingSD: id %1" ).arg( AudioEngine::fHumanizeTimingSD ) );
+		sOutput.append( ", m_pLocker: " );
+		if ( m_pLocker.file == nullptr || m_pLocker.function == nullptr ){
+			sOutput.append( "was not locked yet" );
+		}
+		else {
+			if ( m_pLocker.isLocked ) {
+				sOutput.append( "is currently locked by: " );
+			} else {
+				sOutput.append( "was last locked by: " );
+			}
+			sOutput.append( QString( "[function: %1, line: %2, file: %3]" )
+							.arg( m_pLocker.function ).arg( m_pLocker.line )
+							.arg( m_pLocker.file ) );
+		}
 	}
 	
 	return sOutput;

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -636,10 +636,15 @@ private:
 	 */
 	std::thread::id 	m_LockingThread;
 
+	/**
+	 * Contains the current or last context in which the audio engine
+	 * was locked as well as the locking state.
+	 */
 	struct _locker_struct {
 		const char* file;
 		unsigned int line;
 		const char* function;
+		bool isLocked;
 	} m_pLocker;
 
 	float				m_fProcessTime;


### PR DESCRIPTION
Apart from telling which line, file, and function was last or is currently locking the audio engine the `AudioEngine::m_pLocker` does now also contain a member indicating whether the AE is currently locked or not.

In addition, `m_pLocker` was added to the output of `AudioEngine::toQString()`.

Some debug messages were introduced in the `DiskWriterDriver`
addresses #1820