### PR TITLE
PatternEditor: fix note tail rendering

### DIFF
--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -263,7 +263,7 @@ void PatternEditor::drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote
 			float fNotePitch = pNote->get_octave() * 12 + pNote->get_key();
 			float fStep = Note::pitchToFrequency( ( double )fNotePitch );
 
-			// if there is a noteOff note to the right of this note, only draw
+			// if there is a stop-note to the right of this note, only draw-
 			// its length till there.
 			int nLength = pNote->get_length();
 			auto notes = m_pPattern->get_notes();
@@ -278,7 +278,7 @@ void PatternEditor::drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote
 					 // custom length reaches beyond NoteOff
 					 pNote->get_position() + pNote->get_length() >
 					 ppNote->get_position() ) {
-					// In case there are multiple NoteOffs present, take the
+					// In case there are multiple stop-notes present, take the
 					// shortest distance.
 					nLength = std::min( ppNote->get_position() - pNote->get_position(), nLength );
 				}
@@ -292,8 +292,20 @@ void PatternEditor::drawNoteSymbol( QPainter &p, QPoint pos, H2Core::Note *pNote
 			}
 			p.setPen( notePen );
 			p.setBrush( noteBrush );
-			p.fillRect( x_pos, y_pos +2, width, 3, color );	/// \todo: definire questo colore nelle preferenze
-			p.drawRect( x_pos, y_pos +2, width, 3 );
+
+			// Since the note body is transparent for an inactive note, we try
+			// to start the tail at its boundary. For regular notes we do not
+			// care about an overlap, as it ensures that there are no white
+			// artifacts between tail and note body regardless of the scale
+			// factor.
+			int nRectOnsetX = x_pos;
+			int nRectWidth = width;
+			if ( ! bIsForeground ) {
+				nRectOnsetX = nRectOnsetX + w/2;
+				nRectWidth = nRectWidth - w/2;
+			}
+
+			p.drawRect( nRectOnsetX, y_pos +2, nRectWidth, 3 );
 			p.drawLine( x_pos+width, y_pos, x_pos+width, y_pos + h );
 		}
 


### PR DESCRIPTION
tails were filled with solid color even in case the note is inaccessible

active notes
![active](https://github.com/hydrogen-music/hydrogen/assets/14164547/98485c8a-0180-421e-b208-abb71cd2465c)

inactive notes (previously)
![inactive_old](https://github.com/hydrogen-music/hydrogen/assets/14164547/38145fc9-c65c-4587-aba2-de1f5071e0c1)

inactive notes (now)
![inactive_new](https://github.com/hydrogen-music/hydrogen/assets/14164547/27d51664-8130-45d3-a2d0-39a2f034fdef)
