### PR TITLE
Sampler: fix note length calculation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				  copied into the new one.
 		- Audio Engine: In Song Mode with Loop Mode deactivated Hydrogen
 			missed notes very close to the end of the song.
+		- Fix crash on playing back notes with custom length (#1852).
 		- Pattern Editor (#1859):
 				- Only delete NoteOff notes clicked by the user.
 				- Proper undo of moving notes out of DrumPatternEditor.

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -969,8 +969,8 @@ bool Sampler::renderNoteNoResample(
 		
 		double fTickMismatch;
 		nNoteLength = TransportPosition::computeFrameFromTick(
-			pNote->get_position() + nDelay + pNote->get_length(),
-			&fTickMismatch ) - pNote->getNoteStart();
+			pNote->get_position() + pNote->get_length(), &fTickMismatch ) +
+			nDelay - pNote->getNoteStart();
 	}
 	
 	// The number of frames of the sample left to process.
@@ -1171,21 +1171,14 @@ bool Sampler::renderNoteResample(
 		// PatternEditor. This will be used instead of the full sample
 		// length.
 		double fTickMismatch;
-
-		// Delay is already introduced into the note start used below
-		// in Note::computeNoteStart. We need to account for it in
-		// here to in order to get the length of the note right.
-		const int nDelay = std::clamp(
-			pNote->get_humanize_delay(), -1 * AudioEngine::nMaxTimeHumanize,
-			AudioEngine::nMaxTimeHumanize );
 		
 		nNoteLength = 
-			TransportPosition::computeFrameFromTick( pNote->get_position() + nDelay +
-													 pNote->get_length(), &fTickMismatch,
-													 pSample->get_sample_rate() ) -
-			TransportPosition::computeFrameFromTick( pNote->get_position() + nDelay,
-													 &fTickMismatch,
-													 pSample->get_sample_rate() );
+			TransportPosition::computeFrameFromTick(
+				pNote->get_position() + pNote->get_length(),
+				&fTickMismatch, pSample->get_sample_rate() ) -
+			TransportPosition::computeFrameFromTick(
+				pNote->get_position(), &fTickMismatch,
+				pSample->get_sample_rate() );
 	}
 
 	float fNotePitch = pNote->get_total_pitch() + fLayerPitch;


### PR DESCRIPTION
there was a bug in the calculation of user defined note length in the `Sampler`. The delay introduced due to humanization, like lead lag, is given in frames but was mixed with variables given in ticks. This resulted in absurdly large delays and negative note lengths.

Fixes #1852