### PR TITLE
AppImage: Create a basic Hydrogen.AppImage in AppVeyor pipeline

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,37 +47,37 @@ environment:
   TARGET_VERSION: '1.2.1'
   matrix:
 
-    # - job_name: 'Ubuntu 20.04'
-    #   job_group: 'Linux'
-    #   appveyor_build_worker_image: Ubuntu2004
+    - job_name: 'Ubuntu 20.04'
+      job_group: 'Linux'
+      appveyor_build_worker_image: Ubuntu2004
 
     - job_name: 'Ubuntu 16.04 (AppImage)'
       job_group: 'Linux (AppImage)'
       appveyor_build_worker_image: Ubuntu1604
 
-    # - job_name: 'OS X'
-    #   job_group: 'Mac OS X'
-    #   appveyor_build_worker_image: macos
+    - job_name: 'OS X'
+      job_group: 'Mac OS X'
+      appveyor_build_worker_image: macos
 
-    # - job_name: 'Windows64'
-    #   job_group: 'Windows'
-    #   MSYS: 'C:\msys64\mingw64'
-    #   MSYS_REPO: 'mingw64/mingw-w64-x86_64'
-    #   BUILD_TYPE: "Release"
-    #   CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
-    #   appveyor_build_worker_image: Visual Studio 2019
-    #   LIBSSL: libssl-3-x64.dll
-    #   LIBCRYPTO: libcrypto-3-x64.dll
+    - job_name: 'Windows64'
+      job_group: 'Windows'
+      MSYS: 'C:\msys64\mingw64'
+      MSYS_REPO: 'mingw64/mingw-w64-x86_64'
+      BUILD_TYPE: "Release"
+      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
+      appveyor_build_worker_image: Visual Studio 2019
+      LIBSSL: libssl-3-x64.dll
+      LIBCRYPTO: libcrypto-3-x64.dll
 
-    # - job_name: 'Windows32'
-    #   job_group: 'Windows'
-    #   MSYS: 'C:\msys64\mingw32'
-    #   MSYS_REPO: 'mingw32/mingw-w64-i686'
-    #   BUILD_TYPE: "Release"
-    #   CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
-    #   appveyor_build_worker_image: Visual Studio 2019
-    #   LIBSSL: libssl-3.dll
-    #   LIBCRYPTO: libcrypto-3.dll
+    - job_name: 'Windows32'
+      job_group: 'Windows'
+      MSYS: 'C:\msys64\mingw32'
+      MSYS_REPO: 'mingw32/mingw-w64-i686'
+      BUILD_TYPE: "Release"
+      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
+      appveyor_build_worker_image: Visual Studio 2019
+      LIBSSL: libssl-3.dll
+      LIBCRYPTO: libcrypto-3.dll
 
 build:
   verbosity: detailed

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -247,8 +247,6 @@ for:
         ccache -M 256M || exit 1
         ccache -s || exit 1
 
