### PR TITLE
PatternEditor: fix grid lines colors and rendering

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,15 +16,17 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix crash on playing back notes with custom length (#1852).
 		- macOS: fix naming of CoreMIDI header (#1865).
 		- Fix various rendering issues with custom length notes.
-		- Pattern Editor (#1859):
-				- Only delete stop notes clicked by the user.
-				- Proper undo of moving notes out of DrumPatternEditor.
-				- Custom note lengths are now only drawn till the next stop note.
-				- Highlight selected stop notes too.
+		- Pattern Editor:
+				- Only delete stop notes clicked by the user. (#1859)
+				- Proper undo of moving notes out of DrumPatternEditor. (#1859)
+				- Custom note lengths are now only drawn till the next stop
+				  note. (#1859)
+				- Highlight selected stop notes too. (#1859)
 				- Update selected notes visually on left and right keyboard
-				  movement.
+				  movement. (#1859)
 				- Fixed stop note color which was no different than
 					the default note color (#1854).
+				- Fixed grid line rendering on rational pattern size nominator.
 
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>

--- a/ChangeLog
+++ b/ChangeLog
@@ -27,6 +27,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- Fixed stop note color which was no different than
 					the default note color (#1854).
 				- Fixed grid line rendering on rational pattern size nominator.
+				- Fixed grid line colors on very fine resolution.
 
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -679,7 +679,6 @@ QPoint PatternEditor::movingGridOffset( ) const {
 //! Draw lines for note grid.
 void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 {
-
 	auto pPref = H2Core::Preferences::get_instance();
 	const QColor colorsActive[5] = {
 		QColor( pPref->getColorTheme()->m_patternEditor_line1Color ),
@@ -716,14 +715,17 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 
 		// First, quarter note markers. All the quarter note markers must be drawn.
 		if ( m_nResolution >= nRes ) {
+			float x = PatternEditor::nMargin;
 			p.setPen( QPen( colorsActive[ 0 ], 1, style ) );
-			for ( float x = PatternEditor::nMargin ; x < m_nActiveWidth; x += fStep ) {
+			while ( x < m_nActiveWidth ) {
 				p.drawLine( x, 1, x, m_nEditorHeight - 1 );
+				x += fStep;
 			}
 			
 			p.setPen( QPen( colorsInactive[ 0 ], 1, style ) );
-			for ( float x = m_nActiveWidth ; x < m_nEditorWidth; x += fStep ) {
+			while ( x < m_nEditorWidth ) {
 				p.drawLine( x, 1, x, m_nEditorHeight - 1 );
+				x += fStep;
 			}
 		}
 		nRes *= 2;
@@ -735,16 +737,18 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 		int nColour = 1;
 		while ( m_nResolution >= nRes ) {
 			nColour++;
+			float x = PatternEditor::nMargin + fStep;
 			p.setPen( QPen( colorsActive[ nColour ], 1, style ) );
-			for ( float x = PatternEditor::nMargin + fStep; x < m_nActiveWidth + fStep; x += fStep * 2) {
+			while ( x < m_nActiveWidth + fStep ) {
 				p.drawLine( x, 1, x, m_nEditorHeight - 1 );
+				x += fStep * 2;
 			}
 			
 			p.setPen( QPen( colorsInactive[ nColour ], 1, style ) );
-			for ( float x = m_nActiveWidth + fStep; x < m_nEditorWidth; x += fStep * 2) {
+			while ( x < m_nEditorWidth ) {
 				p.drawLine( x, 1, x, m_nEditorHeight - 1 );
+				x += fStep * 2;
 			}
-			
 			nRes *= 2;
 			fStep /= 2;
 		}
@@ -754,27 +758,33 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 		// Triplet style markers, we only differentiate colours on the
 		// first of every triplet.
 		float fStep = granularity() * m_fGridWidth;
+		float x = PatternEditor::nMargin;
 		p.setPen(  QPen( colorsActive[ 0 ], 1, style ) );
-		for ( float x = PatternEditor::nMargin; x < m_nActiveWidth; x += fStep * 3 ) {
+		while ( x < m_nActiveWidth ) {
 			p.drawLine(x, 1, x, m_nEditorHeight - 1);
+			x += fStep * 3;
 		}
 		
 		p.setPen(  QPen( colorsInactive[ 0 ], 1, style ) );
-		for ( float x = m_nActiveWidth; x < m_nEditorWidth; x += fStep * 3 ) {
+		while ( x < m_nEditorWidth ) {
 			p.drawLine(x, 1, x, m_nEditorHeight - 1);
+			x += fStep * 3;
 		}
 		
 		// Second and third marks
+		x = PatternEditor::nMargin + fStep;
 		p.setPen(  QPen( colorsActive[ 2 ], 1, style ) );
-		for ( float x = PatternEditor::nMargin + fStep; x < m_nActiveWidth + fStep; x += fStep * 3 ) {
+		while ( x < m_nActiveWidth + fStep ) {
 			p.drawLine(x, 1, x, m_nEditorHeight - 1);
 			p.drawLine(x + fStep, 1, x + fStep, m_nEditorHeight - 1);
+			x += fStep * 3;
 		}
 		
 		p.setPen( QPen( colorsInactive[ 2 ], 1, style ) );
-		for ( float x = m_nActiveWidth + fStep; x < m_nEditorWidth; x += fStep * 3 ) {
+		while ( x < m_nEditorWidth ) {
 			p.drawLine(x, 1, x, m_nEditorHeight - 1);
 			p.drawLine(x + fStep, 1, x + fStep, m_nEditorHeight - 1);
+			x += fStep * 3;
 		}
 	}
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -680,19 +680,19 @@ QPoint PatternEditor::movingGridOffset( ) const {
 void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 {
 	auto pPref = H2Core::Preferences::get_instance();
-	const QColor colorsActive[5] = {
+	const std::vector<QColor> colorsActive = {
 		QColor( pPref->getColorTheme()->m_patternEditor_line1Color ),
 		QColor( pPref->getColorTheme()->m_patternEditor_line2Color ),
 		QColor( pPref->getColorTheme()->m_patternEditor_line3Color ),
 		QColor( pPref->getColorTheme()->m_patternEditor_line4Color ),
 		QColor( pPref->getColorTheme()->m_patternEditor_line5Color ),
 	};
-	const QColor colorsInactive[5] = {
+	const std::vector<QColor> colorsInactive = {
 		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 170 ) ),
 		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 190 ) ),
-		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 200 ) ),
 		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 210 ) ),
 		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 230 ) ),
+		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 250 ) ),
 	};
 
 	int nGranularity = granularity() * m_nResolution;
@@ -738,13 +738,15 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 		while ( m_nResolution >= nRes ) {
 			nColour++;
 			float x = PatternEditor::nMargin + fStep;
-			p.setPen( QPen( colorsActive[ nColour ], 1, style ) );
+			p.setPen( QPen( colorsActive[ std::min( nColour, static_cast<int>(colorsActive.size()) - 1 ) ],
+							1, style ) );
 			while ( x < m_nActiveWidth + fStep ) {
 				p.drawLine( x, 1, x, m_nEditorHeight - 1 );
 				x += fStep * 2;
 			}
-			
-			p.setPen( QPen( colorsInactive[ nColour ], 1, style ) );
+
+			p.setPen( QPen( colorsInactive[ std::min( nColour, static_cast<int>(colorsInactive.size()) - 1 ) ],
+							1, style ) );
 			while ( x < m_nEditorWidth ) {
 				p.drawLine( x, 1, x, m_nEditorHeight - 1 );
 				x += fStep * 2;


### PR DESCRIPTION
when setting the pattern size to a rational denominator, e.g. `2.12332`, while having a longer pattern present in the same column with PE locked or active in stacked pattern mode, some grid lines in the inaccessible area were off.

![prior](https://github.com/hydrogen-music/hydrogen/assets/14164547/7edbc3cf-30db-4975-bdad-781829ed1dde)

In addition, on very fine resolutions the colors in the inaccessible area were off.

![wrong_colors](https://github.com/hydrogen-music/hydrogen/assets/14164547/fc6454a6-c07b-412d-863b-b7b0ab1ee7c1)

Now:

![fixed](https://github.com/hydrogen-music/hydrogen/assets/14164547/7123d7fb-4660-436b-aff4-310ef891125d)
