### PR TITLE
Dynamic JACK support check

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2557,6 +2557,25 @@ const PatternList* AudioEngine::getNextPatterns() const {
 	return nullptr;
 }
 
+void AudioEngine::checkJackSupport() {
+#ifdef H2CORE_HAVE_JACK
+	if ( ! JackAudioDriver::checkSupport() ) {
+		WARNINGLOG( "JACK support disabled." );
+		m_bJackSupported = false;
+		return;
+	}
+
+	INFOLOG( "libjack found. JACK support enabled." );
+	m_bJackSupported = true;
+	return;
+
+#else
+	INFOLOG( "Hydrogen was compiled without JACK support." );
+	m_bJackSupported = false;
+	return;
+#endif
+}
+
 QString AudioEngine::toQString( const QString& sPrefix, bool bShort ) const {
 	QString s = Base::sPrintIndention;
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -125,6 +125,49 @@ AudioEngine::AudioEngine()
 	
 	m_AudioProcessCallback = &audioEngine_process;
 
+	// Has to be done before assigning the supported audio drivers.
+	checkJackSupport();
+
+	// The order of the assigned drivers is important as Hydrogen uses
+	// it when trying different drivers in case "Auto" was selected.
+#if defined(WIN32)
+  #ifdef H2CORE_HAVE_PORTAUDIO
+	m_supportedAudioDrivers << "PortAudio";
+  #endif
+	if ( m_bJackSupported ) {
+		m_supportedAudioDrivers << "JACK";
+	}
+#elif defined(__APPLE__)
+  #ifdef H2CORE_HAVE_COREAUDIO
+	m_supportedAudioDrivers << "CoreAudio";
+  #endif
+	if ( m_bJackSupported ) {
+		m_supportedAudioDrivers << "JACK";
+	}
+  #ifdef H2CORE_HAVE_PULSEAUDIO
+	m_supportedAudioDrivers << "PulseAudio";
+  #endif
+  #ifdef H2CORE_HAVE_PORTAUDIO
+	m_supportedAudioDrivers << "PortAudio";
+  #endif
+#else /* Linux */
+	if ( m_bJackSupported ) {
+		m_supportedAudioDrivers << "JACK";
+	}
+  #ifdef H2CORE_HAVE_ALSA
+	m_supportedAudioDrivers << "ALSA";
+  #endif
+  #ifdef H2CORE_HAVE_OSS
+	m_supportedAudioDrivers << "OSS";
+  #endif
+  #ifdef H2CORE_HAVE_PULSEAUDIO
+	m_supportedAudioDrivers << "PulseAudio";
+  #endif
+  #ifdef H2CORE_HAVE_PORTAUDIO
+	m_supportedAudioDrivers << "PortAudio";
+  #endif
+#endif
+
 #ifdef H2CORE_HAVE_LADSPA
 	Effects::create_instance();
 #endif
@@ -897,22 +940,16 @@ void AudioEngine::startAudioDrivers()
 	}
 
 	QString sAudioDriver = pPref->m_sAudioDriver;
-#if defined(WIN32)
-	QStringList drivers = { "PortAudio", "JACK" };
-#elif defined(__APPLE__)
-    QStringList drivers = { "CoreAudio", "JACK", "PulseAudio", "PortAudio" };
-#else /* Linux */
-    QStringList drivers = { "JACK", "ALSA", "OSS", "PulseAudio", "PortAudio" };
-#endif
 
 	if ( sAudioDriver != "Auto" ) {
-		drivers.clear();
-		drivers << sAudioDriver;
+		createAudioDriver( sAudioDriver );
 	}
-	AudioOutput* pAudioDriver;
-	for ( QString sDriver : drivers ) {
-		if ( ( pAudioDriver = createAudioDriver( sDriver ) ) != nullptr ) {
-			break;
+	else {
+		AudioOutput* pAudioDriver;
+		for ( QString sDriver : getSupportedAudioDrivers() ) {
+			if ( ( pAudioDriver = createAudioDriver( sDriver ) ) != nullptr ) {
+				break;
+			}
 		}
 	}
 

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -440,6 +440,8 @@ public:
 	 * Required to not end unit tests prematurely.
 	 */
 	int getEnqueuedNotesNumber() const;
+
+	const QStringList getSupportedAudioDrivers() const;
 	
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of
@@ -709,6 +711,7 @@ private:
 	 */
 	bool m_bJackSupported;
 
+	QStringList m_supportedAudioDrivers;
 };
 
 
@@ -829,6 +832,9 @@ inline std::shared_ptr<Instrument> AudioEngine::getMetronomeInstrument() const {
 }
 inline int AudioEngine::getEnqueuedNotesNumber() const {
 	return m_songNoteQueue.size();
+}
+inline const QStringList AudioEngine::getSupportedAudioDrivers() const {
+	return m_supportedAudioDrivers;
 }
 };
 

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -696,6 +696,19 @@ private:
 	float 			m_fNextBpm;
 	double m_fLastTickEnd;
 	bool m_bLookaheadApplied;
