### PR TITLE
DPE: guard against empty instrument notes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
+	* Release 1.2.4
+	* Fixed
+		- Fix potential segfault on ill-formated notes in .h2song files.
+
 2024-01-12 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3
 	* Added

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -362,7 +362,7 @@ void DiskWriterDriver::disconnect()
 {
 	INFOLOG( "" );
 
-	pthread_join( diskWriterDriverThread, NULL );
+	pthread_join( diskWriterDriverThread, nullptr );
 
 	delete[] m_pOut_L;
 	m_pOut_L = nullptr;

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1101,15 +1101,19 @@ void DrumPatternEditor::drawPattern(QPainter& painter)
 				Note *pNote = noteIt->second;
 
 				int nInstrumentID = pNote->get_instrument_id();
-				if ( nInstrumentID >= noteCount.size() ) {
-					noteCount.resize( nInstrumentID+1, 0 );
+				// An ID of -1 corresponds to an empty instrument.
+				if ( nInstrumentID >= 0 ) {
+					if ( nInstrumentID >= noteCount.size() ) {
+						noteCount.resize( nInstrumentID+1, 0 );
+					}
+
+					if ( ++noteCount[ nInstrumentID ] == 1) {
+						instruments.push( pNote->get_instrument() );
+					}
+
+					drawNote( pNote, painter, bIsForeground );
 				}
 
-				if ( ++noteCount[ nInstrumentID ] == 1) {
-					instruments.push( pNote->get_instrument() );
-				}
-
-				drawNote( pNote, painter, bIsForeground );
 				++noteIt;
 			}
 


### PR DESCRIPTION
In case the drumkit of the song can not be found, the notes in the pattern might correspond to an empty instrument / have an ID of `-1`. This caused a segfault in the current implementation.