### PR TITLE
Fix driver switching whil using JACK

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix various rendering issues with custom length notes.
 		- Fix potential crash/failing startup on Windows in case PortAudio
 			or PortMidi device is already occupied (#1893)
+		- Fix crash on shutdown, song export, or driver changes in the
+			Preferences while using JACK on Linux (#1902, #1867, #1907)
 		- Pattern Editor:
 				- Only delete stop notes clicked by the user. (#1859)
 				- Proper undo of moving notes out of DrumPatternEditor. (#1859)

--- a/src/tests/AudioDriverTest.cpp
+++ b/src/tests/AudioDriverTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include "AudioDriverTest.h"
+
+#include <core/AudioEngine/AudioEngine.h>
+#include <core/Hydrogen.h>
+
+void AudioDriverTest::testDriverSwitching() {
+	___INFOLOG("");
+
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pAudioEngine = pHydrogen->getAudioEngine();
+
+	for ( int ii = 0; ii < 10; ++ii ) {
+		std::cout << ii << std::endl;
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "ALSA" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "OSS" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "JACK" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "PortAudio" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "CoreAudio" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "PulseAudio" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "DiskWriterDriver" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "NullDriver" );
+		pAudioEngine->stopAudioDrivers();
+		pAudioEngine->createAudioDriver( "Fake" );
+	}
+
+	___INFOLOG("done");
+}
+
+void AudioDriverTest::tearDown() {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	auto pAudioEngine = pHydrogen->getAudioEngine();
+
+	pAudioEngine->stopAudioDrivers();
+	pAudioEngine->createAudioDriver( "Fake" );
+
+}

--- a/src/tests/AudioDriverTest.h
+++ b/src/tests/AudioDriverTest.h
@@ -1,0 +1,39 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#ifndef AUDIO_DRIVER_TEST_H
+#define AUDIO_DRIVER_TEST_H
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class AudioDriverTest : public CppUnit::TestCase {
+	CPPUNIT_TEST_SUITE( AudioDriverTest );
+	CPPUNIT_TEST( testDriverSwitching );
+	CPPUNIT_TEST_SUITE_END();
+
+	public:
+		virtual void tearDown();
+
+		// Check that drivers can be switched without any crashes.
+		void testDriverSwitching();
+};
+
+#endif

--- a/src/tests/registeredTests.h
+++ b/src/tests/registeredTests.h
@@ -23,6 +23,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 
 #include "AdsrTest.h"
+#include "AudioDriverTest.h"
 #include "AutomationPathSerializerTest.cpp"
 #include "AutomationPathTest.cpp"
 #include "CoreActionControllerTest.h"
@@ -42,6 +43,7 @@
 #include "XmlTest.h"
 
 CPPUNIT_TEST_SUITE_REGISTRATION( ADSRTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( AudioDriverTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( AutomationPathSerializerTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( AutomationPathTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( CoreActionControllerTest );


### PR DESCRIPTION
for some reason Hydrogen crashes when attempting to audio engine mutex dedicated to the output buffers while switching/stopping drivers.

```
Thread 37 "tests" received signal SIGABRT, Aborted.
[Switching to Thread 0x7fffd1722700 (LWP 4178)]
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
https://github.com/hydrogen-music/hydrogen/issues/1  0x00007ffff6717537 in __GI_abort () at abort.c:79
https://github.com/hydrogen-music/hydrogen/issues/2  0x00007ffff6ac37ec in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
https://github.com/hydrogen-music/hydrogen/issues/3  0x00007ffff6ace966 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
https://github.com/hydrogen-music/hydrogen/issues/4  0x00007ffff6ace9d1 in std::terminate() () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
https://github.com/hydrogen-music/hydrogen/issues/5  0x00007ffff6ace3cc in __gxx_personality_v0 () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
https://github.com/hydrogen-music/hydrogen/issues/6  0x00007ffff68d98a4 in ?? () from /lib/x86_64-linux-gnu/libgcc_s.so.1
https://github.com/hydrogen-music/hydrogen/issues/7  0x00007ffff68d9f4e in _Unwind_ForcedUnwind () from /lib/x86_64-linux-gnu/libgcc_s.so.1
https://github.com/hydrogen-music/hydrogen/issues/8  0x00007ffff79f5c30 in __GI___pthread_unwind (buf=<optimized out>) at unwind.c:121
https://github.com/hydrogen-music/hydrogen/issues/9  0x00007ffff79ea729 in __do_cancel () at ./pthreadP.h:310
https://github.com/hydrogen-music/hydrogen/issues/10 sigcancel_handler (sig=32, si=0x7fffd1721330, ctx=<optimized out>) at nptl-init.c:177
https://github.com/hydrogen-music/hydrogen/issues/11 sigcancel_handler (sig=<optimized out>, si=0x7fffd1721330, ctx=<optimized out>) at nptl-init.c:142
https://github.com/hydrogen-music/hydrogen/issues/12 <signal handler called>
https://github.com/hydrogen-music/hydrogen/issues/13 syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
https://github.com/hydrogen-music/hydrogen/issues/14 0x00007ffff6cc2f05 in QBasicMutex::lockInternal() () from /usr/lib/x86_64-linux-gnu/libQt5Core.so.5
https://github.com/hydrogen-music/hydrogen/issues/15 0x00007ffff7d354dc in QMutexLocker::QMutexLocker (this=0x7fffd1721908, m=0x5555557489d8) at /usr/include/x86_64-linux-gnu/qt5/QtCore/qmutex.h:233
https://github.com/hydrogen-music/hydrogen/issues/16 0x00007ffff7d25be6 in H2Core::AudioEngine::clearAudioBuffers (this=0x555555748950, nFrames=32) at /home/phil/git/hydrogen-1.2/src/core/AudioEngine/AudioEngine.cpp:786
https://github.com/hydrogen-music/hydrogen/issues/17 0x00007ffff7d29223 in H2Core::AudioEngine::audioEngine_process (nframes=32) at /home/phil/git/hydrogen-1.2/src/core/AudioEngine/AudioEngine.cpp:1318
https://github.com/hydrogen-music/hydrogen/issues/18 0x00007ffff64eac8f in Jack::JackClient::CallProcessCallback() () from /usr/local/lib/libjack.so.0
https://github.com/hydrogen-music/hydrogen/issues/19 0x00007ffff64eab96 in Jack::JackClient::ExecuteThread() () from /usr/local/lib/libjack.so.0
https://github.com/hydrogen-music/hydrogen/issues/20 0x00007ffff64e8641 in Jack::JackClient::Execute() () from /usr/local/lib/libjack.so.0
https://github.com/hydrogen-music/hydrogen/issues/21 0x00007ffff6508484 in Jack::JackPosixThread::ThreadHandler(void*) () from /usr/local/lib/libjack.so.0
#22 0x00007ffff79ebea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
https://github.com/hydrogen-music/hydrogen/issues/23 0x00007ffff67f0a2f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

replacing the calls to `QMutexLocker` with raw `.lock()` one of the mutex itself fixes the problem. This might be a Qt bug (but I have not found anything similar in their bug tracker).

I also have to note that I encountered quite a number of crashes of the JACK server itself while switching drivers hundreds of times during debugging (on board sound card and minimal buffer size). But none of them seems to be related to Hydrogen. I will report them upstream.

Fixes #1902
Fixes #1907
Fixes #1867