### PR TITLE
SoundLibraryExportDialog: Fix file browser (#1927)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -589,10 +589,10 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libwinpthread-git
           REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
-          c:\msys64\usr\bin\pacman --noconfirm -S -q -y %MSYS_REPO%-qt5
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
+          c:\msys64\usr\bin\pacman --noconfirm -S -y -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
+          c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
           c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
           ccache -M 256M
           ccache -s

--- a/ChangeLog
+++ b/ChangeLog
@@ -36,6 +36,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- Fixed grid line rendering on rational pattern size nominator.
 				- Fixed grid line colors on very fine resolution.
 		- Fix broken file browser dialogs on Linux when using translations (#1908).
+		- Fix drumkit export on Windows (#1927).
 
 
 2023-09-09 the hydrogen team <hydrogen-devel@lists.sourceforge.net>

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -289,9 +289,7 @@ bool Filesystem::path_usable( const QString& path, bool create, bool silent )
 			INFOLOG( QString( "create user directory : %1" ).arg( path ) );
 		}
 		if ( create && !QDir( "/" ).mkpath( path ) ) {
-			if( !silent ) {
-				ERRORLOG( QString( "unable to create user directory : %1" ).arg( path ) );
-			}
+			ERRORLOG( QString( "unable to create user directory : %1" ).arg( path ) );
 			return false;
 		}
 	}

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -158,7 +158,7 @@ void SoundLibraryExportDialog::on_browseBtn_clicked()
 
 	FileDialog fd(this);
 	fd.setFileMode( QFileDialog::Directory );
-	fd.setAcceptMode( QFileDialog::AcceptSave );
+	fd.setAcceptMode( QFileDialog::AcceptOpen );
 	fd.setDirectory( sPath );
 	fd.setWindowTitle( tr("Directory") );
 

--- a/windows/Build-WinNative.ps1
+++ b/windows/Build-WinNative.ps1
@@ -16,16 +16,16 @@ if($32bit)
     $64bit_string = "OFF"
     $msys_repo='mingw32/mingw-w64-i686'
     $msys='C:\msys64\mingw32'
-    $libssl='libssl-1_1.dll'
-    $libcrypto='libcrypto-1_1.dll'
+    $libssl='libssl-3.dll'
+    $libcrypto='libcrypto-3.dll'
 }
 else
 {
     $64bit_string = "ON"
     $msys_repo='mingw64/mingw-w64-x86_64'
     $msys='C:\msys64\mingw64'
-    $libssl='libssl-1_1-x64.dll'
-    $libcrypto='libcrypto-1_1-x64.dll'
+    $libssl='libssl-3-x64.dll'
+    $libcrypto='libcrypto-3-x64.dll'
 }
 
 


### PR DESCRIPTION
Exporting a drumkit requires the user to select a folder to export it to. (Not the name of the result!)

Since 1.2.0 this was broken at least for Windows in such a way the user was able to select files as well. In addition, double clicking a folder was not selecting but opening it. Also, users were able to see files in the file browser too. In the end, the path had to manually sanitized in our export dialog to ensure it was pointing to an existing folder.

Now, only folders are shown again and they can be selected using the OK button.

Fixes #1927