### PR TITLE
Forward compatibility to 1.3.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3
+	* Added
+		- Forward compatibility for .h2song and drumkit changes introduced in
+			version 1.3.0
 	* Fixed
 		- Restore mute button state of master mixer strip on song load.
 		- Recorded MIDI notes were inserted ahead of the beat (#1851).

--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -52,15 +52,51 @@
 	</xsd:complexType>
 </xsd:element>
 
+<!-- VOLUME ENVELOPE NODE -->
+<xsd:element name="volume">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="volume-position"	type="xsd:nonNegativeInteger"/>
+			<xsd:element name="volume-value"	type="xsd:nonNegativeInteger"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
+<!-- PAN ENVELOPE NODE -->
+<xsd:element name="pan">
+	<xsd:complexType>
+		<xsd:sequence>
+			<xsd:element name="pan-position"	type="xsd:nonNegativeInteger"/>
+			<xsd:element name="pan-value"		type="xsd:nonNegativeInteger"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:element>
+
 <!-- LAYER -->
 <xsd:element name="layer">
 	<xsd:complexType>
 		<xsd:sequence>
-			<xsd:element name="filename"	type="xsd:string"/>
-			<xsd:element name="min"			type="xsd:float"/>
-			<xsd:element name="max"			type="xsd:float"/>
-			<xsd:element name="gain"		type="xsd:float"/>
-			<xsd:element name="pitch"		type="xsd:float"/>
+			<xsd:element name="filename"		type="xsd:string"/>
+			<xsd:element name="min"				type="xsd:float"/>
+			<xsd:element name="max"				type="xsd:float"/>
+			<xsd:element name="gain"			type="xsd:float"/>
+			<xsd:element name="pitch"			type="xsd:float"/>
+			<xsd:element name="ismodified"		type="h2:bool" minOccurs="0"/>
+			<xsd:element name="smode"			type="xsd:string" minOccurs="0"/>
+			<xsd:element name="startframe"		type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="loopframe"		type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="loops"			type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="endframe"		type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="userubber"		type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="rubberdivider"	type="xsd:float" minOccurs="0"/>
+			<xsd:element name="rubberCsettings"	type="xsd:nonNegativeInteger" minOccurs="0"/>
+			<xsd:element name="rubberPitch"		type="xsd:float" minOccurs="0"/>
+			<xsd:sequence>
+				<xsd:element ref="h2:volume" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
+			<xsd:sequence>
+				<xsd:element ref="h2:pan" minOccurs="0" maxOccurs="unbounded"/>
+			</xsd:sequence>
 		</xsd:sequence>
 	</xsd:complexType>
 </xsd:element>
@@ -71,6 +107,8 @@
 		<xsd:sequence>
 			<xsd:element name="id"					type="xsd:integer"/>
 			<xsd:element name="name"				type="xsd:string"/>
+			<xsd:element name="drumkitPath"			type="xsd:string" minOccurs="0"/>
+			<xsd:element name="drumkit"				type="xsd:string" minOccurs="0"/>
 			<xsd:element name="volume"				type="xsd:decimal"/>
 			<xsd:element name="isMuted"				type="h2:bool"/>
 			<xsd:element name="isSoloed"			type="h2:bool"/>
@@ -108,7 +146,7 @@
 				<xsd:element ref="h2:instrumentComponent" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>
 		</xsd:sequence>
-</xsd:complexType>
+	</xsd:complexType>
 </xsd:element>
 
 <!-- DRUMKIT -->

--- a/src/core/Helpers/Future.cpp
+++ b/src/core/Helpers/Future.cpp
@@ -1,0 +1,51 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include <core/Helpers/Future.h>
+
+#include <core/Helpers/Xml.h>
+#include <core/Basics/Drumkit.h>
+#include <core/Basics/DrumkitComponent.h>
+
+namespace H2Core {
+
+std::vector<std::shared_ptr<DrumkitComponent>> Future::loadDrumkitComponentsFromKit( XMLNode* pNode ) {
+	std::vector<std::shared_ptr<DrumkitComponent>> pComponents;
+	XMLNode componentListNode = pNode->firstChildElement( "componentList" );
+	if ( ! componentListNode.isNull() ) {
+		XMLNode componentNode = componentListNode.firstChildElement( "drumkitComponent" );
+		while ( ! componentNode.isNull()  ) {
+			auto pDrumkitComponent = DrumkitComponent::load_from( &componentNode );
+			if ( pDrumkitComponent != nullptr ) {
+				pComponents.push_back(pDrumkitComponent);
+			}
+
+			componentNode = componentNode.nextSiblingElement( "drumkitComponent" );
+		}
+	} else {
+		WARNINGLOG( "componentList node not found" );
+		auto pDrumkitComponent = std::make_shared<DrumkitComponent>( 0, "Main" );
+		pComponents.push_back(pDrumkitComponent);
+	}
+
+	return std::move( pComponents );
+}
+};

--- a/src/core/Helpers/Future.h
+++ b/src/core/Helpers/Future.h
@@ -1,0 +1,46 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2023 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#ifndef H2C_FUTURE_H
+#define H2C_FUTURE_H
+
+#include <core/Object.h>
+#include <memory>
+#include <vector>
+
+namespace H2Core {
+
+class DrumkitComponent;
+class XMLNode;
+
+/** Ensures compatibility with the song format introduced in Hydrogen v1.3.0.
+ *
+ * This code is meant only for the 1.2.X release branch! */
+class Future : public H2Core::Object<Future> {
+		H2_OBJECT(Future)
+public:
+	static std::vector<std::shared_ptr<DrumkitComponent>> loadDrumkitComponentsFromKit(
+		XMLNode* pNode );
+};
+
+};
+
+#endif  // H2C_FUTURE_H


### PR DESCRIPTION
For the 1.3.0 release of Hydrogen the `drumkit.xsd` file will be touched and the .h2song file format will change significantly (instead of storing plain `DrumkitConponent`s and `InstrumentList` in a .h2song a proper drumkit is used).

These changes ensures all Hydrogen releases >= 1.2.3 will be forward compatible to these changes and can load both song and drumkit files properly