### PR TITLE
Fix JACK support

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1313,6 +1313,13 @@ void AudioEngine::clearNoteQueues()
 int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 {
 	AudioEngine* pAudioEngine = Hydrogen::get_instance()->getAudioEngine();
+	// For the JACK driver it is very important (#1867) to not do anything while
+	// the JACK client is stopped/closed. Otherwise it will segfault on mutex
+	// locking or message logging.
+	if ( ! ( pAudioEngine->getState() == AudioEngine::State::Ready ||
+			 pAudioEngine->getState() == AudioEngine::State::Playing ) ) {
+		return 0;
+	}
 	timeval startTimeval = currentTime2();
 
 	pAudioEngine->clearAudioBuffers( nframes );
@@ -1349,6 +1356,7 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 		return 0;
 	}
 
+	// Now that the engine is locked we properly check its state.
 	if ( ! ( pAudioEngine->getState() == AudioEngine::State::Ready ||
 			 pAudioEngine->getState() == AudioEngine::State::Playing ) ) {
 		pAudioEngine->unlock();

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,0 +1,4 @@
+Unit test of Hydrogen's core library. Not to be confused with our [integration tests](../../tests/).
+
+These tests are executed in our **AppVeyor** build pipeline as well as when calling
+our [build.sh](../build.sh) script with `t` as argument.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+Integration tests used to check more complex use-cases we can not cover using
+our [unit tests](../src/tests/).
+
+They are not routinely executed without our **AppVeyor** build pipeline or when
+calling our [build.sh](../build.sh) script with `t` as argument. But they are,
+nevertheless, designed to exit with code `0` on success and with `1` on failure.

--- a/tests/jackTearDown/README.md
+++ b/tests/jackTearDown/README.md
@@ -1,0 +1,18 @@
+Integration test to check whether Hydrogen does properly exit without crashing
+when using the JACK audio driver.
+
+## Requirements
+
+- `hydrogen` - the system-wide installation is used
+- `Go` >= 1.20
+- `JACK`
+
+The code is written and tested on **Linux** Devuan. But since the `OSC` package
+is written in pure `Go` and all other packages used are part of the standard
+library the code _should_ run on **macOS** and **Windows** as well.
+
+## Usage
+
+``` bash
+go run main.go
+```

--- a/tests/jackTearDown/go.mod
+++ b/tests/jackTearDown/go.mod
@@ -1,0 +1,5 @@
+module hydrogen/integrationTests/jackTearDown
+
+go 1.20
+
+require github.com/hypebeast/go-osc v0.0.0-20220308234300-cec5a8a1e5f5

--- a/tests/jackTearDown/go.sum
+++ b/tests/jackTearDown/go.sum
@@ -1,0 +1,2 @@
+github.com/hypebeast/go-osc v0.0.0-20220308234300-cec5a8a1e5f5 h1:fqwINudmUrvGCuw+e3tedZ2UJ0hklSw6t8UPomctKyQ=
+github.com/hypebeast/go-osc v0.0.0-20220308234300-cec5a8a1e5f5/go.mod h1:lqMjoCs0y0GoRRujSPZRBaGb4c5ER6TfkFKSClxkMbY=

--- a/tests/jackTearDown/main.go
+++ b/tests/jackTearDown/main.go
@@ -16,7 +16,7 @@ const oscHydrogenPort = 9000
 
 // hydrogenStartupTime gives an upper limit for the time Hydrogen requires to
 // start up in milliseconds.
-const hydrogenStartupTime = 3000
+const hydrogenStartupTime = 3700
 // hydrogenTearDownTime gives an upper limit for the time required for
 // killHydrogen() to send a quit OSC signal, for Hydrogen to receive it and
 // finish its tear down.

--- a/tests/jackTearDown/main.go
+++ b/tests/jackTearDown/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "os/exec"
+    "time"
+
+    "github.com/hypebeast/go-osc/osc"
+)
+
+// How many times the test should be repeated.
+const numberOfTestRuns = 100
+const oscHydrogenPort = 9000
+
+// hydrogenStartupTime gives an upper limit for the time Hydrogen requires to
+// start up in milliseconds.
+const hydrogenStartupTime = 3000
+
+// hydrogenStartupChan is used by startHydrogen() to indicate that Hydrogen was
+// started.
+var hydrogenStartupChan chan bool
+
+// Integration test checking for errors/crashes when closing Hydrogen while
+// using the JACK driver (on Linux).
+func main() {
+    var err error
+
+    _, err = exec.LookPath("hydrogen")
+    if err != nil {
+        log.Fatalf("[hydrogen] executable could not be found: %v", err.Error())
+    }
+
+    oscClient := osc.NewClient("localhost", oscHydrogenPort)
+
+    hydrogenStartupChan = make(chan bool, 1)
+
+    for ii := 0; ii < numberOfTestRuns; ii++ {
+
+        go killHydrogen(oscClient)
+
+        err = startHydrogen()
+
+        if err != nil {
+            log.Fatalf("Hydrogen exited with non-zero code: %v",
+                err.Error())
+        }
+        log.Printf("Instance [%v] terminated without error\n", ii)
+    }
+}
+
+// Start up Hydrogen using the JACK driver and with a configuration that both
+// enables OSC and uses a specific port unlikely used by another Hydrogen
+// instance (in case another one is already running).
+func startHydrogen() error {
+    hydrogenStartupChan <- true
+
+    cmd := exec.Command("hydrogen", "--driver", "jack", "--nosplash")
+    output, err := cmd.Output()
+    if err != nil {
+        return fmt.Errorf("[startHydrogen] Exited with error [%v]:\n%v\n\n",
+            err, string(output))
+    }
+
+    return nil
+}
+
+func killHydrogen(client *osc.Client) {
+    for {
+        select {
+        case <-hydrogenStartupChan:
+            // Give Hydrogen some time to start up properly
+            time.Sleep(hydrogenStartupTime * time.Millisecond)
+
+            // Hydrogen is ready. Let's shut it down.
+            msg := osc.NewMessage("/Hydrogen/QUIT")
+            err := client.Send(msg)
+            if err != nil {
+                log.Fatalf("[killHydrogen] Unable to send OSC message: %v",
+                    err.Error())
+            }
+            return
+
+        default:
+            time.Sleep(100 * time.Millisecond)
+            continue
+        }
+    }
+}


