### PR TITLE
DWD: check whether driver was stopped

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -711,7 +711,6 @@ bool Hydrogen::startExportSession( int nSampleRate, int nSampleDepth )
 /// Export a song to a wav file
 void Hydrogen::startExportSong( const QString& filename)
 {
-	qDebug() << "[Hydrogen::startExportSong] beginning";
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	getCoreActionController()->locateToTick( 0 );
 	pAudioEngine->play();
@@ -720,7 +719,6 @@ void Hydrogen::startExportSong( const QString& filename)
 	DiskWriterDriver* pDiskWriterDriver = static_cast<DiskWriterDriver*>(pAudioEngine->getAudioDriver());
 	pDiskWriterDriver->setFileName( filename );
 	pDiskWriterDriver->write();
-	qDebug() << "[Hydrogen::startExportSong] end";
 }
 
 void Hydrogen::stopExportSong()

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -240,21 +240,6 @@ void* diskWriterDriver_thread( void* param )
 			
 			// In case the DiskWriter couldn't acquire the lock of the AudioEngine.
 			while( ret == 2 ) {
-				qDebug() << "[diskWriterDriver_thread] while loop could not acquire mutex: "
-						 << nMutexLockAttempts;
-
-				if ( nMutexLockAttempts == 0 ) {
-					qDebug() << "[diskWriterDriver_thread] patternPosition: " <<
-						patternPosition << ", nColumns: " << nColumns <<
-						", nPatternSize: " << nPatternSize <<
-						", fBpm: " << fBpm <<
-						", fTicksize: " << fTicksize <<
-						", filename: " << pDriver->m_sFilename.toLocal8Bit();
-
-					qDebug() << "[diskWriterDriver_thread] "
-							 << pHydrogen->getAudioEngine()->toQString("", true);
-				}
-
 				ret = pDriver->m_processCallback( nUsedBuffer, nullptr );
 
 				// No need for a sleep() statement in here because the
@@ -262,7 +247,6 @@ void* diskWriterDriver_thread( void* param )
 				// already introduces a delay.
 				nMutexLockAttempts++;
 				if ( nMutexLockAttempts > 30 ) {
-					qDebug() << "Too many attempts to lock the AudioEngine. Aborting.";
 					__ERRORLOG( "Too many attempts to lock the AudioEngine. Aborting." );
 					
 					EventQueue::get_instance()->push_event( EVENT_PROGRESS, -1 );

--- a/src/core/IO/DiskWriterDriver.h
+++ b/src/core/IO/DiskWriterDriver.h
@@ -50,6 +50,7 @@ class DiskWriterDriver : public Object<DiskWriterDriver>, public AudioOutput
 		audioProcessCallback	m_processCallback;
 		float*					m_pOut_L;
 		float*					m_pOut_R;
+		bool					 m_bIsRunning;
 
 		DiskWriterDriver( audioProcessCallback processCallback );
 		~DiskWriterDriver();
@@ -85,7 +86,6 @@ class DiskWriterDriver : public Object<DiskWriterDriver>, public AudioOutput
 		}
 
 	private:
-
 
 };
 

--- a/src/tests/TestHelper.cpp
+++ b/src/tests/TestHelper.cpp
@@ -257,9 +257,7 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 			// Ensure audio export does work.
 			CPPUNIT_ASSERT( event.value != -1 );
 			
-			qDebug() << "[TestHelper::exportSong] progress: " << event.value;
 			if ( event.value == 100 ) {
-				qDebug() << "[TestHelper::exportSong] done";
 				bDone = true;
 			}
 		}
@@ -267,7 +265,6 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 			usleep(100 * 1000);
 		}
 	}
-	qDebug() << "[TestHelper::exportSong] stopping export";
 	pHydrogen->stopExportSession();
 
 	auto t1 = std::chrono::high_resolution_clock::now();

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -242,9 +242,7 @@ void TransportTest::testSampleConsistency() {
 	// Apply drumkit containing the long sample to be tested.
 	pCoreActionController->setDrumkit( sDrumkitDir, true );
 
-	qDebug() << "[TransportTest::testSampleConsistency] start export";
 	TestHelper::exportSong( sOutFile );
-	qDebug() << "[TransportTest::testSampleConsistency] done exporting";
 	
 	H2TEST_ASSERT_AUDIO_FILES_DATA_EQUAL( sRefFile, sOutFile );
 	Filesystem::rm( sOutFile );


### PR DESCRIPTION
when using the `DiskWriterDriver` to export audio and stopping it using `AudioEngine::stopAudioDrivers()` while the export is still in progress, there is some sort of deadlock. `stopAudioDrivers` locks the `AudioEngine` and tells the driver to stop. But in doing so `DiskWriterDriver` will just wait for the export to complete (which is not right). But in order to export it needs to call the process function of the audio engine and needs to acquire the audio engine lock therein. Now, since this latter will be done using a tryLock and non zero exit code, there is no real deadlock of the `AudioEngine`. But thread of the `DiskWriterDriver` is not able to work properly anymore.

Now, stopping the `DiskWriterDriver` sets a member variable `m_bIsRunning` which will be checked in the export thread.

addressing #1820