### PR TITLE
InstrumentEditor: fix Midi Out Note range

### DIFF
--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -119,7 +119,7 @@ InstrumentEditor::InstrumentEditor( QWidget* pParent )
 
 	///
 	m_pMidiOutNoteLCD = new LCDSpinBox( m_pInstrumentProp, QSize( 59, 24 ),
-										LCDSpinBox::Type::Int, 0, 100, true );
+										LCDSpinBox::Type::Int, 0, 127, true );
 	m_pMidiOutNoteLCD->move( 161, 257 );
 	m_pMidiOutNoteLCD->setToolTip(QString(tr("Midi out note")));
 	connect( m_pMidiOutNoteLCD, SIGNAL( valueChanged( double ) ),


### PR DESCRIPTION
By accident I limited the range of possible MIDI output notes to `100` in 1.2.0.

The supported range is now [0,127] again.

Fixes #1828