### PR TITLE
Fix image handling in Drumkit Property Dialog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,15 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3
 	* Fixed
-		- Recorded MIDI notes were inserted ahead of the beat (#1851)
 		- Fixed NoteOff (stop note) color which was no different than
-			the default note color (#1854)
+			the default note color (#1854).
+		- Recorded MIDI notes were inserted ahead of the beat (#1851).
+		- Drumkit Property Dialog:
+				- Images were written regardless whether one hits the ok or
+				  cancel button.
+				- When using Save As to create a new drumkit, the added image
+				  was put in the old drumkit folder instead and not properly
+				  copied into the new one.
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.2

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -491,11 +491,11 @@ bool Drumkit::save_samples( const QString& sDrumkitFolder, bool bSilent ) const
 	return true;
 }
 
-bool Drumkit::save_image( const QString& dk_dir, bool bSilent ) const
+bool Drumkit::save_image( const QString& sDrumkitDir, bool bSilent ) const
 {
-	if ( __image.length() > 0 ) {
+	if ( ! __image.isEmpty() && sDrumkitDir != __path ) {
 		QString src = __path + "/" + __image;
-		QString dst = dk_dir + "/" + __image;
+		QString dst = sDrumkitDir + "/" + __image;
 		if ( Filesystem::file_exists( src, bSilent ) ) {
 			if ( ! Filesystem::file_copy( src, dst, bSilent ) ) {
 				ERRORLOG( QString( "Error copying %1 to %2").arg( src ).arg( dst ) );

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.h
@@ -74,6 +74,8 @@ class SoundLibraryPropertiesDialog :  public QDialog,
 	 * other hand, it's opened via "Save As" anything goes.
 	 */
 	bool m_bDrumkitNameLocked;
+
+	QString m_sNewImagePath;
 	
 };
 


### PR DESCRIPTION
- Images were written regardless whether one hits the ok or  cancel button.
- When using Save As to create a new drumkit, the added image was put in the old drumkit folder instead and not properly  copied into the new one.