### PR TITLE
AudioEngine: tweak Linux driver order

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -154,14 +154,14 @@ AudioEngine::AudioEngine()
 	if ( m_bJackSupported ) {
 		m_supportedAudioDrivers << "JACK";
 	}
+  #ifdef H2CORE_HAVE_PULSEAUDIO
+	m_supportedAudioDrivers << "PulseAudio";
+  #endif
   #ifdef H2CORE_HAVE_ALSA
 	m_supportedAudioDrivers << "ALSA";
   #endif
   #ifdef H2CORE_HAVE_OSS
 	m_supportedAudioDrivers << "OSS";
-  #endif
-  #ifdef H2CORE_HAVE_PULSEAUDIO
-	m_supportedAudioDrivers << "PulseAudio";
   #endif
   #ifdef H2CORE_HAVE_PORTAUDIO
 	m_supportedAudioDrivers << "PortAudio";


### PR DESCRIPTION
The "PulseAudio" driver is now tried prior to the "ALSA" one once `Auto` is selected. The former is more easily to use for first-day users (and does not require that much prior knowledge like the nature of ALSA devices)