### PR TITLE
AudioEngine: allow playback to reach end of song

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- When using Save As to create a new drumkit, the added image
 				  was put in the old drumkit folder instead and not properly
 				  copied into the new one.
+		- Audio Engine: In Song Mode with Loop Mode deactivated Hydrogen
+			missed notes very close to the end of the song.
 		- Pattern Editor (#1859):
 				- Only delete NoteOff notes clicked by the user.
 				- Proper undo of moving notes out of DrumPatternEditor.

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -99,6 +99,7 @@ AudioEngine::AudioEngine()
 		, m_pLocker({nullptr, 0, nullptr})
 		, m_fLastTickEnd( 0 )
 		, m_bLookaheadApplied( false )
+		, m_nLoopsDone( 0 )
 {
 	m_pTransportPosition = std::make_shared<TransportPosition>( "Transport" );
 	m_pQueuingPosition = std::make_shared<TransportPosition>( "Queuing" );
@@ -336,6 +337,7 @@ void AudioEngine::reset( bool bWithJackBroadcast ) {
 	m_fMasterPeak_R = 0.0f;
 
 	m_fLastTickEnd = 0;
+	m_nLoopsDone = 0;
 	m_bLookaheadApplied = false;
 
 	m_fSongSizeInTicks = MAX_NOTES;
@@ -458,6 +460,7 @@ void AudioEngine::resetOffsets() {
 	clearNoteQueues();
 
 	m_fLastTickEnd = 0;
+	m_nLoopsDone = 0;
 	m_bLookaheadApplied = false;
 
 	m_pTransportPosition->setFrameOffsetTempo( 0 );
@@ -495,12 +498,14 @@ void AudioEngine::incrementTransportPosition( uint32_t nFrames ) {
 	// done in updateNoteQueue().
 }
 
-bool AudioEngine::isEndOfSongReached() const {
+bool AudioEngine::isEndOfSongReached( std::shared_ptr<TransportPosition> pPos ) const {
 	const auto pSong = Hydrogen::get_instance()->getSong();
 	if ( pSong->getMode() == Song::Mode::Song &&
-		 pSong->getLoopMode() != Song::LoopMode::Enabled &&
-		 m_pTransportPosition->getDoubleTick() >=
-		 m_fSongSizeInTicks ) {
+		 ( pSong->getLoopMode() == Song::LoopMode::Disabled &&
+		   pPos->getDoubleTick() >= m_fSongSizeInTicks ||
+		   pSong->getLoopMode() == Song::LoopMode::Finishing &&
+		   pPos->getDoubleTick() >= m_fSongSizeInTicks *
+		   (1 + static_cast<double>(m_nLoopsDone)) ) ) {
 		return true;
 	}
 
@@ -1056,6 +1061,14 @@ void AudioEngine::restartAudioDrivers()
 
 }
 
+void AudioEngine::handleLoopModeChanged() {
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong->getLoopMode() == Song::LoopMode::Finishing ) {
+		m_nLoopsDone = static_cast<int>(std::floor(
+			m_pTransportPosition->getDoubleTick() / m_fSongSizeInTicks ));
+	}
+}
+
 void AudioEngine::handleDriverChange() {
 
 	if ( Hydrogen::get_instance()->getSong() == nullptr ) {
@@ -1178,7 +1191,7 @@ void AudioEngine::handleSelectedPattern() {
 	}
 }
 
-void AudioEngine::switchMode() {
+void AudioEngine::handleSongModeChanged() {
 	reset( true );
 
 	const auto pSong = Hydrogen::get_instance()->getSong();
@@ -1381,7 +1394,8 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	if ( pAudioEngine->getState() == AudioEngine::State::Playing ) {
 
 		// Check whether the end of the song has been reached.
-		if ( pAudioEngine->isEndOfSongReached() ) {
+		if ( pAudioEngine->isEndOfSongReached(
+				 pAudioEngine->m_pTransportPosition ) ) {
 
 			___INFOLOG( "End of song received" );
 
@@ -2351,8 +2365,7 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 			updateSongTransportPosition( static_cast<double>(nnTick),
 										 nNewFrame, m_pQueuingPosition );
 
-			if ( ( pSong->getLoopMode() != Song::LoopMode::Enabled ) &&
-				 m_pQueuingPosition->getDoubleTick() >= m_fSongSizeInTicks ) {
+			if ( isEndOfSongReached( m_pQueuingPosition ) ) {
 				// Queueing reached end of the song.
 				return;
 			}

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -508,13 +508,8 @@ private:
 	 * Takes all notes from the currently playing patterns, from the
 	 * MIDI queue #m_midiNoteQueue, and those triggered by the
 	 * metronome and pushes them onto #m_songNoteQueue for playback.
-	 *
-	 * \return
-	 * - 0 - on success
-	 * - -1 - if in Hydrogen is in Song::Mode::Song, looping was
-	 * deactivated, and the end of the song was reached.
 	 */
-	int				updateNoteQueue( unsigned nIntervalLengthInFrames );
+	void			updateNoteQueue( unsigned nIntervalLengthInFrames );
 	void 			processAudio( uint32_t nFrames );
 	long long 		computeTickInterval( double* fTickStart, double* fTickEnd, unsigned nIntervalLengthInFrames );
 	void			updateBpmAndTickSize( std::shared_ptr<TransportPosition> pTransportPosition );
@@ -544,6 +539,7 @@ private:
 	 */
 	void			locateToFrame( const long long nFrame );
 	void			incrementTransportPosition( uint32_t nFrames );
+	bool			isEndOfSongReached() const;
 	void			updateTransportPosition( double fTick, long long nFrame,
 											 std::shared_ptr<TransportPosition> pPos );
 	void			updateSongTransportPosition( double fTick, long long nFrame,

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -465,6 +465,7 @@ public:
 	friend bool CoreActionController::deleteTempoMarker( int );
 	friend bool CoreActionController::locateToTick( long nTick, bool );
 	friend bool CoreActionController::activateSongMode( bool );
+	friend bool CoreActionController::activateLoopMode( bool );
 	/** Is allowed to set m_state to State::Ready via setState()*/
 	friend int FakeDriver::connect();
 	friend void JackAudioDriver::updateTransportPosition();
@@ -539,7 +540,7 @@ private:
 	 */
 	void			locateToFrame( const long long nFrame );
 	void			incrementTransportPosition( uint32_t nFrames );
-	bool			isEndOfSongReached() const;
+	bool			isEndOfSongReached( std::shared_ptr<TransportPosition> pPos ) const;
 	void			updateTransportPosition( double fTick, long long nFrame,
 											 std::shared_ptr<TransportPosition> pPos );
 	void			updateSongTransportPosition( double fTick, long long nFrame,
@@ -579,11 +580,17 @@ private:
 	 */
 	void handleDriverChange();
 
+	/** In order to properly support #H2Core::Song::LoopMode::Finishing -
+	 * transport was already looped a couple of times and the user is pressing
+	 * the loop button again to deactivate loop mode - we have to capture the
+	 * number of loops already applied. */
+	void handleLoopModeChanged();
+
 	/**
 	 * Called whenever Hydrogen switches from #Song::Mode::Song into
 	 * #Song::Mode::Pattern or the other way around.
 	 */
-	void switchMode();
+	void handleSongModeChanged();
 
 	Sampler* 			m_pSampler;
 	Synth* 				m_pSynth;
@@ -698,6 +705,10 @@ private:
 	bool m_bJackSupported;
 
 	QStringList m_supportedAudioDrivers;
+
+	/** Indicates how many loops the transport already did when the user presses
+	 * the Loop button again. */
+	int m_nLoopsDone;
 };
 
 

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -166,6 +166,56 @@ void AudioEngineTests::testTransportProcessing() {
 
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
+
+	pAE->setState( AudioEngine::State::Ready );
+	pAE->unlock();
+
+	// Check whether all frames are covered when running playback in song mode
+	// without looping.
+	pCoreActionController->activateLoopMode( false );
+
+	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
+	resetVariables();
+	while ( nn <= nMaxCycles ) {
+		nFrames = frameDist( randomEngine );
+		int nRes = processTransport(
+			"testTransportProcessing : song mode : no looping", nFrames,
+			&nLastLookahead, &nLastTransportFrame, &nTotalFrames,
+			&nLastQueuingTick, &fLastTickIntervalEnd, true );
+		if ( nRes != 0 &&
+			 pTransportPos->getTick() < pAE->getSongSizeInTicks() ) {
+			// End of song reached
+			AudioEngineTests::throwException(
+				QString( "[testTransportProcessing] [song mode : no looping] final tick was not reached at song end. pTransportPos->getTick: [%1], pAE->getSongSizeInTicks: %2" )
+				.arg( pTransportPos->getTick() ).arg( pAE->getSongSizeInTicks() ) );
+		}
+
+		nn++;
+		if ( nn > nMaxCycles ) {
+			AudioEngineTests::throwException(
+				QString( "[testTransportProcessing] [song mode : no looping] end of the song wasn't reached in time. pTransportPos->getFrame(): %1, pTransportPos->getDoubleTick(): %2, pTransportPos->getTickSize(): %3, pAE->getSongSizeInTicks(): %4, nMaxCycles: %5" )
+				.arg( pTransportPos->getFrame() )
+				.arg( pTransportPos->getDoubleTick(), 0, 'f' )
+				.arg( pTransportPos->getTickSize(), 0, 'f' )
+				.arg( pAE->getSongSizeInTicks(), 0, 'f' )
+				.arg( nMaxCycles ) );
+		}
+	}
+
+	pAE->reset( false );
+	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
+
+	pAE->setState( AudioEngine::State::Ready );
+	pAE->unlock();
+
+	// Check whether all frames are covered when running playback in song mode
+	// without looping.
+	pCoreActionController->activateLoopMode( true );
+
+	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
+
 	resetVariables();
 
 	float fBpm;

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -107,6 +107,7 @@ void AudioEngineTests::testTransportProcessing() {
 	pCoreActionController->activateLoopMode( true );
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
     std::random_device randomSeed;
     std::default_random_engine randomEngine( randomSeed() );
@@ -117,7 +118,6 @@ void AudioEngineTests::testTransportProcessing() {
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames, ticks, and queuing
 	// position while using a random buffer size (e.g. like PulseAudio
@@ -181,7 +181,7 @@ void AudioEngineTests::testTransportProcessing() {
 		nFrames = frameDist( randomEngine );
 		pAE->incrementTransportPosition( nFrames );
 
-		if ( pAE->isEndOfSongReached() ) {
+		if ( pAE->isEndOfSongReached( pAE->m_pTransportPosition ) ) {
 			// End of song reached
 			if ( pTransportPos->getTick() < pAE->getSongSizeInTicks() ) {
 				AudioEngineTests::throwException(
@@ -304,6 +304,7 @@ void AudioEngineTests::testTransportProcessingTimeline() {
 	pCoreActionController->activateLoopMode( true );
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
 	// Activating the Timeline without requiring the AudioEngine to be locked.
 	auto activateTimeline = [&]( bool bEnabled ) {
@@ -329,7 +330,6 @@ void AudioEngineTests::testTransportProcessingTimeline() {
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames, ticks, and queuing
 	// position while using a random buffer size (e.g. like PulseAudio
@@ -441,12 +441,12 @@ void AudioEngineTests::testLoopMode() {
 	pCoreActionController->activateSongMode( true );
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
 	// For this call the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames, ticks, and queuing
 	// position while using a random buffer size (e.g. like PulseAudio
@@ -499,9 +499,11 @@ void AudioEngineTests::testLoopMode() {
 		// loop mode.
 		if ( bLoopEnabled && pTransportPos->getDoubleTick() >
 			 fSongSizeInTicks * ( nLoops - 1 ) ) {
+			pAE->setState( AudioEngine::State::Ready );
 			pAE->unlock();
 			pCoreActionController->activateLoopMode( false );
 			pAE->lock( RIGHT_HERE );
+			pAE->setState( AudioEngine::State::Testing );
 		}
 		
 		nn++;
@@ -564,7 +566,7 @@ int AudioEngineTests::processTransport( const QString& sContext,
 	pAE->updateNoteQueue( nFrames );
 	pAE->incrementTransportPosition( nFrames );
 
-	if ( pAE->isEndOfSongReached() ) {
+	if ( pAE->isEndOfSongReached( pAE->m_pTransportPosition ) ) {
 		// Don't check consistency at the end of the song as just the
 		// remaining frames are covered.
 		return -1;
@@ -579,9 +581,10 @@ int AudioEngineTests::processTransport( const QString& sContext,
 	if ( pTransportPos->getFrame() - nFrames -
 		 pTransportPos->getFrameOffsetTempo() != *nLastTransportFrame ) {
 		AudioEngineTests::throwException(
-			QString( "[processTransport : transport] [%1] inconsistent frame update. pTransportPos->getFrame(): %2, nFrames: %3, nLastTransportFrame: %4, pTransportPos->getFrameOffsetTempo(): %5" )
+			QString( "[processTransport : transport] [%1] inconsistent frame update. pTransportPos->getFrame(): %2, nFrames: %3, nLastTransportFrame: %4, pTransportPos->getFrameOffsetTempo(): %5, pAE->m_fSongSizeInTicks: %6, pAE->m_nLoopsDone: %7" )
 			.arg( sContext ).arg( pTransportPos->getFrame() ).arg( nFrames )
-			.arg( *nLastTransportFrame ).arg( pTransportPos->getFrameOffsetTempo() ) );
+			.arg( *nLastTransportFrame ).arg( pTransportPos->getFrameOffsetTempo() )
+			.arg( pAE->m_fSongSizeInTicks ).arg( pAE->m_nLoopsDone ) );
 	}
 	*nLastTransportFrame = pTransportPos->getFrame() -
 			pTransportPos->getFrameOffsetTempo();
@@ -593,14 +596,16 @@ int AudioEngineTests::processTransport( const QString& sContext,
 	// an update has actually taken place.
 	if ( *nLastQueuingTick > 0 && nNoteQueueUpdate > 0 ) {
 		if ( pQueuingPos->getTick() - nNoteQueueUpdate !=
-			 *nLastQueuingTick ) {
+			 *nLastQueuingTick &&
+			 ! pAE->isEndOfSongReached( pQueuingPos ) ) {
 			AudioEngineTests::throwException(
-				QString( "[processTransport : queuing pos] [%1] inconsistent tick update. pQueuingPos->getTick(): %2, nNoteQueueUpdate: %3, nLastQueuingTick: %4, fTickStart: %5, fTickEnd: %6, nFrames = %7, pTransportPos: %8, pQueuingPos: %9" )
+				QString( "[processTransport : queuing pos] [%1] inconsistent tick update. pQueuingPos->getTick(): %2, nNoteQueueUpdate: %3, nLastQueuingTick: %4, fTickStart: %5, fTickEnd: %6, nFrames = %7, pTransportPos: %8, pQueuingPos: %9, pAE->m_fSongSizeInTicks: %10, pAE->m_nLoopsDone: %11" )
 				.arg( sContext ).arg( pQueuingPos->getTick() )
 				.arg( nNoteQueueUpdate ).arg( *nLastQueuingTick )
 				.arg( fTickStart, 0, 'f' ).arg( fTickEnd, 0, 'f' )
 				.arg( nFrames ).arg( pTransportPos->toQString() )
-				.arg( pQueuingPos->toQString() ) );
+				.arg( pQueuingPos->toQString() )
+				.arg( pAE->m_fSongSizeInTicks ).arg( pAE->m_nLoopsDone ));
 		}
 	}
 	*nLastQueuingTick = pQueuingPos->getTick();
@@ -643,6 +648,7 @@ void AudioEngineTests::testTransportRelocation() {
 	auto pTransportPos = pAE->getTransportPosition();
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
     std::random_device randomSeed;
     std::default_random_engine randomEngine( randomSeed() );
@@ -653,7 +659,6 @@ void AudioEngineTests::testTransportRelocation() {
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames and ticks while relocating
 	// transport.
@@ -705,6 +710,7 @@ void AudioEngineTests::testSongSizeChange() {
 	const int nTestColumn = 4;
 	
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
 	pAE->setState( AudioEngine::State::Ready );
@@ -756,6 +762,7 @@ void AudioEngineTests::testSongSizeChangeInLoopMode() {
 	pCoreActionController->activateLoopMode( true );
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
 	const int nColumns = pSong->getPatternGroupVector()->size();
 
@@ -768,7 +775,6 @@ void AudioEngineTests::testSongSizeChangeInLoopMode() {
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	const uint32_t nFrames = 500;
 	const double fInitialSongSize = pAE->m_fSongSizeInTicks;
@@ -812,15 +818,19 @@ void AudioEngineTests::testSongSizeChangeInLoopMode() {
 
 		nNewColumn = columnDist( randomEngine );
 
+		pAE->setState( AudioEngine::State::Ready );
 		pAE->unlock();
 		pCoreActionController->toggleGridCell( nNewColumn, 0 );
 		pAE->lock( RIGHT_HERE );
+		pAE->setState( AudioEngine::State::Testing );
 
 		checkState( QString( "toggling column [%1]" ).arg( nNewColumn ), true );
-														  
+
+		pAE->setState( AudioEngine::State::Ready );
 		pAE->unlock();
 		pCoreActionController->toggleGridCell( nNewColumn, 0 );
 		pAE->lock( RIGHT_HERE );
+		pAE->setState( AudioEngine::State::Testing );
 
 		checkState( QString( "again toggling column [%1]" ).arg( nNewColumn ), false );
 	}
@@ -843,6 +853,7 @@ void AudioEngineTests::testNoteEnqueuing() {
 	pCoreActionController->activateLoopMode( false );
 	pCoreActionController->activateSongMode( true );
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
     std::random_device randomSeed;
     std::default_random_engine randomEngine( randomSeed() );
@@ -853,7 +864,6 @@ void AudioEngineTests::testNoteEnqueuing() {
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	// Check consistency of updated frames and ticks while using a
 	// random buffer size (e.g. like PulseAudio does).
@@ -1057,9 +1067,9 @@ void AudioEngineTests::testNoteEnqueuing() {
 	pCoreActionController->activateSongMode( true );
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	nLoops = 1;
 
@@ -1095,7 +1105,11 @@ void AudioEngineTests::testNoteEnqueuing() {
 		if ( ( pTransportPos->getDoubleTick() >
 			   pAE->m_fSongSizeInTicks * nLoops + 100 ) &&
 			 pSong->getLoopMode() == Song::LoopMode::Enabled ) {
+			pAE->setState( AudioEngine::State::Ready );
+			pAE->unlock();
 			pCoreActionController->activateLoopMode( false );
+			pAE->lock( RIGHT_HERE );
+			pAE->setState( AudioEngine::State::Testing );
 		}
 
 		pAE->updateNoteQueue( nFrames );
@@ -1117,6 +1131,7 @@ void AudioEngineTests::testNoteEnqueuingTimeline() {
 	auto pPref = Preferences::get_instance();
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
     std::random_device randomSeed;
     std::default_random_engine randomEngine( randomSeed() );
@@ -1127,7 +1142,6 @@ void AudioEngineTests::testNoteEnqueuingTimeline() {
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 	AudioEngineTests::resetSampler( __PRETTY_FUNCTION__ );
 
 	uint32_t nFrames;
@@ -1222,12 +1236,12 @@ void AudioEngineTests::testHumanization() {
 	pCoreActionController->activateSongMode( true );
 
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
 	// For reset() the AudioEngine still needs to be in state
 	// Playing or Ready.
 	pAE->reset( false );
 	pAE->m_fSongSizeInTicks = pSong->lengthInTicks();
-	pAE->setState( AudioEngine::State::Testing );
 
 	// Rolls playback from beginning to the end of the song and
 	// captures all notes added to the Sampler.
@@ -1324,10 +1338,12 @@ void AudioEngineTests::testHumanization() {
 	// positions but velocity, pan, leag&lag, and note key as well as
 	// note octave are all customized. Check whether these
 	// customizations reach the Sampler.
+	pAE->setState( AudioEngine::State::Ready );
 	pAE->unlock();
 	pCoreActionController->toggleGridCell( 0, 0 );
 	pCoreActionController->toggleGridCell( 0, 1 );
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
 	std::vector<std::shared_ptr<Note>> notesCustomized;
 	getNotes( &notesCustomized );
@@ -1387,10 +1403,12 @@ void AudioEngineTests::testHumanization() {
 	// expected standard deviation.
 	//
 	// Switch back to pattern 1
+	pAE->setState( AudioEngine::State::Ready );
 	pAE->unlock();
 	pCoreActionController->toggleGridCell( 0, 1 );
 	pCoreActionController->toggleGridCell( 0, 0 );
 	pAE->lock( RIGHT_HERE );
+	pAE->setState( AudioEngine::State::Testing );
 
 	auto checkHumanization = [&]( double fValue, std::vector<std::shared_ptr<Note>>* pNotes ) {
 
@@ -1786,10 +1804,12 @@ void AudioEngineTests::toggleAndCheckConsistency( int nToggleColumn, int nToggle
 		nOldColumn = pTransportPos->getColumn();
 		fPrevTempo = pTransportPos->getBpm();
 		fPrevTickSize = pTransportPos->getTickSize();
-	
+
+		pAE->setState( AudioEngine::State::Ready );
 		pAE->unlock();
 		pCoreActionController->toggleGridCell( nToggleColumn, nToggleRow );
 		pAE->lock( RIGHT_HERE );
+		pAE->setState( AudioEngine::State::Testing );
 
 		const QString sNewContext =
 			QString( "toggleAndCheckConsistency::toggleAndCheck : %1 : toggling (%2,%3)" )

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -911,7 +911,7 @@ bool CoreActionController::activateSongMode( bool bActivate ) {
 		pHydrogen->setMode( Song::Mode::Pattern );
 	}
 	
-	pAudioEngine->switchMode();
+	pAudioEngine->handleSongModeChanged();
 
 	pAudioEngine->unlock();
 	
@@ -950,6 +950,10 @@ bool CoreActionController::activateLoopMode( bool bActivate ) {
 		}
 		bChange = true;
 	}
+
+	pAudioEngine->lock( RIGHT_HERE );
+	pAudioEngine->handleLoopModeChanged();
+	pAudioEngine->unlock();
 	
 	if ( bChange ) {
 		EventQueue::get_instance()->push_event( EVENT_LOOP_MODE_ACTIVATION,


### PR DESCRIPTION
This one took me by surprise. When in Song mode and Looping disable playback did not reach the very end of the song but stopped one "lookahead" before. Since this is a conceptional flaw predating the rewriting of the AudioEngine this might have _always_ been the case. But I have not checked. In any case only the last note on a very fine resolution is affected.

The problem was as follows. In the `AudioEngine` there are two distinct position: a playback position (used by everything outside the audio engine) and a queuing one. The job of the latter is ahead of the transport position and checks for upcoming notes and patches their starting position (as we allow them to lead/lag). These two position also existed (more or less) before the rewrite of the engine. They were just mixed up and dirty most of the time. Now, traditionally the end of the song was determined in `AudioEngine::updateNoteQueue`. But this function acts on the queuing position. This means whenever the end of the song was reported, transport/playback was not finished yet but had to stop too. If there were still notes waiting in the note queue ahead of the playback position, they were not handed to the Sampler and MIDI output.

Now, `AudioEngine::updateNoteQueue` will just stop enqueuing notes (but still update the queuing position) whenever the end of the song is reached. Stopping playback is done at the end of `AudioEngine::audioEngine_process` in case the transport/playback position reached the end. And it is done after all audio processing etc. All notes are now played back.

Addresses #1859 