### PR TITLE
AppImage: reroute system drumkits

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -205,7 +205,7 @@ for:
          exit 0
       fi
 
-      cache_tag=usr_cache_appimage_qt # this can be modified to rebuild deps
+      cache_tag=usr_cache_appimage_qt_new # this can be modified to rebuild deps
 
       ## Since we use a different Linux image we, unfortunately, have
       ## to use a separate cache.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -205,7 +205,7 @@ for:
          exit 0
       fi
 
-      cache_tag=usr_cache_appimage_qt_new # this can be modified to rebuild deps
+      cache_tag=usr_cache_appimage_fresh # this can be modified to rebuild deps
 
       ## Since we use a different Linux image we, unfortunately, have
       ## to use a separate cache.
@@ -221,6 +221,9 @@ for:
         (
           cd /
           sudo tar xf $cache || exit 1
+
+          # Ensure bricked doxygen version get's removed.
+          sudo rm -f /usr/local/bin/doxygen
         )
         echo "done"
       else

--- a/build.sh
+++ b/build.sh
@@ -90,9 +90,17 @@ function cmake_appimage() {
 
 	cd $BUILD_DIR || exit 1
 
+	if [ -d "AppDir" ]; then
+		rm -rf ./AppDir
+	fi
+
 	## Install the compilation result into a folder which will serve
 	## as base for the AppImage.
 	make install DESTDIR=AppDir || exit 1
+
+	if [ -f "Hydrogen-x86_64.AppImage" ]; then
+		rm ./Hydrogen-x86_64.AppImage
+	fi
 
 	## Add custom OpenSSL libraries. They are used as fallback by Qt
     ## and are only dl_opened in case no matching version was found on

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -290,6 +290,11 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode, const QString
 			sInstrumentDrumkitPath = pNode->read_string( "drumkitPath", "",
 														 false, false, bSilent  );
 
+#ifdef H2CORE_HAVE_APPIMAGE
+			sInstrumentDrumkitPath =
+				Filesystem::rerouteDrumkitPath( sInstrumentDrumkitPath );
+#endif
+
 			// Check whether corresponding drumkit exist.
 			// When tweaking or assembling drumkits locally their
 			// absolute paths serve as unique identifiers to keep them

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -406,6 +406,11 @@ std::shared_ptr<Song> Song::loadFrom( XMLNode* pRootNode, const QString& sFilena
 		pRootNode->read_string( "last_loaded_drumkit", "", true, false, true );
 	QString sLastLoadedDrumkitName = 
 		pRootNode->read_string( "last_loaded_drumkit_name", "", true, false, true );
+
+#ifdef H2CORE_HAVE_APPIMAGE
+	sLastLoadedDrumkitPath =
+		Filesystem::rerouteDrumkitPath( sLastLoadedDrumkitPath );
+#endif
 	
 	if ( sLastLoadedDrumkitPath.isEmpty() ) {
 		// Prior to version 1.2.0 the last loaded drumkit was read

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -444,20 +444,19 @@ std::shared_ptr<Song> Song::loadFrom( XMLNode* pRootNode, const QString& sFilena
 	}
 	pSong->setLastLoadedDrumkitPath( sLastLoadedDrumkitPath );
 
+	// Attempt to access the last loaded drumkit to load it into the
+	// SoundLibraryDatabase in case it was a custom one (e.g. loaded
+	// via OSC or from a different system data folder due to a
+	// different install prefix).
+	auto pSoundLibraryDatabase = Hydrogen::get_instance()->getSoundLibraryDatabase();
+	auto pDrumkit = pSoundLibraryDatabase->getDrumkit( sLastLoadedDrumkitPath, true );
+
 	if ( sLastLoadedDrumkitName.isEmpty() ) {
 		// The initial song is loaded after Hydrogen was
 		// bootstrap. So, the SoundLibrary should be present and
 		// filled with all available drumkits.
-		auto pSoundLibraryDatabase = Hydrogen::get_instance()->getSoundLibraryDatabase();
-		if ( pSoundLibraryDatabase != nullptr ) {
-
-			// If it is not already present, we also load the last
-			// loaded drumkit into the database.
-			auto pDrumkit = pSoundLibraryDatabase->getDrumkit(
-				sLastLoadedDrumkitPath, true );
-			if ( pDrumkit != nullptr ) {
-				sLastLoadedDrumkitName = pDrumkit->get_name();
-			}
+		if ( pSoundLibraryDatabase != nullptr && pDrumkit != nullptr ) {
+			sLastLoadedDrumkitName = pDrumkit->get_name();
 		}
 	}
 	pSong->setLastLoadedDrumkitName( sLastLoadedDrumkitName );

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -140,7 +140,7 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sys_path )
 	__usr_cfg_path = QDir::homePath().append( "/.hydrogen/" USR_CONFIG ) ;
 #else
 #ifdef H2CORE_HAVE_APPIMAGE
-	__sys_data_path = QCoreApplication::applicationDirPath().append( "/../share/hydrogen/data/" ) ;
+	__sys_data_path = absolute_path( QCoreApplication::applicationDirPath().append( "/../share/hydrogen/data/" ) ) ;
 #else
 	__sys_data_path = H2_SYS_PATH "/data/";
 #endif
@@ -1032,14 +1032,15 @@ QString Filesystem::ensure_session_compatibility( const QString& sPath ) {
 }
 
 Filesystem::DrumkitType Filesystem::determineDrumkitType( const QString& sPath ) {
-	if ( sPath.contains( Filesystem::sys_drumkits_dir() ) ) {
+	const QString sAbsolutePath = absolute_path( sPath );
+	if ( sAbsolutePath.contains( Filesystem::sys_drumkits_dir() ) ) {
 		return DrumkitType::System;
 	}
-	else if ( sPath.contains( Filesystem::usr_drumkits_dir() ) ) {
+	else if ( sAbsolutePath.contains( Filesystem::usr_drumkits_dir() ) ) {
 		return DrumkitType::User;
 	}
 	else {
-		if ( dir_writable( sPath, true ) ) {
+		if ( dir_writable( sAbsolutePath, true ) ) {
 			return DrumkitType::SessionReadWrite;
 		} else {
 			return DrumkitType::SessionReadOnly;

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -466,6 +466,24 @@ namespace H2Core
 		 */
 		static DrumkitType determineDrumkitType( const QString& sPath );
 
+		/**
+		 * Reroutes stored drumkit paths pointing to a temporary
+		 * AppImage system data folder to the current AppImage one.
+		 *
+		 * Since AppImages are mounted at a random point each time
+		 * they are started the absolute path of their system data
+		 * folder changes every time. To nevertheless support using
+		 * system drumkits consistently, we try to determine whether
+		 * the stored kit is a system one and tweak its path. (Without
+		 * replacing the random part of the path the lookup would fall
+		 * back to a name-based one which _always_ checks user-level
+		 * kits first. Having a GMRockKit in ~/.hydrogen/data/drumkits
+		 * too, would make the system's one inaccessible).
+		 *
+		 * @param sDrumkitPath Absolute path that need rerouting.
+		 */
+		static QString rerouteDrumkitPath( const QString& sDrumkitPath );
+
 	private:
 		static Logger* __logger;                    ///< a pointer to the logger
 		static bool check_sys_paths();              ///< returns true if the system path is consistent

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -225,4 +225,52 @@ void SoundLibraryDatabase::loadPatternFromDirectory( const QString& sPatternDir 
 		}
 	}
 }
+
+QString SoundLibraryDatabase::toQString( const QString& sPrefix, bool bShort ) const {
+	QString s = Base::sPrintIndention;
+	QString sOutput;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[SoundLibraryDatabase]\n" ).arg( sPrefix )
+			.append( QString( "%1%2m_drumkitDatabase:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& [ ssPath, ddrumkit ] : m_drumkitDatabase ) {
+			sOutput.append( QString( "%1%2%2%3: %4\n" ).arg( sPrefix ).arg( s )
+							.arg( ssPath ).arg( ddrumkit->toQString( "", true ) ) );
+		}
+		sOutput.append( QString( "%1%2m_patternInfoVector:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& ppatternInfo : m_patternInfoVector ) {
+			sOutput.append( QString( "%3\n" )
+							.arg( ppatternInfo->toQString( sPrefix + s + s, bShort ) ) );
+		}
+		sOutput.append( QString( "%1%2m_patternCategories: %3\n" ).arg( sPrefix ).arg( s )
+						.arg( m_patternCategories.join( ", " ) ) );
+		sOutput.append( QString( "%1%2m_customDrumkitPaths:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& ssCustomPath : m_customDrumkitPaths ) {
+			sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
+							.arg( ssCustomPath ) );
+		}
+	}
+	else {
+
+		sOutput = QString( "%1[SoundLibraryDatabase]\n" ).arg( sPrefix )
+			.append( QString( "%1%2m_drumkitDatabase:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& eentry : m_drumkitDatabase ) {
+			sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
+							.arg( eentry.first ) );
+		}
+		sOutput.append( QString( "%1%2m_patternInfoVector:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& ppatternInfo : m_patternInfoVector ) {
+			sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
+							.arg( ppatternInfo->getPath() ) );
+		}
+		sOutput.append( QString( "%1%2m_patternCategories: %3\n" ).arg( sPrefix ).arg( s )
+						.arg( m_patternCategories.join( ", " ) ) );
+		sOutput.append( QString( "%1%2m_customDrumkitPaths:\n" ).arg( sPrefix ).arg( s ) );
+		for ( const auto& ssCustomPath : m_customDrumkitPaths ) {
+			sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
+							.arg( ssCustomPath ) );
+		}
+	}
+
+	return sOutput;
+}
 };

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -80,6 +80,16 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 	void loadPatternFromDirectory( const QString& path );
 	bool isPatternInstalled( const QString& sPatternName ) const;
 
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 * every new line
+	 * \param bShort Instead of the whole content of all classes
+	 * stored as members just a single unique identifier will be
+	 * displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
+
 private:
 	std::map<QString,std::shared_ptr<Drumkit>> m_drumkitDatabase;
 	

--- a/src/core/SoundLibrary/SoundLibraryInfo.cpp
+++ b/src/core/SoundLibrary/SoundLibraryInfo.cpp
@@ -114,5 +114,42 @@ SoundLibraryInfo::~SoundLibraryInfo()
 	//default deconstructor
 }
 
+QString SoundLibraryInfo::toQString( const QString& sPrefix, bool bShort ) const {
+	QString s = Base::sPrintIndention;
+	QString sOutput;
+	if ( ! bShort ) {
+		sOutput = QString( "%1[SoundLibraryInfo]\n" ).arg( sPrefix )
+			.append( QString( "%1%2m_sName: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sName ) )
+			.append( QString( "%1%2m_sURL: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sURL ) )
+			.append( QString( "%1%2m_sInfo: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sInfo ) )
+			.append( QString( "%1%2m_sAuthor: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sAuthor ) )
+			.append( QString( "%1%2m_sCategory: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sCategory ) )
+			.append( QString( "%1%2m_sType: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sType ) )
+			.append( QString( "%1%2m_license:\n%3" ).arg( sPrefix ).arg( s )
+					 .arg( m_license.toQString( sPrefix + s + s, bShort ) ) )
+			.append( QString( "%1%2m_sImage: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sImage ) )
+			.append( QString( "%1%2m_imageLicense:\n%3" ).arg( sPrefix ).arg( s )
+					 .arg( m_imageLicense.toQString( sPrefix + s + s, bShort ) ) )
+			.append( QString( "%1%2m_sPath: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sPath ) );
+	}
+	else {
+
+		sOutput = QString( "[SoundLibraryInfo]" )
+			.append( QString( " m_sName: %1" ).arg( m_sName ) )
+			.append( QString( ", m_sURL: %1" ).arg( m_sURL ) )
+			.append( QString( ", m_sInfo: %1" ).arg( m_sInfo ) )
+			.append( QString( ", m_sAuthor: %1" ).arg( m_sAuthor ) )
+			.append( QString( ", m_sCategory: %1" ).arg( m_sCategory ) )
+			.append( QString( ", m_sType: %1" ).arg( m_sType ) )
+			.append( QString( ", m_license: %1" )
+					 .arg( m_license.toQString( "", bShort ) ) )
+			.append( QString( ", m_sImage: %1" ).arg( m_sImage ) )
+			.append( QString( ", m_imageLicense: %1" )
+					 .arg( m_imageLicense.toQString( "", bShort ) ) )
+			.append( QString( ", m_sPath: %1" ).arg( m_sPath ) );
+	}
+
+	return sOutput;
+}
 }; //namespace H2Core
 

--- a/src/core/SoundLibrary/SoundLibraryInfo.h
+++ b/src/core/SoundLibrary/SoundLibraryInfo.h
@@ -145,6 +145,15 @@ class SoundLibraryInfo : public H2Core::Object<SoundLibraryInfo>
 			return m_sDrumkitName;
 		}
 
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 * every new line
+	 * \param bShort Instead of the whole content of all classes
+	 * stored as members just a single unique identifier will be
+	 * displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
 		QString m_sName;


### PR DESCRIPTION
Since AppImages are mounted at a random point each time they are started, the absolute path of their system data folder changes every time. To nevertheless support using system drumkits consistently, we try to determine whether the stored kit is a system one and tweak its path. (Without replacing the random part of the path the lookup would fall back to a name-based one which _always_ checks user-level kits first. Having a GMRockKit in `~/.hydrogen/data/drumkits` too, would make the systems one inaccessible).

addresses #1836 