### PR TITLE
AudioEngine: truncate custom note length on pattern end

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2499,6 +2499,16 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 													   pAutomationPath->get_value( fPos ) );
 						}
 
+						// Ensure the custom length of the note does not exceed
+						// the length of the current pattern.
+						if ( pCopiedNote->get_length() != -1 ) {
+							pCopiedNote->set_length(
+								std::min(
+									static_cast<long>(pCopiedNote->get_length()),
+									static_cast<long>(pPattern->get_length()) -
+									m_pQueuingPosition->getPatternTickPosition() ) );
+						}
+
 						// DEBUGLOG( QString( "m_pQueuingPosition: %1, new note: %2" )
 						// 		  .arg( m_pQueuingPosition->toQString() )
 						// 		  .arg( pCopiedNote->toQString() ) );


### PR DESCRIPTION
in case a custom note length was defined and the pattern length was reduced afterwards it is now ensured that the custom length is truncated at the end of the pattern. Else, the note could ring beyond what is visually indicated to be its end.

Addresses #1873