### PR TITLE
Rework develop build versioning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -543,7 +543,7 @@ for:
           FOR /F "delims=" %%i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%%i'
           FOR /F "delims=" %%i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%%i'
           REM *** Note: no single quotes around the last %%i as the output is already quoted ***
-          FOR /F "delims=" %%i IN ('"git log --pretty=format:'%h' -n 1"') DO set GIT_COMMIT_HASH=%%i
+          FOR /F "delims=" %%i IN ('"git log --pretty=format:'%%h' -n 1"') DO set GIT_COMMIT_HASH=%%i
 
           REM *** If the last tag matches the display version (we are working on the
           REM *** same branch the tag is located in - the release branch), we will use

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,6 +90,41 @@ init:
           UPLOAD_ARTIFACTS=true
       fi
 
+      # In case we are not at a tag, we append some additional information to a)
+      # indicate that the artifact is not an official release and b) allow use
+      # to track down which sources it corresponds to.
+      #
+      # Attention: the code for determining the version string is present in the
+      # top-level CMakeLists.txt file too. Be sure to tweak both.
+      DISPLAY_VERSION=$TARGET_VERSION
+      if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
+          # If the last tag matches the display version (we are working on the
+          # same branch the tag is located in - the release branch), we will use
+          # `git describe` since it nicely adds the number of commits passed
+          # since the tag next to the current commit id.
+          DISPLAY_VERSION=$(git describe --tags)
+      else
+          # We are working on a release which is not a patch release of the last
+          # one (feature branch, develop branch, master after splitting of a
+          # dedicated release branch). We just add the commit hash to the
+          # display version.
+          DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
+      fi
+
+  - cmd: |-
+      REM *** Upload artifacts in case either the branch is named *-artifacts or HEAD is located on a tag. ***
+      if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
+      if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
+
+      set DISPLAY_VERSION=%TARGET_VERSION%
+      FOR /F "delims=" %i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%i'
+      FOR /F "delims=" %i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%i'
+      REM *** Note: no single quotes around the last %i as the output is already quoted ***
+      FOR /F "delims=" %i IN ('"git log --pretty=format:'%h' -n 1"') DO set GIT_COMMIT_HASH=%i
+
+      if %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%GIT_DESCRIPTION%
+      if not %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%TARGET_VERSION%-%GIT_COMMIT_HASH% tb
+
 for:
   - 
     matrix:
@@ -328,7 +363,9 @@ for:
         --output appimage || exit 1
 
       echo -e "\n *** Upload AppImage ***\n"
-      appveyor PushArtifact Hydrogen-x86_64.AppImage || exit 1
+      TARGET_NAME=Hydrogen-${DISPLAY_VERSION}-x86_64.AppImage
+      mv Hydrogen-x86_64.AppImage ${TARGET_NAME} || exit 1
+      appveyor PushArtifact ${TARGET_NAME} || exit 1
 
   - 
     cache: /Users/appveyor/cache_dir
