### PR TITLE
PatternEditor: proper undo of moving notes out of editor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				  copied into the new one.
 		- Pattern Editor (#1859):
 				- Only delete NoteOff notes clicked by the user.
+				- Proper undo of moving notes out of DrumPatternEditor
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.2

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -611,7 +611,7 @@ void DrumPatternEditor::selectionMoveEndEvent( QInputEvent *ev )
 														   false,
 														   false,
 														   false,
-														   true ) );
+														   pNote->get_note_off() ) );
 			}
 
 		} else {
@@ -631,7 +631,7 @@ void DrumPatternEditor::selectionMoveEndEvent( QInputEvent *ev )
 														   false,
 														   false,
 														   false,
-														   false ) );
+														   pNote->get_note_off() ) );
 			} else {
 				// Move note
 				pUndo->push( new SE_moveNoteAction( nPosition, nInstrument, m_nSelectedPatternNumber,


### PR DESCRIPTION
Addresses #1859 