### PR TITLE
Sampler: rework handling of notes with custom length on tempo changes

### DIFF
--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -1679,13 +1679,13 @@ void AudioEngineTests::checkAudioConsistency( const std::vector<std::shared_ptr<
 						
 						const int nSampleFrames =
 							ppNewNote->get_instrument()->get_component( nn )
-							->get_layer( pSelectedLayer->SelectedLayer )
+							->get_layer( pSelectedLayer->nSelectedLayer )
 							->get_sample()->get_frames();
 						const double fExpectedFrames =
-							std::min( static_cast<double>(pSelectedLayer->SamplePosition) +
+							std::min( static_cast<double>(pSelectedLayer->fSamplePosition) +
 									  fPassedFrames,
 									  static_cast<double>(nSampleFrames) );
-						if ( std::abs( ppNewNote->get_layer_selected( nn )->SamplePosition -
+						if ( std::abs( ppNewNote->get_layer_selected( nn )->fSamplePosition -
 									   fExpectedFrames ) > 1 ) {
 							AudioEngineTests::throwException(
 								QString( "[checkAudioConsistency] [%4] glitch in audio render. Diff: %9\nPre: %1\nPost: %2\nwith passed frames: %3, nSampleFrames: %5, fExpectedFrames: %6, sample sampleRate: %7, driver sampleRate: %8\n" )
@@ -1695,7 +1695,7 @@ void AudioEngineTests::checkAudioConsistency( const std::vector<std::shared_ptr<
 								.arg( nSampleFrames ).arg( fExpectedFrames, 0, 'f' )
 								.arg( ppOldNote->getSample( nn )->get_sample_rate() )
 								.arg( nSampleRate )
-								.arg( ppNewNote->get_layer_selected( nn )->SamplePosition -
+								.arg( ppNewNote->get_layer_selected( nn )->fSamplePosition -
 									  fExpectedFrames, 0, 'g', 30 ) );
 						}
 					}

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -75,8 +75,9 @@ Note::Note( std::shared_ptr<Instrument> pInstrument, int nPosition, float fVeloc
 
 		for ( const auto& pCompo : *pInstrument->get_components() ) {
 			std::shared_ptr<SelectedLayerInfo> pSampleInfo = std::make_shared<SelectedLayerInfo>();
-			pSampleInfo->SelectedLayer = -1;
-			pSampleInfo->SamplePosition = 0;
+			pSampleInfo->nSelectedLayer = -1;
+			pSampleInfo->fSamplePosition = 0;
+			pSampleInfo->nNoteLength = -1;
 
 			__layers_selected[ pCompo->get_drumkit_componentID() ] = pSampleInfo;
 		}
@@ -122,8 +123,9 @@ Note::Note( Note* other, std::shared_ptr<Instrument> instrument )
 
 	for ( const auto& mm : other->__layers_selected ) {
 		std::shared_ptr<SelectedLayerInfo> pSampleInfo = std::make_shared<SelectedLayerInfo>();
-		pSampleInfo->SelectedLayer = mm.second->SelectedLayer;
-		pSampleInfo->SamplePosition = mm.second->SamplePosition;
+		pSampleInfo->nSelectedLayer = mm.second->nSelectedLayer;
+		pSampleInfo->fSamplePosition = mm.second->fSamplePosition;
+		pSampleInfo->nNoteLength = mm.second->nNoteLength;
 		
 		__layers_selected[ mm.first ] = pSampleInfo;
 	}
@@ -183,8 +185,9 @@ void Note::map_instrument( std::shared_ptr<InstrumentList> pInstrumentList )
 
 		for ( const auto& ppCompo : *pInstr->get_components() ) {
 			std::shared_ptr<SelectedLayerInfo> sampleInfo = std::make_shared<SelectedLayerInfo>();
-			sampleInfo->SelectedLayer = -1;
-			sampleInfo->SamplePosition = 0;
+			sampleInfo->nSelectedLayer = -1;
+			sampleInfo->fSamplePosition = 0;
+			sampleInfo->nNoteLength = -1;
 
 			__layers_selected[ ppCompo->get_drumkit_componentID() ] = sampleInfo;
 		}
@@ -219,7 +222,7 @@ bool Note::isPartiallyRendered() const {
 	bool bRes = false;
 
 	for ( auto ll : __layers_selected ) {
-		if ( ll.second->SamplePosition > 0 ) {
+		if ( ll.second->fSamplePosition > 0 ) {
 			bRes = true;
 			break;
 		}
@@ -279,20 +282,20 @@ std::shared_ptr<Sample> Note::getSample( int nComponentID, int nSelectedLayer ) 
 		return nullptr;
 	}
 
-	if( pSelectedLayer->SelectedLayer != -1 ||
+	if( pSelectedLayer->nSelectedLayer != -1 ||
 		nSelectedLayer != -1 ) {
 		// This function was already called for this note and a
 		// specific layer the sample will be taken from was already
 		// selected or it is provided as an input argument.
 
-		int nLayer = pSelectedLayer->SelectedLayer != -1 ?
-			pSelectedLayer->SelectedLayer : nSelectedLayer;
+		int nLayer = pSelectedLayer->nSelectedLayer != -1 ?
+			pSelectedLayer->nSelectedLayer : nSelectedLayer;
 
-		if ( pSelectedLayer->SelectedLayer != -1 &&
+		if ( pSelectedLayer->nSelectedLayer != -1 &&
 			 nSelectedLayer != -1 &&
-			 pSelectedLayer->SelectedLayer != nSelectedLayer ) {
+			 pSelectedLayer->nSelectedLayer != nSelectedLayer ) {
 			WARNINGLOG( QString( "Previously selected layer [%1] and requested layer [%2] differ. The previous one will be used." )
-						.arg( pSelectedLayer->SelectedLayer )
+						.arg( pSelectedLayer->nSelectedLayer )
 						.arg( nSelectedLayer ) );
 		}
 		
@@ -405,7 +408,7 @@ std::shared_ptr<Sample> Note::getSample( int nComponentID, int nSelectedLayer ) 
 				return nullptr;
 			} 
 
-			pSelectedLayer->SelectedLayer = nLayerPicked;
+			pSelectedLayer->nSelectedLayer = nLayerPicked;
 			auto pLayer = pInstrCompo->get_layer( nLayerPicked );
 			pSample = pLayer->get_sample();
 
@@ -576,11 +579,12 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 						.arg( sPrefix ).arg( s ) );
 		for ( auto ll : __layers_selected ) {
 			if ( ll.second != nullptr ) {
-				sOutput.append( QString( "%1%2[component: %3, selected layer: %4, sample position: %5]\n" )
+				sOutput.append( QString( "%1%2[component: %3, selected layer: %4, sample position: %5, note length: %6]\n" )
 								.arg( sPrefix ).arg( s + s )
 								.arg( ll.first )
-								.arg( ll.second->SelectedLayer )
-								.arg( ll.second->SamplePosition ) );
+								.arg( ll.second->nSelectedLayer )
+								.arg( ll.second->fSamplePosition )
+								.arg( ll.second->nNoteLength ) );
 			} else {
 				sOutput.append( QString( "%1%2[component: %3, selected layer info: nullptr]\n" )
 								.arg( sPrefix ).arg( s + s )
@@ -631,10 +635,11 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 		sOutput.append( QString( ", layers_selected: " ) );
 		for ( auto ll : __layers_selected ) {
 			if ( ll.second != nullptr ) {
-				sOutput.append( QString( "[component: %1, selected layer: %2, sample position: %3] " )
+				sOutput.append( QString( "[component: %1, selected layer: %2, sample position: %3, note length: %4] " )
 								.arg( ll.first )
-								.arg( ll.second->SelectedLayer )
-								.arg( ll.second->SamplePosition ) );
+								.arg( ll.second->nSelectedLayer )
+								.arg( ll.second->fSamplePosition )
+								.arg( ll.second->nNoteLength ) );
 			} else {
 				sOutput.append( QString( "[component: %1, selected layer info: nullptr]" )
 								.arg( ll.first ) );

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -58,15 +58,40 @@ class ADSR;
 class Instrument;
 class InstrumentList;
 
+/** Auxiliary variables storing the rendering state of a #H2Core::Note within
+ * the #H2Core::Sampler */
 struct SelectedLayerInfo {
-	/** Selected layer during layer selection
-	 * 
-	 * If set to -1 (during creation), Sampler::renderNote() will
-	 * determine which layer to use and overrides this variable with
-	 * the corresponding value.
-	 */
-	int SelectedLayer;
-	float SamplePosition;	///< place marker for overlapping process() cycles
+	/** Selected layer during rendering in the #H2Core::Sampler.
+	 *
+	 * If set to -1 (during creation), Sampler::renderNote() will determine
+	 * which layer to use and overrides this variable with the corresponding
+	 * value. */
+	int nSelectedLayer;
+
+	/** Stores the frame till which the #H2Core::Sample of the selected
+	 * #H2Core::InstrumentLayer using #nSelectedLayer was already rendered. If
+	 * several cycles of #Sampler::renderNote() are required, this variable
+	 * corresponds to the starting point of each cycle.
+	 *
+	 * It is given in float instead of int/long - what one might expect when
+	 * talking about frames - since it also serves as the fraction of the
+	 * #H2Core::Sample already processed in case it has to be resampled. */
+	float fSamplePosition;
+
+	/** Frame / #fSamplePosition at which rendering of the current note is
+	 * considered done.
+	 *
+	 * For regular notes this is the number of frames of the #H2Core::Sample
+	 * corresponding to #nSelectedLayer.
+	 *
+	 * If, however, the user specifies the length of a note things are more
+	 * complex. The length is specified in the GUI in **ticks** and this
+	 * variable is the corresponding value in frames. Now, whenever manually
+	 * adjusting the tempo or adding/deleting a tempo marker the length of the
+	 * note in frames differs for the new speed. In case rendering did already
+	 * started, it is important to not rescale the whole length of the note but
+	 * just the fraction between #fSamplePosition and the former #nNoteLength.*/
+	int nNoteLength;
 };
 
 /**
@@ -222,6 +247,7 @@ class Note : public H2Core::Object<Note>
 		 * selected sample
 		 * */
 	std::shared_ptr<SelectedLayerInfo> get_layer_selected( int CompoID );
+	std::map<int, std::shared_ptr<SelectedLayerInfo>> get_layers_selected() const;
 
 
 		void set_probability( float value );
@@ -594,6 +620,11 @@ inline void Note::set_probability( float value )
 inline std::shared_ptr<SelectedLayerInfo> Note::get_layer_selected( int CompoID )
 {
 	return __layers_selected[ CompoID ];
+}
+
+inline std::map<int, std::shared_ptr<SelectedLayerInfo>> Note::get_layers_selected() const
+{
+	return __layers_selected;
 }
 
 inline int Note::get_humanize_delay() const


### PR DESCRIPTION
- `Note::SelectedLayerInfo` was refactored to comply with your naming conventions
- `Note::SelectedLayerInfo::nNoteLength` was introduced to store the length of a note once it is first rendered in the `Sampler`. Doing it at each rendering cycles causes issues on manual tempo changes.
- `Sampler::handleTimelineOrTempoChange` does now also scale the part of a note/sample still left for rendering in case rendering already has begun. This is important in case of manual tempo changes for notes with user defined length.

Addresses https://github.com/hydrogen-music/hydrogen/issues/1873