@@ -422,7 +459,7 @@ for:
       (
         cd build
         PATH="$(brew --prefix qt5)/bin:$PATH"
-        ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen${PKG_SUFFIX}.dmg
+        ../macos/build_dmg.sh -v src/gui/hydrogen.app Hydrogen-${DISPLAY_VERSION}.dmg
 
         if [ "$UPLOAD_ARTIFACTS" == "true" ]; then
             appveyor PushArtifact Hydrogen*.dmg -DeploymentName Installer;
@@ -453,11 +490,6 @@ for:
     cache: '%USERPROFILE%\AppData\Roaming\ccache'
     before_build:
       cmd: |-
-
-          REM *** Upload artifacts in case either the branch is named ***
-          REM *** *-artifacts or HEAD is located on a tag. ***
-          if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
-          if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
 
           if not %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32 appveyor exit
 
@@ -548,8 +580,8 @@ on_finish:
   - cmd: if %UPLOAD_ARTIFACTS%=="true"  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\CMakeFiles\CMakeConfigureLog.yaml
   - cmd: if EXIST %APPVEYOR_BUILD_FOLDER%\build\testOutput.log appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\testOutput.log
 
-  - cmd: if %UPLOAD_ARTIFACTS%=="true" if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win64.exe || cmd /c "exit /b 1"
-  - cmd: if %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%TARGET_VERSION%-win32.exe || cmd /c "exit /b 1"
+  - cmd: if %UPLOAD_ARTIFACTS%=="true" if not %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%DISPLAY_VERSION%-win64.exe || cmd /c "exit /b 1"
+  - cmd: if %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32  appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\build\Hydrogen-%DISPLAY_VERSION%-win32.exe || cmd /c "exit /b 1"
 
   - cmd: |
       if %UPLOAD_ARTIFACTS%=="true" curl -F file=@%APPVEYOR_BUILD_FOLDER%\build\test_installation.xml https://ci.appveyor.com/api/testresults/junit/%APPVEYOR_JOB_ID%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -545,7 +545,7 @@ for:
 
           echo %TARGET_VERSION%
 
-          FOR /F "delims=" %%i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%%i'
+          FOR /F "delims=" %%i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG=%%i
           echo %GIT_LAST_TAG%
 
           FOR /F "delims=" %%i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%%i'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -527,10 +527,6 @@ for:
     cache: '%USERPROFILE%\AppData\Roaming\ccache'
     before_build:
       cmd: |-
-          REM *** Upload artifacts in case either the branch is named *-artifacts or HEAD is located on a tag. ***
-          if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
-          if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
-
           REM *** In case we are not at a tag, we append some additional information to a)
           REM *** indicate that the artifact is not an official release and b) allow use
           REM *** to track down which sources it corresponds to.
@@ -540,10 +536,18 @@ for:
           REM *** the copies in all other pipelines (it can't, unfortunately, moved in the
           REM *** `init` section as the git repo is not available at this point yet).
           set DISPLAY_VERSION=%TARGET_VERSION%
+
+          echo %TARGET_VERSION%
+
           FOR /F "delims=" %%i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%%i'
+          echo %GIT_LAST_TAG%
+
           FOR /F "delims=" %%i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%%i'
+          echo %GIT_DESCRIPTION%
+
           REM *** Note: no single quotes around the last %%i as the output is already quoted ***
           FOR /F "delims=" %%i IN ('"git log --pretty=format:'%%h' -n 1"') DO set GIT_COMMIT_HASH=%%i
+          echo %GIT_COMMIT_HASH%
 
           REM *** If the last tag matches the display version (we are working on the
           REM *** same branch the tag is located in - the release branch), we will use
@@ -556,6 +560,8 @@ for:
           REM *** dedicated release branch). We just add the commit hash to the
           REM *** display version.
           if not %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%TARGET_VERSION%-%GIT_COMMIT_HASH%
+
+          echo %DISPLAY_VERSION%
 
           if not %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32 appveyor exit
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -548,10 +548,9 @@ for:
           FOR /F "delims=" %%i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG=%%i
           echo %GIT_LAST_TAG%
 
-          FOR /F "delims=" %%i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%%i'
+          FOR /F "delims=" %%i IN ('"git describe --tags"') DO set GIT_DESCRIPTION=%%i
           echo %GIT_DESCRIPTION%
 
-          REM *** Note: no single quotes around the last %%i as the output is already quoted ***
           FOR /F "delims=" %%i IN ('"git log --pretty=format:'%%h' -n 1"') DO set GIT_COMMIT_HASH=%%i
           echo %GIT_COMMIT_HASH%
 
@@ -567,6 +566,9 @@ for:
           REM *** display version.
           if not %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%TARGET_VERSION%-%GIT_COMMIT_HASH%
 
