### PR TITLE
AppImage: Support SSL and use Qt 5.15

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -205,7 +205,7 @@ for:
          exit 0
       fi
 
-      cache_tag=usr_cache_appimage # this can be modified to rebuild deps
+      cache_tag=usr_cache_appimage_ssl # this can be modified to rebuild deps
 
       ## Since we use a different Linux image we, unfortunately, have
       ## to use a separate cache.
@@ -233,6 +233,16 @@ for:
         sudo apt-get install -y clang qt5-default qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libqt5svg5-dev || exit 1
         sudo apt-get install -y liblo-dev libpulse-dev libportmidi-dev portaudio19-dev libcppunit-dev liblrdf-dev librubberband-dev ladspa-sdk ccache appstream intltool desktop-file-utils || exit 1
         sudo rm /usr/local/bin/doxygen || exit 1
+
+        # Ubuntu 16.04 is shipped with OpenSSL 1.0.2 which is not
+        # compatible with v 1.1.1X expected by Qt
+        git clone https://github.com/openssl/openssl || exit 1
+        cd openssl || exit 1
+        git checkout OpenSSL_1_1_1t || exit 1
+        ./config || exit 1
+        make -j $(nproc) || exit 1
+        sudo make install || exit 1
+        cd ..
 
         # liblo version shipped in Ubuntu 16.04 is to low for Hydrogen
         # to compile.
@@ -294,6 +304,12 @@ for:
       chmod +x linuxdeploy-plugin-qt-x86_64.AppImage || exit 1
 
       echo -e "\n *** Building AppImage ***\n"
+
+      ## Add custom OpenSSL libraries. They are used as fallback by Qt
+      ## and are only dl_opened in case no matching version was found
+      ## on system level.
+      cp /usr/local/lib/libssl.so.1.1 AppDir/usr/bin || exit 1
+      cp /usr/local/lib/libcrypto.so.1.1 AppDir/usr/bin || exit 1
 
       LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/ ./linuxdeploy-x86_64.AppImage \
         --appdir AppDir \

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -205,7 +205,7 @@ for:
          exit 0
       fi
 
-      cache_tag=usr_cache_appimage_ssl # this can be modified to rebuild deps
+      cache_tag=usr_cache_appimage_qt # this can be modified to rebuild deps
 
       ## Since we use a different Linux image we, unfortunately, have
       ## to use a separate cache.
@@ -230,8 +230,11 @@ for:
 
         sudo python3 ./treestate.py scan /usr usr.json || exit 1
         sudo apt-get update || exit 1
-        sudo apt-get install -y clang qt5-default qttools5-dev qttools5-dev-tools libqt5xmlpatterns5-dev libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libqt5svg5-dev || exit 1
+        sudo apt-get install -y clang libarchive-dev libsndfile1-dev libasound2-dev libjack-jackd2-dev libflac-dev libgl1-mesa-dev libgles2-mesa-dev libglu1-mesa-dev libogg-dev libvorbis-dev mesa-common-dev libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 || exit 1
         sudo apt-get install -y liblo-dev libpulse-dev libportmidi-dev portaudio19-dev libcppunit-dev liblrdf-dev librubberband-dev ladspa-sdk ccache appstream intltool desktop-file-utils || exit 1
+
+        # The doxygen version provided in the repo is bricked and
+        # would crash the `liblo` build.
         sudo rm /usr/local/bin/doxygen || exit 1
 
         # Ubuntu 16.04 is shipped with OpenSSL 1.0.2 which is not
@@ -271,6 +274,8 @@ for:
       git submodule init || exit 1
       git submodule update || exit 1
 
+      export PATH=$HOME/Qt/5.15.2/gcc_64/bin:$PATH
+      export Qt5Widgets_DIR=$HOME/Qt/5.15.2/gcc_64/lib/cmake/Qt5Widgets
       export CMAKE_CXX_FLAGS="-fstrict-enums -fstack-protector-strong -Werror=format-security -Wformat -Wunused-result -D_FORTIFY_SOURCE=2"
 
       CPUS=$(nproc)
@@ -282,7 +287,8 @@ for:
             -DWANT_RUBBERBAND=1 \
             -DWANT_APPIMAGE=1 \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_INSTALL_PREFIX=/usr ..|| exit 1
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_PREFIX_PATH=$HOME/Qt/5.15.2/gcc_64 .. || exit 1
       make -j $CPUS || exit 1
 
       ccache -s || exit 1
@@ -308,10 +314,10 @@ for:
       ## Add custom OpenSSL libraries. They are used as fallback by Qt
       ## and are only dl_opened in case no matching version was found
       ## on system level.
-      cp /usr/local/lib/libssl.so.1.1 AppDir/usr/bin || exit 1
-      cp /usr/local/lib/libcrypto.so.1.1 AppDir/usr/bin || exit 1
+      cp /usr/local/lib/libssl.so.1.1 AppDir/usr/lib || exit 1
+      cp /usr/local/lib/libcrypto.so.1.1 AppDir/usr/lib || exit 1
 
-      LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/ ./linuxdeploy-x86_64.AppImage \
+      LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/:AppDir/usr/lib:$HOME/Qt/5.15.2/gcc_64/lib ./linuxdeploy-x86_64.AppImage \
         --appdir AppDir \
         --executable AppDir/usr/bin/hydrogen \
         --desktop-file AppDir/usr/share/applications/org.hydrogenmusic.Hydrogen.desktop \

