### PR TITLE
Sampler: consistently apply PlaybackTrack volume

### DIFF
--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -909,6 +909,9 @@ bool Sampler::processPlaybackTrack(int nBufferSize)
 								break;
 					}
 			}
+
+			fVal_L *= pSong->getPlaybackTrackVolume();
+			fVal_R *= pSong->getPlaybackTrackVolume();
 			
 			if ( fVal_L > fInstrPeak_L ) {
 				fInstrPeak_L = fVal_L;


### PR DESCRIPTION
the playback track volume set by a slider in the top left part of the Song Editor was only applied if the playback track did share the same sample rate as the audio engine.

fixes #1449