+          REM *** Remove quotes from variable as this would prevent use from
+          REM *** properly find the file during upload.
+          set DISPLAY_VERSION=%DISPLAY_VERSION:'=%
           echo %DISPLAY_VERSION%
 
           if not %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32 appveyor exit

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -108,10 +108,9 @@ for:
       # indicate that the artifact is not an official release and b) allow use
       # to track down which sources it corresponds to.
       #
-      # Attention: the code for determining the version string is present in the
-      # top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
-      # the copies in all other pipelines (it can't, unfortunately, moved in the
-      # `init` section as the git repo is not available at this point yet).
+      # Attention: Be sure to tweak both. Also adjust the copies in all other
+      # pipelines (it can't, unfortunately, moved in the `init` section as the
+      # git repo is not available at this point yet).
       DISPLAY_VERSION=$TARGET_VERSION
       if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
           # If the last tag matches the display version (we are working on the
@@ -126,6 +125,8 @@ for:
           # display version.
           DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
       fi
+
+      echo $DISPLAY_VERSION
 
       cache_tag=usr_cache_portmidi # this can be modified to rebuild deps
 
@@ -189,8 +190,9 @@ for:
               -DWANT_LRDF=1 \
               -DWANT_PORTMIDI=1 \
               -DWANT_PORTAUDIO=1 \
-              -DWANT_RUBBERBAND=1 .. \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DWANT_RUBBERBAND=1 \
+              -DDISPLAY_VERSION_PIPELINE=${DISPLAY_VERSION} \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .. \
           && \
         make -j $CPUS
 
@@ -229,10 +231,9 @@ for:
       # indicate that the artifact is not an official release and b) allow use
       # to track down which sources it corresponds to.
       #
-      # Attention: the code for determining the version string is present in the
-      # top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
-      # the copies in all other pipelines (it can't, unfortunately, moved in the
-      # `init` section as the git repo is not available at this point yet).
+      # Attention: Be sure to tweak both. Also adjust the copies in all other
+      # pipelines (it can't, unfortunately, moved in the `init` section as the
+      # git repo is not available at this point yet).
       DISPLAY_VERSION=$TARGET_VERSION
       if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
           # If the last tag matches the display version (we are working on the
@@ -247,6 +248,8 @@ for:
           # display version.
           DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
       fi
+
+      echo $DISPLAY_VERSION
 
       if [ "$UPLOAD_ARTIFACTS" == "false" ]; then
          echo "Skipping AppImage build as artifacts are not requested"
@@ -338,6 +341,7 @@ for:
             -DWANT_RUBBERBAND=1 \
             -DWANT_APPIMAGE=1 \
             -DWANT_DYNAMIC_JACK_CHECK=1 \
+            -DDISPLAY_VERSION_PIPELINE=${DISPLAY_VERSION} \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_PREFIX_PATH=$HOME/Qt/5.15.2/gcc_64 .. || exit 1
@@ -393,10 +397,9 @@ for:
       # indicate that the artifact is not an official release and b) allow use
       # to track down which sources it corresponds to.
       #
-      # Attention: the code for determining the version string is present in the
-      # top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
-      # the copies in all other pipelines (it can't, unfortunately, moved in the
-      # `init` section as the git repo is not available at this point yet).
+      # Attention: Be sure to tweak both. Also adjust the copies in all other
+      # pipelines (it can't, unfortunately, moved in the `init` section as the
+      # git repo is not available at this point yet).
       DISPLAY_VERSION=$TARGET_VERSION
       if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
           # If the last tag matches the display version (we are working on the
@@ -411,6 +414,8 @@ for:
           # display version.
           DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
       fi
+
+      echo $DISPLAY_VERSION
 
       ###############################################################
       # Set up macOS dependencies
@@ -488,6 +493,7 @@ for:
               cd build &&                                                       \
               cmake -DWANT_LASH=1                                               \
                     -DWANT_LRDF=1                                               \
+                    -DDISPLAY_VERSION_PIPELINE=${DISPLAY_VERSION}               \
                     -DWANT_RUBBERBAND=1 .. &&                                   \
               make -j $CPUS
       ) || exit 1
