### PR TITLE
 tests: proper setup and tear down

### DIFF
--- a/src/tests/AudioDriverTest.cpp
+++ b/src/tests/AudioDriverTest.cpp
@@ -23,6 +23,13 @@
 
 #include <core/AudioEngine/AudioEngine.h>
 #include <core/Hydrogen.h>
+#include <core/Preferences/Preferences.h>
+
+void AudioDriverTest::setUp() {
+	auto pPref = H2Core::Preferences::get_instance();
+	m_nPrevBufferSize = pPref->m_nBufferSize;
+	m_sPrevAudioDriver = pPref->m_sAudioDriver;
+}
 
 void AudioDriverTest::testDriverSwitching() {
 	___INFOLOG("");
@@ -59,7 +66,10 @@ void AudioDriverTest::tearDown() {
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 
+	auto pPref = H2Core::Preferences::get_instance();
+	pPref->m_nBufferSize = m_nPrevBufferSize;
+	pPref->m_sAudioDriver = m_sPrevAudioDriver;
+
 	pAudioEngine->stopAudioDrivers();
 	pAudioEngine->createAudioDriver( "Fake" );
-
 }

--- a/src/tests/AudioDriverTest.h
+++ b/src/tests/AudioDriverTest.h
@@ -24,16 +24,23 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
+#include <QString>
+
 class AudioDriverTest : public CppUnit::TestCase {
 	CPPUNIT_TEST_SUITE( AudioDriverTest );
 	CPPUNIT_TEST( testDriverSwitching );
 	CPPUNIT_TEST_SUITE_END();
 
 	public:
+		virtual void setUp();
 		virtual void tearDown();
 
 		// Check that drivers can be switched without any crashes.
 		void testDriverSwitching();
+
+	private:
+		int m_nPrevBufferSize;
+		QString m_sPrevAudioDriver;
 };
 
 #endif


### PR DESCRIPTION
of AudioDriverTest. Switching the audio drivers round and round does overwrite the buffer size setting done in the main routine before triggering the unit test. These have to be reapplied.
