### PR TITLE
fix selected pattern on rearrangment

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1192,7 +1192,7 @@ void AudioEngine::handleSelectedPattern() {
 			}
 		}
 
-		pHydrogen->setSelectedPatternNumber( nPatternNumber, true );
+		pHydrogen->setSelectedPatternNumber( nPatternNumber, true, true );
 	}
 }
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -886,9 +886,12 @@ void Hydrogen::updateSelectedPattern( bool bNeedsLock ) {
 	}
 }
 
-void Hydrogen::setSelectedPatternNumber( int nPat, bool bNeedsLock )
+void Hydrogen::setSelectedPatternNumber( int nPat, bool bNeedsLock, bool bForce )
 {
 	if ( nPat == m_nSelectedPatternNumber ) {
+		if ( bForce ) {
+			EventQueue::get_instance()->push_event( EVENT_SELECTED_PATTERN_CHANGED, -1 );
+		}
 		return;
 	}
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -293,11 +293,16 @@ void			previewSample( Sample *pSample );
 	/**
 	 * Sets #m_nSelectedPatternNumber.
 	 *
-	 *\param nPat Sets #m_nSelectedPatternNumber
-	 * \param bNeedsLock Whether the function was called with the
-	 * audio engine locked already or it should do so itself.
+	 * \param nPat Sets #m_nSelectedPatternNumber
+	 * \param bNeedsLock Whether the function was called with the audio engine
+	 *   locked already or it should do so itself.
+	 * \param bForce When present, the `EVENT_SELECTED_PATTERN_CHANGED` will be
+	 *   triggered regardless of @a nPat. This is important when rearranging
+	 *   patterns in the song editor while the pattern editor is locked.
 	 */
-	void			setSelectedPatternNumber( int nPat, bool bNeedsLock = true );
+	void			setSelectedPatternNumber( int nPat,
+											  bool bNeedsLock = true,
+											  bool bForce = false );
 
 	/**
 	 * Updates the selected pattern to the one recorded note will be


### PR DESCRIPTION
whenever the PatternEditor was locked, the bottom-most pattern was, and manully dragged above another pattern, which is active as well, in the Song Editor, the Pattern Editor did not update and was still showing the "old" pattern. It got out of sync with the currently selected pattern.