### PR TITLE
Use imported drumkit immediately on open from Finder

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1775,8 +1775,22 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 			}
 
 		} else if ( sFileName.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
-			H2Core::Drumkit::install( sFileName );
-
+			QString sImportedPath;
+			if ( H2Core::Drumkit::install( sFileName, "", &sImportedPath ) ) {
+				auto pSoundLibraryDatabase = pHydrogen->getSoundLibraryDatabase();
+				if ( pSoundLibraryDatabase != nullptr ) {
+					pSoundLibraryDatabase->update();
+					auto pDrumkit = pSoundLibraryDatabase->getDrumkit( sImportedPath );
+					if ( pDrumkit == nullptr ) {
+						ERRORLOG( QString( "Unable to load freshly imported kit [%1]" )
+								  .arg( sFileName ) );
+					}
+					auto pAction = new SE_switchDrumkitAction(
+						pDrumkit, pHydrogen->getSong()->getDrumkit(), false,
+						SE_switchDrumkitAction::Type::SwitchDrumkit );
+					h2app->m_pUndoStack->push( pAction );
+				}
+			}
 		} else if ( sFileName.endsWith( H2Core::Filesystem::playlist_ext ) ) {
 			bool loadlist = pHydrogenApp->getPlayListDialog()->loadListByFileName( sFileName );
 			if ( loadlist ) {


### PR DESCRIPTION
Previously, importing drumkit by opening it in Finder would import the kit, but not update the widget or provide any other feedback to let the user know it was actually successful, or allow them to start using it.