### PR TITLE
PatternEditor: harmonize custom length & NoteOff

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,7 +12,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				  copied into the new one.
 		- Pattern Editor (#1859):
 				- Only delete NoteOff notes clicked by the user.
-				- Proper undo of moving notes out of DrumPatternEditor
+				- Proper undo of moving notes out of DrumPatternEditor.
+				- Custom note lengths are now only drawn till the next NoteOff.
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.2

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1047,6 +1047,9 @@ void DrumPatternEditor::paste()
 ///
 void DrumPatternEditor::drawPattern(QPainter& painter)
 {
+	if ( m_pPattern == nullptr ) {
+		return;
+	}
 	auto pPref = H2Core::Preferences::get_instance();
 
 	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
@@ -1139,6 +1142,9 @@ void DrumPatternEditor::drawPattern(QPainter& painter)
 ///
 void DrumPatternEditor::drawNote( Note *note, QPainter& p, bool bIsForeground )
 {
+	if ( m_pPattern == nullptr ) {
+		return;
+	}
 	auto pInstrList = Hydrogen::get_instance()->getSong()->getInstrumentList();
 	int nInstrument = pInstrList->index( note->get_instrument() );
 	if ( nInstrument == -1 ) {


### PR DESCRIPTION
The custom length of a note is only drawn till the nearest NoteOff note. As this one stop the audio rendering of the note having the length reaching beyond it is bad.

addresses #1859 

## Previous UX

![noteOffScreenshot](https://github.com/hydrogen-music/hydrogen/assets/14164547/22d17917-8c9f-4e8a-a3f7-021dac82eae6)

## New UX

Create a note with a custom note length

![state1](https://github.com/hydrogen-music/hydrogen/assets/14164547/9b1fc10e-ff01-4184-9df5-d4897ff1058a)

Add a NoteOff (<kbd>Shift</kbd> + `left click`)

![state2](https://github.com/hydrogen-music/hydrogen/assets/14164547/3f560c82-c0a2-4f22-8918-d7bea639a592)

Add another NoteOff

![state3](https://github.com/hydrogen-music/hydrogen/assets/14164547/c055e643-cd4c-465f-9996-1203fd310234)

Move those NoteOffs to another instrument

![state4](https://github.com/hydrogen-music/hydrogen/assets/14164547/4488751c-c304-40a8-868b-fdbf31fc55ea)

and back in.

![state5](https://github.com/hydrogen-music/hydrogen/assets/14164547/0c4a279e-fc9c-486f-a2a7-d78625ae2500)

All these actions can be properly undone.