### PR TITLE
Fix missing include QFileDialog

### DIFF
--- a/src/gui/src/Widgets/FileDialog.h
+++ b/src/gui/src/Widgets/FileDialog.h
@@ -23,6 +23,7 @@
 #define FILEDIALOG_H
 
 #include <QDialog>
+#include <QFileDialog>
 #include <core/Object.h>
 
 /** Custom file dialog checking whether the user has write access to


### PR DESCRIPTION
This include was necessary but was missed because precompiled header usage masked the problem.