@@ -597,7 +603,7 @@ for:
           rename "C:\Program Files\Git\usr\bin\sh.exe" "sh2.exe"
           mkdir build
           cd build
-          cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%BUILD_TYPE% %CMAKE_FLAGS% -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
+          cmake -G "%GENERATOR%" -DDISPLAY_VERSION_PIPELINE=%DISPLAY_VERSION% -DCMAKE_BUILD_TYPE=%BUILD_TYPE% %CMAKE_FLAGS% -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ..
 
     build_script:
       - cmd: |-

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -540,10 +540,10 @@ for:
           REM *** the copies in all other pipelines (it can't, unfortunately, moved in the
           REM *** `init` section as the git repo is not available at this point yet).
           set DISPLAY_VERSION=%TARGET_VERSION%
-          FOR /F "delims=" %i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%i'
-          FOR /F "delims=" %i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%i'
-          REM *** Note: no single quotes around the last %i as the output is already quoted ***
-          FOR /F "delims=" %i IN ('"git log --pretty=format:'%h' -n 1"') DO set GIT_COMMIT_HASH=%i
+          FOR /F "delims=" %%i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%%i'
+          FOR /F "delims=" %%i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%%i'
+          REM *** Note: no single quotes around the last %%i as the output is already quoted ***
+          FOR /F "delims=" %%i IN ('"git log --pretty=format:'%h' -n 1"') DO set GIT_COMMIT_HASH=%%i
 
           REM *** If the last tag matches the display version (we are working on the
           REM *** same branch the tag is located in - the release branch), we will use

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,12 +90,28 @@ init:
           UPLOAD_ARTIFACTS=true
       fi
 
+  - cmd: |-
+      REM *** Upload artifacts in case either the branch is named *-artifacts or HEAD is located on a tag. ***
+      if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
+      if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
+
+for:
+  - 
+    matrix:
+      only:
+        - job_group: 'Linux'
+
+    cache: $HOME/cache_dir
+
+    before_build: |-
       # In case we are not at a tag, we append some additional information to a)
       # indicate that the artifact is not an official release and b) allow use
       # to track down which sources it corresponds to.
       #
       # Attention: the code for determining the version string is present in the
-      # top-level CMakeLists.txt file too. Be sure to tweak both.
+      # top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
+      # the copies in all other pipelines (it can't, unfortunately, moved in the
+      # `init` section as the git repo is not available at this point yet).
       DISPLAY_VERSION=$TARGET_VERSION
       if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
           # If the last tag matches the display version (we are working on the
@@ -110,30 +126,6 @@ init:
           # display version.
           DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
       fi
-
-  - cmd: |-
-      REM *** Upload artifacts in case either the branch is named *-artifacts or HEAD is located on a tag. ***
-      if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
-      if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
-
-      set DISPLAY_VERSION=%TARGET_VERSION%
-      FOR /F "delims=" %i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%i'
-      FOR /F "delims=" %i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%i'
-      REM *** Note: no single quotes around the last %i as the output is already quoted ***
-      FOR /F "delims=" %i IN ('"git log --pretty=format:'%h' -n 1"') DO set GIT_COMMIT_HASH=%i
-
-      if %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%GIT_DESCRIPTION%
-      if not %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%TARGET_VERSION%-%GIT_COMMIT_HASH% tb
-
-for:
-  - 
-    matrix:
-      only:
-        - job_group: 'Linux'
-
-    cache: $HOME/cache_dir
-
-    before_build: |-
 
       cache_tag=usr_cache_portmidi # this can be modified to rebuild deps
 
@@ -233,6 +225,29 @@ for:
     cache: $HOME/cache_dir_appimage
 
     before_build: |-
