### PR TITLE
Tolerate negative length notes (impossibly early release)

### DIFF
--- a/src/core/Basics/Adsr.cpp
+++ b/src/core/Basics/Adsr.cpp
@@ -177,7 +177,7 @@ bool ADSR::applyADSR( float *pLeft, float *pRight, int nFinalBufferPos, int nRel
 	int nBufferPos = 0;
 
 	// If the release point is somehow in the past, move direcly to Release
-	if ( nReleaseFrame <= 0 && m_state != State::Release ) {
+	if ( nReleaseFrame <= 0 && m_state != State::Release && m_state != State::Idle ) {
 		WARNINGLOG( QString( "Impossibly early release for ADSR: " ).arg( this->toQString() ) );
 		nReleaseFrame = 0;
 		m_state = State::Release;

--- a/src/core/Basics/Adsr.cpp
+++ b/src/core/Basics/Adsr.cpp
@@ -176,6 +176,13 @@ bool ADSR::applyADSR( float *pLeft, float *pRight, int nFinalBufferPos, int nRel
 {
 	int nBufferPos = 0;
 
+	// If the release point is somehow in the past, move direcly to Release
+	if ( nReleaseFrame <= 0 && m_state != State::Release ) {
+		WARNINGLOG( QString( "Impossibly early release for ADSR: " ).arg( this->toQString() ) );
+		nReleaseFrame = 0;
+		m_state = State::Release;
+	}
+
 	if ( m_state == State::Attack ) {
 		int nAttackFrames = std::min( nFinalBufferPos, nReleaseFrame );
 		if ( nAttackFrames * fStep > m_nAttack ) {


### PR DESCRIPTION
The AudioEngine could (and still can in rare circumstances) calculate the length of a note as negative. Previously this would have caused the ADSR implementation to write past the beginning of the buffer as pre-Release states would assume that Release must be in the future.

Instead, detect an early Release point and move directly to the Release state.