### PR TITLE
EventQueue serialization and debug messages

### DIFF
--- a/src/core/EventQueue.cpp
+++ b/src/core/EventQueue.cpp
@@ -25,6 +25,117 @@
 namespace H2Core
 {
 
+QString Event::typeToQString( EventType type ) {
+	switch( type ) {
+	case EVENT_NONE:
+		return "EVENT_NONE";
+	case EVENT_STATE:
+		return "EVENT_STATE";
+	case EVENT_PLAYING_PATTERNS_CHANGED:
+		return "EVENT_PLAYING_PATTERNS_CHANGED";
+	case EVENT_NEXT_PATTERNS_CHANGED:
+		return "EVENT_NEXT_PATTERNS_CHANGED";
+	case EVENT_PATTERN_MODIFIED:
+		return "EVENT_PATTERN_MODIFIED";
+	case EVENT_SELECTED_PATTERN_CHANGED:
+		return "EVENT_SELECTED_PATTERN_CHANGED";
+	case EVENT_SELECTED_INSTRUMENT_CHANGED:
+		return "EVENT_SELECTED_INSTRUMENT_CHANGED";
+	case EVENT_INSTRUMENT_PARAMETERS_CHANGED:
+		return "EVENT_INSTRUMENT_PARAMETERS_CHANGED";
+	case EVENT_MIDI_ACTIVITY:
+		return "EVENT_MIDI_ACTIVITY";
+	case EVENT_XRUN:
+		return "EVENT_XRUN";
+	case EVENT_NOTEON:
+		return "EVENT_NOTEON";
+	case EVENT_ERROR:
+		return "EVENT_ERROR";
+	case EVENT_METRONOME:
+		return "EVENT_METRONOME";
+	case EVENT_PROGRESS:
+		return "EVENT_PROGRESS";
+	case EVENT_JACK_SESSION:
+		return "EVENT_JACK_SESSION";
+	case EVENT_PLAYLIST_LOADSONG:
+		return "EVENT_PLAYLIST_LOADSONG";
+	case EVENT_UNDO_REDO:
+		return "EVENT_UNDO_REDO";
+	case EVENT_SONG_MODIFIED:
+		return "EVENT_SONG_MODIFIED";
+	case EVENT_TEMPO_CHANGED:
+		return "EVENT_TEMPO_CHANGED";
+	case EVENT_UPDATE_PREFERENCES:
+		return "EVENT_UPDATE_PREFERENCES";
+	case EVENT_UPDATE_SONG:
+		return "EVENT_UPDATE_SONG";
+	case EVENT_QUIT:
+		return "EVENT_QUIT";
+	case EVENT_TIMELINE_ACTIVATION:
+		return "EVENT_TIMELINE_ACTIVATION";
+	case EVENT_TIMELINE_UPDATE:
+		return "EVENT_TIMELINE_UPDATE";
+	case EVENT_JACK_TRANSPORT_ACTIVATION:
+		return "EVENT_JACK_TRANSPORT_ACTIVATION";
+	case EVENT_JACK_TIMEBASE_STATE_CHANGED:
+		return "EVENT_JACK_TIMEBASE_STATE_CHANGED";
+	case EVENT_SONG_MODE_ACTIVATION:
+		return "EVENT_SONG_MODE_ACTIVATION";
+	case EVENT_STACKED_MODE_ACTIVATION:
+		return "EVENT_STACKED_MODE_ACTIVATION";
+	case EVENT_LOOP_MODE_ACTIVATION:
+		return "EVENT_LOOP_MODE_ACTIVATION";
+	case EVENT_ACTION_MODE_CHANGE:
+		return "EVENT_ACTION_MODE_CHANGE";
+	case EVENT_GRID_CELL_TOGGLED:
+		return "EVENT_GRID_CELL_TOGGLED";
+	case EVENT_COLUMN_CHANGED:
+		return "EVENT_COLUMN_CHANGED";
+	case EVENT_DRUMKIT_LOADED:
+		return "EVENT_DRUMKIT_LOADED";
+	case EVENT_PATTERN_EDITOR_LOCKED:
+		return "EVENT_PATTERN_EDITOR_LOCKED";
+	case EVENT_RELOCATION:
+		return "EVENT_RELOCATION";
+	case EVENT_BBT_CHANGED:
+		return "EVENT_BBT_CHANGED";
+	case EVENT_SONG_SIZE_CHANGED:
+		return "EVENT_SONG_SIZE_CHANGED";
+	case EVENT_DRIVER_CHANGED:
+		return "EVENT_DRIVER_CHANGED";
+	case EVENT_PLAYBACK_TRACK_CHANGED:
+		return "EVENT_PLAYBACK_TRACK_CHANGED";
+	case EVENT_SOUND_LIBRARY_CHANGED:
+		return "EVENT_SOUND_LIBRARY_CHANGED";
+	case EVENT_NEXT_SHOT:
+		return "EVENT_NEXT_SHOT";
+	case EVENT_MIDI_MAP_CHANGED:
+		return "EVENT_MIDI_MAP_CHANGED";
+	default:
+		break;
+	}
+
+	return QString( "Unknown event: [%1]" ).arg( static_cast<int>(type));
+}
+
+QString Event::toQString( const QString& sPrefix, bool bShort ) const {
+	QString s = Base::sPrintIndention;
+	QString sOutput;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[Event]\n" ).arg( sPrefix )
+			.append( QString( "%1%2type: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( Event::typeToQString( type ) ) )
+			.append( QString( "%1%2value: %3\n" ).arg( sPrefix ).arg( s ).arg( value ) );
+	}
+	else {
+		sOutput = QString( "[Event]" )
+			.append( QString( " type: %1" ).arg( Event::typeToQString( type ) ) )
+			.append( QString( ", value: %1\n" ).arg( value ) );
+	}
+
+	return sOutput;
+}
+
 EventQueue* EventQueue::__instance = nullptr;
 
 void EventQueue::create_instance()
@@ -98,6 +209,62 @@ Event EventQueue::pop_event()
 	nIndex = nIndex % MAX_EVENTS;
 //	INFOLOG( QString( "[popEvent] %1 : %2 %3" ).arg( nIndex ).arg( __events_buffer[ nIndex ].type ).arg( __events_buffer[ nIndex ].value ) );
 	return __events_buffer[ nIndex ];
+}
+
+QString EventQueue::toQString( const QString& sPrefix, bool bShort ) {
+	std::lock_guard< std::mutex > lock( m_mutex );
+
+	const int nReadIndex =  __read_index % MAX_EVENTS;
+	const int nWriteIndex =  __write_index % MAX_EVENTS;
+
+	QString s = Base::sPrintIndention;
+	QString sOutput, sIndexPrefix;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[EventQueue]\n" ).arg( sPrefix )
+			.append( QString( "%1%2__read_index: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( __read_index ) )
+			.append( QString( "%1%2__write_index: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( __write_index ) )
+			.append( QString( "%1%2m_bSilent: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( m_bSilent ) )
+			.append( QString( "%1%2__events_buffer: \n" ).arg( sPrefix ).arg( s ) );
+		for ( int ii = 0; ii < MAX_EVENTS; ii++ ) {
+			sIndexPrefix = "";
+			if ( ii == nReadIndex ) {
+				sIndexPrefix.append( "[READ] " );
+			}
+			if ( ii == nWriteIndex ) {
+				sIndexPrefix.append( "[WRITE] " );
+			}
+
+			sOutput.append( QString( "%1%1%2%3: %4%5\n" ).arg( sPrefix ).arg( s )
+							.arg( ii ).arg( sIndexPrefix )
+							.arg( __events_buffer[ ii ].toQString( "", true ) ) );
+		}
+		sOutput.append( "\n" );
+	}
+	else {
+		sOutput = QString( "[EventQueue] " )
+			.append( QString( "__read_index: %1" ).arg( __read_index ) )
+			.append( QString( ", __write_index: %1" ).arg( __write_index ) )
+			.append( QString( ", m_bSilent: %1" ).arg( m_bSilent ) )
+			.append( QString( ", __events_buffer: [" ) );
+		for ( int ii = 0; ii < MAX_EVENTS; ii++ ) {
+			sIndexPrefix = "";
+			if ( ii == nReadIndex ) {
+				sIndexPrefix.append( "[READ] " );
+			}
+			if ( ii == nWriteIndex ) {
+				sIndexPrefix.append( "[WRITE] " );
+			}
+
+			sOutput.append( QString( "%1: %2%3, " ).arg( ii ).arg( sIndexPrefix )
+							.arg( __events_buffer[ ii ].toQString( "", true ) ) );
+		}
+		sOutput.append( "]\n" );
+	}
+
+	return sOutput;
 }
 
 };

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -197,6 +197,21 @@ public:
 	/** Additional information to describe the actual context of
 	    the engine.*/
 	int value;
+
+	/**
+	 * Get string representation of #EventType.
+	 */
+	static QString typeToQString( EventType type );
+	
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 * every new line
+	 * \param bShort Instead of the whole content of all classes
+	 * stored as members just a single unique identifier will be
+	 * displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 };
 
 /** Object handling the communication between the core of Hydrogen and
@@ -281,6 +296,16 @@ public:/**
 
 	bool getSilent() const;
 	void setSilent( bool bSilent );
+	
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 * every new line
+	 * \param bShort Instead of the whole content of all classes
+	 * stored as members just a single unique identifier will be
+	 * displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true );
 
 private:
 	/**

--- a/src/tests/TestHelper.cpp
+++ b/src/tests/TestHelper.cpp
@@ -252,7 +252,12 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 
 	bool bDone = false;
 	while ( ! bDone ) {
+
+		___DEBUGLOG( pQueue->toQString() );
+
 		H2Core::Event event = pQueue->pop_event();
+
+		___DEBUGLOG( event.toQString() );
 
 		if (event.type == H2Core::EVENT_PROGRESS) {
 			___DEBUGLOG( QString( "progress: %1" ).arg( event.value ) );
@@ -265,7 +270,7 @@ void TestHelper::exportSong( const QString& sSongFile, const QString& sFileName 
 			}
 		}
 		else if ( event.type == H2Core::EVENT_NONE ) {
-			___DEBUGLOG( "event none" );
+			// No new event left.
 			usleep(100 * 1000);
 		}
 	}
@@ -291,12 +296,20 @@ void TestHelper::exportSong( const QString& sFileName )
 		pInstrumentList->get(i)->set_currently_exported( true );
 	}
 
+	___DEBUGLOG( "pre startExportSession" );
 	pHydrogen->startExportSession( 44100, 16 );
+	___DEBUGLOG( "post startExportSession" );
 	pHydrogen->startExportSong( sFileName );
+	___DEBUGLOG( "post startExportSong" );
 
 	bool bDone = false;
 	while ( ! bDone ) {
+
+		___DEBUGLOG( pQueue->toQString() );
+		
 		H2Core::Event event = pQueue->pop_event();
+
+		___DEBUGLOG( event.toQString() );
 
 		// Ensure audio export does work.
 		CPPUNIT_ASSERT( !(event.type == H2Core::EVENT_PROGRESS && event.value == -1) );
@@ -305,10 +318,13 @@ void TestHelper::exportSong( const QString& sFileName )
 			bDone = true;
 		}
 		else if ( event.type == H2Core::EVENT_NONE ) {
+			// No new event left.
 			usleep(100 * 1000);
 		}
 	}
+	___DEBUGLOG( "pre stopExportSession" );
 	pHydrogen->stopExportSession();
+	___DEBUGLOG( "post stopExportSession" );
 
 	auto t1 = std::chrono::high_resolution_clock::now();
 	double t = std::chrono::duration<double>( t1 - t0 ).count();


### PR DESCRIPTION
Both `Event` and `EventQueue` do now have a `toQString()` method.

addresses #1820 