--- a/build.sh
+++ b/build.sh
@@ -94,6 +94,19 @@ function cmake_appimage() {
 	## as base for the AppImage.
 	make install DESTDIR=AppDir || exit 1
 
+	## Add custom OpenSSL libraries. They are used as fallback by Qt
+    ## and are only dl_opened in case no matching version was found on
+    ## system level.
+	LIB_SSL=$(find /usr -name "libssl.so.1.1*" | head -n 1)
+	LIB_CRYPTO=$(find /usr -name "libcrypto.so.1.1*" | head -n 1)
+	ISSUE_ERROR=0
+	if [[ "$(echo $LIB_SSL | wc -c)" == "1" || "$(echo $LIB_CRYPTO | wc -c)" == "1" ]]; then
+		ISSUE_ERROR=1
+	else
+		cp $LIB_SSL AppDir/usr/lib || exit 1
+		cp $LIB_CRYPTO AppDir/usr/lib || exit 1
+	fi
+
 	## Copy required shared libraries and pack the resulting AppImage
 	LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/ linuxdeploy \
 				--appdir AppDir \
@@ -102,6 +115,12 @@ function cmake_appimage() {
 				--icon-file AppDir/usr/share/hydrogen/data/img/gray/icon.svg \
 				--plugin qt \
 				--output appimage || exit 1
+
+	if [[ "$ISSUE_ERROR" == "1" ]]; then
+		echo -e "\nERROR: unable to find 'libssl.so' and 'libcrypto.so'. They won't be integrated in the AppImage and you should be careful handing it to others\n"
+	else
+		echo -e "\nAppImage bundled with [$LIB_SSL] and [$LIB_CRYPTO]\n"
+	fi
 
 	cd ..
 }

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -23,6 +23,8 @@
 #include <QtGui>
 #include <QtWidgets>
 #include <QLibraryInfo>
+#include <QProcess>
+#include <QSslSocket>
 
 #include <core/config.h>
 #include <core/Version.h>
@@ -477,6 +479,30 @@ int main(int argc, char *argv[])
 
 			exit( 1 );
 		}
+
+#ifdef H2CORE_HAVE_APPIMAGE
+		// Within an AppImage we provide our own version of Qt. But we
+		// also have to ensure to provide an OpenSSL shared object
+		// compatible with that particular version. As shipping
+		// `libssl.so` and `libcrypto.so` is discouraged and
+		// blacklisted by `linuxdeploy-qt`, we manually put them in
+		// the application folder. This way Qt tries to load the
+		// system's libraries first and only falls back to the ones we
+		// provide in case it couldn't find it.
+		//
+		// With the following logs we can determine if a fallback did
+		// happen.
+		
+		QProcess process;
+		process.start( "openssl", QStringList( "version" ));
+		process.waitForFinished(-1);
+		QString sStdout = process.readAllStandardOutput();
+		___INFOLOG( QString( "OpenSSL supported: [%1], version OS: [%2], version used by Hydrogen: [%3]" )
+					.arg( QSslSocket::supportsSsl() )
+					.arg( sStdout.trimmed() )
+					.arg( QSslSocket::sslLibraryVersionString() ) )
+#endif
+
 
 		SplashScreen *pSplash = new SplashScreen();
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -493,14 +493,20 @@ int main(int argc, char *argv[])
 		// With the following logs we can determine if a fallback did
 		// happen.
 		
+		QString sCurrentDir = QDir::currentPath();
+		QDir::setCurrent( QCoreApplication::applicationDirPath() );
 		QProcess process;
 		process.start( "openssl", QStringList( "version" ));
 		process.waitForFinished(-1);
 		QString sStdout = process.readAllStandardOutput();
-		___INFOLOG( QString( "OpenSSL supported: [%1], version OS: [%2], version used by Hydrogen: [%3]" )
+		___INFOLOG( QString( "current: %1, application: %2" ).arg( sCurrentDir )
+					.arg( QCoreApplication::applicationDirPath() ) );
+		___INFOLOG( QString( "OpenSSL supported: [%1], version OS: [%2], Qt runtime: [%3], Qt build: [%4]" )
 					.arg( QSslSocket::supportsSsl() )
 					.arg( sStdout.trimmed() )
-					.arg( QSslSocket::sslLibraryVersionString() ) )
+					.arg( QSslSocket::sslLibraryVersionString() )
+					.arg( QSslSocket::sslLibraryBuildVersionString() ) );
+		QDir::setCurrent( sCurrentDir );
 #endif
 
 


### PR DESCRIPTION
The Qt version we use within the AppImage (5.15) does attempt to `dl_open` an OpenSSL library of the 1.1.1 family (AFAIR they are API/ABI compatible). If loading this shared object fails, downloading drumkits will not be possible.

However, some older OS versions, like Ubuntu 16.04, still have a 1.0.1 while other might even omit it all together and just ship >=v3. (e.g. Fedora 38 I used for testing). The latter might occur more often in the future since 1.1.1 reaches LTS end on 11.09.2023.

To mitigate this problem, we add our own `libcrypto.so.1.1` and `libssl.so.1.1` in the AppImage. They are build from source using the latest 1.1.1 series tag (1_1_1t). I also added an info log message during startup (just for the AppImage build) that indicate which OpenSSL version is used.

Bundling crypto libraries is bad. I know. But I think it is better than use HTTP instead of HTTPS requests (as shipping AppImages unable to download kits is out of the question).

@cme what do you think? Is this something we should do?

addresses #1836     