### PR TITLE
DPE: update note selection on keyboard input

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- Proper undo of moving notes out of DrumPatternEditor.
 				- Custom note lengths are now only drawn till the next stop note.
 				- Highlight selected stop notes too.
+				- Update selected notes visually on left and right keyboard
+				  movement.
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.2

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -789,6 +789,13 @@ void DrumPatternEditor::keyPressEvent( QKeyEvent *ev )
 	m_selection.updateKeyboardCursorPosition( getKeyboardCursorRect() );
 	m_pPatternEditorPanel->ensureCursorVisible();
 
+	if ( m_selection.isLasso() ) {
+		// Since event was used to alter the note selection, we invalidate
+		// background and force a repainting of all note symbols (including
+		// whether or not they are selected).
+		invalidateBackground();
+	}
+
 	if ( ! pHydrogenApp->hideKeyboardCursor() ) {
 		// Immediate update to prevent visual delay.
 		m_pPatternEditorPanel->getInstrumentList()->repaintInstrumentLines();


### PR DESCRIPTION
When using the keyboard to select notes the updated selection list was not consistently rendered. Moving up or down was fine. But moving left or right did just alter the size of the selection lasso but did not update the selection of the notes themselves. Or more precisely: the notes were properly selected but the white ellipse highlighting them as selected was not drawn as the background was not touched.

Now, whenever a keyboard event occurs and the selection lasso is active, the background of the `DrumPatternEditor` will be recreated.

This could of course be done more efficiently, like only redrawing in case the actual selection changes or/and only redraw those spots that changed. Well, maybe some day.

Addresses #1859 