-        echo "till here"
-
         (
           sudo python3 ./treestate.py updates usr.json /usr > updates || exit 1
           echo $(wc -l updates) updates
@@ -292,7 +290,7 @@ for:
       chmod +x linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
 
       echo -e "\n *** Building AppImage ***\n"
-      linuxdeploy --appdir AppDir \
+      ./linuxdeploy-x86_64.AppImage --appdir AppDir \
         --executable AppDir/usr/bin/hydrogen \
         --library AppDir/usr/lib/x86_64-linux-gnu/libhydrogen-core-*.so \
         --desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -267,8 +267,12 @@ for:
       echo "Building with $CPUS cpus"
       mkdir build || exit 1
       cd build || exit 1
-      cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 .. \
-        -DWANT_APPIMAGE=1 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache || exit 1
+      cmake -DWANT_LASH=1 \
+            -DWANT_LRDF=1 \
+            -DWANT_RUBBERBAND=1 \
+            -DWANT_APPIMAGE=1 \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_INSTALL_PREFIX=/usr ..|| exit 1
       make -j $CPUS || exit 1
 
       ccache -s || exit 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -281,6 +281,10 @@ for:
 
       echo -e "\n *** Retrieve AppImage toolchain ***\n"
 
+      ls AppDir/usr/lib/
+      ls AppDir/usr/lib/x86_64-linux-gnu/
+      tree AppDir
+
       ## We do not cache this binary since it represents a rolling
       ## release and it releases us from the burden for keeping it
       ## up-to-date manually.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -258,7 +258,7 @@ for:
       mkdir build || exit 1
       cd build || exit 1
       cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 .. \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache || exit 1
+        -DWANT_APPIMAGE=1 -DCMAKE_CXX_COMPILER_LAUNCHER=ccache || exit 1
       make -j $CPUS || exit 1
 
       ccache -s || exit 1
@@ -275,10 +275,18 @@ for:
       ## release and it releases us from the burden for keeping it
       ## up-to-date manually.
       wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage || exit 1
+      wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
       chmod +x linuxdeploy-x86_64.AppImage || exit 1
+      chmod +x linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
 
       echo -e "\n *** Building AppImage ***\n"
-      ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage || exit 1
+      linuxdeploy --appdir AppDir \
+        --executable AppDir/usr/bin/hydrogen \
+        --library AppDir/usr/lib/x86_64-linux-gnu/libhydrogen-core-*.so \
+        --desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \
+        --icon-file AppDir/usr/share/hydrogen/data/img/gray/icon.svg \
+        --plugin qt \
+        --output appimage || exit 1
 
       echo -e "\n *** Upload AppImage ***\n"
       appveyor PushArtifact Hydrogen-x86_64.AppImage || exit 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -216,6 +216,8 @@ for:
       mkdir -p $cdir/ccache || exit 1
       ln -s $cdir/ccache $HOME/.ccache || exit 1
 
+      python3 --version
+
       if [ -d $cdir ] && [ -f $cache ]; then
         echo "=== Unpacking cached /var $cache ==="
         (
@@ -228,7 +230,8 @@ for:
 
         mkdir -p $cdir || exit 1
 
-        sudo python3 ./treestate.py scan /usr usr.json || exit 1
+        sudo python3 ./treestate.py scan /usr usr.json
+        echo $?
         sudo apt-get update || exit 1
         sudo apt-get install -y clang qt5-default qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libqt5svg5-dev || exit 1
         sudo apt-get install -y liblo-dev libpulse-dev libportmidi-dev portaudio19-dev libcppunit-dev liblrdf-dev librubberband-dev ladspa-sdk ccache appstream intltool desktop-file-utils || exit 1
@@ -236,8 +239,11 @@ for:
         ccache -M 256M || exit 1
         ccache -s || exit 1
 
+        echo "till here"
+
         (
-          sudo python3 ./treestate.py updates usr.json /usr > updates || exit 1
+          sudo python3 ./treestate.py updates usr.json /usr > updates
+          echo $?
           echo $(wc -l updates) updates
           sudo tar cf $cache_tar -T updates || exit 1
           sudo nice xz -9 -T0 $cache_tar || exit 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -197,7 +197,7 @@ for:
       only:
         - job_group: 'Linux (AppImage)'
 
-    cache: $HOME/cache_dir
+    cache: $HOME/cache_dir_appimage
 
     before_build: |-
       if [ "$UPLOAD_ARTIFACTS" == "false" ]; then
@@ -209,7 +209,7 @@ for:
 
       ## Since we use a different Linux image we, unfortunately, have
       ## to use a separate cache.
-      cdir=$HOME/cache_dir
+      cdir=$HOME/cache_dir_appimage
       cache_tar=$cdir/$cache_tag.tar
       cache=$cache_tar.xz
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -216,8 +216,6 @@ for:
       mkdir -p $cdir/ccache || exit 1
       ln -s $cdir/ccache $HOME/.ccache || exit 1
 
-      python3 --version
-
       if [ -d $cdir ] && [ -f $cache ]; then
         echo "=== Unpacking cached /var $cache ==="
         (
@@ -230,8 +228,7 @@ for:
 
         mkdir -p $cdir || exit 1
 
-        sudo python3 ./treestate.py scan /usr usr.json
-        echo $?
+        sudo python3 ./treestate.py scan /usr usr.json || exit 1
         sudo apt-get update || exit 1
         sudo apt-get install -y clang qt5-default qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libqt5svg5-dev || exit 1
         sudo apt-get install -y liblo-dev libpulse-dev libportmidi-dev portaudio19-dev libcppunit-dev liblrdf-dev librubberband-dev ladspa-sdk ccache appstream intltool desktop-file-utils || exit 1
@@ -253,8 +250,7 @@ for:
         echo "till here"
 
         (
-          sudo python3 ./treestate.py updates usr.json /usr > updates
-          echo $?
+          sudo python3 ./treestate.py updates usr.json /usr > updates || exit 1
           echo $(wc -l updates) updates
           sudo tar cf $cache_tar -T updates || exit 1
           sudo nice xz -9 -T0 $cache_tar || exit 1

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,6 +51,10 @@ environment:
       job_group: 'Linux'
       appveyor_build_worker_image: Ubuntu2004
 
+    - job_name: 'Ubuntu 16.04 (AppImage)'
+      job_group: 'Linux_AppImage'
+      appveyor_build_worker_image: Ubuntu1604
+
     - job_name: 'OS X'
       job_group: 'Mac OS X'
       appveyor_build_worker_image: macos
@@ -187,6 +191,97 @@ for:
       appstreamcli validate ../linux/org.hydrogenmusic.Hydrogen.metainfo.xml || exit 1
 
       ( exit $res )
+
+for:
+  - 
+    matrix:
+      only:
+        - job_group: 'Linux_AppImage'
+
+    cache: $HOME/cache_dir
+
+    before_build: |-
+      if [ "$UPLOAD_ARTIFACTS" == "false" ]; then
+         echo "Skipping AppImage build as artifacts are not requested"
+         exit 0
+      fi
+
+      cache_tag=usr_cache_appimage # this can be modified to rebuild deps
+
+      ## Since we use a different Linux image we, unfortunately, have
+      ## to use a separate cache.
+      cdir=$HOME/cache_dir
+      cache_tar=$cdir/$cache_tag.tar
+      cache=$cache_tar.xz
+
+      mkdir -p $cdir/ccache || exit 1
+      ln -s $cdir/ccache $HOME/.ccache || exit 1
+
+      if [ -d $cdir ] && [ -f $cache ]; then
+        echo "=== Unpacking cached /var $cache ==="
+        (
+          cd /
+          sudo tar xf $cache || exit 1
+        )
+        echo "done"
+      else
+        echo "=== Building dependencies ==="
+
+        mkdir -p $cdir || exit 1
+
+        sudo python3 ./treestate.py scan /usr usr.json || exit 1
+        sudo apt-get update || exit 1
+        sudo apt-get install -y clang qt5-default qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libqt5svg5-dev || exit 1
+        sudo apt-get install -y liblo-dev libpulse-dev libportmidi-dev portaudio19-dev libcppunit-dev liblrdf-dev librubberband-dev ladspa-sdk ccache appstream intltool desktop-file-utils || exit 1
+        sudo rm /usr/local/bin/doxygen || exit 1
+        ccache -M 256M || exit 1
+        ccache -s || exit 1
+
+        (
+          sudo python3 ./treestate.py updates usr.json /usr > updates || exit 1
+          echo $(wc -l updates) updates
+          sudo tar cf $cache_tar -T updates || exit 1
+          sudo nice xz -9 -T0 $cache_tar || exit 1
+          du -h $cache
+
+        ) 2>&1 | sed 's/^/CACHE: /' &
+      fi
+
+    build_script: |-
+      git submodule init || exit 1
+      git submodule update || exit 1
+
+      export CMAKE_CXX_FLAGS="-fstrict-enums -fstack-protector-strong -Werror=format-security -Wformat -Wunused-result -D_FORTIFY_SOURCE=2"
+
+      CPUS=$(nproc)
+      echo "Building with $CPUS cpus"
+      mkdir build || exit 1
+      cd build || exit 1
+      cmake -DWANT_LASH=1 -DWANT_LRDF=1 -DWANT_RUBBERBAND=1 .. \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache || exit 1
+      make -j $CPUS || exit 1
+
+      ccache -s || exit 1
+
+      wait
+      echo "=== Build cache usage is " $( du -h $cdir | tail -1 ) "==="
+
+      echo -e "\n *** Creating AppDir ***\n"
+      make install DESTDIR=AppDir || exit 1
+
+      echo -e "\n *** Retrieve AppImage toolchain ***\n"
+
+      ## We do not cache this binary since it represents a rolling
+      ## release and it releases us from the burden for keeping it
+      ## up-to-date manually.
+      wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage || exit 1
+      chmod +x linuxdeploy-x86_64.AppImage || exit 1
+
+      echo -e "\n *** Building AppImage ***\n"
+      ./linuxdeploy-x86_64.AppImage --appdir AppDir --output appimage || exit 1
+
+      echo -e "\n *** Upload AppImage ***\n"
+      appveyor PushArtifact Hydrogen-x86_64.AppImage || exit 1
 
   - 
     cache: /Users/appveyor/cache_dir

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -236,6 +236,17 @@ for:
         sudo apt-get install -y clang qt5-default qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libqt5svg5-dev || exit 1
         sudo apt-get install -y liblo-dev libpulse-dev libportmidi-dev portaudio19-dev libcppunit-dev liblrdf-dev librubberband-dev ladspa-sdk ccache appstream intltool desktop-file-utils || exit 1
         sudo rm /usr/local/bin/doxygen || exit 1
+
+        # liblo version shipped in Ubuntu 16.04 is to low for Hydrogen
+        # to compile.
+        git clone https://github.com/radarsat1/liblo || exit 1
+        cd liblo || exit 1
+        git checkout 0.31 || exit 1
+        ./autogen.sh || exit 1
+        make || exit 1
+        sudo make install || exit 1
+        cd ..
+
         ccache -M 256M || exit 1
         ccache -s || exit 1
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -285,10 +285,6 @@ for:
 
       echo -e "\n *** Retrieve AppImage toolchain ***\n"
 
-      ls AppDir/usr/lib/
-      ls AppDir/usr/lib/x86_64-linux-gnu/
-      tree AppDir
-
       ## We do not cache this binary since it represents a rolling
       ## release and it releases us from the burden for keeping it
       ## up-to-date manually.
@@ -298,9 +294,10 @@ for:
       chmod +x linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
 
       echo -e "\n *** Building AppImage ***\n"
-      ./linuxdeploy-x86_64.AppImage --appdir AppDir \
+
+      LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/ ./linuxdeploy-x86_64.AppImage \
+        --appdir AppDir \
         --executable AppDir/usr/bin/hydrogen \
-        --library AppDir/usr/lib/x86_64-linux-gnu/libhydrogen-core-*.so \
         --desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \
         --icon-file AppDir/usr/share/hydrogen/data/img/gray/icon.svg \
         --plugin qt \

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -52,7 +52,7 @@ environment:
       appveyor_build_worker_image: Ubuntu2004
 
     - job_name: 'Ubuntu 16.04 (AppImage)'
-      job_group: 'Linux_AppImage'
+      job_group: 'Linux (AppImage)'
       appveyor_build_worker_image: Ubuntu1604
 
     - job_name: 'OS X'
@@ -192,11 +192,10 @@ for:
 
       ( exit $res )
 
-for:
   - 
     matrix:
       only:
-        - job_group: 'Linux_AppImage'
+        - job_group: 'Linux (AppImage)'
 
     cache: $HOME/cache_dir
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,37 +47,37 @@ environment:
   TARGET_VERSION: '1.2.1'
   matrix:
 
-    - job_name: 'Ubuntu 20.04'
-      job_group: 'Linux'
-      appveyor_build_worker_image: Ubuntu2004
+    # - job_name: 'Ubuntu 20.04'
+    #   job_group: 'Linux'
+    #   appveyor_build_worker_image: Ubuntu2004
 
     - job_name: 'Ubuntu 16.04 (AppImage)'
       job_group: 'Linux (AppImage)'
       appveyor_build_worker_image: Ubuntu1604
 
-    - job_name: 'OS X'
-      job_group: 'Mac OS X'
-      appveyor_build_worker_image: macos
+    # - job_name: 'OS X'
+    #   job_group: 'Mac OS X'
+    #   appveyor_build_worker_image: macos
 
-    - job_name: 'Windows64'
-      job_group: 'Windows'
-      MSYS: 'C:\msys64\mingw64'
-      MSYS_REPO: 'mingw64/mingw-w64-x86_64'
-      BUILD_TYPE: "Release"
-      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
-      appveyor_build_worker_image: Visual Studio 2019
-      LIBSSL: libssl-3-x64.dll
-      LIBCRYPTO: libcrypto-3-x64.dll
+    # - job_name: 'Windows64'
+    #   job_group: 'Windows'
+    #   MSYS: 'C:\msys64\mingw64'
+    #   MSYS_REPO: 'mingw64/mingw-w64-x86_64'
+    #   BUILD_TYPE: "Release"
+    #   CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
+    #   appveyor_build_worker_image: Visual Studio 2019
+    #   LIBSSL: libssl-3-x64.dll
+    #   LIBCRYPTO: libcrypto-3-x64.dll
 
-    - job_name: 'Windows32'
-      job_group: 'Windows'
-      MSYS: 'C:\msys64\mingw32'
-      MSYS_REPO: 'mingw32/mingw-w64-i686'
-      BUILD_TYPE: "Release"
-      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
-      appveyor_build_worker_image: Visual Studio 2019
-      LIBSSL: libssl-3.dll
-      LIBCRYPTO: libcrypto-3.dll
+    # - job_name: 'Windows32'
+    #   job_group: 'Windows'
+    #   MSYS: 'C:\msys64\mingw32'
+    #   MSYS_REPO: 'mingw32/mingw-w64-i686'
+    #   BUILD_TYPE: "Release"
+    #   CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
+    #   appveyor_build_worker_image: Visual Studio 2019
+    #   LIBSSL: libssl-3.dll
+    #   LIBCRYPTO: libcrypto-3.dll
 
 build:
   verbosity: detailed

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ moc_*.cc
 moc_*.cpp_parameters
 /.tags
 /build
+/build-appimage
 /cmake_opts
 /hydrogen
 /libs/hydrogen/include/hydrogen/config.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,12 @@ ELSE()
     SET(H2CORE_HAVE_BUNDLE FALSE)
 ENDIF()
 
+IF(WANT_FAT_BUILD)
+    SET(H2CORE_HAVE_FAT_BUILD TRUE)
+ELSE()
+    SET(H2CORE_HAVE_FAT_BUILD FALSE)
+ENDIF()
+
 IF(WANT_SHARED)
     SET(H2CORE_LIBRARY_TYPE SHARED)
 ELSE()
@@ -339,8 +345,8 @@ COLOR_MESSAGE("${cyan}Installation Summary${reset}
 * Data path                    : ${H2_DATA_PATH}
 * core library build as        : ${H2CORE_LIBRARY_TYPE}
 * debug capabilities           : ${H2CORE_HAVE_DEBUG}
-* macosx bundle                : ${H2CORE_HAVE_BUNDLE}
-* fat build                    : ${WANT_FAT_BUILD}
+* macOS bundle                 : ${H2CORE_HAVE_BUNDLE}
+* Windows fat build            : ${H2CORE_HAVE_FAT_BUILD}
 * AppImage build               : ${H2CORE_HAVE_APPIMAGE}\n"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,8 @@ IF(APPLE)
     OPTION(WANT_BUNDLE      "Build a MAC OSX bundle application" ON)
 ENDIF()
 
+OPTION(WANT_APPIMAGE "Build Linux AppImage" OFF)
+
 OPTION(WANT_CPPUNIT         "Include CppUnit test suite" ON)
 
 include(Sanitizers)
@@ -134,6 +136,12 @@ IF(WANT_DEBUG)
 	SET(CMAKE_CXX_FLAGS "$ENV{CMAKE_CXX_FLAGS} -O0")
 ELSE()
 	SET(CMAKE_CXX_FLAGS "$ENV{CMAKE_CXX_FLAGS} -O3 -ffast-math")
+ENDIF()
+
+IF(WANT_APPIMAGE)
+  SET(H2CORE_HAVE_APPIMAGE TRUE)
+ELSE()
+  SET(H2CORE_HAVE_APPIMAGE FALSE)
 ENDIF()
 
 IF (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -332,7 +340,8 @@ COLOR_MESSAGE("${cyan}Installation Summary${reset}
 * core library build as        : ${H2CORE_LIBRARY_TYPE}
 * debug capabilities           : ${H2CORE_HAVE_DEBUG}
 * macosx bundle                : ${H2CORE_HAVE_BUNDLE}
-* fat build                    : ${WANT_FAT_BUILD}\n"
+* fat build                    : ${WANT_FAT_BUILD}
+* AppImage build               : ${H2CORE_HAVE_APPIMAGE}\n"
 )
 
 COLOR_MESSAGE("${cyan}Main librarires${reset}")

--- a/build.sh
+++ b/build.sh
@@ -95,9 +95,9 @@ function cmake_appimage() {
 	make install DESTDIR=AppDir || exit 1
 
 	## Copy required shared libraries and pack the resulting AppImage
-	linuxdeploy --appdir AppDir \
+	LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/ linuxdeploy \
+				--appdir AppDir \
 				--executable AppDir/usr/bin/hydrogen \
-				--library AppDir/usr/lib/x86_64-linux-gnu/libhydrogen-core-*.so \
 				--desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \
 				--icon-file AppDir/usr/share/hydrogen/data/img/gray/icon.svg \
 				--plugin qt \

--- a/build.sh
+++ b/build.sh
@@ -97,6 +97,7 @@ function cmake_appimage() {
 	## Copy required shared libraries and pack the resulting AppImage
 	linuxdeploy --appdir AppDir \
 				--executable AppDir/usr/bin/hydrogen \
+				--library AppDir/usr/lib/x86_64-linux-gnu/libhydrogen-core-*.so \
 				--desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \
 				--icon-file AppDir/usr/share/hydrogen/data/img/gray/icon.svg \
 				--plugin qt \
@@ -239,7 +240,7 @@ for arg in $@; do
     case $arg in
 		appimage)
 			BUILD_DIR=./build-appimage
-			CMAKE_OPTIONS="$CMAKE_OPTIONS -DWANT_DEBUG=0 -DCMAKE_INSTALL_PREFIX=/usr"
+			CMAKE_OPTIONS="$CMAKE_OPTIONS -DWANT_APPIMAGE=1 -DCMAKE_INSTALL_PREFIX=/usr"
 			cmd="cmake_appimage";;
         c|clean)
             cmd="cmake_clean";;

--- a/build.sh
+++ b/build.sh
@@ -67,6 +67,44 @@ function cmake_rm() {
     echo -e " * rm cmake files\n" && rm -fr $BUILD_DIR 2>/dev/null
 }
 
+## Build a Hydrogen-x86_64.AppImage file.
+function cmake_appimage() {
+
+	## Check for AppImage toolchain.
+	which linuxdeploy
+	if [[ "$?" != "0" ]]; then
+		read -p "AppImage toolchain not present yet. Should it be downloaded? [y|N]: " consent
+		if [[ "$consent" == "y" ]]; then
+			wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage || exit 1
+			chmod +x linuxdeploy-x86_64.AppImage || exit 1
+			wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
+			chmod +x linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
+			echo -e "AppImage toolchain was successfully downloaded. Please put it as 'linuxdeploy' into \$PATH. E.g. using\n\tln -s $PWD/linuxdeploy-x86_64.AppImage $HOME/bin/linuxdeploy\n"
+		fi
+
+		exit 1
+	fi
+
+	## Perform a regular cmake build.
+	cmake_make
+
+	cd $BUILD_DIR || exit 1
+
+	## Install the compilation result into a folder which will serve
+	## as base for the AppImage.
+	make install DESTDIR=AppDir || exit 1
+
+	## Copy required shared libraries and pack the resulting AppImage
+	linuxdeploy --appdir AppDir \
+				--executable AppDir/usr/bin/hydrogen \
+				--desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \
+				--icon-file AppDir/usr/share/hydrogen/data/img/gray/icon.svg \
+				--plugin qt \
+				--output appimage || exit 1
+
+	cd ..
+}
+
 function cmake_make() {
 	SILENT=1 update_translations
 
@@ -191,6 +229,7 @@ if [ $# -eq 0 ]; then
     echo "   t[ests]   => execute tests"
     echo "   p[kg]     => build source package"
     echo "   translate => update all translation files"
+	echo "   appimage  => build an AppImage file"
     echo "   z         => build using ccache and run from tree"
     echo "ex: $0 r m pkg x"
     exit 1
@@ -198,6 +237,10 @@ fi
 
 for arg in $@; do
     case $arg in
+		appimage)
+			BUILD_DIR=./build-appimage
+			CMAKE_OPTIONS="$CMAKE_OPTIONS -DWANT_DEBUG=0 -DCMAKE_INSTALL_PREFIX=/usr"
+			cmd="cmake_appimage";;
         c|clean)
             cmd="cmake_clean";;
         r|rm)

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -139,7 +139,11 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sys_path )
 	__usr_data_path = QDir::homePath().append( "/.hydrogen/data/" ) ;
 	__usr_cfg_path = QDir::homePath().append( "/.hydrogen/" USR_CONFIG ) ;
 #else
+#ifdef H2CORE_HAVE_APPIMAGE
+	__sys_data_path = QCoreApplication::applicationDirPath().append( "/../share/hydrogen/data/" ) ;
+#else
 	__sys_data_path = H2_SYS_PATH "/data/";
+#endif
 	__usr_data_path = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
 	__usr_cfg_path = QDir::homePath().append( "/" H2_USR_PATH "/" USR_CONFIG );
 #endif

--- a/src/core/config.h.in
+++ b/src/core/config.h.in
@@ -40,6 +40,9 @@
 #ifndef H2CORE_HAVE_BUNDLE
 #cmakedefine H2CORE_HAVE_BUNDLE
 #endif
+#ifndef H2CORE_HAVE_APPIMAGE
+#cmakedefine H2CORE_HAVE_APPIMAGE
+#endif
 #ifndef H2CORE_HAVE_LIBSNDFILE
 #cmakedefine H2CORE_HAVE_LIBSNDFILE
 #endif

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -75,8 +75,8 @@ NotePropertiesRuler::NotePropertiesRuler( QWidget *parent, PatternEditorPanel *p
 	// menu options specific to this later.
 	delete m_pPopupMenu;
 	m_pPopupMenu = new QMenu( this );
-	m_pPopupMenu->addAction( tr( "Select &all" ), this, &PatternEditor::selectAll );
-	m_pPopupMenu->addAction( tr( "Clear selection" ), this, &PatternEditor::selectNone );
+	m_pPopupMenu->addAction( tr( "Select &all" ), this, SLOT( selectAll() ) );
+	m_pPopupMenu->addAction( tr( "Clear selection" ), this, SLOT( selectNone() ) );
 
 	setMouseTracking( true );
 }

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -85,12 +85,12 @@ PatternEditor::PatternEditor( QWidget *pParent,
 
 	// Popup context menu
 	m_pPopupMenu = new QMenu( this );
-	m_pPopupMenu->addAction( tr( "&Cut" ), this, &PatternEditor::cut );
-	m_pPopupMenu->addAction( tr( "&Copy" ), this, &PatternEditor::copy );
-	m_pPopupMenu->addAction( tr( "&Paste" ), this, &PatternEditor::paste );
-	m_pPopupMenu->addAction( tr( "&Delete" ), this, &PatternEditor::deleteSelection );
-	m_pPopupMenu->addAction( tr( "Select &all" ), this, &PatternEditor::selectAll );
-	m_pPopupMenu->addAction( tr( "Clear selection" ), this, &PatternEditor::selectNone );
+	m_pPopupMenu->addAction( tr( "&Cut" ), this, SLOT( cut() ) );
+	m_pPopupMenu->addAction( tr( "&Copy" ), this, SLOT( copy() ) );
+	m_pPopupMenu->addAction( tr( "&Paste" ), this, SLOT( paste() ) );
+	m_pPopupMenu->addAction( tr( "&Delete" ), this, SLOT( deleteSelection() ) );
+	m_pPopupMenu->addAction( tr( "Select &all" ), this, SLOT( selectAll() ) );
+	m_pPopupMenu->addAction( tr( "Clear selection" ), this, SLOT( selectNone() ) );
 
 	qreal pixelRatio = devicePixelRatio();
 	m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -132,7 +132,8 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 
 	m_pFunctionPopup->addSection( tr( "Instrument" ) );
 	m_pFunctionPopup->addAction( tr( "Rename instrument" ), this, SLOT( functionRenameInstrument() ) );
-	m_pFunctionPopup->addAction( tr( "Delete instrument" ), this, [=](){
+	auto deleteAction = m_pFunctionPopup->addAction( tr( "Delete instrument" ) );
+	connect( deleteAction, &QAction::triggered, this, [=](){
 		HydrogenApp::get_instance()->getMainForm()->
 			functionDeleteInstrument( m_nInstrumentNumber );} );
 	m_pFunctionPopup->setObjectName( "PatternEditorFunctionPopup" );

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -120,7 +120,9 @@ InstrumentLine::InstrumentLine(QWidget* pParent)
 	m_pFunctionPopup->addMenu( m_pFunctionPopupSub );
 
 	m_pFunctionPopup->addAction( tr( "Randomize velocity" ), this, SLOT( functionRandomizeVelocity() ) );
-	m_pFunctionPopup->addAction( tr( "Select notes" ), this, &InstrumentLine::selectInstrumentNotes );
+	auto selectNotesAction = m_pFunctionPopup->addAction( tr( "Select notes" ) );
+	connect( selectNotesAction, &QAction::triggered, this,
+			 &InstrumentLine::selectInstrumentNotes );
 
 	m_pFunctionPopup->addSection( tr( "Edit all patterns" ) );
 	m_pFunctionPopup->addAction( tr( "Cut notes"), this, SLOT( functionCutNotesAllPatterns() ) );

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -437,7 +437,11 @@ public:
 			m_pClickEvent = new QMouseEvent(QEvent::MouseButtonPress,
 											ev->localPos(), ev->windowPos(), ev->screenPos(),
 											m_mouseButton, ev->buttons(), ev->modifiers(),
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 											Qt::MouseEventSynthesizedByApplication);
+#else
+											Qt::MouseEventSynthesizedByQt);
+#endif
 			m_pClickEvent->setTimestamp( ev->timestamp() );
 		}
 	}

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -434,13 +434,15 @@ public:
 			m_mouseState = Down;
 			m_mouseButton = ev->button();
 			assert( m_pClickEvent == nullptr );
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 			m_pClickEvent = new QMouseEvent(QEvent::MouseButtonPress,
 											ev->localPos(), ev->windowPos(), ev->screenPos(),
 											m_mouseButton, ev->buttons(), ev->modifiers(),
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
 											Qt::MouseEventSynthesizedByApplication);
 #else
-											Qt::MouseEventSynthesizedByQt);
+			m_pClickEvent = new QMouseEvent(QEvent::MouseButtonPress,
+											ev->localPos(), ev->windowPos(), ev->screenPos(),
+											m_mouseButton, ev->buttons(), ev->modifiers());
 #endif
 			m_pClickEvent->setTimestamp( ev->timestamp() );
 		}

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -112,12 +112,12 @@ SongEditor::SongEditor( QWidget *parent, QScrollArea *pScrollView, SongEditorPan
 
 	// Popup context menu
 	m_pPopupMenu = new QMenu( this );
-	m_pPopupMenu->addAction( tr( "&Cut" ), this, &SongEditor::cut );
-	m_pPopupMenu->addAction( tr( "&Copy" ), this, &SongEditor::copy );
-	m_pPopupMenu->addAction( tr( "&Paste" ), this, &SongEditor::paste );
-	m_pPopupMenu->addAction( tr( "&Delete" ), this, &SongEditor::deleteSelection );
-	m_pPopupMenu->addAction( tr( "Select &all" ), this, &SongEditor::selectAll );
-	m_pPopupMenu->addAction( tr( "Clear selection" ), this, &SongEditor::selectNone );
+	m_pPopupMenu->addAction( tr( "&Cut" ), this, SLOT( cut() ) );
+	m_pPopupMenu->addAction( tr( "&Copy" ), this, SLOT( copy() ) );
+	m_pPopupMenu->addAction( tr( "&Paste" ), this, SLOT( paste() ) );
+	m_pPopupMenu->addAction( tr( "&Delete" ), this, SLOT( deleteSelection() ) );
+	m_pPopupMenu->addAction( tr( "Select &all" ), this, SLOT( selectAll() ) );
+	m_pPopupMenu->addAction( tr( "Clear selection" ), this, SLOT( selectNone() ) );
 	m_pPopupMenu->setObjectName( "SongEditorPopup" );
 
 	HydrogenApp::get_instance()->addEventListener( this );

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -48,15 +48,16 @@ LCDCombo::LCDCombo( QWidget *pParent, QSize size, bool bModifyOnChange )
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &LCDCombo::onPreferencesChanged );
 	// Mark the current song modified if there was an user interaction
 	// with the widget.
-	connect( this, QOverload<int>::of(&QComboBox::activated),
-			 [=](int){
-				 if ( m_bModifyOnChange ) {
-					 H2Core::Hydrogen::get_instance()->setIsModified( true );
-				 }
-			 });
+	connect( this, SIGNAL( activated(int) ), this, SLOT( handleIsModified(int) ) );
 }
 
 LCDCombo::~LCDCombo() {
+}
+
+void LCDCombo::handleIsModified( int ) {
+	if ( m_bModifyOnChange ) {
+		H2Core::Hydrogen::get_instance()->setIsModified( true );
+	}
 }
 
 void LCDCombo::addItem( const QString& sText, const QVariant& userData ) {

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -52,6 +52,7 @@ public:
 
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
+	void handleIsModified( int );
 
 private:
 	void updateStyleSheet();

--- a/treestate.py
+++ b/treestate.py
@@ -30,7 +30,7 @@ def writeTree(filename, tree):
 def readTree(filename):
     with open(filename, "r") as f:
         if f == None:
-            print(f"*** couldn't open {filename} ***")
+            print("*** couldn't open {} ***".format(filename))
         return json.load(f)
 
 # Find updates in tree between states A and B
@@ -56,10 +56,10 @@ def findUpdates(a, b):
 
 def help():
     print("Syntax:")
-    print(f"  {sys.argv[0]} scan path stateFile")
-    print(f"      Record the state of <path> in <stateFile>")
-    print(f"  {sys.argv[0]} updates stateFile path")
-    print(f"      Print the paths of objects in <path> which have updated since <stateFile>")
+    print("  {} scan path stateFile".format(sys.argv[0]))
+    print("      Record the state of <path> in <stateFile>")
+    print("  {} updates stateFile path".format(sys.argv[0]))
+    print("      Print the paths of objects in <path> which have updated since <stateFile>")
     exit()
 
 
@@ -87,6 +87,6 @@ elif sys.argv[1] == 'updates':
     findUpdates(readTree(a), scanTreeState(b))
 
 else:
-    print(f"Unknown command: {sys.argv[1]}")
+    print("Unknown command: {}".format(sys.argv[1]))
     help()
 


### PR DESCRIPTION
This patch introduces code to build an AppImage version of Hydrogen using both our `build.sh` script as well as using the AppVeyor pipeline. Whenever the latter is triggered for an `-artifacts` branch or a tag a `Hydrogen.AppImage` will be generated and uploaded.

The main idea of AppImage (as far as I got it) is to build on the oldest possible system to harness forward ABI compatibility of `gcc` in order to allow running the image on as many systems as possible. (Linux versions using `clang` or linking against `musl` will most probably not work). Therefore, I used the **Ubuntu 16.04** image of AppVeyor and the code required some changes to support it

- code fixes to be compatible with Qt 5.5 (very old)
- `treestate.py` is now compatible with Python 3.5

I tested the image on a Fedora 38 live system and it most worked. There are still a couple of things to be fixed and more tests on more OSs to be done. But I'll address them in separate PRs.

Fixes #1504 