### PR TITLE
Render song editor background grid with dotted lines.

### DIFF
--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1165,7 +1165,7 @@ void SongEditor::createBackground()
 	}
 
 	p.setPen( QPen( pPref->getColorTheme()->m_songEditor_lineColor, 1,
-					Qt::SolidLine ) );
+					Qt::DotLine ) );
 
 	// vertical lines
 	for ( float ii = 0; ii <= nMaxPatternSequence + 1; ii++) {


### PR DESCRIPTION
This makes it easier to see the active cells and song structure, and should be easier on the eyes, reducing "grid illusions".

![image](https://github.com/hydrogen-music/hydrogen/assets/768466/721f55da-03c6-434c-bf9d-0a1f540c9448)
