### PR TITLE
CLEAR_PATTERN and CLEAR_INSTRUMENT commands + consistent note handling

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -590,10 +590,10 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portaudio
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libwinpthread-git
+          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
           c:\msys64\usr\bin\pacman --noconfirm -S -y -q %MSYS_REPO%-ladspa-sdk
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-liblo
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -63,6 +63,7 @@ environment:
       job_group: 'Windows'
       MSYS: 'C:\msys64\mingw64'
       MSYS_REPO: 'mingw64/mingw-w64-x86_64'
+      PACKAGE_PREFIX: 'mingw-w64-x86_64'
       BUILD_TYPE: "Release"
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
       appveyor_build_worker_image: Visual Studio 2019
@@ -73,6 +74,7 @@ environment:
       job_group: 'Windows'
       MSYS: 'C:\msys64\mingw32'
       MSYS_REPO: 'mingw32/mingw-w64-i686'
+      PACKAGE_PREFIX: 'mingw-w64-i686'
       BUILD_TYPE: "Release"
       CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
       appveyor_build_worker_image: Visual Studio 2019
@@ -593,8 +595,8 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-liblo
-          c:\msys64\usr\bin\pacman --noconfirm --assume-installed mingw-w64-x86_64-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
-          c:\msys64\usr\bin\pacman --noconfirm --assume-installed mingw-w64-x86_64-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
+          c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
+          c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
 
           ccache -M 256M
           ccache -s

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,9 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- `CLEAR_INSTRUMENT` - to remove all notes of the selected pattern
 				  associated with the provided instrument number.
 				- `CLEAR_PATTERN` - to remove all notes of the selected pattern.
+		- OSC commands
+				- `NOTE_ON` and `NOTE_OFF` which are handled like incoming MIDI events
+				  without triggering their associated actions.
 	* Changed
 		- Grid lines in the Song Editor are now rendered dotted to emphasize that
 			this is the space the patterns in rather than objects in their own right.

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix persistent of hihat pressure group settings while changing/restarting
 			MIDI drivers.
 		- Fix mapping of `NOTE_OFF` MIDI messages in hihat pressure groups.
