### PR TITLE
AppVeyor/Win: hard-code Qt5 version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -589,10 +589,10 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libwinpthread-git
           REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
-          c:\msys64\usr\bin\pacman --noconfirm -S -q -y %MSYS_REPO%-qt5
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
+          c:\msys64\usr\bin\pacman --noconfirm -S -y -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
+          c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
           c:\msys64\usr\bin\pacman --noconfirm -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
           ccache -M 256M
           ccache -s


### PR DESCRIPTION
for some reason the Qt5 package can not be found in the Win32 build https://ci.appveyor.com/project/mauser/hydrogen/builds/48874619/job/3cptmn98gvsgu2sb anymore. It happened several times in a row but it is still quite strange. After all, the package for mingw64 follows the exact same naming conventions and it could be found there.

The package is pinned to version 5.15.5-1 for now.

Added to #1803 