+      # In case we are not at a tag, we append some additional information to a)
+      # indicate that the artifact is not an official release and b) allow use
+      # to track down which sources it corresponds to.
+      #
+      # Attention: the code for determining the version string is present in the
+      # top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
+      # the copies in all other pipelines (it can't, unfortunately, moved in the
+      # `init` section as the git repo is not available at this point yet).
+      DISPLAY_VERSION=$TARGET_VERSION
+      if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
+          # If the last tag matches the display version (we are working on the
+          # same branch the tag is located in - the release branch), we will use
+          # `git describe` since it nicely adds the number of commits passed
+          # since the tag next to the current commit id.
+          DISPLAY_VERSION=$(git describe --tags)
+      else
+          # We are working on a release which is not a patch release of the last
+          # one (feature branch, develop branch, master after splitting of a
+          # dedicated release branch). We just add the commit hash to the
+          # display version.
+          DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
+      fi
+
       if [ "$UPLOAD_ARTIFACTS" == "false" ]; then
          echo "Skipping AppImage build as artifacts are not requested"
          exit 0
@@ -374,6 +389,28 @@ for:
         - job_group: 'Mac OS X'
 
     before_build: |-
+      # In case we are not at a tag, we append some additional information to a)
+      # indicate that the artifact is not an official release and b) allow use
+      # to track down which sources it corresponds to.
+      #
+      # Attention: the code for determining the version string is present in the
+      # top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
+      # the copies in all other pipelines (it can't, unfortunately, moved in the
+      # `init` section as the git repo is not available at this point yet).
+      DISPLAY_VERSION=$TARGET_VERSION
+      if [[ "$(git describe --abbrev=0)" == "$TARGET_VERSION" ]]; then
+          # If the last tag matches the display version (we are working on the
+          # same branch the tag is located in - the release branch), we will use
+          # `git describe` since it nicely adds the number of commits passed
+          # since the tag next to the current commit id.
+          DISPLAY_VERSION=$(git describe --tags)
+      else
+          # We are working on a release which is not a patch release of the last
+          # one (feature branch, develop branch, master after splitting of a
+          # dedicated release branch). We just add the commit hash to the
+          # display version.
+          DISPLAY_VERSION="$TARGET_VERSION-$(git log --pretty=format:'%h' -n 1)"
+      fi
 
       ###############################################################
       # Set up macOS dependencies
@@ -490,6 +527,35 @@ for:
     cache: '%USERPROFILE%\AppData\Roaming\ccache'
     before_build:
       cmd: |-
+          REM *** Upload artifacts in case either the branch is named *-artifacts or HEAD is located on a tag. ***
+          if defined APPVEYOR_REPO_TAG_NAME (set UPLOAD_ARTIFACTS="true") else (echo No tag name defined)
+          if not "%APPVEYOR_REPO_BRANCH%"=="%APPVEYOR_REPO_BRANCH:-artifacts=%" set UPLOAD_ARTIFACTS="true"
+
+          REM *** In case we are not at a tag, we append some additional information to a)
+          REM *** indicate that the artifact is not an official release and b) allow use
+          REM *** to track down which sources it corresponds to.
+          REM ***
+          REM *** Attention: the code for determining the version string is present in the
+          REM *** top-level CMakeLists.txt file too. Be sure to tweak both. Also adjust
+          REM *** the copies in all other pipelines (it can't, unfortunately, moved in the
+          REM *** `init` section as the git repo is not available at this point yet).
+          set DISPLAY_VERSION=%TARGET_VERSION%
+          FOR /F "delims=" %i IN ('"git describe --abbrev=0"') DO set GIT_LAST_TAG='%i'
+          FOR /F "delims=" %i IN ('"git describe --tags"') DO set GIT_DESCRIPTION='%i'
+          REM *** Note: no single quotes around the last %i as the output is already quoted ***
+          FOR /F "delims=" %i IN ('"git log --pretty=format:'%h' -n 1"') DO set GIT_COMMIT_HASH=%i
+
+          REM *** If the last tag matches the display version (we are working on the
+          REM *** same branch the tag is located in - the release branch), we will use
+          REM *** `git describe` since it nicely adds the number of commits passed
+          REM *** since the tag next to the current commit id.
+          if %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%GIT_DESCRIPTION%
+
+          REM *** We are working on a release which is not a patch release of the last
+          REM *** one (feature branch, develop branch, master after splitting of a
+          REM *** dedicated release branch). We just add the commit hash to the
+          REM *** display version.
+          if not %GIT_LAST_TAG%==%TARGET_VERSION% set DISPLAY_VERSION=%TARGET_VERSION%-%GIT_COMMIT_HASH%
 
           if not %UPLOAD_ARTIFACTS%=="true" if %job_name%==Windows32 appveyor exit
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ if(VERSION_SUFFIX)
 endif()
 
 # Consider any tagged commit as a release build
