### PR TITLE
debug: add logs to debug #1820

### DIFF
--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -662,6 +662,7 @@ void Hydrogen::restartDrivers()
 
 bool Hydrogen::startExportSession( int nSampleRate, int nSampleDepth )
 {
+	DEBUGLOG( "" );
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	
 	if ( pAudioEngine->getState() == AudioEngine::State::Playing ) {
@@ -685,7 +686,9 @@ bool Hydrogen::startExportSession( int nSampleRate, int nSampleDepth )
 	 * which is not the DiskWriter driver.
 	 * Stop the current driver and fire up the DiskWriter.
 	 */
+	DEBUGLOG( "pre stopAudioDrivers" );
 	pAudioEngine->stopAudioDrivers();
+	DEBUGLOG( "post stopAudioDrivers" );
 
 	AudioOutput* pDriver =
 		pAudioEngine->createAudioDriver( "DiskWriterDriver" );
@@ -705,12 +708,15 @@ bool Hydrogen::startExportSession( int nSampleRate, int nSampleDepth )
 
 	m_bExportSessionIsActive = true;
 
+	DEBUGLOG( "done" );
+
 	return true;
 }
 
 /// Export a song to a wav file
 void Hydrogen::startExportSong( const QString& filename)
 {
+	DEBUGLOG( "" );
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	getCoreActionController()->locateToTick( 0 );
 	pAudioEngine->play();
@@ -718,18 +724,23 @@ void Hydrogen::startExportSong( const QString& filename)
 
 	DiskWriterDriver* pDiskWriterDriver = static_cast<DiskWriterDriver*>(pAudioEngine->getAudioDriver());
 	pDiskWriterDriver->setFileName( filename );
+	DEBUGLOG( "pre write()" );
 	pDiskWriterDriver->write();
+	DEBUGLOG( "done" );
 }
 
 void Hydrogen::stopExportSong()
 {
+	DEBUGLOG( "" );
 	AudioEngine* pAudioEngine = m_pAudioEngine;
 	pAudioEngine->getSampler()->stopPlayingNotes();
 	getCoreActionController()->locateToTick( 0 );
+	DEBUGLOG( "done" );
 }
 
 void Hydrogen::stopExportSession()
 {
+	DEBUGLOG( "" );
 	std::shared_ptr<Song> pSong = getSong();
 	pSong->setMode( m_oldEngineMode );
 	if ( m_bOldLoopEnabled ) {
@@ -739,11 +750,13 @@ void Hydrogen::stopExportSession()
 	}
 	
 	AudioEngine* pAudioEngine = m_pAudioEngine;
-	
+
+	DEBUGLOG( "pre restartAudioDrivers" );
  	pAudioEngine->restartAudioDrivers();
 	if ( pAudioEngine->getAudioDriver() == nullptr ) {
 		ERRORLOG( "Unable to restart previous audio driver after exporting song." );
 	}
+	DEBUGLOG( "post restartAudioDrivers" );
 	m_bExportSessionIsActive = false;
 }
 

--- a/src/tests/TestHelper.cpp
+++ b/src/tests/TestHelper.cpp
@@ -245,7 +245,9 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 		pInstrumentList->get(i)->set_currently_exported( true );
 	}
 
+	___DEBUGLOG( "pre startExportSession" );
 	pHydrogen->startExportSession( 44100, 16 );
+	___DEBUGLOG( "pre startExportSong" );
 	pHydrogen->startExportSong( sFileName );
 
 	bool bDone = false;
@@ -253,6 +255,7 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 		H2Core::Event event = pQueue->pop_event();
 
 		if (event.type == H2Core::EVENT_PROGRESS) {
+			___DEBUGLOG( QString( "progress: %1" ).arg( event.value ) );
 
 			// Ensure audio export does work.
 			CPPUNIT_ASSERT( event.value != -1 );
@@ -262,10 +265,13 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 			}
 		}
 		else if ( event.type == H2Core::EVENT_NONE ) {
+			___DEBUGLOG( "event none" );
 			usleep(100 * 1000);
 		}
 	}
+	___DEBUGLOG( "pre stopExportSession" );
 	pHydrogen->stopExportSession();
+	___DEBUGLOG( "post stopExportSession" );
 
 	auto t1 = std::chrono::high_resolution_clock::now();
 	double t = std::chrono::duration<double>( t1 - t0 ).count();

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -124,11 +124,11 @@ int main( int argc, char **argv)
 	
 	unsigned logLevelOpt = H2Core::Logger::None;
 	if( parser.isSet(verboseOption) || parser.isSet( outputFileOption ) ){
-		if( !sVerbosityString.isEmpty() )
-		{
+		if ( !sVerbosityString.isEmpty() ) {
 			logLevelOpt =  H2Core::Logger::parse_log_level( sVerbosityString.toLocal8Bit() );
 		} else {
-			logLevelOpt = H2Core::Logger::Error|H2Core::Logger::Warning|H2Core::Logger::Info;
+			logLevelOpt = H2Core::Logger::Error | H2Core::Logger::Warning |
+				H2Core::Logger::Info | H2Core::Logger::Debug;
 		}
 	}
 


### PR DESCRIPTION
it seems the `DiskWriterDriver` is getting killed in the macOS pipeline _before_ the song in `TransportTests::testSampleConsistency` was fully exported. I added some debug logs that might help determining why this is the case