### PR TITLE
Button: fix adaptive font size (#1908)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -35,6 +35,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 					the default note color (#1854).
 				- Fixed grid line rendering on rational pattern size nominator.
 				- Fixed grid line colors on very fine resolution.
+		- Fix broken file browser dialogs on Linux when using translations (#1908).
 
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -435,18 +435,21 @@ void Button::updateFont() {
 
 	QFont font( pPref->getLevel3FontFamily() );
 	font.setPixelSize( nPixelSize );
-	setFont( font );
 
 	if ( m_size.width() > m_size.height() ) {
 		// Check whether the width of the text fits the available frame
 		// width of the button.
-		while ( fontMetrics().size( Qt::TextSingleLine, text() ).width() > width()
-				&& nPixelSize > 1 ) {
+		while ( QFontMetrics( font ).size( Qt::TextSingleLine, text() ).width() >
+				width() && nPixelSize > 1 ) {
 			nPixelSize--;
 			font.setPixelSize( nPixelSize );
-			setFont( font );
 		}
 	}
+
+	// This method must not be called more than once in this routine. Otherwise,
+	// a repaint of the widget is triggered, which calls `updateFont()` again
+	// and we are trapped in an infinite loop.
+	setFont( font );
 }
 	
 void Button::paintEvent( QPaintEvent* ev )

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -155,19 +155,21 @@ void ClickableLabel::updateFont( QString sFontFamily, H2Core::FontTheme::FontSiz
 		font.setPixelSize( nPixelSize );
 	}
 	font.setBold( true );
-	
-	setFont( font );
 
-	if ( ! m_size.isNull() ) {
+	if ( ! m_size.isNull() || width() > height() ) {
 		// Check whether the width of the text fits the available frame
 		// width of the label
-		while ( fontMetrics().size( Qt::TextSingleLine, text() ).width() > width()
-				&& nPixelSize > 1 ) {
+		while ( QFontMetrics( font ).size( Qt::TextSingleLine, text() ).width() >
+				width() && nPixelSize > 1 ) {
 			nPixelSize--;
 			font.setPixelSize( nPixelSize );
-			setFont( font );
 		}
 	}
+
+	// This method must not be called more than once in this routine. Otherwise,
+	// a repaint of the widget is triggered, which calls `updateFont()` again
+	// and we are trapped in an infinite loop.
+	setFont( font );
 }
 
 void ClickableLabel::onPreferencesChanged( H2Core::Preferences::Changes changes ) {


### PR DESCRIPTION
Whenever the width of a text exceeds the width of the `Button` itself, the font size will be stepwise decreased till the text fits the button. This stepwise shrinking was done by assigning the font in each step and checking the resulting proportions.

Setting the font of a widget more than once, however, seems to mark it dirty and triggers rerendering. Since `Button::updateFont()` is called as part of `Button::paintEvent()` we will get ourselves trapped in an infinite loop.

Surprisingly, this was not triggered unless one uses one of the more outdated translations. And even more surprisingly this seems to not result in any bad behavior other than Qt being unable to open the native File browser on Linux (in a native build. AppImages were not affected).

The same fix was applied to `ClickableLabel` to assure we won't get into trouble there either.

Fixes https://github.com/hydrogen-music/hydrogen/issues/1908