+
+	/**
+	 * Attempts to dynamically load the JACK 2 shared library
+	 * and stores the result in #m_bJackSupported.
+	 */
+	void checkJackSupport();
+
+	/**
+	 * Whether or not the shared library of the JACK server could be
+	 * found on the system at runtime.
+	 */
+	bool m_bJackSupported;
+
 };
 
 

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cmath>
 #include <jack/metadata.h>
+#include <QLibrary>
 
 #include <core/Hydrogen.h>
 #include <core/AudioEngine/AudioEngine.h>
@@ -1198,6 +1199,26 @@ void JackAudioDriver::printJackTransportPos( const jack_position_t* pPos ) {
 			  << ", frame_time: " << pPos->frame_time
 			  << ", next_time: " << pPos->next_time
 			  << "\033[0m" << std::endl;
+}
+
+bool JackAudioDriver::checkSupport() {
+
+	QLibrary jackLib( "libjack" );
+
+	if ( ! jackLib.load() ) {
+		WARNINGLOG( QString( "Unable to load libjack: %1" )
+					.arg( jackLib.errorString() ) );
+		return false;
+	}
+
+	void* jack_connect = (void*)jackLib.resolve( "jack_connect" );
+	if ( jack_connect == nullptr ) {
+		ERRORLOG( QString( "libjack found but unable to resolve jack_connect symbol: %1" )
+				  .arg( jackLib.errorString() ) );
+		return false;
+	}
+
+	return true;
 }
 };
 

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -358,6 +358,14 @@ public:
 	 * the presence of an external timebase master.*/
 	void relocateUsingBBT();
 
+	/**
+	 * Attempts to load the JACK shared library at runtime and to
+	 * resolve a prominent symbol.
+	 *
+	 * @return Whether or not JACK support appears to be functional.
+	 */
+	static bool checkSupport();
+
 private:
 
 	/** Compares the BBT information stored in #m_JackTransportPos and
@@ -560,7 +568,6 @@ private:
 	 * More user-friendly version of #m_nTimebaseTracking.
 	 */ 
 	Timebase m_timebaseState;
-
 };
 
 }; // H2Core namespace

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -236,24 +236,9 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	driverComboBox->setSize( audioTabWidgetSizeTop );
 	driverComboBox->clear();
 	driverComboBox->addItem( "Auto" );
-#ifdef H2CORE_HAVE_JACK
-	driverComboBox->addItem( "JACK" );
-#endif
-#ifdef H2CORE_HAVE_ALSA
-	driverComboBox->addItem( "ALSA" );
-#endif
-#ifdef H2CORE_HAVE_OSS
-	driverComboBox->addItem( "OSS" );
-#endif
-#ifdef H2CORE_HAVE_PORTAUDIO
-	driverComboBox->addItem( "PortAudio" );
-#endif
-#ifdef H2CORE_HAVE_COREAUDIO
-	driverComboBox->addItem( "CoreAudio" );
-#endif
-#ifdef H2CORE_HAVE_PULSEAUDIO
-	driverComboBox->addItem( "PulseAudio" );
-#endif
+	for ( const QString& ssDriver : pHydrogen->getAudioEngine()->getSupportedAudioDrivers() ) {
+		driverComboBox->addItem( ssDriver );
+	}
 
 	if( driverComboBox->findText(pPref->m_sAudioDriver) > -1){
 		driverComboBox->setCurrentIndex(driverComboBox->findText(pPref->m_sAudioDriver));


### PR DESCRIPTION
when using JACK the `libjack.so|.dylib|.dll` has to be present on the system. For Hydrogen provided via Linux OS repos this is no problem as the corresponding package is installed as well.

But in our Windows and macOS bundles as well in the Flatpak and AppImage version on Linux this _is_ a problem as the `libjack` shared lib must not be included in the bundle. If it is present on system, Hydrogen JACK support works as expected. If not, Hydrogen still suggests in the GUI that JACK is available.

With the following fix we check at runtime whether `libjack` is present or not. In the latter case, it will not be covered by the "Auto" driver and is not shown in the Preferences Dialog. The implementation of the `JackAudioDriver`, however, was not touched. The resulting `hydrogen` binary is still linked against `libjack` and no JACK support should break.

In addition, a list of supported audio drivers is now just compiled once in the constructor of `AudioEngine` (and not in two different places and two different ways).

addresses #1836 