### PR TITLE
xsd: allow unbound number of notes in pattern

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		  (#1828) (introduced in v1.2.0).
 		- Hydrogen does now successfully startup even if no data folder is
 		  present on user and system level.
+		- Allow an arbitrary number of notes in a pattern (#1827).
 
 2023-06-08 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.1

--- a/data/xsd/drumkit_pattern.xsd
+++ b/data/xsd/drumkit_pattern.xsd
@@ -71,7 +71,7 @@
 			<xsd:element name="noteList">
 				<xsd:complexType>
 					<xsd:sequence>
-						<xsd:element ref="h2:note" minOccurs="0" maxOccurs="1000"/>
+						<xsd:element ref="h2:note" minOccurs="0" maxOccurs="unbounded"/>
 					</xsd:sequence>
 				</xsd:complexType>
 			</xsd:element>


### PR DESCRIPTION
There was a limitation in the XSD file that set the maximum number of allow notes within a pattern to `1000`. This number can easily be reached by setting resolution to `off` and filling all notes for a couple of instruments. Curiously, Qt treated this number wrong and also deemed paterns containing more than `100` notes as invalid.

Once considered invalid, Hydrogen thinks this pattern is of a legacy format. But since it is not, loading partially fails.

I removed the constraint for a maximum number of notes.

fixes #1827