### PR TITLE
Preferences: drop restoreLastSong|Playlist

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,6 +42,10 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Fixed
 		- Components can now carry arbitrary names and name duplication is handled
 			properly.
+	* Removed
+		- Preferences options `restoreLastSong` and `restoreLastPlaylist` were
+			dropped. Instead, both will always be restored automatically. In order to
+			start with a blank song/playlist, load a new one before quitting.
 
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -4145,10 +4145,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;General</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>&amp;Sistema d&apos;Àudio</translation>
     </message>
@@ -4286,14 +4282,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -4011,10 +4011,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;Obecné</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>Audio &amp;systém</translation>
     </message>
@@ -4281,14 +4277,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -4180,10 +4180,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;Generell</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>Audio&amp;system</translation>
     </message>
@@ -4354,14 +4350,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Prefer larger</source>
         <translation>Bevorzuge Größere</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation>Zuletzt geöffneten &amp;Song beim Start öffnen</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
-        <translation>Zuletzt geöffnete &amp;Playlist beim Start öffnen</translation>
     </message>
     <message>
         <source>Use &amp;relative paths for playlist</source>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -4115,10 +4115,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Alt+O</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>###</source>
         <translation>###</translation>
     </message>
@@ -4326,14 +4322,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -3980,10 +3980,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>first step, adjust timing mismatch between controller/keyboard trigger latency and computed bpm</source>
         <translation></translation>
     </message>
@@ -4266,14 +4262,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -3980,10 +3980,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>first step, adjust timing mismatch between controller/keyboard trigger latency and computed bpm</source>
         <translation></translation>
     </message>
@@ -4266,14 +4262,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -4196,10 +4196,6 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
         <translation>&amp;General</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>&amp;Sistema de Audio</translation>
     </message>
@@ -4338,14 +4334,6 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
         <translation>Idioma / Γλώσσα / Язык / 言語</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation>Reabrir última canción &amp;utilizada</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
-        <translation>Reabrir última lista de re&amp;producción utilizada</translation>
     </message>
     <message>
         <source>Use &amp;relative paths for playlist</source>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -4129,10 +4129,6 @@ Le chemin vers le script et le nom du script doivent être sans espaces.</transl
         <translation>&amp;Général</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>&amp;Système audio</translation>
     </message>
@@ -4379,14 +4375,6 @@ Le chemin vers le script et le nom du script doivent être sans espaces.</transl
     <message>
         <source>MIDI driver</source>
         <translation>Pilote MIDI</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation>Réouvrir le dernier morceau utili&amp;sé</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
-        <translation>Réouvrir la dernière liste de lecture utili&amp;sée</translation>
     </message>
     <message>
         <source>Use &amp;relative paths for playlist</source>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -4104,10 +4104,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;Xeral</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>&amp;Sistema de son</translation>
     </message>
@@ -4313,14 +4309,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -4072,10 +4072,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Path to the Rubberband command-line utility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4265,14 +4261,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -4054,10 +4054,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4255,14 +4251,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -4079,10 +4079,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation></translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>###</source>
         <translation>###</translation>
     </message>
@@ -4288,14 +4284,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -4168,10 +4168,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>一般(&amp;G)</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>オーディオシステム(&amp;S)</translation>
     </message>
@@ -4309,14 +4305,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -4008,10 +4008,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>Al&amp;gemeen</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+H</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>Audio &amp;Systeem</translation>
     </message>
@@ -4262,14 +4258,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -4004,10 +4004,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;Ogólne</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>&amp;System Audio</translation>
     </message>
@@ -4258,14 +4254,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -4118,10 +4118,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
         <translation>Alt+O</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>###</source>
         <translation>###</translation>
     </message>
@@ -4303,14 +4299,6 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -4163,10 +4163,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>О&amp;бщие</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+п</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>&amp;Звуковая система</translation>
     </message>
@@ -4308,14 +4304,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -4114,10 +4114,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;Опште</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>Звучни &amp;систем</translation>
     </message>
@@ -4315,14 +4311,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -4049,10 +4049,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>###</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4255,14 +4251,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -4175,10 +4175,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
         <translation>&amp;Загальні</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+З</translation>
-    </message>
-    <message>
         <source>Audio &amp;System</source>
         <translation>З&amp;вукова система</translation>
     </message>
@@ -4320,14 +4316,6 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -4035,10 +4035,6 @@ The path to the script and the scriptname must without whitespaces.</source>
         <translation>常规(&amp;G)</translation>
     </message>
     <message>
-        <source>Alt+R</source>
-        <translation>Alt+R</translation>
-    </message>
-    <message>
         <source>first step, adjust timing mismatch between controller/keyboard trigger latency and computed bpm</source>
         <translation>第一步，调整控制器/键盘触发延迟和计算所得 BPM 之间的时序不匹配</translation>
     </message>