-execute_process(COMMAND git describe --exact-match --tags OUTPUT_VARIABLE GIT_TAG)
-if(GIT_TAG)
+execute_process(COMMAND git describe --exact-match --tags OUTPUT_VARIABLE GIT_ON_TAG)
+if(GIT_ON_TAG)
     set(IS_DEVEL_BUILD "false")
 else()
     set(IS_DEVEL_BUILD "true")
@@ -38,20 +38,24 @@ else()
     #
     # Attention: the code for determining the version string is present in the
     # .appveyor file too. Be sure to tweak both.
-    execute_process(COMMAND git describe --abbrev=0 OUTPUT_VARIABLE GIT_LAST_TAG)
-    if(${DISPLAY_VERSION} MATCHES ${GIT_LAST_TAG})
+    execute_process(COMMAND git describe --abbrev=0
+        OUTPUT_VARIABLE GIT_LAST_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if("${DISPLAY_VERSION}" STREQUAL "${GIT_LAST_TAG}")
         # If the last tag matches the display version (we are working on the
         # same branch the tag is located in - the release branch), we will use
         # `git describe` since it nicely adds the number of commits passed since
         # the tag next to the current commit id.
-        execute_process(COMMAND git describe --tags OUTPUT_VARIABLE GIT_DESCRIPTION)
+        execute_process(COMMAND git describe --tags
+            OUTPUT_VARIABLE GIT_DESCRIPTION OUTPUT_STRIP_TRAILING_WHITESPACE)
         set(DISPLAY_VERSION "${GIT_DESCRIPTION}")
     else()
         # We are working on a release which is not a patch release of the last
         # one (feature branch, develop branch, master after splitting of a
         # dedicated release branch). We just add the commit hash to the display
         # version.
-        execute_process(COMMAND git log --pretty=format:'%h' -n 1 OUTPUT_VARIABLE GIT_REVISION)
+        execute_process(COMMAND git log --pretty=format:'%h' -n 1
+            OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
         set(DISPLAY_VERSION "${DISPLAY_VERSION}-${GIT_REVISION}")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,10 +506,6 @@ if(MINGW)
     set(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/data\\\\img\\\\h2-icon.bmp")
     #Begin NSIS Customizations
 
-    if(H2CORE_HAVE_DEBUG)
-        set(DEBUG_SUFFIX "_dbg")
-    endif()
-
     # Installers for 32- vs. 64-bit CMake:
     #  - Root install directory (displayed to end user at installer-run time)
     #  - "NSIS package/display name" (text used in the installer GUI)
@@ -522,7 +518,7 @@ if(MINGW)
     else()
 		set(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES")
 		set(CPACK_NSIS_PACKAGE_NAME "Hydrogen - ${DISPLAY_VERSION}")
-		set(CPACK_PACKAGE_FILE_NAME "Hydrogen-${DISPLAY_VERSION}-win32${DEBUG_SUFFIX}")
+		set(CPACK_PACKAGE_FILE_NAME "Hydrogen-${DISPLAY_VERSION}-win32")
 		#set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_NAME}${CPACK_PACKAGE_VERSION}")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,27 @@ if(GIT_TAG)
     set(IS_DEVEL_BUILD "false")
 else()
     set(IS_DEVEL_BUILD "true")
-    execute_process(COMMAND git log --pretty=format:'%h' -n 1 OUTPUT_VARIABLE GIT_REVISION)
-    set(DISPLAY_VERSION "${DISPLAY_VERSION}+${GIT_REVISION}")
+
+    # For developer builds we append some additional data to version.
+    #
+    # Attention: the code for determining the version string is present in the
+    # .appveyor file too. Be sure to tweak both.
+    execute_process(COMMAND git describe --abbrev=0 OUTPUT_VARIABLE GIT_LAST_TAG)
+    if(${DISPLAY_VERSION} MATCHES ${GIT_LAST_TAG})
+        # If the last tag matches the display version (we are working on the
+        # same branch the tag is located in - the release branch), we will use
+        # `git describe` since it nicely adds the number of commits passed since
+        # the tag next to the current commit id.
+        execute_process(COMMAND git describe --tags OUTPUT_VARIABLE GIT_DESCRIPTION)
+        set(DISPLAY_VERSION "${GIT_DESCRIPTION}")
+    else()
+        # We are working on a release which is not a patch release of the last
+        # one (feature branch, develop branch, master after splitting of a
+        # dedicated release branch). We just add the commit hash to the display
+        # version.
+        execute_process(COMMAND git log --pretty=format:'%h' -n 1 OUTPUT_VARIABLE GIT_REVISION)
+        set(DISPLAY_VERSION "${DISPLAY_VERSION}-${GIT_REVISION}")
+    endif()
 endif()
 
 set(LIBSNDFILE_VERSION_PREV "1.0.17")
@@ -498,12 +517,12 @@ if(MINGW)
     if(WIN64)
         set(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES64")
 		set(CPACK_NSIS_PACKAGE_NAME "Hydrogen - ${DISPLAY_VERSION} 64Bit")
-		set(CPACK_PACKAGE_FILE_NAME "Hydrogen-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-win64")
+		set(CPACK_PACKAGE_FILE_NAME "Hydrogen-${DISPLAY_VERSION}-win64")
 		#set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_NAME}${CPACK_PACKAGE_VERSION} 64Bit")
     else()
 		set(CPACK_NSIS_INSTALL_ROOT "$PROGRAMFILES")
 		set(CPACK_NSIS_PACKAGE_NAME "Hydrogen - ${DISPLAY_VERSION}")
-		set(CPACK_PACKAGE_FILE_NAME "Hydrogen-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}-win32${DEBUG_SUFFIX}")
+		set(CPACK_PACKAGE_FILE_NAME "Hydrogen-${DISPLAY_VERSION}-win32${DEBUG_SUFFIX}")
 		#set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "${CPACK_PACKAGE_NAME}${CPACK_PACKAGE_VERSION}")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,11 +21,6 @@ set(VERSION_PATCH "2")
 #set(VERSION_SUFFIX "beta1")
 
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
-set(DISPLAY_VERSION "${VERSION}")
-
-if(VERSION_SUFFIX)
-    set(DISPLAY_VERSION "${DISPLAY_VERSION}-${VERSION_SUFFIX}")
-endif()
 
 # Consider any tagged commit as a release build
 execute_process(COMMAND git describe --exact-match --tags OUTPUT_VARIABLE GIT_ON_TAG)
@@ -33,30 +28,45 @@ if(GIT_ON_TAG)
     set(IS_DEVEL_BUILD "false")
 else()
     set(IS_DEVEL_BUILD "true")
+endif()
 
-    # For developer builds we append some additional data to version.
-    #
-    # Attention: the code for determining the version string is present in the
-    # .appveyor file too. Be sure to tweak both.
-    execute_process(COMMAND git describe --abbrev=0
-        OUTPUT_VARIABLE GIT_LAST_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
+# In order to avoid for things to get out of sync, it is also possible to hand
+# over a version (from e.g. the build pipeline) and bypass the version string
+# composition in here. But this only affects display string. Major, minor, and
+# patch version in here must still match the TARGET_VERSION of the pipeline!
+set(DISLPAY_VERSION_PIPELINE "" CACHE INTERNAL "")
 
-    if("${DISPLAY_VERSION}" STREQUAL "${GIT_LAST_TAG}")
-        # If the last tag matches the display version (we are working on the
-        # same branch the tag is located in - the release branch), we will use
-        # `git describe` since it nicely adds the number of commits passed since
-        # the tag next to the current commit id.
-        execute_process(COMMAND git describe --tags
-            OUTPUT_VARIABLE GIT_DESCRIPTION OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(DISPLAY_VERSION "${GIT_DESCRIPTION}")
-    else()
-        # We are working on a release which is not a patch release of the last
-        # one (feature branch, develop branch, master after splitting of a
-        # dedicated release branch). We just add the commit hash to the display
-        # version.
-        execute_process(COMMAND git log --pretty=format:'%h' -n 1
-            OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
-        set(DISPLAY_VERSION "${DISPLAY_VERSION}-${GIT_REVISION}")
+if(NOT ${DISPLAY_VERSION_PIPELINE} STREQUAL "")
+    set(DISPLAY_VERSION "${DISPLAY_VERSION_PIPELINE}")
+else()
+    set(DISPLAY_VERSION "${VERSION}")
+
+    if(VERSION_SUFFIX)
+        set(DISPLAY_VERSION "${DISPLAY_VERSION}-${VERSION_SUFFIX}")
+    endif()
+
+    if(GIT_ON_TAG)
+        # For developer builds we append some additional data to version.
+        execute_process(COMMAND git describe --abbrev=0
+            OUTPUT_VARIABLE GIT_LAST_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        if("${DISPLAY_VERSION}" STREQUAL "${GIT_LAST_TAG}")
+            # If the last tag matches the display version (we are working on the
+            # same branch the tag is located in - the release branch), we will use
+            # `git describe` since it nicely adds the number of commits passed since
+            # the tag next to the current commit id.
+            execute_process(COMMAND git describe --tags
+                OUTPUT_VARIABLE GIT_DESCRIPTION OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(DISPLAY_VERSION "${GIT_DESCRIPTION}")
+        else()
+            # We are working on a release which is not a patch release of the last
+            # one (feature branch, develop branch, master after splitting of a
+            # dedicated release branch). We just add the commit hash to the display
+            # version.
+            execute_process(COMMAND git log --pretty=format:'%h' -n 1
+                OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
+            set(DISPLAY_VERSION "${DISPLAY_VERSION}-${GIT_REVISION}")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Previously the version of a develop build was only suffixed with an abbreviated commit hash within Hydrogen itself. The binaries produced by build pipelines only contained the raw target version. E.g. a binary "Hydrogen-1.2.2-win64.exe" showed version "Hydrogen-1.2.2-2a78f9c" internally. That a) may confuse users so they mistake it for an officially released version (actually happened in an issue), b) makes it harder for users/us to report the proper version used/correlate it with the underlying sources, and c) is annoying as multiple test binaries end up in the Download folder and things will be confusing.

Instead, the same version string shown internally is now also used to name all binaries produced by the build pipelines.

I did slight changes in the format of the version string:
- if the target version specified in `CMakeLists.txt` or `.appveyor` matches the last tag (we are on a release branch), the `git describe --tag` output is used as version string. It looks very similar to our regular one but also includes the number of commits since the last tag. Which is a helpful information.
- I reverted the separator between patch version and commit hash suffix from "+" to "-" again to better match the output produced by `git describe --tags`

In addition, the internal `cmake` variable `DISPLAY_VERSION_PIPELINE` was introduced using which the construction of a DISPLAY_VERSION within CMake can be bypassed. This is added as an auxiliary measure so the pipelines will always know the name of the created (Windows) artifacts and both the artifacts name and the version displayed inside do match.

Nevertheless, the `TARGET_VERSION` in `.appyevor` and major, minor, patch in `CMakeLists.txt` must still match.