### PR TITLE
Song: remember master mute state

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3
 	* Fixed
+		- Restore mute button state of master mixer strip on song load.
 		- Recorded MIDI notes were inserted ahead of the beat (#1851).
 		- Drumkit Property Dialog:
 				- Images were written regardless whether one hits the ok or

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -238,6 +238,8 @@ std::shared_ptr<Song> Song::loadFrom( XMLNode* pRootNode, const QString& sFilena
 
 	std::shared_ptr<Song> pSong = std::make_shared<Song>( sName, sAuthor, fBpm, fVolume );
 
+	pSong->setIsMuted( pRootNode->read_bool( "isMuted", false, true, false,
+											 bSilent ) );
 	pSong->setMetronomeVolume( pRootNode->read_float( "metronomeVolume", 0.5,
 													  false, false, bSilent ) );
 	pSong->setNotes( pRootNode->read_string( "notes", "...", false, false, bSilent ) );
@@ -758,6 +760,7 @@ void Song::writeTo( XMLNode* pRootNode, bool bSilent ) {
 	pRootNode->write_string( "version", QString( get_version().c_str() ) );
 	pRootNode->write_float( "bpm", m_fBpm );
 	pRootNode->write_float( "volume", m_fVolume );
+	pRootNode->write_bool( "isMuted", m_bIsMuted );
 	pRootNode->write_float( "metronomeVolume", m_fMetronomeVolume );
 	pRootNode->write_string( "name", m_sName );
 	pRootNode->write_string( "author", m_sAuthor );


### PR DESCRIPTION
Seems like the state of the mute button in the Master Mixer strip was accidentially dropped during refactoring (at least since 1.1.0)