@@ -4322,14 +4318,6 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Language / Γλώσσα / Язык / 言語</source>
         <translation>语言/Language/Γλώσσα/Язык</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;song</source>
-        <translation>重新打开上次的乐曲(&amp;S)</translation>
-    </message>
-    <message>
-        <source>Reopen last used &amp;playlist</source>
-        <translation>重新打开上次的播放列表(&amp;P)</translation>
     </message>
     <message>
         <source>Use &amp;relative paths for playlist</source>

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -361,9 +361,8 @@ int main(int argc, char *argv[])
 				pSong = Song::load( songFilename );
 			} else {
 				/* Try load last song */
-				bool restoreLastSong = preferences->isRestoreLastSongEnabled();
 				QString filename = preferences->getLastSongFilename();
-				if ( restoreLastSong && ( !filename.isEmpty() )) {
+				if ( !filename.isEmpty() ) {
 					pSong = Song::load( filename );
 				}
 			}

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -230,8 +230,6 @@ Preferences::Preferences()
 	m_nOscTemporaryPort = -1;
 
 	//___ General properties ___
-	m_brestoreLastSong = true;
-	m_brestoreLastPlaylist = false;
 	m_bUseLash = false;
 	m_bShowDevelWarning = false;
 	m_bShowNoteOverwriteWarning = true;
@@ -352,8 +350,6 @@ bool Preferences::loadPreferences( bool bGlobal )
 			__playselectedinstrument = rootNode.read_bool( "instrumentInputMode", __playselectedinstrument, false, false );
 			m_bShowDevelWarning = rootNode.read_bool( "showDevelWarning", m_bShowDevelWarning, false, false );
 			m_bShowNoteOverwriteWarning = rootNode.read_bool( "showNoteOverwriteWarning", m_bShowNoteOverwriteWarning, false, false );
-			m_brestoreLastSong = rootNode.read_bool( "restoreLastSong", m_brestoreLastSong, false, false );
-			m_brestoreLastPlaylist = rootNode.read_bool( "restoreLastPlaylist", m_brestoreLastPlaylist, false, false );
 			m_bUseLash = rootNode.read_bool( "useLash", false, false, false );
 			__useTimelineBpm = rootNode.read_bool( "useTimeLine", __useTimelineBpm, false, false );
 			m_nMaxBars = rootNode.read_int( "maxBars", 400, false, false );
@@ -878,8 +874,6 @@ bool Preferences::savePreferences()
 
 	////// GENERAL ///////
 	rootNode.write_string( "preferredLanguage", m_sPreferredLanguage );
-	rootNode.write_bool( "restoreLastSong", m_brestoreLastSong );
-	rootNode.write_bool( "restoreLastPlaylist", m_brestoreLastPlaylist );
 
 	rootNode.write_bool( "useLash", m_bsetLash );
 	rootNode.write_bool( "useTimeLine", __useTimelineBpm );

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -426,8 +426,6 @@ public:
 	const QString&	getPreferredLanguage();
 	void			setPreferredLanguage( const QString& sLanguage );
 
-	void			setRestoreLastSongEnabled( bool restore );
-	void			setRestoreLastPlaylistEnabled( bool restore );
 	void			setUseRelativeFilenamesForPlaylists( bool value );
 
 	void			setShowDevelWarning( bool value );
@@ -436,8 +434,6 @@ public:
 	bool			getShowNoteOverwriteWarning();
 	void			setShowNoteOverwriteWarning( bool bValue );
 
-	bool			isRestoreLastSongEnabled();
-	bool			isRestoreLastPlaylistEnabled();
 	bool			isPlaylistUsingRelativeFilenames();
 
 	void			setLastSongFilename( const QString& filename );
@@ -698,9 +694,6 @@ private:
 	 ///rubberband bpm change queue
 	bool				m_useTheRubberbandBpmChangeEvent;
 
-	///< Restore last song?
-	bool				m_brestoreLastSong;
-	bool				m_brestoreLastPlaylist;
 	bool				m_bUseLash;
 	///< Show development version warning?
 	bool				m_bShowDevelWarning;
@@ -1038,14 +1031,6 @@ inline void Preferences::setPreferredLanguage( const QString& sLanguage ) {
 	m_sPreferredLanguage = sLanguage;
 }
 
-inline void Preferences::setRestoreLastSongEnabled( bool restore ) {
-	m_brestoreLastSong = restore;
-}
-
-inline void Preferences::setRestoreLastPlaylistEnabled( bool restore ) {
-	m_brestoreLastPlaylist = restore;
-}
-
 inline void Preferences::setUseRelativeFilenamesForPlaylists( bool value ) {
 	m_bUseRelativeFilenamesForPlaylists= value;
 }
@@ -1072,14 +1057,6 @@ inline void Preferences::setHideKeyboardCursor( bool value ) {
 
 inline bool Preferences::hideKeyboardCursor() {
 	return m_bHideKeyboardCursor;
-}
-
-inline bool Preferences::isRestoreLastSongEnabled() {
-	return m_brestoreLastSong;
-}
-
-inline bool Preferences::isRestoreLastPlaylistEnabled() {
-	return m_brestoreLastPlaylist;
 }
 
 inline bool Preferences::isPlaylistUsingRelativeFilenames() {

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -123,9 +123,7 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 		std::shared_ptr<H2Core::Song>pSong = nullptr;
 
 		if ( sSongFilename.isEmpty() ) {
-			if ( pPref->isRestoreLastSongEnabled() ) {
-				sSongFilename = pPref->getLastSongFilename();
-			}
+			sSongFilename = pPref->getLastSongFilename();
 		}
 
 		bool bRet = false;
@@ -204,8 +202,7 @@ MainForm::MainForm( QApplication * pQApplication, QString sSongFilename )
 	m_pUndoView->setWindowTitle(tr("Undo history"));
 
 	//restore last playlist
-	if ( pPref->isRestoreLastPlaylistEnabled() &&
-		 ! pPref->getLastPlaylistFilename().isEmpty() ) {
+	if ( ! pPref->getLastPlaylistFilename().isEmpty() ) {
 		bool bLoadSuccessful = h2app->getPlayListDialog()->loadListByFileName(
 			pPref->getLastPlaylistFilename() );
 		if ( bLoadSuccessful ) {

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -169,8 +169,6 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	// General tab
 	QSize generalTabWidgetSize( 60, 24 );
 	
-	restoreLastUsedSongCheckbox->setChecked( pPref->isRestoreLastSongEnabled() );
-	restoreLastUsedPlaylistCheckbox->setChecked( pPref->isRestoreLastPlaylistEnabled() );
 	useRelativePlaylistPathsCheckbox->setChecked( pPref->isPlaylistUsingRelativeFilenames() );
 	hideKeyboardCursor->setChecked( pPref->hideKeyboardCursor() );
 
@@ -1024,18 +1022,6 @@ void PreferencesDialog::on_okBtn_clicked()
 	// General tab
 	//////////////////////////////////////////////////////////////////
 	bool bGeneralOptionAltered = false;
-	
-	if ( pPref->isRestoreLastSongEnabled() !=
-		 restoreLastUsedSongCheckbox->isChecked() ) {
-		pPref->setRestoreLastSongEnabled( restoreLastUsedSongCheckbox->isChecked() );
-		bGeneralOptionAltered = true;
-	}
-	
-	if ( pPref->isRestoreLastPlaylistEnabled() !=
-		 restoreLastUsedPlaylistCheckbox->isChecked() ) {
-		pPref->setRestoreLastPlaylistEnabled( restoreLastUsedPlaylistCheckbox->isChecked() );
-		bGeneralOptionAltered = true;
-	}
 	
 	if ( pPref->isPlaylistUsingRelativeFilenames() !=
 		 useRelativePlaylistPathsCheckbox->isChecked() ) {

--- a/src/gui/src/PreferencesDialog/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog_UI.ui
@@ -57,38 +57,6 @@
         </layout>
        </item>
        <item>
-        <widget class="QCheckBox" name="restoreLastUsedSongCheckbox">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Reopen last used &amp;song</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+R</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="restoreLastUsedPlaylistCheckbox">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Reopen last used &amp;playlist</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+R</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <widget class="QCheckBox" name="useRelativePlaylistPathsCheckbox">
          <property name="text">
           <string>Use &amp;relative paths for playlist</string>


### PR DESCRIPTION
`Preferences` options `restoreLastSong` and `restoreLastPlaylist` were dropped. Instead, both will always be restored automatically. I think this is a reasonable UX nowadays. Especially, since the default for `restoreLastPlaylist` is currently `false`. This took me by surprise at least twice by now.

In case anyone want's to start from a new song/playlist, she could (with #1955) just open a new song/playlist and close Hydrogen. Since (https://github.com/hydrogen-music/hydrogen/pull/1955/commits/b0cda77a5b40889e3ae6a1c2ee4159f158de527c) an empty string will be stored as last file. In my point of view this is reasonable since it is done after an explicit user interaction to discard the current file. For songs we even do not loose anything, since the previous last song is still listed in "recently opened".

But it is a breaking change after all. So, I split it off #1955. @cme what do you think? Is this an improvement?