### PR TITLE
PortAudio: fix buzzing sound during startup (#1932)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4
 	* Fixed
 		- Fix potential segfault on ill-formated notes in .h2song files.
+		- Fix buzzing sound during startup when using Port Audio (#1932).
 
 2024-01-12 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1317,7 +1317,8 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	// the JACK client is stopped/closed. Otherwise it will segfault on mutex
 	// locking or message logging.
 	if ( ! ( pAudioEngine->getState() == AudioEngine::State::Ready ||
-			 pAudioEngine->getState() == AudioEngine::State::Playing ) ) {
+			 pAudioEngine->getState() == AudioEngine::State::Playing ) &&
+		 dynamic_cast<JackAudioDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
 		return 0;
 	}
 	timeval startTimeval = currentTime2();

--- a/src/core/IO/PortAudioDriver.cpp
+++ b/src/core/IO/PortAudioDriver.cpp
@@ -162,6 +162,14 @@ int PortAudioDriver::connect()
 	m_pOut_L = new float[ MAX_BUFFER_SIZE ];
 	m_pOut_R = new float[ MAX_BUFFER_SIZE ];
 
+	// Reset buffers to avoid noise during startup (e.g. in case the callback
+	// was not able to obtain the audio engine lock, the arbitrary numbers
+	// filling the buffer after creation will be passed to the audio output).
+	for ( int ii = 0; ii < MAX_BUFFER_SIZE; ii++ ) {
+		m_pOut_L[ ii ] = 0;
+		m_pOut_R[ ii ] = 0;
+	}
+
 	int err;
 	if ( ! m_bInitialised ) {
 		err = Pa_Initialize();


### PR DESCRIPTION
The buffers of Port Audio driver were not reset after initialization. With the latest JACK patch in place this caused the arbitrary buffer content to be played back during startup until the Audio Engine was ready.

In addition, the JACK patch was restricted to be only active when the JACK driver is actually used.

I was a little too confident in here and it uncovered other bugs in production.