### PR TITLE
CoreMIDI: fix naming of header files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Audio Engine: In Song Mode with Loop Mode deactivated Hydrogen
 			missed notes very close to the end of the song.
 		- Fix crash on playing back notes with custom length (#1852).
+		- macOS: fix naming of CoreMIDI header (#1865).
 		- Pattern Editor (#1859):
 				- Only delete stop notes clicked by the user.
 				- Proper undo of moving notes out of DrumPatternEditor.

--- a/src/core/IO/CoreMidiDriver.h
+++ b/src/core/IO/CoreMidiDriver.h
@@ -33,7 +33,7 @@
 
 #if defined(H2CORE_HAVE_COREMIDI) || _DOXYGEN_
 
-#include <CoreMidi/CoreMidi.h>
+#include <CoreMIDI/CoreMIDI.h>
 
 namespace H2Core
 {


### PR DESCRIPTION
fixes #1865