+		- Fix segfault when using MIDI sense button in table of Preferences > MIDI
+			after removing rows above it from the table.
 
 2024-01-12 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix build failure without precompiled headers (e.g. on Gentoo) (#1944)
 		- Fix persistent of hihat pressure group settings while changing/restarting
 			MIDI drivers.
+		- Fix mapping of `NOTE_OFF` MIDI messages in hihat pressure groups.
 
 2024-01-12 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4
+	* Added
+		- MIDI and OSC commands
+				- `CLEAR_INSTRUMENT` - to remove all notes of the selected pattern
+				  associated with the provided instrument number.
+				- `CLEAR_PATTERN` - to remove all notes of the selected pattern.
 	* Changed
 		- Grid lines in the Song Editor are now rendered dotted to emphasize that
 			this is the space the patterns in rather than objects in their own right.

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix potential segfault on ill-formated notes in .h2song files.
 		- Fix buzzing sound during startup when using Port Audio (#1932).
 		- Fix build failure without precompiled headers (e.g. on Gentoo) (#1944)
+		- Fix persistent of hihat pressure group settings while changing/restarting
+			MIDI drivers.
 
 2024-01-12 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,12 +2,14 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4
 	* Added
 		- MIDI and OSC commands
-				- `CLEAR_INSTRUMENT` - to remove all notes of the selected pattern
-				  associated with the provided instrument number.
+				- `CLEAR_SELECTED_INSTRUMENT` - to remove all notes of the selected
+				  pattern associated with the currently selected instrument.
 				- `CLEAR_PATTERN` - to remove all notes of the selected pattern.
 		- OSC commands
 				- `NOTE_ON` and `NOTE_OFF` which are handled like incoming MIDI events
 				  without triggering their associated actions.
+				- `CLEAR_INSTRUMENT` - to remove all notes of the selected pattern
+ 				  associated with the provided instrument number.
 	* Changed
 		- Grid lines in the Song Editor are now rendered dotted to emphasize that
 			this is the space the patterns in rather than objects in their own right.

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,9 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Changed
 		- Grid lines in the Song Editor are now rendered dotted to emphasize that
 			this is the space the patterns in rather than objects in their own right.
+		- Virtual keyboard strokes are now mapped exactly as incoming MIDI `NOTE_ON`
+			events (respecting both "Use output note as input note" and hihat pressure
+			groups). But do not trigger associated actions (#1770).
 	* Fixed
 		- Fix potential segfault on ill-formated notes in .h2song files.
 		- Fix buzzing sound during startup when using Port Audio (#1932).

--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -36,6 +36,7 @@
 #include <core/Basics/InstrumentList.h>
 #include <core/Basics/InstrumentComponent.h>
 #include <core/Basics/InstrumentLayer.h>
+#include <core/IO/MidiCommon.h>
 #include <core/Sampler/Sampler.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
@@ -56,7 +57,7 @@ Instrument::Instrument( const int id, const QString& name, std::shared_ptr<ADSR>
 	, __filter_resonance( 0.0 )
 	, __pitch_offset( 0.0 )
 	, __random_pitch_factor( 0.0 )
-	, __midi_out_note( 36 + id )
+	, __midi_out_note( MidiMessage::instrumentOffset + id )
 	, __midi_out_channel( -1 )
 	, __stop_notes( false )
 	, __sample_selection_alg( VELOCITY )

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -28,6 +28,7 @@
 #include <core/Basics/Sample.h>
 
 #include <core/Helpers/Xml.h>
+#include <core/IO/MidiCommon.h>
 #include <core/License.h>
 
 #include <set>
@@ -350,7 +351,7 @@ bool InstrumentList::has_all_midi_notes_same() const
 void InstrumentList::set_default_midi_out_notes()
 {
 	for( int i=0; i<__instruments.size(); i++ ) {
-		__instruments[i]->set_midi_out_note( i + 36 );
+		__instruments[i]->set_midi_out_note( i + MidiMessage::instrumentOffset );
 	}
 }
 

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -29,6 +29,8 @@
 #include <core/Basics/Instrument.h>
 #include <core/Basics/Sample.h>
 
+#include <core/IO/MidiCommon.h>
+
 #define KEY_MIN                 0
 #define KEY_MAX                 11
 #define OCTAVE_MIN              -3
@@ -46,9 +48,6 @@
 #define PAN_MAX                 0.5f
 #define LEAD_LAG_MIN            -1.0f
 #define LEAD_LAG_MAX            1.0f
-
-/* Should equal (default __octave + OCTAVE_OFFSET) * KEYS_PER_OCTAVE + default __key */
-#define MIDI_DEFAULT_OFFSET     36
 
 namespace H2Core
 {
@@ -684,7 +683,8 @@ inline int Note::get_midi_key() const
 	/* TODO ???
 	if( !has_instrument() ) { return (__octave + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE + __key; }
 	*/
-	return ( __octave + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE + __key + __instrument->get_midi_out_note() - MIDI_DEFAULT_OFFSET;
+	return ( __octave + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE + __key +
+		__instrument->get_midi_out_note() - MidiMessage::instrumentOffset;
 }
 
 inline int Note::get_midi_velocity() const

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1748,14 +1748,10 @@ bool CoreActionController::handleNote( int nNote, float fVelocity ) {
 		}
 	}
 
-	auto pMidiInput = pHydrogen->getMidiInput();
-	int nHihatOpenness = 127;
-	if ( pMidiInput != nullptr ) {
-		nHihatOpenness = pMidiInput->getHihatOpenness();
-	}
 
 	// Only look to change instrument if the current note is actually of hihat
 	// and hihat openness is outside the instrument selected
+	const int nHihatOpenness = pHydrogen->getHihatOpenness();
 	if ( pInstrument != nullptr &&
 		 pInstrument->get_hihat_grp() >= 0 &&
 		 ( nHihatOpenness < pInstrument->get_lower_cc() ||

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -407,9 +407,10 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * @param nNote determines which note will be triggered and is defined
 		 *   between [36,127] inspired by the General MIDI standard.
 		 * @param fVelocity how "hard" the note was triggered.
+		 * @param bNoteOff whether note should trigger or stop sound.
 		 *
 		 * @return bool true on success */
-		bool handleNote( int nNote, float fVelocity );
+		bool handleNote( int nNote, float fVelocity, bool bNoteOff = false );
 
 	/**
 	 * In case a different preferences file was loaded with Hydrogen

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -401,6 +401,16 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 */
     	bool toggleGridCell( int nColumn, int nRow );
 
+		/** Handle an incoming note event, e.g. a MIDI or OSC NOTE_ON or
+		 * NOTE_OFF as well as virtual keyboard stroke.
+		 *
+		 * @param nNote determines which note will be triggered and is defined
+		 *   between [36,127] inspired by the General MIDI standard.
+		 * @param fVelocity how "hard" the note was triggered.
+		 *
+		 * @return bool true on success */
+		bool handleNote( int nNote, float fVelocity );
+
 	/**
 	 * In case a different preferences file was loaded with Hydrogen
 	 * already fully set up this function refreshes all corresponding

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -354,7 +354,7 @@ void Hydrogen::midi_noteOn( Note *note )
 	m_pAudioEngine->noteOn( note );
 }
 
-void Hydrogen::addRealtimeNote(	int		nInstrument,
+bool Hydrogen::addRealtimeNote(	int		nInstrument,
 								float	fVelocity,
 								bool	bNoteOff,
 								int		nNote )
@@ -374,7 +374,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 
 	if ( pSong == nullptr ) {
 		ERRORLOG( "No song set yet" );
-		return;
+		return false;
 	}
 
 	m_pAudioEngine->lock( RIGHT_HERE );
@@ -385,7 +385,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 			ERRORLOG( QString( "Provided instrument [%1] not found" )
 					  .arg( nInstrument ) );
 			pAudioEngine->unlock();
-			return;
+			return false;
 		}
 	}
 
@@ -408,7 +408,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 			ERRORLOG( QString( "Provided column [%1] out of bound [%2,%3)" )
 					  .arg( nColumn ).arg( 0 )
 					  .arg( pColumns->size() ) );
-			return;
+			return false;
 		}
 		// Locate nTickInPattern -- may need to jump back one column
 		nTickInPattern = pAudioEngine->getTransportPosition()->getPatternTickPosition();
@@ -442,7 +442,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 		if ( ! pCurrentPattern ) {
 			ERRORLOG( "Current pattern invalid" );
 			pAudioEngine->unlock(); // unlock the audio engine
-			return;
+			return false;
 		}
 
 		// Locate nTickInPattern -- may need to wrap around end of pattern
@@ -474,7 +474,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 				  .arg( nInstrumentNumber )
 				  .arg( bPlaySelectedInstrument ) );
 		pAudioEngine->unlock();
-		return;
+		return false;
 	}
 
 	// Record note
@@ -557,7 +557,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 	// Play back the note.
 	if ( ! pInstr->hasSamples() ) {
 		pAudioEngine->unlock();
-		return;
+		return true;
 	}
 	
 	if ( bPlaySelectedInstrument ) {
@@ -592,6 +592,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 	}
 
 	m_pAudioEngine->unlock(); // unlock the audio engine
+	return true;
 }
 
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -356,7 +356,6 @@ void Hydrogen::midi_noteOn( Note *note )
 
 void Hydrogen::addRealtimeNote(	int		nInstrument,
 								float	fVelocity,
-								float	fPan,
 								bool	bNoteOff,
 								int		nNote )
 {
@@ -393,6 +392,7 @@ void Hydrogen::addRealtimeNote(	int		nInstrument,
 	// Get current pattern and column
 	const Pattern* pCurrentPattern = nullptr;
 	long nTickInPattern = 0;
+	const float fPan = 0;
 
 	bool doRecord = pPref->getRecordEvents();
 	if ( getMode() == Song::Mode::Song && doRecord &&

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -114,6 +114,7 @@ Hydrogen::Hydrogen() : m_nSelectedInstrumentNumber( 0 )
 					 , m_nLastRecordedMIDINoteTick( 0 )
 					 , m_bSessionDrumkitNeedsRelinking( false )
 					 , m_bSessionIsExported( false )
+					 , m_nHihatOpenness( 127 )
 {
 	if ( __instance ) {
 		ERRORLOG( "Hydrogen audio engine is already running" );
@@ -1719,9 +1720,12 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 		sOutput.append( QString( "%1%2lastMidiEvent: %3\n" ).arg( sPrefix ).arg( s )
 						.arg( MidiMessage::EventToQString( m_lastMidiEvent ) ) )
 			.append( QString( "%1%2lastMidiEventParameter: %3\n" ).arg( sPrefix ).arg( s ).arg( m_nLastMidiEventParameter ) )
+			.append( QString( "%1%2m_nHihatOpenness: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_nHihatOpenness ) )
 			.append( QString( "%1%2m_nInstrumentLookupTable: [ %3 ... %4 ]\n" ).arg( sPrefix ).arg( s )
 					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS -1 ] ) );
-	} else {
+	}
+	else {
 		
 		sOutput = QString( "%1[Hydrogen]" ).arg( sPrefix )
 			.append( QString( ", __song: " ) );
@@ -1771,7 +1775,9 @@ QString Hydrogen::toQString( const QString& sPrefix, bool bShort ) const {
 		}
 		sOutput.append( QString( ", lastMidiEvent: %1" )
 						.arg( MidiMessage::EventToQString( m_lastMidiEvent ) ) )
-			.append( QString( ", lastMidiEventParameter: %1" ).arg( m_nLastMidiEventParameter ) )
+			.append( QString( ", lastMidiEventParameter: %1" )
+					 .arg( m_nLastMidiEventParameter ) )
+			.append( QString( ", m_nHihatOpenness: %1" ).arg( m_nHihatOpenness ) )
 			.append( QString( ", m_nInstrumentLookupTable: [ %1 ... %2 ]" )
 					 .arg( m_nInstrumentLookupTable[ 0 ] ).arg( m_nInstrumentLookupTable[ MAX_INSTRUMENTS -1 ] ) );
 	}

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -192,7 +192,7 @@ public:
 
 	void updateSongSize();
 
-		void			addRealtimeNote ( int instrument,
+		bool			addRealtimeNote ( int instrument,
 							  float velocity,
 							  bool noteoff=false,
 							  int msg1=0 );

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -197,6 +197,9 @@ public:
 							  bool noteoff=false,
 							  int msg1=0 );
 
+		int getHihatOpenness() const;
+		void setHihatOpenness( int nValue );
+
 		void			restartDrivers();
 
 		AudioOutput*		getAudioOutput() const;
@@ -598,6 +601,9 @@ private:
 
 	SoundLibraryDatabase* m_pSoundLibraryDatabase;
 
+		/** Controls the instrument selection within a hihat group. */
+		int m_nHihatOpenness;
+
 	/** 
 	 * Constructor, entry point, and initialization of the
 	 * Hydrogen application.
@@ -688,6 +694,12 @@ inline int Hydrogen::getLastMidiEventParameter() const {
 }
 inline void	Hydrogen::setLastMidiEventParameter( int nParam ) {
 	m_nLastMidiEventParameter = nParam;
+}
+inline int Hydrogen::getHihatOpenness() const {
+	return m_nHihatOpenness;
+}
+inline void Hydrogen::setHihatOpenness( int nValue ) {
+	m_nHihatOpenness = std::clamp( nValue, 0, 127 );
 }
 };
 

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -194,7 +194,6 @@ public:
 
 		void			addRealtimeNote ( int instrument,
 							  float velocity,
-							  float fPan = 0.0f,
 							  bool noteoff=false,
 							  int msg1=0 );
 

--- a/src/core/IO/MidiCommon.h
+++ b/src/core/IO/MidiCommon.h
@@ -84,6 +84,12 @@ public:
 	 * #Event. */
 	static QStringList getEventList();
 
+		/** When recording notes using MIDI NOTE_ON events this offset will be
+		 * applied to the provided pitch in order to map it to an instrument
+		 * number in the current drmmkit. It corresponds to the electric bass
+		 * drum in the General MIDI notation. */
+		static constexpr int instrumentOffset = 36;
+
 	MidiMessageType m_type;
 	int m_nData1;
 	int m_nData2;

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -234,7 +234,7 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 		return;
 	}
 
-	pHydrogen->getCoreActionController()->handleNote( nNote, fVelocity );
+	pHydrogen->getCoreActionController()->handleNote( nNote, fVelocity, false );
 }
 
 /*
@@ -256,37 +256,8 @@ void MidiInput::handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke )
 		return;
 	}
 
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
-	auto pInstrList = pHydrogen->getSong()->getInstrumentList();
-
-	int nNote = msg.m_nData1;
-	int nInstrument = nNote - MidiMessage::instrumentOffset;
-	std::shared_ptr<Instrument> pInstr = nullptr;
-
-	if ( Preferences::get_instance()->__playselectedinstrument ){
-		nInstrument = pHydrogen->getSelectedInstrumentNumber();
-		pInstr = pInstrList->get( pHydrogen->getSelectedInstrumentNumber());
-	}
-	else if( Preferences::get_instance()->m_bMidiFixedMapping ) {
-		pInstr = pInstrList->findMidiNote( nNote );
-		nInstrument = pInstrList->index( pInstr );
-	}
-	else {
-		if( nInstrument < 0 || nInstrument >= pInstrList->size()) {
-			WARNINGLOG( QString( "Instrument number [%1] - derived from note [%2] - out of bound note [%3,%4]" )
-						.arg( nInstrument ).arg( nNote )
-						.arg( 0 ).arg( pInstrList->size() ) );
-			return;
-		}
-		pInstr = pInstrList->get( nInstrument );
-	}
-
-	if( pInstr == nullptr ) {
-		WARNINGLOG( QString( "Can't find corresponding Instrument for note %1" ).arg( nNote ));
-		return;
-	}
-
-	Hydrogen::get_instance()->addRealtimeNote( nInstrument, 0.0, true, nNote );
+	Hydrogen::get_instance()->getCoreActionController()->
+		handleNote( msg.m_nData1, 0.0, true );
 }
 
 void MidiInput::handleSysexMessage( const MidiMessage& msg )

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -235,8 +235,6 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 		return;
 	}
 
-	static const float fPan = 0.f;
-
 	int nInstrument = nNote - 36;
 	auto pInstrList = pHydrogen->getSong()->getInstrumentList();
 	std::shared_ptr<Instrument> pInstr = nullptr;
@@ -287,7 +285,7 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 		}
 	}
 
-	pHydrogen->addRealtimeNote( nInstrument, fVelocity, fPan, false, nNote );
+	pHydrogen->addRealtimeNote( nInstrument, fVelocity, false, nNote );
 }
 
 /*
@@ -339,7 +337,7 @@ void MidiInput::handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke )
 		return;
 	}
 
-	Hydrogen::get_instance()->addRealtimeNote( nInstrument, 0.0, 0.0, true, nNote );
+	Hydrogen::get_instance()->addRealtimeNote( nInstrument, 0.0, true, nNote );
 }
 
 void MidiInput::handleSysexMessage( const MidiMessage& msg )

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -235,7 +235,7 @@ void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
 		return;
 	}
 
-	int nInstrument = nNote - 36;
+	int nInstrument = nNote - MidiMessage::instrumentOffset;
 	auto pInstrList = pHydrogen->getSong()->getInstrumentList();
 	std::shared_ptr<Instrument> pInstr = nullptr;
 		
@@ -311,7 +311,7 @@ void MidiInput::handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke )
 	auto pInstrList = pHydrogen->getSong()->getInstrumentList();
 
 	int nNote = msg.m_nData1;
-	int nInstrument = nNote - 36;
+	int nInstrument = nNote - MidiMessage::instrumentOffset;
 	std::shared_ptr<Instrument> pInstr = nullptr;
 
 	if ( Preferences::get_instance()->__playselectedinstrument ){

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -37,7 +37,6 @@ namespace H2Core
 
 MidiInput::MidiInput()
 		: m_bActive( false )
-		, m_nHihatOpenness ( 127 )
 {
 	//
 
@@ -175,7 +174,7 @@ void MidiInput::handleControlChangeMessage( const MidiMessage& msg )
 	}
 
 	if ( msg.m_nData1 == 04 ) {
-		m_nHihatOpenness = msg.m_nData2;
+		pHydrogen->setHihatOpenness( msg.m_nData2 );
 	}
 
 	pHydrogen->setLastMidiEvent( MidiMessage::Event::CC );

--- a/src/core/IO/MidiInput.h
+++ b/src/core/IO/MidiInput.h
@@ -55,19 +55,11 @@ public:
 	void handleProgramChangeMessage( const MidiMessage& msg );
 	void handlePolyphonicKeyPressureMessage( const MidiMessage& msg );
 
-		int getHihatOpenness() const {
-			return m_nHihatOpenness;
-		};
-
 protected:
 	bool m_bActive;
 
 	void handleNoteOnMessage( const MidiMessage& msg );
 	void handleNoteOffMessage( const MidiMessage& msg, bool CymbalChoke );
-
-
-private:
-	int m_nHihatOpenness;
 };
 
 };

--- a/src/core/IO/MidiInput.h
+++ b/src/core/IO/MidiInput.h
@@ -55,6 +55,10 @@ public:
 	void handleProgramChangeMessage( const MidiMessage& msg );
 	void handlePolyphonicKeyPressureMessage( const MidiMessage& msg );
 
+		int getHihatOpenness() const {
+			return m_nHihatOpenness;
+		};
+
 protected:
 	bool m_bActive;
 
@@ -63,7 +67,7 @@ protected:
 
 
 private:
-	int __hihat_cc_openess;
+	int m_nHihatOpenness;
 };
 
 };

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -1256,8 +1256,14 @@ bool MidiActionManager::clear_instrument( std::shared_ptr<Action> pAction,
 	int nInstrumentNumber = pAction->getValue().toInt(&ok,10) ;
 
 	if ( pSong->getInstrumentList()->size() < nInstrumentNumber ) {
+		WARNINGLOG( QString( "Provided instrument number [%1] out of bound. Set to maximum allowed value [%2]" )
+					.arg( nInstrumentNumber )
+					.arg( pSong->getInstrumentList()->size() - 1 ) );
 		nInstrumentNumber = pSong->getInstrumentList()->size() -1;
-	} else if ( nInstrumentNumber < 0 ) {
+	}
+	else if ( nInstrumentNumber < 0 ) {
+		WARNINGLOG( QString( "Provided instrument number [%1] out of bound. Set to minimum allowed value [%2]" )
+					.arg( nInstrumentNumber ).arg( 0 ) );
 		nInstrumentNumber = 0;
 	}
 

--- a/src/core/MidiAction.cpp
+++ b/src/core/MidiAction.cpp
@@ -192,8 +192,8 @@ MidiActionManager::MidiActionManager() {
 	m_actionMap.insert(std::make_pair("SELECT_INSTRUMENT", std::make_pair( &MidiActionManager::select_instrument, 0 ) ));
 	m_actionMap.insert(std::make_pair("UNDO_ACTION", std::make_pair( &MidiActionManager::undo_action, 0 ) ));
 	m_actionMap.insert(std::make_pair("REDO_ACTION", std::make_pair( &MidiActionManager::redo_action, 0 ) ));
-	m_actionMap.insert(std::make_pair("CLEAR_INSTRUMENT", std::make_pair(
-										  &MidiActionManager::clear_instrument, 0 ) ));
+	m_actionMap.insert(std::make_pair("CLEAR_SELECTED_INSTRUMENT", std::make_pair(
+										  &MidiActionManager::clear_selected_instrument, 0 ) ));
 	m_actionMap.insert(std::make_pair("CLEAR_PATTERN", std::make_pair(
 										  &MidiActionManager::clear_pattern, 0 ) ));
 	/*
@@ -1244,33 +1244,21 @@ int MidiActionManager::getParameterNumber( const QString& sActionType ) const {
 	return -1;
 }
 
-bool MidiActionManager::clear_instrument( std::shared_ptr<Action> pAction,
-										  Hydrogen* pHydrogen ) {
+bool MidiActionManager::clear_selected_instrument( std::shared_ptr<Action> pAction,
+												   Hydrogen* pHydrogen ) {
 	auto pSong = pHydrogen->getSong();
 	if ( pSong == nullptr ) {
 		ERRORLOG( "no song set" );
 		return false;
 	}
 
-	bool ok;
-	int nInstrumentNumber = pAction->getValue().toInt(&ok,10) ;
-
-	if ( pSong->getInstrumentList()->size() < nInstrumentNumber ) {
-		WARNINGLOG( QString( "Provided instrument number [%1] out of bound. Set to maximum allowed value [%2]" )
-					.arg( nInstrumentNumber )
-					.arg( pSong->getInstrumentList()->size() - 1 ) );
-		nInstrumentNumber = pSong->getInstrumentList()->size() -1;
-	}
-	else if ( nInstrumentNumber < 0 ) {
-		WARNINGLOG( QString( "Provided instrument number [%1] out of bound. Set to minimum allowed value [%2]" )
-					.arg( nInstrumentNumber ).arg( 0 ) );
-		nInstrumentNumber = 0;
+	const int nInstr = pHydrogen->getSelectedInstrumentNumber();
+	if ( nInstr == -1 ) {
+		WARNINGLOG( "No instrument selected" );
+		return false;
 	}
 
-	pHydrogen->setSelectedInstrumentNumber( nInstrumentNumber );
-
-	return pHydrogen->getCoreActionController()->
-		clearInstrumentInPattern( nInstrumentNumber );
+	return pHydrogen->getCoreActionController()->clearInstrumentInPattern( nInstr );
 }
 
 bool MidiActionManager::clear_pattern( std::shared_ptr<Action> pAction,

--- a/src/core/MidiAction.h
+++ b/src/core/MidiAction.h
@@ -212,7 +212,7 @@ class MidiActionManager : public H2Core::Object<MidiActionManager>
 		bool redo_action(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool gain_level_absolute(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool pitch_level_absolute(std::shared_ptr<Action> , H2Core::Hydrogen * );
-		bool clear_instrument(std::shared_ptr<Action> , H2Core::Hydrogen * );
+		bool clear_selected_instrument(std::shared_ptr<Action> , H2Core::Hydrogen * );
 		bool clear_pattern(std::shared_ptr<Action> , H2Core::Hydrogen * );
 
 		int m_nLastBpmChangeCCParameter;

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -991,6 +991,21 @@ void OscServer::REMOVE_PATTERN_Handler(lo_arg **argv, int argc) {
 	pController->removePattern( static_cast<int>(std::round( argv[0]->f )) );
 }
 
+void OscServer::CLEAR_INSTRUMENT_Handler(lo_arg **argv,int i)
+{
+	INFOLOG( "processing message" );
+	H2Core::Hydrogen::get_instance()->getCoreActionController()
+		->clearInstrumentInPattern( static_cast<int>(std::round( argv[0]->f )) );
+}
+
+void OscServer::CLEAR_PATTERN_Handler( lo_arg **argv, int i )
+{
+	INFOLOG( "processing message" );
+	std::shared_ptr<Action> pAction = std::make_shared<Action>( "CLEAR_PATTERN" );
+	MidiActionManager::get_instance()->handleAction( pAction );
+}
+
+
 void OscServer::SONG_EDITOR_TOGGLE_GRID_CELL_Handler(lo_arg **argv, int argc) {
 	INFOLOG( "processing message" );
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
@@ -1347,6 +1362,9 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/NEW_PATTERN", "s", NEW_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/OPEN_PATTERN", "s", OPEN_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/REMOVE_PATTERN", "f", REMOVE_PATTERN_Handler);
+	m_pServerThread->add_method("/Hydrogen/CLEAR_INSTRUMENT", "f", CLEAR_INSTRUMENT_Handler);
+	m_pServerThread->add_method("/Hydrogen/CLEAR_PATTERN", "", CLEAR_PATTERN_Handler);
+	m_pServerThread->add_method("/Hydrogen/CLEAR_PATTERN", "f", CLEAR_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/SONG_EDITOR_TOGGLE_GRID_CELL", "ff", SONG_EDITOR_TOGGLE_GRID_CELL_Handler);
 	m_pServerThread->add_method("/Hydrogen/LOAD_DRUMKIT", "s", LOAD_DRUMKIT_Handler);
 	m_pServerThread->add_method("/Hydrogen/LOAD_DRUMKIT", "sf", LOAD_DRUMKIT_Handler);

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -992,6 +992,19 @@ void OscServer::REMOVE_PATTERN_Handler(lo_arg **argv, int argc) {
 	pController->removePattern( static_cast<int>(std::round( argv[0]->f )) );
 }
 
+void OscServer::CLEAR_SELECTED_INSTRUMENT_Handler(lo_arg **argv,int i)
+{
+	INFOLOG( "processing message" );
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	const int nInstr = pHydrogen->getSelectedInstrumentNumber();
+	if ( nInstr == -1 ) {
+		WARNINGLOG( "No instrument selected" );
+		return;
+	}
+
+	pHydrogen->getCoreActionController()->clearInstrumentInPattern( nInstr );
+}
+
 void OscServer::CLEAR_INSTRUMENT_Handler(lo_arg **argv,int i)
 {
 	INFOLOG( "processing message" );
@@ -1406,6 +1419,10 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/OPEN_PATTERN", "s", OPEN_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/REMOVE_PATTERN", "f", REMOVE_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/CLEAR_INSTRUMENT", "f", CLEAR_INSTRUMENT_Handler);
+	m_pServerThread->add_method("/Hydrogen/CLEAR_SELECTED_INSTRUMENT", "",
+								CLEAR_SELECTED_INSTRUMENT_Handler);
+	m_pServerThread->add_method("/Hydrogen/CLEAR_SELECTED_INSTRUMENT", "f",
+								CLEAR_SELECTED_INSTRUMENT_Handler);
 	m_pServerThread->add_method("/Hydrogen/CLEAR_PATTERN", "", CLEAR_PATTERN_Handler);
 	m_pServerThread->add_method("/Hydrogen/CLEAR_PATTERN", "f", CLEAR_PATTERN_Handler);
 

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -744,6 +744,26 @@ class OscServer : public H2Core::Object<OscServer>
 		 */
 		static void REMOVE_PATTERN_Handler(lo_arg **argv, int argc);
 		/**
+		 * The handler expects the user to provide the number of the instrument
+		 * for which all notes should be removed from the currently selected
+		 * pattern.
+		 *
+		 * \param argv The "f" field does contain the instrument number
+		 * (caution: it starts at 0).
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void CLEAR_INSTRUMENT_Handler(lo_arg **argv, int argc);
+		/**
+		 * The handler removes all notes from the the currently selected
+		 * pattern.
+		 *
+		 * \param argv The "f" field does contain the instrument number
+		 * (caution: it starts at 0).
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void CLEAR_PATTERN_Handler(lo_arg **argv, int argc);
+
+		/**
 		 * Triggers CoreActionController::songEditorToggleGridCell().
 		 *
 		 * The handler expects the user to provide the pattern number

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -764,6 +764,28 @@ class OscServer : public H2Core::Object<OscServer>
 		static void CLEAR_PATTERN_Handler(lo_arg **argv, int argc);
 
 		/**
+		 * Provides a similar behavior as a NOTE_ON MIDI message.
+		 *
+		 * \param argv The first "f" holds the note. It is designed after the
+		 *   MIDI NOTE_ON handling and expects an integer between 36 and 127
+		 *   (inspired by the General MIDI standard).
+		 *   The second "f" field contains the velocity of the new note within
+		 *   the range of [0, 1.0]
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void NOTE_ON_Handler(lo_arg **argv, int argc);
+
+		/**
+		 * Provides a similar behavior as a NOTE_OFF MIDI message.
+		 *
+		 * \param argv The "f" field holds the note. It is designed after the
+		 *   MIDI NOTE_ON handling and expects an integer between 36 and 127
+		 *   (inspired by the General MIDI standard).
+		 * \param argc Number of arguments passed by the OSC message.
+		 */
+		static void NOTE_OFF_Handler(lo_arg **argv, int argc);
+
+		/**
 		 * Triggers CoreActionController::songEditorToggleGridCell().
 		 *
 		 * The handler expects the user to provide the pattern number

--- a/src/core/OscServer.h
+++ b/src/core/OscServer.h
@@ -743,6 +743,7 @@ class OscServer : public H2Core::Object<OscServer>
 		 * \param argc Number of arguments passed by the OSC message.
 		 */
 		static void REMOVE_PATTERN_Handler(lo_arg **argv, int argc);
+		static void CLEAR_SELECTED_INSTRUMENT_Handler(lo_arg **argv, int argc);
 		/**
 		 * The handler expects the user to provide the number of the instrument
 		 * for which all notes should be removed from the currently selected

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -35,6 +35,7 @@
 #include <core/Basics/DrumkitComponent.h>
 #include <core/Basics/Playlist.h>
 #include <core/Lilipond/Lilypond.h>
+#include <core/IO/MidiCommon.h>
 #include <core/NsmClient.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
@@ -1958,7 +1959,8 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 
 				float velocity = 0.8;
 
-				pHydrogen->addRealtimeNote( row, velocity, false, row + 36 );
+				pHydrogen->addRealtimeNote( row, velocity, false,
+											row + MidiMessage::instrumentOffset );
 
 				return true; // eat event
 			}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1707,7 +1707,10 @@ void MainForm::initKeyInstMap()
 {
 
 	QString loc = QLocale::system().name();
-	int instr = 0;
+
+	// Mimics a MIDI NOTE_ON event which has pitch values between
+	// MidiMessage::instrumentOffset and 127.
+	int nNote = MidiMessage::instrumentOffset;
 
 	///POSIX Locale
 	//locale for keyboardlayout QWERTZ
@@ -1720,85 +1723,85 @@ void MainForm::initKeyInstMap()
 	// en_GB, en_US, en_ZA, usw.
 
 	if ( loc.contains( "de" ) || loc.contains( "DE" )){ ///QWERTZ
-		keycodeInstrumentMap[Qt::Key_Y] = instr++;
-		keycodeInstrumentMap[Qt::Key_S] = instr++;
-		keycodeInstrumentMap[Qt::Key_X] = instr++;
-		keycodeInstrumentMap[Qt::Key_D] = instr++;
-		keycodeInstrumentMap[Qt::Key_C] = instr++;
-		keycodeInstrumentMap[Qt::Key_V] = instr++;
-		keycodeInstrumentMap[Qt::Key_G] = instr++;
-		keycodeInstrumentMap[Qt::Key_B] = instr++;
-		keycodeInstrumentMap[Qt::Key_H] = instr++;
-		keycodeInstrumentMap[Qt::Key_N] = instr++;
-		keycodeInstrumentMap[Qt::Key_J] = instr++;
-		keycodeInstrumentMap[Qt::Key_M] = instr++;
+		keycodeInstrumentMap[Qt::Key_Y] = nNote++;
+		keycodeInstrumentMap[Qt::Key_S] = nNote++;
+		keycodeInstrumentMap[Qt::Key_X] = nNote++;
+		keycodeInstrumentMap[Qt::Key_D] = nNote++;
+		keycodeInstrumentMap[Qt::Key_C] = nNote++;
+		keycodeInstrumentMap[Qt::Key_V] = nNote++;
+		keycodeInstrumentMap[Qt::Key_G] = nNote++;
+		keycodeInstrumentMap[Qt::Key_B] = nNote++;
+		keycodeInstrumentMap[Qt::Key_H] = nNote++;
+		keycodeInstrumentMap[Qt::Key_N] = nNote++;
+		keycodeInstrumentMap[Qt::Key_J] = nNote++;
+		keycodeInstrumentMap[Qt::Key_M] = nNote++;
 
-		keycodeInstrumentMap[Qt::Key_Q] = instr++;
-		keycodeInstrumentMap[Qt::Key_2] = instr++;
-		keycodeInstrumentMap[Qt::Key_W] = instr++;
-		keycodeInstrumentMap[Qt::Key_3] = instr++;
-		keycodeInstrumentMap[Qt::Key_E] = instr++;
-		keycodeInstrumentMap[Qt::Key_R] = instr++;
-		keycodeInstrumentMap[Qt::Key_5] = instr++;
-		keycodeInstrumentMap[Qt::Key_T] = instr++;
-		keycodeInstrumentMap[Qt::Key_6] = instr++;
-		keycodeInstrumentMap[Qt::Key_Z] = instr++;
-		keycodeInstrumentMap[Qt::Key_7] = instr++;
-		keycodeInstrumentMap[Qt::Key_U] = instr++;
+		keycodeInstrumentMap[Qt::Key_Q] = nNote++;
+		keycodeInstrumentMap[Qt::Key_2] = nNote++;
+		keycodeInstrumentMap[Qt::Key_W] = nNote++;
+		keycodeInstrumentMap[Qt::Key_3] = nNote++;
+		keycodeInstrumentMap[Qt::Key_E] = nNote++;
+		keycodeInstrumentMap[Qt::Key_R] = nNote++;
+		keycodeInstrumentMap[Qt::Key_5] = nNote++;
+		keycodeInstrumentMap[Qt::Key_T] = nNote++;
+		keycodeInstrumentMap[Qt::Key_6] = nNote++;
+		keycodeInstrumentMap[Qt::Key_Z] = nNote++;
+		keycodeInstrumentMap[Qt::Key_7] = nNote++;
+		keycodeInstrumentMap[Qt::Key_U] = nNote++;
 	}
 	else if ( loc.contains( "fr" ) || loc.contains( "FR" )){ ///AZERTY
-		keycodeInstrumentMap[Qt::Key_W] = instr++;
-		keycodeInstrumentMap[Qt::Key_S] = instr++;
-		keycodeInstrumentMap[Qt::Key_X] = instr++;
-		keycodeInstrumentMap[Qt::Key_D] = instr++;
-		keycodeInstrumentMap[Qt::Key_C] = instr++;
-		keycodeInstrumentMap[Qt::Key_V] = instr++;
-		keycodeInstrumentMap[Qt::Key_G] = instr++;
-		keycodeInstrumentMap[Qt::Key_B] = instr++;
-		keycodeInstrumentMap[Qt::Key_H] = instr++;
-		keycodeInstrumentMap[Qt::Key_N] = instr++;
-		keycodeInstrumentMap[Qt::Key_J] = instr++;
-		keycodeInstrumentMap[Qt::Key_Question] = instr++;
+		keycodeInstrumentMap[Qt::Key_W] = nNote++;
+		keycodeInstrumentMap[Qt::Key_S] = nNote++;
+		keycodeInstrumentMap[Qt::Key_X] = nNote++;
+		keycodeInstrumentMap[Qt::Key_D] = nNote++;
+		keycodeInstrumentMap[Qt::Key_C] = nNote++;
+		keycodeInstrumentMap[Qt::Key_V] = nNote++;
+		keycodeInstrumentMap[Qt::Key_G] = nNote++;
+		keycodeInstrumentMap[Qt::Key_B] = nNote++;
+		keycodeInstrumentMap[Qt::Key_H] = nNote++;
+		keycodeInstrumentMap[Qt::Key_N] = nNote++;
+		keycodeInstrumentMap[Qt::Key_J] = nNote++;
+		keycodeInstrumentMap[Qt::Key_Question] = nNote++;
 
-		keycodeInstrumentMap[Qt::Key_A] = instr++;
-		keycodeInstrumentMap[Qt::Key_2] = instr++;
-		keycodeInstrumentMap[Qt::Key_Z] = instr++;
-		keycodeInstrumentMap[Qt::Key_3] = instr++;
-		keycodeInstrumentMap[Qt::Key_E] = instr++;
-		keycodeInstrumentMap[Qt::Key_R] = instr++;
-		keycodeInstrumentMap[Qt::Key_5] = instr++;
-		keycodeInstrumentMap[Qt::Key_T] = instr++;
-		keycodeInstrumentMap[Qt::Key_6] = instr++;
-		keycodeInstrumentMap[Qt::Key_Y] = instr++;
-		keycodeInstrumentMap[Qt::Key_7] = instr++;
-		keycodeInstrumentMap[Qt::Key_U] = instr++;
+		keycodeInstrumentMap[Qt::Key_A] = nNote++;
+		keycodeInstrumentMap[Qt::Key_2] = nNote++;
+		keycodeInstrumentMap[Qt::Key_Z] = nNote++;
+		keycodeInstrumentMap[Qt::Key_3] = nNote++;
+		keycodeInstrumentMap[Qt::Key_E] = nNote++;
+		keycodeInstrumentMap[Qt::Key_R] = nNote++;
+		keycodeInstrumentMap[Qt::Key_5] = nNote++;
+		keycodeInstrumentMap[Qt::Key_T] = nNote++;
+		keycodeInstrumentMap[Qt::Key_6] = nNote++;
+		keycodeInstrumentMap[Qt::Key_Y] = nNote++;
+		keycodeInstrumentMap[Qt::Key_7] = nNote++;
+		keycodeInstrumentMap[Qt::Key_U] = nNote++;
 	}else
 	{ /// default QWERTY
-		keycodeInstrumentMap[Qt::Key_Z] = instr++;
-		keycodeInstrumentMap[Qt::Key_S] = instr++;
-		keycodeInstrumentMap[Qt::Key_X] = instr++;
-		keycodeInstrumentMap[Qt::Key_D] = instr++;
-		keycodeInstrumentMap[Qt::Key_C] = instr++;
-		keycodeInstrumentMap[Qt::Key_V] = instr++;
-		keycodeInstrumentMap[Qt::Key_G] = instr++;
-		keycodeInstrumentMap[Qt::Key_B] = instr++;
-		keycodeInstrumentMap[Qt::Key_H] = instr++;
-		keycodeInstrumentMap[Qt::Key_N] = instr++;
-		keycodeInstrumentMap[Qt::Key_J] = instr++;
-		keycodeInstrumentMap[Qt::Key_M] = instr++;
+		keycodeInstrumentMap[Qt::Key_Z] = nNote++;
+		keycodeInstrumentMap[Qt::Key_S] = nNote++;
+		keycodeInstrumentMap[Qt::Key_X] = nNote++;
+		keycodeInstrumentMap[Qt::Key_D] = nNote++;
+		keycodeInstrumentMap[Qt::Key_C] = nNote++;
+		keycodeInstrumentMap[Qt::Key_V] = nNote++;
+		keycodeInstrumentMap[Qt::Key_G] = nNote++;
+		keycodeInstrumentMap[Qt::Key_B] = nNote++;
+		keycodeInstrumentMap[Qt::Key_H] = nNote++;
+		keycodeInstrumentMap[Qt::Key_N] = nNote++;
+		keycodeInstrumentMap[Qt::Key_J] = nNote++;
+		keycodeInstrumentMap[Qt::Key_M] = nNote++;
 
-		keycodeInstrumentMap[Qt::Key_Q] = instr++;
-		keycodeInstrumentMap[Qt::Key_2] = instr++;
-		keycodeInstrumentMap[Qt::Key_W] = instr++;
-		keycodeInstrumentMap[Qt::Key_3] = instr++;
-		keycodeInstrumentMap[Qt::Key_E] = instr++;
-		keycodeInstrumentMap[Qt::Key_R] = instr++;
-		keycodeInstrumentMap[Qt::Key_5] = instr++;
-		keycodeInstrumentMap[Qt::Key_T] = instr++;
-		keycodeInstrumentMap[Qt::Key_6] = instr++;
-		keycodeInstrumentMap[Qt::Key_Y] = instr++;
-		keycodeInstrumentMap[Qt::Key_7] = instr++;
-		keycodeInstrumentMap[Qt::Key_U] = instr++;
+		keycodeInstrumentMap[Qt::Key_Q] = nNote++;
+		keycodeInstrumentMap[Qt::Key_2] = nNote++;
+		keycodeInstrumentMap[Qt::Key_W] = nNote++;
+		keycodeInstrumentMap[Qt::Key_3] = nNote++;
+		keycodeInstrumentMap[Qt::Key_E] = nNote++;
+		keycodeInstrumentMap[Qt::Key_R] = nNote++;
+		keycodeInstrumentMap[Qt::Key_5] = nNote++;
+		keycodeInstrumentMap[Qt::Key_T] = nNote++;
+		keycodeInstrumentMap[Qt::Key_6] = nNote++;
+		keycodeInstrumentMap[Qt::Key_Y] = nNote++;
+		keycodeInstrumentMap[Qt::Key_7] = nNote++;
+		keycodeInstrumentMap[Qt::Key_U] = nNote++;
 	}
 }
 
@@ -1951,16 +1954,14 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 		// virtual keyboard handling
 		if  ( k->modifiers() == Qt::NoModifier ) {
 			std::map<int,int>::iterator found = keycodeInstrumentMap.find ( k->key() );
-			if (found != keycodeInstrumentMap.end()) {
-				//			INFOLOG( "[eventFilter] virtual keyboard event" );
-				// insert note at the current column in time
-				// if event recording enabled
-				int row = (*found).second;
+			if ( found != keycodeInstrumentMap.end() ) {
+				const int nNote = (*found).second;
 
-				float velocity = 0.8;
+				INFOLOG( QString( "[Virtual Keyboard] triggering note [%1]" )
+						 .arg( nNote ) );
 
-				pHydrogen->addRealtimeNote( row, velocity, false,
-											row + MidiMessage::instrumentOffset );
+				pHydrogen->getCoreActionController()->handleNote(
+					nNote, 0.8, false );
 
 				return true; // eat event
 			}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1958,7 +1958,7 @@ bool MainForm::eventFilter( QObject *o, QEvent *e )
 
 				float velocity = 0.8;
 
-				pHydrogen->addRealtimeNote( row, velocity, 0.f, false, row + 36 );
+				pHydrogen->addRealtimeNote( row, velocity, false, row + 36 );
 
 				return true; // eat event
 			}

--- a/src/gui/src/Widgets/MidiSenseWidget.cpp
+++ b/src/gui/src/Widgets/MidiSenseWidget.cpp
@@ -87,7 +87,6 @@ MidiSenseWidget::MidiSenseWidget(QWidget* pParent, bool bDirectWrite, std::share
 };
 
 MidiSenseWidget::~MidiSenseWidget(){
-	INFOLOG("DESTROY");
 	m_pUpdateTimer->stop();
 }
 

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -67,20 +67,27 @@ MidiTable::~MidiTable()
 	}
 }
 
-void MidiTable::midiSensePressed( int row ){
+void MidiTable::midiSensePressed( int nRow ){
 
-	m_nCurrentMidiAutosenseRow = row;
+	m_nCurrentMidiAutosenseRow = nRow;
 	MidiSenseWidget midiSenseWidget( this );
 	midiSenseWidget.exec();
 
-	LCDCombo * eventCombo =  dynamic_cast <LCDCombo *> ( cellWidget( row, 1 ) );
-	LCDSpinBox * eventSpinner = dynamic_cast <LCDSpinBox *> ( cellWidget( row, 2 ) );
+	LCDCombo* pEventCombo = dynamic_cast<LCDCombo*>( cellWidget( nRow, 1 ) );
+	LCDSpinBox* pEventSpinner = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 2 ) );
+	if ( pEventCombo == nullptr ) {
+		ERRORLOG( QString( "No event combobox in row [%1]" ).arg( nRow ) );
+		return;
+	}
+	if ( pEventSpinner == nullptr ) {
+		ERRORLOG( QString( "No event spinner in row [%1]" ).arg( nRow ) );
+		return;
+	}
 
-
-	eventCombo->setCurrentIndex( eventCombo->findText(
+	pEventCombo->setCurrentIndex( pEventCombo->findText(
 									 H2Core::MidiMessage::EventToQString(
 										 midiSenseWidget.getLastMidiEvent() ) ) );
-	eventSpinner->setValue( midiSenseWidget.getLastMidiEventParameter() );
+	pEventSpinner->setValue( midiSenseWidget.getLastMidiEventParameter() );
 
 	m_pUpdateTimer->start( 100 );
 

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -72,6 +72,10 @@ void MidiTable::midiSensePressed( int nRow ){
 	m_nCurrentMidiAutosenseRow = nRow;
 	MidiSenseWidget midiSenseWidget( this );
 	midiSenseWidget.exec();
+	if ( midiSenseWidget.getLastMidiEvent() == H2Core::MidiMessage::Event::Null ) {
+		// Rejected
+		return;
+	}
 
 	LCDCombo* pEventCombo = dynamic_cast<LCDCombo*>( cellWidget( nRow, 1 ) );
 	LCDSpinBox* pEventSpinner = dynamic_cast<LCDSpinBox*>( cellWidget( nRow, 2 ) );

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -147,14 +147,17 @@ void MidiTable::insertNewRow(std::shared_ptr<Action> pAction, QString eventStrin
 	midiSenseButton->setIconSize( QSize( 13, 13 ) );
 	midiSenseButton->setToolTip( tr("press button to record midi event") );
 
-	QSignalMapper *signalMapper = new QSignalMapper(this);
-
-	connect(midiSenseButton, SIGNAL( clicked()), signalMapper, SLOT( map() ));
-	signalMapper->setMapping( midiSenseButton, oldRowCount );
-	connect( signalMapper, SIGNAL(mapped( int ) ), this, SLOT( midiSensePressed(int) ) );
+	connect( midiSenseButton, &QPushButton::clicked, [=](){
+		for ( int ii = 0; ii < rowCount(); ii++ ) {
+			if ( cellWidget( ii, 0 ) == midiSenseButton ) {
+				midiSensePressed( ii );
+				return;
+			}
+		}
+		ERRORLOG( QString( "Unable to midiSenseButton of initial row [%1] in MidiTable!" )
+				  .arg( oldRowCount ) );
+	});
 	setCellWidget( oldRowCount, 0, midiSenseButton );
-
-
 
 	LCDCombo *eventBox = new LCDCombo(this);
 	eventBox->setSize( QSize( m_nColumn1Width, m_nRowHeight ) );

--- a/src/tests/MidiNoteTest.cpp
+++ b/src/tests/MidiNoteTest.cpp
@@ -25,7 +25,10 @@
 #include <core/Hydrogen.h>
 #include <core/Basics/Instrument.h>
 #include <core/Basics/InstrumentList.h>
+#include <core/Basics/Note.h>
 #include <core/Basics/Song.h>
+
+#include <core/IO/MidiCommon.h>
 
 #include <QFileInfo>
 
@@ -40,6 +43,7 @@ using namespace H2Core;
 
 class MidiNoteTest : public CppUnit::TestCase {
 	CPPUNIT_TEST_SUITE( MidiNoteTest );
+	CPPUNIT_TEST( testDefaultValues );
 	CPPUNIT_TEST( testLoadLegacySong );
 	CPPUNIT_TEST( testLoadNewSong );
 	CPPUNIT_TEST_SUITE_END();
@@ -49,6 +53,13 @@ class MidiNoteTest : public CppUnit::TestCase {
 	void setUp() override
 	{
 		Hydrogen::create_instance();
+	}
+
+	void testDefaultValues() {
+		___INFOLOG( "" );
+		CPPUNIT_ASSERT( ( OCTAVE_DEFAULT + OCTAVE_OFFSET ) * KEYS_PER_OCTAVE ==
+						MidiMessage::instrumentOffset );
+		___INFOLOG( "passed" );
 	}
 
 	void testLoadLegacySong()


### PR DESCRIPTION
As discussed in #1948 new MIDI and OSC commands were introduced
- `CLEAR_INSTRUMENT` - to remove all notes of the selected pattern associated with the provided instrument number.
- `CLEAR_PATTERN` - to remove all notes of the selected pattern.

With these new endpoints it is now possible to properly construct patterns using solely a MIDI devices. Previously, notes could only be added but not deleted.

In addition, we now use a common code basis for mapping incoming notes and instruments. Using this also `NOTE_OFF` MIDI events are properly mapped to hihat pressure groups and notes inserted via the virtual keyboard are now mapped exactly the same as MIDI notes (fixes #1770).

While I was at it I also introduced the OSC commands
- `NOTE_ON`
- `NOTE_OFF`

using which one can now record note in the same way as using the MIDI interface.

 (In case you are wondering why I keep adding more and more OSC endpoints: It is not that I think this protocol will take off at some point. Instead, all those endpoints can be very easily refactored into a HTTP-based REST API. I do not have any plans for writing a new UI. But I try to gradually path the way by moving functionality from the Qt-based GUI into the core and expose them. What I have in mind is a headless Hydrogen version, like our `h2player`, people can run and create/use a web-based UI on top of it. Maybe small and dedicated ones e.g. for live performances, playlist handling, practicing etc).

I also found a segfault in the Preferences > MIDI > `MidiTable` and fixed it.
