### PR TITLE
Fix segfault on panic button

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1176,8 +1176,10 @@ void Hydrogen::__kill_instruments()
 
 void Hydrogen::__panic()
 {
+	m_pAudioEngine->lock( RIGHT_HERE );
 	sequencer_stop();
 	m_pAudioEngine->getSampler()->stopPlayingNotes();
+	m_pAudioEngine->unlock();
 }
 
 bool Hydrogen::hasJackAudioDriver() const {


### PR DESCRIPTION
Seems like no one is using the panic button to immediately stop transport as well as audio processing.

Since at least v1.0.0-beta2 the call to `Hydrogen::__panic` was not guarded by locking the `AudioEngine` mutex. This lead to segfaults when hitting the panic button while playback was rolling.