### PR TITLE
Fix MIDI recording

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
+	* Release 1.2.3
+	* Fixed
+		- Recorded MIDI notes were inserted ahead of the beat (#1851)
+
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.2
 	* Added

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2173,10 +2173,6 @@ long long AudioEngine::computeTickInterval( double* fTickStart, double* fTickEnd
 		nFrameStart = pPos->getFrame();
 	}
 	
-	// We don't use the getLookaheadInFrames() function directly
-	// because the lookahead contains both a frame-based and a
-	// tick-based component and would be twice as expensive to
-	// calculate using the mentioned call.
 	long long nLeadLagFactor = getLeadLagInFrames( pPos->getDoubleTick() );
 
 	// Timeline disabled: 
@@ -2565,11 +2561,6 @@ long long AudioEngine::getLeadLagInFrames( double fTick ) {
 	// 			.arg( nFrameEnd - nFrameStart ).arg( fTick, 0, 'f' ) );
 
 	return nFrameEnd - nFrameStart;
-}
-
-long long AudioEngine::getLookaheadInFrames() {
-	return getLeadLagInFrames( m_pTransportPosition->getDoubleTick() ) +
-		AudioEngine::nMaxTimeHumanize + 1;
 }
 
 const PatternList* AudioEngine::getPlayingPatterns() const {

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -353,11 +353,6 @@ public:
 	 * Note::__lead_lag times the value calculated by this function.
 	 */
 	long long		getLeadLagInFrames( double fTick );
-	/** Calculates time offset (in frames) #m_pQueuingPosition will be
-	 * ahead of the #m_pTransportPosition.
-	 *
-	 * \return Frame offset*/
-	long long getLookaheadInFrames();
 
 	double getSongSizeInTicks() const;
 


### PR DESCRIPTION
there were still some remnants of the old audio engine in `Hydrogen::addRealtimeNote`, which used the lookahead to calculate the position where to insert the recorded MIDI note too. But this is not necessary anymore.

Fixes #1851 