### PR TITLE
Fix drumkit Save As

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,6 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3
 	* Fixed
-		- Fixed NoteOff (stop note) color which was no different than
-			the default note color (#1854).
 		- Recorded MIDI notes were inserted ahead of the beat (#1851).
 		- Drumkit Property Dialog:
 				- Images were written regardless whether one hits the ok or
@@ -10,6 +8,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- When using Save As to create a new drumkit, the added image
 				  was put in the old drumkit folder instead and not properly
 				  copied into the new one.
+		- Allow to Save As drumkits derived from kits not found on the
+			current system.
 		- Audio Engine: In Song Mode with Loop Mode deactivated Hydrogen
 			missed notes very close to the end of the song.
 		- Fix crash on playing back notes with custom length (#1852).
@@ -20,6 +20,9 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- Highlight selected stop notes too.
 				- Update selected notes visually on left and right keyboard
 				  movement.
+				- Fixed stop note color which was no different than
+					the default note color (#1854).
+
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.2

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -58,6 +58,8 @@ Drumkit::Drumkit() : __samples_loaded( false ),
 					 __license( License() ),
 					 __imageLicense( License() )
 {
+	QDir usrDrumkitPath( Filesystem::usr_drumkits_dir() );
+	__path = usrDrumkitPath.filePath( __name );
 	__components = std::make_shared<std::vector<std::shared_ptr<DrumkitComponent>>>();
 	__instruments = std::make_shared<InstrumentList>();
 }

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2431,6 +2431,27 @@ void MainForm::editDrumkitProperties( bool bDrumkitNameLocked )
 	
 	auto pDrumkit = pHydrogen->getSoundLibraryDatabase()
 		->getDrumkit( pHydrogen->getLastLoadedDrumkitPath() );
+
+	if ( pDrumkit == nullptr ) {
+		ERRORLOG( QString( "Unable to find drumkit at path [%1]. Trying drumkit name [%2] instead." )
+				  .arg( pHydrogen->getLastLoadedDrumkitPath() )
+				  .arg( pHydrogen->getLastLoadedDrumkitName() ) );
+		// No luck when searching for the kit using the absolute path found in
+		// the .h2song. Let's try the last loaded drumkit name.
+		const QString sDrumkitPath =
+			Filesystem::drumkit_path_search( pHydrogen->getLastLoadedDrumkitName(),
+											 Filesystem::Lookup::stacked, true );
+		pDrumkit = pHydrogen->getSoundLibraryDatabase()
+			->getDrumkit( sDrumkitPath );
+	}
+
+	if ( pDrumkit == nullptr && ! bDrumkitNameLocked ) {
+		ERRORLOG( QString( "Unable to find drumkit of name [%1] either. Falling back to empty one." )
+				  .arg( pHydrogen->getLastLoadedDrumkitName() ) );
+		// If that didn't worked either and the user wants to "Save As", we fall
+		// back to the default kit.
+		pDrumkit = std::make_shared<Drumkit>();
+	}
 	
 	if ( pDrumkit != nullptr ){
 


### PR DESCRIPTION
whenever the last loaded kit is not present on the current system.

First, the path of the last loaded kit found in a .h2song is tried. Second, the last loaded kit name is used. If none of these resulted in a valid drumkit, an empty one will be used as basis instead.