### PR TITLE
Improve resilience in audio driver handling

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1357,13 +1357,23 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
-	assert( pSong );
+	if ( pSong == nullptr ) {
+		assert( pSong );
+		ERRORLOG( "Invalid song" );
+		return 1;
+	}
 
 	// Sync transport with server (in case the current audio driver is
 	// designed that way)
 #ifdef H2CORE_HAVE_JACK
 	if ( Hydrogen::get_instance()->hasJackTransport() ) {
-		static_cast<JackAudioDriver*>( pHydrogen->getAudioOutput() )->updateTransportPosition();
+		auto pAudioDriver = pHydrogen->getAudioOutput();
+		if ( pAudioDriver == nullptr ) {
+			ERRORLOG( "AudioDriver is not ready!" );
+			assert( pAudioDriver );
+			return 1;
+		}
+		static_cast<JackAudioDriver*>( pAudioDriver )->updateTransportPosition();
 	}
 #endif
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -950,10 +950,10 @@ void AudioEngine::startAudioDrivers()
 		return;
 	}
 
-	if ( m_pAudioDriver ) {	// check if audio driver is still alive
+	if ( m_pAudioDriver != nullptr ) {	// check if audio driver is still alive
 		ERRORLOG( "The audio driver is still alive" );
 	}
-	if ( m_pMidiDriver ) {	// check if midi driver is still alive
+	if ( m_pMidiDriver != nullptr ) {	// check if midi driver is still alive
 		ERRORLOG( "The MIDI driver is still active" );
 	}
 

--- a/src/core/AudioEngine/TransportPosition.cpp
+++ b/src/core/AudioEngine/TransportPosition.cpp
@@ -216,10 +216,21 @@ long long TransportPosition::computeFrameFromTick( const double fTick, double* f
 	const auto pSong = pHydrogen->getSong();
 	const auto pTimeline = pHydrogen->getTimeline();
 	const auto pAudioEngine = pHydrogen->getAudioEngine();
-	assert( pSong );
+	const auto pAudioDriver = pHydrogen->getAudioOutput();
+
+	if ( pSong == nullptr || pTimeline == nullptr ) {
+		ERRORLOG( "Invalid song" );
+		*fTickMismatch = 0;
+		return 0;
+	}
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		*fTickMismatch = 0;
+		return 0;
+	}
 
 	if ( nSampleRate == 0 ) {
-		nSampleRate = pHydrogen->getAudioOutput()->getSampleRate();
+		nSampleRate = pAudioDriver->getSampleRate();
 	}
 	const int nResolution = pSong->getResolution();
 	const double fSongSizeInTicks = pAudioEngine->getSongSizeInTicks();
@@ -462,10 +473,19 @@ double TransportPosition::computeTickFromFrame( const long long nFrame, int nSam
 	const auto pSong = pHydrogen->getSong();
 	const auto pTimeline = pHydrogen->getTimeline();
 	const auto pAudioEngine = pHydrogen->getAudioEngine();
-	assert( pSong );
+	const auto pAudioDriver = pHydrogen->getAudioOutput();
+
+	if ( pSong == nullptr || pTimeline == nullptr ) {
+		ERRORLOG( "Invalid song" );
+		return 0;
+	}
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return 0;
+	}
 
 	if ( nSampleRate == 0 ) {
-		nSampleRate = pHydrogen->getAudioOutput()->getSampleRate();
+		nSampleRate = pAudioDriver->getSampleRate();
 	}
 	const int nResolution = pSong->getResolution();
 	double fTick = 0;

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -117,9 +117,6 @@ void Sampler::process( uint32_t nFrames )
 		return;
 	}
 	
-	AudioOutput* pAudioOutpout = pHydrogen->getAudioOutput();
-	assert( pAudioOutpout );
-
 	memset( m_pMainOut_L, 0, nFrames * sizeof( float ) );
 	memset( m_pMainOut_R, 0, nFrames * sizeof( float ) );
 
@@ -534,6 +531,11 @@ bool Sampler::renderNote( Note* pNote, unsigned nBufferSize )
 
 	long long nFrame;
 	auto pAudioDriver = pHydrogen->getAudioOutput();
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return true;
+	}
+
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 	if ( pAudioEngine->getState() == AudioEngine::State::Playing ||
 		 pAudioEngine->getState() == AudioEngine::State::Testing ) {
@@ -801,12 +803,17 @@ bool Sampler::renderNote( Note* pNote, unsigned nBufferSize )
 bool Sampler::processPlaybackTrack(int nBufferSize)
 {
 	Hydrogen* pHydrogen = Hydrogen::get_instance();
-	auto pAudioDriver = Hydrogen::get_instance()->getAudioOutput();
-	auto pAudioEngine = Hydrogen::get_instance()->getAudioEngine();
+	auto pAudioDriver = pHydrogen->getAudioOutput();
+	auto pAudioEngine = pHydrogen->getAudioEngine();
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 
 	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
+		return true;
+	}
+
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
 		return true;
 	}
 
