### PR TITLE
Properly fail on missing data folder

### DIFF
--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -6069,6 +6069,13 @@ Are you sure?</source>
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -6064,6 +6064,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -6136,6 +6136,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+    <translation>Keine [hydrogen.conf] Datei gefunden. Hydrogen wurde höchstwahrscheinlich nicht richtig installiert. Abbruch...</translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -6139,7 +6139,7 @@ Would you like to keep or discard the remaining instruments and notes?
     <name>Startup</name>
     <message>
         <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
-    <translation>Keine [hydrogen.conf] Datei gefunden. Hydrogen wurde höchstwahrscheinlich nicht richtig installiert. Abbruch...</translation>
+        <translation>Keine [hydrogen.conf] Datei gefunden. Hydrogen wurde höchstwahrscheinlich nicht richtig installiert. Abbruch...</translation>
     </message>
 </context>
 <context>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -6144,6 +6144,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -6047,6 +6047,13 @@ Are you sure?</source>
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -6047,6 +6047,13 @@ Are you sure?</source>
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -6155,6 +6155,13 @@ Los primeros %2 instrumentos serán reemplazados con los nuevos intrumentos y ma
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -6155,6 +6155,13 @@ Souhaitez-vous conserver ou abandonner les instruments et notes restant ?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -6110,6 +6110,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -6064,6 +6064,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -6052,6 +6052,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -6078,6 +6078,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -6103,6 +6103,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -6061,6 +6061,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -6056,6 +6056,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -6132,6 +6132,13 @@ Você gostaria de manter ou descartar os instrumentos e anotações restantes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -6098,6 +6098,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -6128,6 +6128,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -6053,6 +6053,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -6133,6 +6133,13 @@ Would you like to keep or discard the remaining instruments and notes?
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -6136,6 +6136,13 @@ Are you sure?</source>
     </message>
 </context>
 <context>
+    <name>Startup</name>
+    <message>
+        <source>No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>VirtualPatternDialog</name>
     <message>
         <source>Select virtual pattern</source>

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -269,8 +269,14 @@ Preferences::Preferences()
 	//////////////// END OF DEFAULT SETTINGS ////////////////////////////////
 	/////////////////////////////////////////////////////////////////////////
 
-	loadPreferences( true );	// Global settings
-	loadPreferences( false );	// User settings
+	const bool bGlobalPrefLoaded = loadPreferences( true );
+	const bool bUserPrefLoaded = loadPreferences( false );
+	if ( bGlobalPrefLoaded || bUserPrefLoaded ) {
+		m_bLoadingSuccessful = true;
+	} else {
+		m_bLoadingSuccessful = false;
+	}
+		
 }
 
 
@@ -289,7 +295,7 @@ Preferences::~Preferences()
 ///
 /// Load the preferences file
 ///
-void Preferences::loadPreferences( bool bGlobal )
+bool Preferences::loadPreferences( bool bGlobal )
 {
 	// We do not required the recently used variables to be
 	// accumulated throughout various configuration files.
@@ -313,7 +319,7 @@ void Preferences::loadPreferences( bool bGlobal )
 		if ( bGlobal ) {
 			ERRORLOG( QString( "Global preferences file [%1] is not readable!" )
 					  .arg( sPreferencesFilename ) );
-			return;
+			return false;
 		}
 		else {
 			WARNINGLOG( QString( "User-level preferences file [%1] is not readable! It will be recreated." )
@@ -836,7 +842,10 @@ void Preferences::loadPreferences( bool bGlobal )
 	if ( bRecreate && ! bGlobal ) {
 		WARNINGLOG( "Recreating configuration file." );
 		savePreferences();
+		return false;
 	}
+
+	return true;
 }
 
 

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -404,7 +404,7 @@ public:
 	~Preferences();
 
 	/// Load the preferences file
-	void			loadPreferences( bool bGlobal );
+	bool			loadPreferences( bool bGlobal );
 
 	/// Save the preferences file
 	bool			savePreferences();
@@ -679,6 +679,8 @@ public:
 
 	const std::shared_ptr<Shortcuts> getShortcuts() const;
 	void setShortcuts( const std::shared_ptr<Shortcuts> pShortcuts );
+
+	bool getLoadingSuccessful() const;
 	
 private:
 	/**
@@ -828,6 +830,8 @@ private:
 
 	WindowProperties readWindowProperties( XMLNode parent, const QString& windowName, WindowProperties defaultProp );
 	void writeWindowProperties( XMLNode parent, const QString& windowName, const WindowProperties& prop );
+
+	bool m_bLoadingSuccessful;
 };
 
 inline QString			Preferences::getLastExportPatternAsDirectory() const {
@@ -1477,6 +1481,9 @@ inline const std::shared_ptr<Shortcuts> Preferences::getShortcuts() const {
 }
 inline void Preferences::setShortcuts( const std::shared_ptr<Shortcuts> pShortcuts ) {
 	m_pShortcuts = pShortcuts;
+}
+inline bool Preferences::getLoadingSuccessful() const {
+	return m_bLoadingSuccessful;
 }
 };
 

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -73,9 +73,17 @@ InstrumentEditorPanel::~InstrumentEditorPanel()
 }
 
 void InstrumentEditorPanel::drumkitLoadedEvent() {
-	auto pComponentList = H2Core::Hydrogen::get_instance()->getSong()->getComponents();
-
-	m_pInstrumentEditor->selectComponent(pComponentList->front()->get_id());
+	auto pSong = H2Core::Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+	
+	auto pComponentList = pSong->getComponents();
+	if ( pComponentList != nullptr && pComponentList->size() > 0 ) {
+		m_pInstrumentEditor->selectComponent( pComponentList->front()->get_id() );
+	} else {
+		m_pInstrumentEditor->selectComponent( -1 );
+	}
 	m_pInstrumentEditor->selectedInstrumentChangedEvent();
 }
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -459,6 +459,25 @@ int main(int argc, char *argv[])
 			pPref->getShortcuts()->createDefaultShortcuts();
 		}
 
+		if ( ! pPref->getLoadingSuccessful() ) {
+
+			QMessageBox::critical( nullptr, "Hydrogen",
+				QString( QT_TRANSLATE_NOOP( "Startup",															   "No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting..." ) ) );
+			
+			// Neither the Preferences on system level nor the ones at
+			// user level could be loaded successfully. Hydrogen was
+			// most probably not installed properly. Abort.
+			delete pQApp;
+			delete pPref;
+
+			delete MidiMap::get_instance();
+
+			___ERRORLOG( "No preferences file found. Aborting..." );
+			delete H2Core::Logger::get_instance();
+
+			exit( 1 );
+		}
+
 		SplashScreen *pSplash = new SplashScreen();
 
 #ifdef H2CORE_HAVE_OSC


### PR DESCRIPTION
In case neither `data` folder at system nor at user level is present, Hydrogen is pretty useless. However, there is no indication (apart from log messages) what is going wrong. Especially for first-day users requiring to inspect the logs is a little bit much.

Instead, Hydrogen does check now whether the `hydrogen.conf` file exists on system and user level and returns with code `1` instead of starting up in case none of the two could be found. It also shows a critical pop dialogs stating "No [hydrogen.conf] file found. Hydrogen was not installed properly. Aborting...".

On the other hand, I also do not want to restrict usage too much. In addition to aborting, Hydrogen writes a new preferences file at user level too. This way the popup + exit will just occur once.

In case no drumkits are present (e.g. a first run of Hydrogen with its `data` folder not properly installed on system level) `Song` does not contain any components. The `InstrumentEditor` needs to take this into account. Previously it segfaulted.