### PR TITLE
AudioEngine: add drivers to log messages

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -535,7 +535,7 @@ void AudioEngine::updateTransportPosition( double fTick, long long nFrame, std::
 
 	assert( pSong );
 	
-	// AE_WARNINGLOG( QString( "[Before] fTick: %1, nFrame: %2, pos: %3" )
+	// AE_DEBUGLOG( QString( "[Before] fTick: %1, nFrame: %2, pos: %3" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( pPos->toQString( "", true ) ) );
@@ -570,7 +570,7 @@ void AudioEngine::updateTransportPosition( double fTick, long long nFrame, std::
 		EventQueue::get_instance()->push_event( EVENT_BBT_CHANGED, 0 );
 	}
 	
-	// AE_WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, pos: %3, frame: %4" )
+	// AE_DEBUGLOG( QString( "[After] fTick: %1, nFrame: %2, pos: %3, frame: %4" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( pPos->toQString( "", true ) )
@@ -621,7 +621,7 @@ void AudioEngine::updatePatternTransportPosition( double fTick, long long nFrame
 
 void AudioEngine::updateSongTransportPosition( double fTick, long long nFrame, std::shared_ptr<TransportPosition> pPos ) {
 
-	// AE_WARNINGLOG( QString( "[Before] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4" )
+	// AE_DEBUGLOG( QString( "[Before] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( m_fSongSizeInTicks, 0, 'f' )
@@ -673,7 +673,7 @@ void AudioEngine::updateSongTransportPosition( double fTick, long long nFrame, s
 		handleSelectedPattern();
 	}
 
-	// AE_WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4, frame: %5" )
+	// AE_DEBUGLOG( QString( "[After] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4, frame: %5" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( m_fSongSizeInTicks, 0, 'f' )
@@ -1722,7 +1722,7 @@ void AudioEngine::updateSongSize() {
 	
 	const int nOldColumn = m_pTransportPosition->getColumn();
 
-	// AE_WARNINGLOG( QString( "[Before] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
+	// AE_DEBUGLOG( QString( "[Before] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
 	// 			.arg( fNewStrippedTick, 0, 'f' )
 	// 			.arg( fRepetitions )
 	// 			.arg( m_fSongSizeInTicks )
@@ -1740,7 +1740,7 @@ void AudioEngine::updateSongSize() {
 		}
 		locate( 0 );
 		
-		// AE_WARNINGLOG( QString( "[End of song reached] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
+		// AE_DEBUGLOG( QString( "[End of song reached] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
 		// 			.arg( fNewStrippedTick, 0, 'f' )
 		// 			.arg( fRepetitions )
 		// 			.arg( m_fSongSizeInTicks )
@@ -1823,7 +1823,7 @@ void AudioEngine::updateSongSize() {
 		nNewFrame - m_pTransportPosition->getFrame() +
 		m_pTransportPosition->getFrameOffsetTempo() );
 		
-	// AE_INFOLOG(QString( "[update] nNewFrame: %1, m_pTransportPosition->getFrame() (old): %2, m_pTransportPosition->getFrameOffsetTempo(): %3, fNewTick: %4, m_pTransportPosition->getDoubleTick() (old): %5, m_pTransportPosition->getTickOffsetSongSize() : %6, tick offset (without rounding): %7, fNewSongSizeInTicks: %8, fRepetitions: %9, fNewStrippedTick: %10, nNewPatternStartTick: %11")
+	// AE_DEBUGLOG(QString( "[update] nNewFrame: %1, m_pTransportPosition->getFrame() (old): %2, m_pTransportPosition->getFrameOffsetTempo(): %3, fNewTick: %4, m_pTransportPosition->getDoubleTick() (old): %5, m_pTransportPosition->getTickOffsetSongSize() : %6, tick offset (without rounding): %7, fNewSongSizeInTicks: %8, fRepetitions: %9, fNewStrippedTick: %10, nNewPatternStartTick: %11")
 	// 		.arg( nNewFrame )
 	// 		.arg( m_pTransportPosition->getFrame() )
 	// 		.arg( m_pTransportPosition->getFrameOffsetTempo() )
@@ -1884,7 +1884,7 @@ void AudioEngine::updateSongSize() {
 		return;
 	}
 
-	// AE_WARNINGLOG( QString( "[After] fNewTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
+	// AE_DEBUGLOG( QString( "[After] fNewTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
 	// 			.arg( fNewTick, 0, 'g', 30 )
 	// 			.arg( fRepetitions, 0, 'f' )
 	// 			.arg( m_fSongSizeInTicks )
@@ -2104,7 +2104,7 @@ void AudioEngine::updateVirtualPatterns() {
 
 void AudioEngine::handleTimelineChange() {
 
-	// AE_INFOLOG( QString( "before:\n%1\n%2" )
+	// AE_DEBUGLOG( QString( "before:\n%1\n%2" )
 	// 		 .arg( m_pTransportPosition->toQString() )
 	// 		 .arg( m_pQueuingPosition->toQString() ) );
 
@@ -2130,7 +2130,7 @@ void AudioEngine::handleTimelineChange() {
 		calculateTransportOffsetOnBpmChange( m_pTransportPosition );
 	}
 	
-	// AE_INFOLOG( QString( "after:\n%1\n%2" )
+	// AE_DEBUGLOG( QString( "after:\n%1\n%2" )
 	// 		 .arg( m_pTransportPosition->toQString() )
 	// 		 .arg( m_pQueuingPosition->toQString() ) );
 }
@@ -2292,7 +2292,7 @@ long long AudioEngine::computeTickInterval( double* fTickStart, double* fTickEnd
 	*fTickEnd = TransportPosition::computeTickFromFrame( nFrameEnd ) -
 		pPos->getTickOffsetQueuing();
 
-	// AE_INFOLOG( QString( "nFrame: [%1,%2], fTick: [%3, %4], fTick (without offset): [%5,%6], m_pTransportPosition->getTickOffsetQueuing(): %7, nLookahead: %8, nIntervalLengthInFrames: %9, m_pTransportPosition: %10, m_pQueuingPosition: %11,_bLookaheadApplied: %12" )
+	// AE_DEBUGLOG( QString( "nFrame: [%1,%2], fTick: [%3, %4], fTick (without offset): [%5,%6], m_pTransportPosition->getTickOffsetQueuing(): %7, nLookahead: %8, nIntervalLengthInFrames: %9, m_pTransportPosition: %10, m_pQueuingPosition: %11,_bLookaheadApplied: %12" )
 	// 		 .arg( nFrameStart )
 	// 		 .arg( nFrameEnd )
 	// 		 .arg( *fTickStart, 0, 'f' )
@@ -2376,7 +2376,7 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 	// up.
 	m_fLastTickEnd = fTickEndComp;
 
-	// AE_WARNINGLOG( QString( "tick interval (floor): [%1,%2], tick interval (computed): [%3,%4], nLeadLagFactor: %5, m_fSongSizeInTicks: %6, m_pTransportPosition: %7, m_pQueuingPosition: %8")
+	// AE_DEBUGLOG( QString( "tick interval (floor): [%1,%2], tick interval (computed): [%3,%4], nLeadLagFactor: %5, m_fSongSizeInTicks: %6, m_pTransportPosition: %7, m_pQueuingPosition: %8")
 	// 			.arg( nTickStart ).arg( nTickEnd )
 	// 			.arg( fTickStartComp, 0, 'f' ).arg( fTickEndComp, 0, 'f' )
 	// 			.arg( nLeadLagFactor )
@@ -2623,7 +2623,7 @@ long long AudioEngine::getLeadLagInFrames( double fTick ) {
 												 AudioEngine::getLeadLagInTicks(),
 												 &fTmp );
 
-	// AE_WARNINGLOG( QString( "nFrameStart: %1, nFrameEnd: %2, diff: %3, fTick: %4" )
+	// AE_DEBUGLOG( QString( "nFrameStart: %1, nFrameEnd: %2, diff: %3, fTick: %4" )
 	// 			.arg( nFrameStart ).arg( nFrameEnd )
 	// 			.arg( nFrameEnd - nFrameStart ).arg( fTick, 0, 'f' ) );
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -70,6 +70,15 @@
 namespace H2Core
 {
 
+#define AE_INFOLOG(x) INFOLOG( QString( "[%1] %2" ) \
+	.arg( Hydrogen::get_instance()->getAudioEngine()->getDriverNames() ).arg( x ) );
+#define AE_WARNINGLOG(x) WARNINGLOG( QString( "[%1] %2" ) \
+	.arg( Hydrogen::get_instance()->getAudioEngine()->getDriverNames() ).arg( x ) );
+#define AE_ERRORLOG(x) ERRORLOG( QString( "[%1] %2" ) \
+	.arg( Hydrogen::get_instance()->getAudioEngine()->getDriverNames() ).arg( x ) );
+#define AE_DEBUGLOG(x) DEBUGOG( QString( "[%1] %2" ) \
+	.arg( Hydrogen::get_instance()->getAudioEngine()->getDriverNames() ).arg( x ) );
+
 /** Gets the current time.
  * \return Current time obtained by gettimeofday()*/
 inline timeval currentTime2()
@@ -178,13 +187,13 @@ AudioEngine::~AudioEngine()
 {
 	stopAudioDrivers();
 	if ( getState() != State::Initialized ) {
-		ERRORLOG( "Error the audio engine is not in State::Initialized" );
+		AE_ERRORLOG( "Error the audio engine is not in State::Initialized" );
 		return;
 	}
 	m_pSampler->stopPlayingNotes();
 
 	this->lock( RIGHT_HERE );
-	INFOLOG( "*** Hydrogen audio engine shutdown ***" );
+	AE_INFOLOG( "*** Hydrogen audio engine shutdown ***" );
 
 	clearNoteQueues();
 
@@ -271,7 +280,7 @@ bool AudioEngine::tryLockFor( std::chrono::microseconds duration, const char* fi
 	bool res = m_EngineMutex.try_lock_for( duration );
 	if ( !res ) {
 		// Lock not obtained
-		WARNINGLOG( QString( "Lock timeout: lock timeout %1:%2:%3, lock held by %4:%5:%6" )
+		AE_WARNINGLOG( QString( "Lock timeout: lock timeout %1:%2:%3, lock held by %4:%5:%6" )
 					.arg( file ).arg( function ).arg( line )
 					.arg( m_pLocker.file ).arg( m_pLocker.function ).arg( m_pLocker.line ));
 		return false;
@@ -303,10 +312,10 @@ void AudioEngine::unlock()
 
 void AudioEngine::startPlayback()
 {
-	INFOLOG( "" );
+	AE_INFOLOG( "" );
 
 	if ( getState() != State::Ready ) {
-	   ERRORLOG( "Error the audio engine is not in State::Ready" );
+	   AE_ERRORLOG( "Error the audio engine is not in State::Ready" );
 		return;
 	}
 
@@ -317,10 +326,10 @@ void AudioEngine::startPlayback()
 
 void AudioEngine::stopPlayback()
 {
-	INFOLOG( "" );
+	AE_INFOLOG( "" );
 
 	if ( getState() != State::Playing ) {
-		ERRORLOG( QString( "Error the audio engine is not in State::Playing but [%1]" )
+		AE_ERRORLOG( QString( "Error the audio engine is not in State::Playing but [%1]" )
 				  .arg( static_cast<int>( getState() ) ) );
 		return;
 	}
@@ -400,7 +409,7 @@ float AudioEngine::getElapsedTime() const {
 void AudioEngine::locate( const double fTick, bool bWithJackBroadcast ) {
 	const auto pHydrogen = Hydrogen::get_instance();
 
-	// DEBUGLOG( QString( "fTick: %1" ).arg( fTick ) );
+	// AE_DEBUGLOG( QString( "fTick: %1" ).arg( fTick ) );
 
 #ifdef H2CORE_HAVE_JACK
 	// In case Hydrogen is using the JACK server to sync transport, it
@@ -429,7 +438,7 @@ void AudioEngine::locate( const double fTick, bool bWithJackBroadcast ) {
 
 void AudioEngine::locateToFrame( const long long nFrame ) {
 
-	// DEBUGLOG( QString( "nFrame: %1" ).arg( nFrame ) );
+	// AE_DEBUGLOG( QString( "nFrame: %1" ).arg( nFrame ) );
 	
 	resetOffsets();
 
@@ -441,7 +450,7 @@ void AudioEngine::locateToFrame( const long long nFrame ) {
 	// a heuristic in order to not experience any glitches upon
 	// relocation.
 	if ( std::fmod( fNewTick, std::floor( fNewTick ) ) >= 0.97 ) {
-		INFOLOG( QString( "Computed tick [%1] will be rounded to [%2] in order to avoid glitches" )
+		AE_INFOLOG( QString( "Computed tick [%1] will be rounded to [%2] in order to avoid glitches" )
 				 .arg( fNewTick, 0, 'E', -1 ).arg( std::round( fNewTick ) ) );
 		fNewTick = std::round( fNewTick );
 	}
@@ -491,7 +500,7 @@ void AudioEngine::incrementTransportPosition( uint32_t nFrames ) {
 	const double fNewTick = TransportPosition::computeTickFromFrame( nNewFrame );
 	m_pTransportPosition->m_fTickMismatch = 0;
 
-	// DEBUGLOG( QString( "nFrames: %1, old frame: %2, new frame: %3, old tick: %4, new tick: %5, ticksize: %6" )
+	// AE_DEBUGLOG( QString( "nFrames: %1, old frame: %2, new frame: %3, old tick: %4, new tick: %5, ticksize: %6" )
 	// 		  .arg( nFrames )
 	// 		  .arg( m_pTransportPosition->getFrame() )
 	// 		  .arg( nNewFrame )
@@ -526,7 +535,7 @@ void AudioEngine::updateTransportPosition( double fTick, long long nFrame, std::
 
 	assert( pSong );
 	
-	// WARNINGLOG( QString( "[Before] fTick: %1, nFrame: %2, pos: %3" )
+	// AE_WARNINGLOG( QString( "[Before] fTick: %1, nFrame: %2, pos: %3" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( pPos->toQString( "", true ) ) );
@@ -561,7 +570,7 @@ void AudioEngine::updateTransportPosition( double fTick, long long nFrame, std::
 		EventQueue::get_instance()->push_event( EVENT_BBT_CHANGED, 0 );
 	}
 	
-	// WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, pos: %3, frame: %4" )
+	// AE_WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, pos: %3, frame: %4" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( pPos->toQString( "", true ) )
@@ -612,7 +621,7 @@ void AudioEngine::updatePatternTransportPosition( double fTick, long long nFrame
 
 void AudioEngine::updateSongTransportPosition( double fTick, long long nFrame, std::shared_ptr<TransportPosition> pPos ) {
 
-	// WARNINGLOG( QString( "[Before] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4" )
+	// AE_WARNINGLOG( QString( "[Before] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( m_fSongSizeInTicks, 0, 'f' )
@@ -625,7 +634,7 @@ void AudioEngine::updateSongTransportPosition( double fTick, long long nFrame, s
 	pPos->setFrame( nFrame );
 
 	if ( fTick < 0 ) {
-		ERRORLOG( QString( "[%1] Provided tick [%2] is negative!" )
+		AE_ERRORLOG( QString( "[%1] Provided tick [%2] is negative!" )
 				  .arg( pPos->getLabel() )
 				  .arg( fTick, 0, 'f' ) );
 		return;
@@ -664,7 +673,7 @@ void AudioEngine::updateSongTransportPosition( double fTick, long long nFrame, s
 		handleSelectedPattern();
 	}
 
-	// WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4, frame: %5" )
+	// AE_WARNINGLOG( QString( "[After] fTick: %1, nFrame: %2, m_fSongSizeInTicks: %3, pos: %4, frame: %5" )
 	// 			.arg( fTick, 0, 'f' )
 	// 			.arg( nFrame )
 	// 			.arg( m_fSongSizeInTicks, 0, 'f' )
@@ -710,7 +719,7 @@ void AudioEngine::updateBpmAndTickSize( std::shared_ptr<TransportPosition> pPos 
 	}
 
 	if ( fNewTickSize == 0 ) {
-		ERRORLOG( QString( "[%1] Something went wrong while calculating the tick size. [oldTS: %2, newTS: %3]" )
+		AE_ERRORLOG( QString( "[%1] Something went wrong while calculating the tick size. [oldTS: %2, newTS: %3]" )
 				  .arg( pPos->getLabel() )
 				  .arg( fOldTickSize, 0, 'f' ).arg( fNewTickSize, 0, 'f' ) );
 		return;
@@ -722,7 +731,7 @@ void AudioEngine::updateBpmAndTickSize( std::shared_ptr<TransportPosition> pPos 
 	// arbitrary values.
 	pPos->setLastLeadLagFactor( 0 );
 
-	// DEBUGLOG(QString( "[%1] [%7,%8] sample rate: %2, tick size: %3 -> %4, bpm: %5 -> %6" )
+	// AE_DEBUGLOG(QString( "[%1] [%7,%8] sample rate: %2, tick size: %3 -> %4, bpm: %5 -> %6" )
 	// 		 .arg( pPos->getLabel() )
 	// 		 .arg( static_cast<float>(m_pAudioDriver->getSampleRate()))
 	// 		 .arg( fOldTickSize, 0, 'f' )
@@ -757,7 +766,7 @@ void AudioEngine::calculateTransportOffsetOnBpmChange( std::shared_ptr<Transport
 			nNewFrame + nNewLookahead ) + pPos->getTickMismatch();
 		pPos->setTickOffsetQueuing( fNewTickEnd - m_fLastTickEnd );
 
-		// DEBUGLOG( QString( "[%1 : [%2] timeline] old frame: %3, new frame: %4, tick: %5, nNewLookahead: %6, pPos->getFrameOffsetTempo(): %7, pPos->getTickOffsetQueuing(): %8, fNewTickEnd: %9, m_fLastTickEnd: %10" )
+		// AE_DEBUGLOG( QString( "[%1 : [%2] timeline] old frame: %3, new frame: %4, tick: %5, nNewLookahead: %6, pPos->getFrameOffsetTempo(): %7, pPos->getTickOffsetQueuing(): %8, fNewTickEnd: %9, m_fLastTickEnd: %10" )
 		// 		  .arg( pPos->getLabel() )
 		// 		  .arg( Hydrogen::get_instance()->isTimelineEnabled() )
 		// 		  .arg( pPos->getFrame() )
@@ -827,7 +836,7 @@ void AudioEngine::clearAudioBuffers( uint32_t nFrames )
 
 AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 {
-	INFOLOG( QString( "Creating driver [%1]" ).arg( sDriver ) );
+	AE_INFOLOG( QString( "Creating driver [%1]" ).arg( sDriver ) );
 
 	auto pPref = Preferences::get_instance();
 	auto pHydrogen = Hydrogen::get_instance();
@@ -859,7 +868,7 @@ AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 		pAudioDriver = new PulseAudioDriver( m_AudioProcessCallback );
 	}
 	else if ( sDriver == "Fake" ) {
-		WARNINGLOG( "*** Using FAKE audio driver ***" );
+		AE_WARNINGLOG( "*** Using FAKE audio driver ***" );
 		pAudioDriver = new FakeDriver( m_AudioProcessCallback );
 	}
 	else if ( sDriver == "DiskWriterDriver" ) {
@@ -869,20 +878,20 @@ AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 		pAudioDriver = new NullDriver( m_AudioProcessCallback );
 	}
 	else {
-		ERRORLOG( QString( "Unknown driver [%1]" ).arg( sDriver ) );
+		AE_ERRORLOG( QString( "Unknown driver [%1]" ).arg( sDriver ) );
 		raiseError( Hydrogen::UNKNOWN_DRIVER );
 		return nullptr;
 	}
 
 	if ( pAudioDriver == nullptr ) {
-		INFOLOG( QString( "Unable to create driver [%1]" ).arg( sDriver ) );
+		AE_INFOLOG( QString( "Unable to create driver [%1]" ).arg( sDriver ) );
 		return nullptr;
 	}
 
 	// Initialize the audio driver
 	int nRes = pAudioDriver->init( pPref->m_nBufferSize );
 	if ( nRes != 0 ) {
-		ERRORLOG( QString( "Error code [%2] while initializing audio driver [%1]." )
+		AE_ERRORLOG( QString( "Error code [%2] while initializing audio driver [%1]." )
 				  .arg( sDriver ).arg( nRes ) );
 		delete pAudioDriver;
 		return nullptr;
@@ -909,7 +918,7 @@ AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 	nRes = m_pAudioDriver->connect();
 	if ( nRes != 0 ) {
 		raiseError( Hydrogen::ERROR_STARTING_DRIVER );
-		ERRORLOG( QString( "Error code [%2] while connecting audio driver [%1]." )
+		AE_ERRORLOG( QString( "Error code [%2] while connecting audio driver [%1]." )
 				  .arg( sDriver ).arg( nRes ) );
 
 		this->lock( RIGHT_HERE );
@@ -941,20 +950,20 @@ AudioOutput* AudioEngine::createAudioDriver( const QString& sDriver )
 
 void AudioEngine::startAudioDrivers()
 {
-	INFOLOG("");
+	AE_INFOLOG("");
 	Preferences *pPref = Preferences::get_instance();
 	
 	if ( getState() != State::Initialized ) {
-		ERRORLOG( QString( "Audio engine is not in State::Initialized but [%1]" )
+		AE_ERRORLOG( QString( "Audio engine is not in State::Initialized but [%1]" )
 				  .arg( static_cast<int>( getState() ) ) );
 		return;
 	}
 
 	if ( m_pAudioDriver != nullptr ) {	// check if audio driver is still alive
-		ERRORLOG( "The audio driver is still alive" );
+		AE_ERRORLOG( "The audio driver is still alive" );
 	}
 	if ( m_pMidiDriver != nullptr ) {	// check if midi driver is still alive
-		ERRORLOG( "The MIDI driver is still active" );
+		AE_ERRORLOG( "The MIDI driver is still active" );
 	}
 
 	QString sAudioDriver = pPref->m_sAudioDriver;
@@ -972,7 +981,7 @@ void AudioEngine::startAudioDrivers()
 	}
 
 	if ( m_pAudioDriver == nullptr ) {
-		ERRORLOG( QString( "Couldn't start audio driver [%1], falling back to NullDriver" )
+		AE_ERRORLOG( QString( "Couldn't start audio driver [%1], falling back to NullDriver" )
 				  .arg( sAudioDriver ) );
 		createAudioDriver( "NullDriver" );
 	}
@@ -1020,7 +1029,7 @@ void AudioEngine::startAudioDrivers()
 
 void AudioEngine::stopAudioDrivers()
 {
-	INFOLOG( "" );
+	AE_INFOLOG( "" );
 
 	this->lock( RIGHT_HERE );
 
@@ -1030,7 +1039,7 @@ void AudioEngine::stopAudioDrivers()
 
 	if ( ( m_state != State::Prepared )
 		 && ( m_state != State::Ready ) ) {
-		ERRORLOG( QString( "Audio engine is not in State::Prepared or State::Ready but [%1]" )
+		AE_ERRORLOG( QString( "Audio engine is not in State::Prepared or State::Ready but [%1]" )
 				  .arg( static_cast<int>(m_state) ) );
 		this->unlock();
 		return;
@@ -1081,7 +1090,7 @@ void AudioEngine::handleLoopModeChanged() {
 void AudioEngine::handleDriverChange() {
 
 	if ( Hydrogen::get_instance()->getSong() == nullptr ) {
-		WARNINGLOG( "no song set yet" );
+		AE_WARNINGLOG( "no song set yet" );
 		return;
 	}
 	
@@ -1095,7 +1104,7 @@ float AudioEngine::getBpmAtColumn( int nColumn ) {
 	auto pSong = pHydrogen->getSong();
 
 	if ( pSong == nullptr ) {
-		WARNINGLOG( "no song set yet" );
+		AE_WARNINGLOG( "no song set yet" );
 		return MIN_BPM;
 	}
 
@@ -1109,7 +1118,7 @@ float AudioEngine::getBpmAtColumn( int nColumn ) {
 		const float fJackMasterBpm = pHydrogen->getMasterBpm();
 		if ( ! std::isnan( fJackMasterBpm ) && fBpm != fJackMasterBpm ) {
 			fBpm = fJackMasterBpm;
-			// DEBUGLOG( QString( "Tempo update by the JACK server [%1]").arg( fJackMasterBpm ) );
+			// AE_DEBUGLOG( QString( "Tempo update by the JACK server [%1]").arg( fJackMasterBpm ) );
 		}
 	}
 	else if ( pSong->getIsTimelineActivated() &&
@@ -1117,7 +1126,7 @@ float AudioEngine::getBpmAtColumn( int nColumn ) {
 
 		const float fTimelineBpm = pHydrogen->getTimeline()->getTempoAtColumn( nColumn );
 		if ( fTimelineBpm != fBpm ) {
-			// DEBUGLOG( QString( "Set tempo to timeline value [%1]").arg( fTimelineBpm ) );
+			// AE_DEBUGLOG( QString( "Set tempo to timeline value [%1]").arg( fTimelineBpm ) );
 			fBpm = fTimelineBpm;
 		}
 	}
@@ -1125,7 +1134,7 @@ float AudioEngine::getBpmAtColumn( int nColumn ) {
 		// Change in speed due to user interaction with the BPM widget
 		// or corresponding MIDI or OSC events.
 		if ( pAudioEngine->getNextBpm() != fBpm ) {
-			// DEBUGLOG( QString( "BPM changed via Widget, OSC, or MIDI from [%1] to [%2]." )
+			// AE_DEBUGLOG( QString( "BPM changed via Widget, OSC, or MIDI from [%1] to [%2]." )
 			// 		  .arg( fBpm ).arg( pAudioEngine->getNextBpm() ) );
 			fBpm = pAudioEngine->getNextBpm();
 		}
@@ -1201,7 +1210,7 @@ void AudioEngine::handleSongModeChanged() {
 
 	const auto pSong = Hydrogen::get_instance()->getSong();
 	if ( pSong == nullptr ) {
-		ERRORLOG( "no song set" );
+		AE_ERRORLOG( "no song set" );
 		return;
 	}
 
@@ -1232,7 +1241,7 @@ void AudioEngine::processPlayNotes( unsigned long nframes )
 		Note *pNote = m_songNoteQueue.top();
 		const long long nNoteStartInFrames = pNote->getNoteStart();
 
-		// DEBUGLOG( QString( "m_pTransportPosition->getDoubleTick(): %1, m_pTransportPosition->getFrame(): %2, nframes: %3, " )
+		// AE_DEBUGLOG( QString( "m_pTransportPosition->getDoubleTick(): %1, m_pTransportPosition->getFrame(): %2, nframes: %3, " )
 		// 		  .arg( m_pTransportPosition->getDoubleTick() )
 		// 		  .arg( m_pTransportPosition->getFrame() )
 		// 		  .arg( nframes )
@@ -1322,6 +1331,7 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 		return 0;
 	}
 	timeval startTimeval = currentTime2();
+	const auto sDrivers = pAudioEngine->getDriverNames();
 
 	pAudioEngine->clearAudioBuffers( nframes );
 
@@ -1348,7 +1358,8 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	 */
 	if ( !pAudioEngine->tryLockFor( std::chrono::microseconds( (int)(1000.0*fSlackTime) ),
 							  RIGHT_HERE ) ) {
-		___ERRORLOG( QString( "Failed to lock audioEngine in allowed %1 ms, missed buffer" ).arg( fSlackTime ) );
+		___ERRORLOG( QString( "[%1] Failed to lock audioEngine in allowed %2 ms, missed buffer" )
+					 .arg( sDrivers ).arg( fSlackTime ) );
 
 		if ( dynamic_cast<DiskWriterDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
 			return 2;	// inform the caller that we could not acquire the lock
@@ -1368,8 +1379,6 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	if ( pSong == nullptr ) {
 		assert( pSong );
-		ERRORLOG( "Invalid song" );
-		return 1;
 	}
 
 	// Sync transport with server (in case the current audio driver is
@@ -1378,7 +1387,8 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	if ( Hydrogen::get_instance()->hasJackTransport() ) {
 		auto pAudioDriver = pHydrogen->getAudioOutput();
 		if ( pAudioDriver == nullptr ) {
-			ERRORLOG( "AudioDriver is not ready!" );
+			___ERRORLOG( QString( "[%1] AudioDriver is not ready!" )
+						 .arg( sDrivers ) );
 			assert( pAudioDriver );
 			return 1;
 		}
@@ -1421,7 +1431,7 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 		if ( pAudioEngine->isEndOfSongReached(
 				 pAudioEngine->m_pTransportPosition ) ) {
 
-			___INFOLOG( "End of song received" );
+			___INFOLOG( QString( "[%1] End of song received" ).arg( sDrivers ) );
 
 			if ( pHydrogen->getMidiOutput() != nullptr ) {
 				pHydrogen->getMidiOutput()->handleQueueAllNoteOff();
@@ -1438,7 +1448,7 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 
 			if ( dynamic_cast<FakeDriver*>(pAudioEngine->m_pAudioDriver) !=
 				 nullptr ) {
-				___INFOLOG( "End of song." );
+				___INFOLOG( QString( "[%1] End of song." ).arg( sDrivers ) );
 
 				// TODO This part of the code might not be reached
 				// anymore.
@@ -1461,9 +1471,11 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	if ( pAudioEngine->m_fProcessTime > pAudioEngine->m_fMaxProcessTime ) {
 		___WARNINGLOG( "" );
 		___WARNINGLOG( "----XRUN----" );
-		___WARNINGLOG( QString( "XRUN of %1 msec (%2 > %3)" )
+		___WARNINGLOG( QString( "[%1] XRUN of %2 msec (%3 > %4)" )
+					   .arg( sDrivers )
 					   .arg( ( pAudioEngine->m_fProcessTime - pAudioEngine->m_fMaxProcessTime ) )
-					   .arg( pAudioEngine->m_fProcessTime ).arg( pAudioEngine->m_fMaxProcessTime ) );
+					   .arg( pAudioEngine->m_fProcessTime )
+					   .arg( pAudioEngine->m_fMaxProcessTime ) );
 		___WARNINGLOG( QString( "Ladspa process time = %1" ).arg( fLadspaTime ) );
 		___WARNINGLOG( "------------" );
 		___WARNINGLOG( "" );
@@ -1578,12 +1590,12 @@ void AudioEngine::setState( AudioEngine::State state ) {
 void AudioEngine::setNextBpm( float fNextBpm ) {
 	if ( fNextBpm > MAX_BPM ) {
 		m_fNextBpm = MAX_BPM;
-		WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
+		AE_WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
 					.arg( fNextBpm ).arg( MAX_BPM ) );
 	}
 	else if ( fNextBpm < MIN_BPM ) {
 		m_fNextBpm = MIN_BPM;
-		WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
+		AE_WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
 					.arg( fNextBpm ).arg( MIN_BPM ) );
 	}
 	
@@ -1594,12 +1606,12 @@ void AudioEngine::setSong( std::shared_ptr<Song> pNewSong )
 {
 	auto pHydrogen = Hydrogen::get_instance();
 	
-	INFOLOG( QString( "Set song: %1" ).arg( pNewSong->getName() ) );
+	AE_INFOLOG( QString( "Set song: %1" ).arg( pNewSong->getName() ) );
 	
 	this->lock( RIGHT_HERE );
 
 	if ( getState() != State::Prepared ) {
-		ERRORLOG( QString( "Error the audio engine is not in State::Prepared but [%1]" )
+		AE_ERRORLOG( QString( "Error the audio engine is not in State::Prepared but [%1]" )
 				  .arg( static_cast<int>( getState() ) ) );
 	}
 
@@ -1637,7 +1649,7 @@ void AudioEngine::removeSong()
 	}
 
 	if ( getState() != State::Ready ) {
-		ERRORLOG( QString( "Error the audio engine is not in State::Ready but [%1]" )
+		AE_ERRORLOG( QString( "Error the audio engine is not in State::Ready but [%1]" )
 				  .arg( static_cast<int>( getState() ) ) );
 		this->unlock();
 		return;
@@ -1656,7 +1668,7 @@ void AudioEngine::updateSongSize() {
 	auto pSong = pHydrogen->getSong();
 
 	if ( pSong == nullptr ) {
-		ERRORLOG( "No song set yet" );
+		AE_ERRORLOG( "No song set yet" );
 		return;
 	}
 
@@ -1710,7 +1722,7 @@ void AudioEngine::updateSongSize() {
 	
 	const int nOldColumn = m_pTransportPosition->getColumn();
 
-	// WARNINGLOG( QString( "[Before] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
+	// AE_WARNINGLOG( QString( "[Before] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
 	// 			.arg( fNewStrippedTick, 0, 'f' )
 	// 			.arg( fRepetitions )
 	// 			.arg( m_fSongSizeInTicks )
@@ -1728,7 +1740,7 @@ void AudioEngine::updateSongSize() {
 		}
 		locate( 0 );
 		
-		// WARNINGLOG( QString( "[End of song reached] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
+		// AE_WARNINGLOG( QString( "[End of song reached] fNewStrippedTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
 		// 			.arg( fNewStrippedTick, 0, 'f' )
 		// 			.arg( fRepetitions )
 		// 			.arg( m_fSongSizeInTicks )
@@ -1763,7 +1775,7 @@ void AudioEngine::updateSongSize() {
 		// enlarged, or shrunk. We need to compensate this in order to
 		// keep the current pattern tick position constant.
 
-		// DEBUGLOG( QString( "[nPatternStartTick mismatch] old: %1, new: %2" )
+		// AE_DEBUGLOG( QString( "[nPatternStartTick mismatch] old: %1, new: %2" )
 		// 		  .arg( m_pTransportPosition->getPatternStartTick() )
 		// 		  .arg( nNewPatternStartTick ) );
 		
@@ -1777,7 +1789,7 @@ void AudioEngine::updateSongSize() {
 		static_cast<long>(std::floor( fNewStrippedTick )) - nNewPatternStartTick;
 	if ( nNewPatternTickPosition != m_pTransportPosition->getPatternTickPosition() &&
 		 ! bEmptySong ) {
-		ERRORLOG( QString( "[nPatternTickPosition mismatch] old: %1, new: %2" )
+		AE_ERRORLOG( QString( "[nPatternTickPosition mismatch] old: %1, new: %2" )
 				  .arg( m_pTransportPosition->getPatternTickPosition() )
 				  .arg( nNewPatternTickPosition ) );
 	}
@@ -1811,7 +1823,7 @@ void AudioEngine::updateSongSize() {
 		nNewFrame - m_pTransportPosition->getFrame() +
 		m_pTransportPosition->getFrameOffsetTempo() );
 		
-	// INFOLOG(QString( "[update] nNewFrame: %1, m_pTransportPosition->getFrame() (old): %2, m_pTransportPosition->getFrameOffsetTempo(): %3, fNewTick: %4, m_pTransportPosition->getDoubleTick() (old): %5, m_pTransportPosition->getTickOffsetSongSize() : %6, tick offset (without rounding): %7, fNewSongSizeInTicks: %8, fRepetitions: %9, fNewStrippedTick: %10, nNewPatternStartTick: %11")
+	// AE_INFOLOG(QString( "[update] nNewFrame: %1, m_pTransportPosition->getFrame() (old): %2, m_pTransportPosition->getFrameOffsetTempo(): %3, fNewTick: %4, m_pTransportPosition->getDoubleTick() (old): %5, m_pTransportPosition->getTickOffsetSongSize() : %6, tick offset (without rounding): %7, fNewSongSizeInTicks: %8, fRepetitions: %9, fNewStrippedTick: %10, nNewPatternStartTick: %11")
 	// 		.arg( nNewFrame )
 	// 		.arg( m_pTransportPosition->getFrame() )
 	// 		.arg( m_pTransportPosition->getFrameOffsetTempo() )
@@ -1860,7 +1872,7 @@ void AudioEngine::updateSongSize() {
 #ifdef H2CORE_HAVE_DEBUG
 	if ( nOldColumn != m_pTransportPosition->getColumn() && ! bEmptySong &&
 		 nOldColumn != -1 && m_pTransportPosition->getColumn() != -1 ) {
-		ERRORLOG( QString( "[nColumn mismatch] old: %1, new: %2" )
+		AE_ERRORLOG( QString( "[nColumn mismatch] old: %1, new: %2" )
 				  .arg( nOldColumn )
 				  .arg( m_pTransportPosition->getColumn() ) );
 	}
@@ -1872,7 +1884,7 @@ void AudioEngine::updateSongSize() {
 		return;
 	}
 
-	// WARNINGLOG( QString( "[After] fNewTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
+	// AE_WARNINGLOG( QString( "[After] fNewTick: %1, fRepetitions: %2, m_fSongSizeInTicks: %3, fNewSongSizeInTicks: %4, transport: %5, queuing: %6" )
 	// 			.arg( fNewTick, 0, 'g', 30 )
 	// 			.arg( fRepetitions, 0, 'f' )
 	// 			.arg( m_fSongSizeInTicks )
@@ -1910,7 +1922,7 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 	auto pSong = pHydrogen->getSong();
 	auto pPlayingPatterns = pPos->getPlayingPatterns();
 
-	// DEBUGLOG( QString( "pre: %1" ).arg( pPos->toQString() ) );
+	// AE_DEBUGLOG( QString( "pre: %1" ).arg( pPos->toQString() ) );
 
 	if ( pHydrogen->getMode() == Song::Mode::Song ) {
 
@@ -1928,7 +1940,7 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 
 		auto nColumn = std::max( pPos->getColumn(), 0 );
 		if ( nColumn >= pSong->getPatternGroupVector()->size() ) {
-			ERRORLOG( QString( "Provided column [%1] exceeds allowed range [0,%2]. Using 0 as fallback." )
+			AE_ERRORLOG( QString( "Provided column [%1] exceeds allowed range [0,%2]. Using 0 as fallback." )
 					  .arg( nColumn ).arg( pSong->getPatternGroupVector()->size() - 1 ) );
 			nColumn = 0;
 		}
@@ -2003,7 +2015,7 @@ void AudioEngine::updatePlayingPatternsPos( std::shared_ptr<TransportPosition> p
 		pPos->setPatternSize( MAX_NOTES );
 	}
 	
-	// DEBUGLOG( QString( "post: %1" ).arg( pPos->toQString() ) );
+	// AE_DEBUGLOG( QString( "post: %1" ).arg( pPos->toQString() ) );
 	
 }
 
@@ -2092,7 +2104,7 @@ void AudioEngine::updateVirtualPatterns() {
 
 void AudioEngine::handleTimelineChange() {
 
-	// INFOLOG( QString( "before:\n%1\n%2" )
+	// AE_INFOLOG( QString( "before:\n%1\n%2" )
 	// 		 .arg( m_pTransportPosition->toQString() )
 	// 		 .arg( m_pQueuingPosition->toQString() ) );
 
@@ -2118,7 +2130,7 @@ void AudioEngine::handleTimelineChange() {
 		calculateTransportOffsetOnBpmChange( m_pTransportPosition );
 	}
 	
-	// INFOLOG( QString( "after:\n%1\n%2" )
+	// AE_INFOLOG( QString( "after:\n%1\n%2" )
 	// 		 .arg( m_pTransportPosition->toQString() )
 	// 		 .arg( m_pQueuingPosition->toQString() ) );
 }
@@ -2169,7 +2181,7 @@ void AudioEngine::handleSongSizeChange() {
 		if ( notes.size() > 0 ) {
 			for ( auto nnote : notes ) {
 
-				// DEBUGLOG( QString( "[song queue] name: %1, pos: %2 -> %3, tick offset: %4, tick offset floored: %5" )
+				// AE_DEBUGLOG( QString( "[song queue] name: %1, pos: %2 -> %3, tick offset: %4, tick offset floored: %5" )
 				// 		  .arg( nnote->get_instrument()->get_name() )
 				// 		  .arg( nnote->get_position() )
 				// 		  .arg( std::max( nnote->get_position() + nTickOffset,
@@ -2193,7 +2205,7 @@ void AudioEngine::handleSongSizeChange() {
 		if ( notes.size() > 0 ) {
 			for ( auto nnote : notes ) {
 
-				// DEBUGLOG( QString( "[midi queue] name: %1, pos: %2 -> %3, tick offset: %4, tick offset floored: %5" )
+				// AE_DEBUGLOG( QString( "[midi queue] name: %1, pos: %2 -> %3, tick offset: %4, tick offset floored: %5" )
 				// 		  .arg( nnote->get_instrument()->get_name() )
 				// 		  .arg( nnote->get_position() )
 				// 		  .arg( std::max( nnote->get_position() + nTickOffset,
@@ -2280,7 +2292,7 @@ long long AudioEngine::computeTickInterval( double* fTickStart, double* fTickEnd
 	*fTickEnd = TransportPosition::computeTickFromFrame( nFrameEnd ) -
 		pPos->getTickOffsetQueuing();
 
-	// INFOLOG( QString( "nFrame: [%1,%2], fTick: [%3, %4], fTick (without offset): [%5,%6], m_pTransportPosition->getTickOffsetQueuing(): %7, nLookahead: %8, nIntervalLengthInFrames: %9, m_pTransportPosition: %10, m_pQueuingPosition: %11,_bLookaheadApplied: %12" )
+	// AE_INFOLOG( QString( "nFrame: [%1,%2], fTick: [%3, %4], fTick (without offset): [%5,%6], m_pTransportPosition->getTickOffsetQueuing(): %7, nLookahead: %8, nIntervalLengthInFrames: %9, m_pTransportPosition: %10, m_pQueuingPosition: %11,_bLookaheadApplied: %12" )
 	// 		 .arg( nFrameStart )
 	// 		 .arg( nFrameEnd )
 	// 		 .arg( *fTickStart, 0, 'f' )
@@ -2364,7 +2376,7 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 	// up.
 	m_fLastTickEnd = fTickEndComp;
 
-	// WARNINGLOG( QString( "tick interval (floor): [%1,%2], tick interval (computed): [%3,%4], nLeadLagFactor: %5, m_fSongSizeInTicks: %6, m_pTransportPosition: %7, m_pQueuingPosition: %8")
+	// AE_WARNINGLOG( QString( "tick interval (floor): [%1,%2], tick interval (computed): [%3,%4], nLeadLagFactor: %5, m_fSongSizeInTicks: %6, m_pTransportPosition: %7, m_pQueuingPosition: %8")
 	// 			.arg( nTickStart ).arg( nTickEnd )
 	// 			.arg( fTickStartComp, 0, 'f' ).arg( fTickEndComp, 0, 'f' )
 	// 			.arg( nLeadLagFactor )
@@ -2530,7 +2542,7 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 									m_pQueuingPosition->getPatternTickPosition() ) );
 						}
 
-						// DEBUGLOG( QString( "m_pQueuingPosition: %1, new note: %2" )
+						// AE_DEBUGLOG( QString( "m_pQueuingPosition: %1, new note: %2" )
 						// 		  .arg( m_pQueuingPosition->toQString() )
 						// 		  .arg( pCopiedNote->toQString() ) );
 
@@ -2550,7 +2562,7 @@ void AudioEngine::noteOn( Note *note )
 	if ( ! ( getState() == State::Playing ||
 			 getState() == State::Ready ||
 			 getState() == State::Testing ) ) {
-		ERRORLOG( QString( "Error the audio engine is not in State::Ready, State::Playing, or State::Testing but [%1]" )
+		AE_ERRORLOG( QString( "Error the audio engine is not in State::Ready, State::Playing, or State::Testing but [%1]" )
 					 .arg( static_cast<int>( getState() ) ) );
 		delete note;
 		return;
@@ -2611,7 +2623,7 @@ long long AudioEngine::getLeadLagInFrames( double fTick ) {
 												 AudioEngine::getLeadLagInTicks(),
 												 &fTmp );
 
-	// WARNINGLOG( QString( "nFrameStart: %1, nFrameEnd: %2, diff: %3, fTick: %4" )
+	// AE_WARNINGLOG( QString( "nFrameStart: %1, nFrameEnd: %2, diff: %3, fTick: %4" )
 	// 			.arg( nFrameStart ).arg( nFrameEnd )
 	// 			.arg( nFrameEnd - nFrameStart ).arg( fTick, 0, 'f' ) );
 
@@ -2641,15 +2653,15 @@ void AudioEngine::checkJackSupport() {
 	// importing the file) or by passing the `-d jack` CLI option.
 	if ( Preferences::get_instance()->m_sAudioDriver != "JACK" ) {
 		if ( ! JackAudioDriver::checkSupport() ) {
-			WARNINGLOG( "JACK support disabled." );
+			AE_WARNINGLOG( "JACK support disabled." );
 			m_bJackSupported = false;
 			return;
 		}
 
-		INFOLOG( "JACK support enabled." );
+		AE_INFOLOG( "JACK support enabled." );
 	}
 	else {
-		INFOLOG( "Dynamic JACK support skipped. JACK support enabled." );
+		AE_INFOLOG( "Dynamic JACK support skipped. JACK support enabled." );
 	}
   #endif
 
@@ -2657,7 +2669,7 @@ void AudioEngine::checkJackSupport() {
 	return;
 
 #else
-	INFOLOG( "Hydrogen was compiled without JACK support." );
+	AE_INFOLOG( "Hydrogen was compiled without JACK support." );
 	m_bJackSupported = false;
 	return;
 #endif
@@ -2784,6 +2796,84 @@ QString AudioEngine::toQString( const QString& sPrefix, bool bShort ) const {
 	}
 	
 	return sOutput;
+}
+
+QString AudioEngine::getDriverNames() const {
+	QString sAudioDriver( "unknown" );
+	QString sMidiInputDriver( "unknown" );
+	QString sMidiOutputDriver( "unknown" );
+
+	if ( m_pAudioDriver == nullptr ) {
+		sAudioDriver = "nullptr";
+	} else if ( dynamic_cast<JackAudioDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "JACK";
+	} else if ( dynamic_cast<PortAudioDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "PortAudio";
+	} else if ( dynamic_cast<CoreAudioDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "CoreAudio";
+	} else if ( dynamic_cast<PulseAudioDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "PulseAudio";
+	} else if ( dynamic_cast<OssDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "OSS";
+	} else if ( dynamic_cast<AlsaAudioDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "ALSA";
+	} else if ( dynamic_cast<FakeDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "Fake";
+	} else if ( dynamic_cast<NullDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "NULL";
+	} else if ( dynamic_cast<DiskWriterDriver*>(m_pAudioDriver) != nullptr ) {
+		sAudioDriver = "Disk";
+	}
+	
+	if ( m_pMidiDriver == nullptr ) {
+		sMidiInputDriver = "nullptr";
+#ifdef H2CORE_HAVE_ALSA
+	} else if ( dynamic_cast<AlsaMidiDriver*>(m_pMidiDriver) != nullptr ) {
+		sMidiInputDriver = "ALSA";
+#endif
+#ifdef H2CORE_HAVE_PORTMIDI
+	} else if ( dynamic_cast<PortMidiDriver*>(m_pMidiDriver) != nullptr ) {
+		sMidiInputDriver = "PortMidi";
+#endif
+#ifdef H2CORE_HAVE_COREMIDI
+	} else if ( dynamic_cast<CoreMidiDriver*>(m_pMidiDriver) != nullptr ) {
+		sMidiInputDriver = "CoreMidi";
+#endif
+#ifdef H2CORE_HAVE_JACK
+	} else if ( dynamic_cast<JackMidiDriver*>(m_pMidiDriver) != nullptr ) {
+		sMidiInputDriver = "JACK";
+#endif
+	}
+		
+	if ( m_pMidiDriverOut == nullptr ) {
+		sMidiOutputDriver = "nullptr";
+#ifdef H2CORE_HAVE_ALSA
+	} else if ( dynamic_cast<AlsaMidiDriver*>(m_pMidiDriverOut) != nullptr ) {
+		sMidiOutputDriver = "ALSA";
+#endif
+#ifdef H2CORE_HAVE_PORTMIDI
+	} else if ( dynamic_cast<PortMidiDriver*>(m_pMidiDriverOut) != nullptr ) {
+		sMidiOutputDriver = "PortMidi";
+#endif
+#ifdef H2CORE_HAVE_COREMIDI
+	} else if ( dynamic_cast<CoreMidiDriver*>(m_pMidiDriverOut) != nullptr ) {
+		sMidiOutputDriver = "CoreMidi";
+#endif
+#ifdef H2CORE_HAVE_JACK
+	} else if ( dynamic_cast<JackMidiDriver*>(m_pMidiDriverOut) != nullptr ) {
+		sMidiOutputDriver = "JACK";
+#endif
+	}
+	
+	auto res = QString( "%1|" ).arg( sAudioDriver );
+	if ( sMidiInputDriver == sMidiOutputDriver ) {
+		res.append( QString( "%1" ).arg( sMidiInputDriver ) );
+	} else {
+		res.append( QString( "in: %1;out: %2" ).arg( sMidiInputDriver )
+					.arg( sMidiOutputDriver ) );
+	}
+
+	return std::move( res );
 }
 
 void AudioEngineLocking::assertAudioEngineLocked() const 

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -592,6 +592,8 @@ private:
 	 */
 	void handleSongModeChanged();
 
+	QString getDriverNames() const;
+
 	Sampler* 			m_pSampler;
 	Synth* 				m_pSynth;
 	AudioOutput *		m_pAudioDriver;


### PR DESCRIPTION
Since I tweaked the issue template and it is asking the user to attach a log as well as provided a description in the Wiki, we have a lot more error logs in new issues. Which is definitely good. Still, they could be more expressive.

With this patch the audio and MIDI drivers used are added to all log messages of the AudioEngine. This might help us interpreting them and spotting errors more easily.

Logs do now look like

> (I) AudioEngine::createAudioDriver [nullptr|nullptr] Creating driver [PortAudio]
> ...
> (I) AudioEngine::startPlayback [PortAudio|PortMidi]