@@ -817,9 +824,13 @@ bool Sampler::processPlaybackTrack(int nBufferSize)
 		return true;
 	}
 
-	auto pCompo = m_pPlaybackTrackInstrument->get_components()->front();
-	auto pSample = pCompo->get_layer(0)->get_sample();
+	const auto pCompo = m_pPlaybackTrackInstrument->get_components()->front();
+	if ( pCompo == nullptr ) {
+		ERRORLOG( "Invalid component of playback instrument" );
+		return true;
+	}
 
+	auto pSample = pCompo->get_layer(0)->get_sample();
 	if ( pSample == nullptr ) {
 		ERRORLOG( "Unable to process playback track" );
 		EventQueue::get_instance()->push_event( EVENT_ERROR,
@@ -998,7 +1009,27 @@ bool Sampler::renderNoteResample(
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioDriver = pHydrogen->getAudioOutput();
 	auto pSong = pHydrogen->getSong();
+
+	if ( pSong == nullptr ) {
+		ERRORLOG( "Invalid song" );
+		return true;
+	}
+
+	if ( pNote == nullptr ) {
+		ERRORLOG( "Invalid note" );
+		return true;
+	}
+
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return true;
+	}
+
 	auto pInstrument = pNote->get_instrument();
+	if ( pInstrument == nullptr ) {
+		ERRORLOG( "Invalid note instrument" );
+		return true;
+	}
 
 	const float fNotePitch = pNote->get_total_pitch() + fLayerPitch;
 	const bool bResample = fNotePitch != 0 ||

--- a/src/core/Sampler/Sampler.h
+++ b/src/core/Sampler/Sampler.h
@@ -42,7 +42,6 @@ class DrumkitComponent;
 class Instrument;
 struct SelectedLayerInfo;
 class InstrumentComponent;
-class AudioOutput;
 
 ///
 /// Waveform based sampler.

--- a/src/gui/src/AudioEngineInfoForm.cpp
+++ b/src/gui/src/AudioEngineInfoForm.cpp
@@ -164,7 +164,7 @@ void AudioEngineInfoForm::updateInfo()
 
 	// Midi driver info
 	MidiInput *pMidiDriver = pHydrogen->getMidiInput();
-	if (pMidiDriver) {
+	if ( pMidiDriver != nullptr ) {
 		midiDriverName->setText( pMidiDriver->class_name() );
 	}
 	else {

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -592,14 +592,22 @@ void HydrogenApp::showStatusBarMessage( const QString& sMessage, const QString& 
 }
 
 void HydrogenApp::XRunEvent() {
-	showStatusBarMessage( QString( "XRUNS [%1]!!!" )
-						 .arg( Hydrogen::get_instance()->getAudioOutput()->getXRuns() ) );
+	const auto pAudioDriver = Hydrogen::get_instance()->getAudioOutput();
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return;
+	}
+	showStatusBarMessage( QString( "XRUNS [%1]!!!" ) .arg( pAudioDriver->getXRuns() ) );
 }
 
 void HydrogenApp::updateWindowTitle()
 {
 	auto pSong = Hydrogen::get_instance()->getSong();
-	assert(pSong);
+	if ( pSong == nullptr ) {
+		ERRORLOG( "invalid song" );
+		assert(pSong);
+		return;
+	}
 
 	QString sTitle = Filesystem::untitled_song_name();
 

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -334,6 +334,13 @@ void LadspaFXProperties::updateControls()
 void LadspaFXProperties::selectFXBtnClicked()
 {
 #ifdef H2CORE_HAVE_LADSPA
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pAudioDriver = pHydrogen->getAudioOutput();
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return;
+	}
+
 	LadspaFXSelector fxSelector(m_nLadspaFX);
 	if (fxSelector.exec() == QDialog::Accepted) {
 		QString sSelectedFX = fxSelector.getSelectedFX();
@@ -344,7 +351,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 			for (uint i = 0; i < pluginList.size(); i++) {
 				H2Core::LadspaFXInfo *pFXInfo = pluginList[i];
 				if (pFXInfo->m_sName == sSelectedFX ) {
-					int nSampleRate = Hydrogen::get_instance()->getAudioOutput()->getSampleRate();
+					int nSampleRate = pAudioDriver->getSampleRate();
 					pFX = LadspaFX::load( pFXInfo->m_sFilename, pFXInfo->m_sLabel, nSampleRate );
 					pFX->setEnabled( true );
 					break;
@@ -352,7 +359,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 			}
 			Effects::get_instance()->setLadspaFX( pFX, m_nLadspaFX );
 
-			Hydrogen::get_instance()->restartLadspaFX();
+			pHydrogen->restartLadspaFX();
 			updateControls();
 		}
 		else {	// no plugin selected

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -1261,7 +1261,7 @@ void PreferencesDialog::updateDriverInfoLabel() {
 			.append( "</font></b>" );
 #else
 		auto pAlsaDriver =
-			dynamic_cast<H2Core::AlsaAudioDriver*>(Hydrogen::get_instance()->getAudioOutput());
+			dynamic_cast<H2Core::AlsaAudioDriver*>(pAudioDriver);
 		if ( pAlsaDriver != nullptr ) {
 			sInfo.append( "<br>" ).append( tr( "Currently connected to device: " ) )
 				.append( "<b>" ).append( pAlsaDriver->m_sAlsaAudioDevice )
@@ -1459,7 +1459,17 @@ void PreferencesDialog::setDriverInfoPortAudio() {
 	latencyTargetLabel->show();
 	latencyTargetSpinBox->show();
 	latencyValueLabel->show();
-	latencyValueLabel->setText( QString("Current: %1 frames").arg( H2Core::Hydrogen::get_instance()->getAudioOutput()->getLatency() ) );
+
+	const auto pAudioDriver = H2Core::Hydrogen::get_instance()->getAudioOutput();
+	int nLatency;
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return;
+	}
+	else {
+		nLatency = pAudioDriver->getLatency();
+	}
+	latencyValueLabel->setText( QString("Current: %1 frames").arg( nLatency ) );
 
 	bufferSizeSpinBox->setToolTip( "" );
 	sampleRateComboBox->setToolTip( "" );

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -368,7 +368,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	// MIDI tab - list midi input ports
 	midiPortComboBox->clear();
 	midiPortComboBox->addItem( pCommonStrings->getPreferencesNone() );
-	if ( pHydrogen->getMidiInput() ) {
+	if ( pHydrogen->getMidiInput() != nullptr ) {
 		std::vector<QString> midiOutList = pHydrogen->getMidiInput()->getOutputPortList();
 
 		if ( midiOutList.size() != 0 ) {
@@ -389,7 +389,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	midiOutportComboBox->setSize( midiTabWidgetSize );
 	midiOutportComboBox->clear();
 	midiOutportComboBox->addItem( pCommonStrings->getPreferencesNone() );
-	if ( pHydrogen->getMidiOutput() ) {
+	if ( pHydrogen->getMidiOutput() != nullptr ) {
 		std::vector<QString> midiOutList = pHydrogen->getMidiOutput()->getInputPortList();
 
 		if ( midiOutList.size() != 0 ) {

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -853,8 +853,16 @@ void SampleEditor::valueChangedLoopCountSpinBox( int )
 		if ( ! m_bAdjusting ) on_PlayOrigPushButton_clicked();
 		return;
 	}
-	if ( m_nSlframes > Hydrogen::get_instance()->getAudioOutput()->getSampleRate() * 60 ){
-		Hydrogen::get_instance()->getAudioEngine()->getSampler()->stopPlayingNotes();
+
+	const auto pHydrogen = Hydrogen::get_instance();
+	const auto pAudioDriver = pHydrogen->getAudioOutput();
+	if ( pAudioDriver == nullptr ) {
+		ERRORLOG( "AudioDriver is not ready!" );
+		return;
+	}
+
+	if ( m_nSlframes > pAudioDriver->getSampleRate() * 60 ){
+		pHydrogen->getAudioEngine()->getSampler()->stopPlayingNotes();
 		m_pMainSampleWaveDisplay->paintLocatorEvent( -1 , false);
 		m_pTimer->stop();
 		m_bPlayButton = false;
@@ -862,7 +870,7 @@ void SampleEditor::valueChangedLoopCountSpinBox( int )
 	__loops.count = count; 
 	setUnclean();
 	setSamplelengthFrames();
-	if ( m_nSlframes > Hydrogen::get_instance()->getAudioOutput()->getSampleRate() * 60 * 30){ // >30 min
+	if ( m_nSlframes > pAudioDriver->getSampleRate() * 60 * 30){ // >30 min
 		LoopCountSpinBox->setMaximum(LoopCountSpinBox->value() -1);
 	}
 


### PR DESCRIPTION
The audio driver can be changed/switched and in the process it becomes `nullptr` .

Between stopping the driver (resetting it to `nullptr`) and assigning a new one the `AudioEngine` is unlocked. Especially in case the "Auto" driver was selected and multiple drivers are tried before finding a fitting one there are quite a number of opportunities for causing a crash by attempting to call its methods.

This does not happen on a regular basis, tough, wasn't reported and I never encountered in using "production" code. But due to another bug during local development Hydrogen crashed during startup with almost no way to bring it up again.

To ensure this never happens in productive code, I introduced checks for `nullptr` on all calls to its members. It's neither atomic nor guarded by a mutex. But it is already more resilent and, I think, sufficiently save.

The most cleanest way would to enclose all calls to audio and MIDI drivers with `AudioEngine` locks and rewrite the driver restarting in such a way it does not need an unlock before having assigned a valid driver. But this is a lot of rewriting in very essential parts and I will put this in `master` and not the upcoming patch release.