### PR DESCRIPTION
Probably due to some upstream JACK bugs (not sure) Hydrogen does occassionally segfault when stopping the `JackAudioDriver`. Turns out JACK has a number of issues with thread joining. During teardown of the driver we must ensure it does not do any communication, like locking the `AudioEngine` or enqueuing a message in our `Logger`. Otherwise the thread calling `jack_client_close` might segfault.

Now, the callback of the `AudioEngine` checks its state twice. Once without locking (in order to `return` when it is not ready yet/anymore) and another time while locked to properly check the state. It is a little dirty. But I do not see what else we can do from within the Hydrogen code base

Fixes #1929 

---

Previous text:

Lately we have quite a number of reports of Hydrogen crashing during shutdown or song export all related to our `JackAudioDriver` (#1902, #1907, #1867).

I have to admit I have seen those for quite a while now on my device. But since they are occurring very rarely (like one out of 20) and neither my Hydrogen nor JACK are in a "production" setup, I didn't bothered after giving it a first, inconclusive shot. But the JACK version I use (`1.9.21`) seems to tickle down the package repos and more and more users get the same issues as well.

I wrote a `Go`-based integration test starting up Hydrogen hundreds of times and killing it via OSC right away. This way I'm now able to reproduce the issue.

So far it looks like this is an upstream problem and code of JACK crashes when attempting to tear down the `JackAudioDriver`. We might need a way to protect against crashing driver code. But I'm far from understand what is going on and still need to check and read into a couple of things first.