### PR TITLE
Remove autosave files when user declines to restore from them

### DIFF
--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -77,14 +77,16 @@ bool CoreActionController::setStripVolume( int nStrip, float fVolumeValue, bool 
 	
 	auto pInstr = getStrip( nStrip );
 	if ( pInstr != nullptr ) {
-	
+
+		if ( pInstr->get_volume() != fVolumeValue ) {
+			pHydrogen->setIsModified( true );
+		}
+
 		pInstr->set_volume( fVolumeValue );
 	
 		if ( bSelectStrip ) {
 			pHydrogen->setSelectedInstrumentNumber( nStrip );
 		}
-	
-		pHydrogen->setIsModified( true );
 
 		return sendStripVolumeFeedback( nStrip );
 	}
@@ -108,10 +110,12 @@ bool CoreActionController::setMasterIsMuted( bool bIsMuted )
 		ERRORLOG( "no song set" );
 		return false;
 	}
-	
+
+	if ( pSong->getIsMuted() != bIsMuted ) {
+		pHydrogen->setIsModified( true );
+	}
+
 	pSong->setIsMuted( bIsMuted );
-	
-	pHydrogen->setIsModified( true );
 
 	return sendMasterIsMutedFeedback();
 }
@@ -131,11 +135,13 @@ bool CoreActionController::setStripIsMuted( int nStrip, bool bIsMuted )
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pInstr = getStrip( nStrip );
 	if ( pInstr != nullptr ) {
+		if ( pInstr->is_muted() != bIsMuted ) {
+			pHydrogen->setIsModified( true );
+		}
+
 		pInstr->set_muted( bIsMuted );
 
 		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
-	
-		pHydrogen->setIsModified( true );
 
 		return sendStripIsMutedFeedback( nStrip );
 	}
@@ -153,17 +159,18 @@ bool CoreActionController::toggleStripIsSoloed( int nStrip )
 	return setStripIsSoloed( nStrip, !pInstr->is_soloed() );
 }
 
-bool CoreActionController::setStripIsSoloed( int nStrip, bool isSoloed )
+bool CoreActionController::setStripIsSoloed( int nStrip, bool bIsSoloed )
 {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pInstr = getStrip( nStrip );
 	if ( pInstr != nullptr ) {
+		if ( pInstr->is_soloed() != bIsSoloed ) {
+			pHydrogen->setIsModified( true );
+		}
 	
-		pInstr->set_soloed( isSoloed );
+		pInstr->set_soloed( bIsSoloed );
 
 		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
-	
-		pHydrogen->setIsModified( true );
 
 		return sendStripIsSoloedFeedback( nStrip );
 	}
@@ -176,12 +183,14 @@ bool CoreActionController::setStripPan( int nStrip, float fValue, bool bSelectSt
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pInstr = getStrip( nStrip );
 	if ( pInstr != nullptr ) {
-	
+
+		if ( pInstr->getPanWithRangeFrom0To1() != fValue ) {
+			pHydrogen->setIsModified( true );
+		}
+
 		pInstr->setPanWithRangeFrom0To1( fValue );
 		
 		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
-		
-		pHydrogen->setIsModified( true );
 		
 		if ( bSelectStrip ) {
 			pHydrogen->setSelectedInstrumentNumber( nStrip );
@@ -199,13 +208,15 @@ bool CoreActionController::setStripPanSym( int nStrip, float fValue, bool bSelec
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pInstr = getStrip( nStrip );
 	if ( pInstr != nullptr ) {
-	
+
+		if ( pInstr->getPan() != fValue ) {
+			pHydrogen->setIsModified( true );
+		}
+
 		pInstr->setPan( fValue );
-		
+
 		EventQueue::get_instance()->push_event( EVENT_INSTRUMENT_PARAMETERS_CHANGED, nStrip );
-		
-		pHydrogen->setIsModified( true );
-		
+
 		if ( bSelectStrip ) {
 			pHydrogen->setSelectedInstrumentNumber( nStrip );
 		}
@@ -526,6 +537,7 @@ bool CoreActionController::newSong( const QString& sSongPath ) {
 
 bool CoreActionController::openSong( const QString& sSongPath, const QString& sRecoverSongPath ) {
 	auto pHydrogen = Hydrogen::get_instance();
+	bool bModified = false;
  
 	// Check whether the provided path is valid.
 	if ( !Filesystem::isSongPathValid( sSongPath, true ) ) {
@@ -542,7 +554,7 @@ bool CoreActionController::openSong( const QString& sSongPath, const QString& sR
 		}
 		// The autosaved file we've just recovered counts as a modified version
 		// of the intended song.
-		pHydrogen->setIsModified( true );
+		bModified = true;
 	} else {
 		pSong = Song::load( sSongPath );
 	}
@@ -552,8 +564,10 @@ bool CoreActionController::openSong( const QString& sSongPath, const QString& sR
 				  .arg( sSongPath ) );
 		return false;
 	}
-	
-	return setSong( pSong );
+
+	setSong( pSong );
+	pSong->setIsModified( bModified );
+	return true;
 }
 
 bool CoreActionController::openSong( std::shared_ptr<Song> pSong ) {
@@ -1798,10 +1812,12 @@ void CoreActionController::setBpm( float fBpm ) {
 	pAudioEngine->setNextBpm( fBpm );
 	pAudioEngine->unlock();
 
-	// Store it's value in the .h2song file.
-	pHydrogen->getSong()->setBpm( fBpm );
+	if ( pHydrogen->getSong()->getBpm() != fBpm ) {
+		// Store it's value in the .h2song file.
+		pHydrogen->getSong()->setBpm( fBpm );
 
-	pHydrogen->setIsModified( true );
+		pHydrogen->setIsModified( true );
+	}
 	
 	EventQueue::get_instance()->push_event( EVENT_TEMPO_CHANGED, -1 );
 }

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -540,6 +540,9 @@ bool CoreActionController::openSong( const QString& sSongPath, const QString& sR
 		if ( pSong != nullptr ) {
 			pSong->setFilename( sSongPath );
 		}
+		// The autosaved file we've just recovered counts as a modified version
+		// of the intended song.
+		pHydrogen->setIsModified( true );
 	} else {
 		pSong = Song::load( sSongPath );
 	}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -432,6 +432,8 @@ bool HydrogenApp::openSong( QString sFilename ) {
 		int nRet = msgBox.exec();
 
 		if ( nRet == QMessageBox::Discard ) {
+			QFile file( sRecoverFilename );
+			file.remove();
 			sRecoverFilename = "";
 		}
 	}

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -599,11 +599,6 @@ void InstrumentEditor::updateSongEvent( int nValue ) {
 	if ( nValue == 0 ) {
 		updateComponentLabels();
 		selectedInstrumentChangedEvent();
-
-		// The function call above sets some spurious isModified when
-		// updating the states of the widgets. This has to be reset
-		// for a freshly loaded song.
-		H2Core::Hydrogen::get_instance()->setIsModified( false );
 	}
 }
 
@@ -1376,9 +1371,9 @@ void InstrumentEditor::selectLayer( int nLayer )
 
 void InstrumentEditor::muteGroupChanged( double fValue )
 {
-	 if ( m_pInstrument == nullptr ) {
-		 return;
-	 }
+	if ( m_pInstrument == nullptr ) {
+		return;
+	}
 
 	m_pInstrument->set_mute_group( static_cast<int>(fValue) );
 	selectedInstrumentChangedEvent();	// force an update
@@ -1387,23 +1382,27 @@ void InstrumentEditor::muteGroupChanged( double fValue )
 void InstrumentEditor::onIsStopNoteCheckBoxClicked( bool on )
 {
 	if ( m_pInstrument == nullptr ) {
-		 return;
-	 }
+		return;
+	}
 
-	m_pInstrument->set_stop_notes( on );
-	Hydrogen::get_instance()->setIsModified( true );
-	selectedInstrumentChangedEvent();	// force an update
+	if ( m_pInstrument->is_stop_notes() != on ) {
+		m_pInstrument->set_stop_notes( on );
+		Hydrogen::get_instance()->setIsModified( true );
+		selectedInstrumentChangedEvent();	// force an update
+	}
 }
 
 void InstrumentEditor::onIsApplyVelocityCheckBoxClicked( bool on )
 {
-	 if ( m_pInstrument == nullptr ) {
-		 return;
-	 }
+	if ( m_pInstrument == nullptr ) {
+		return;
+	}
 
-	m_pInstrument->set_apply_velocity( on );
-	Hydrogen::get_instance()->setIsModified( true );
-	selectedInstrumentChangedEvent();	// force an update
+	if ( m_pInstrument->get_apply_velocity() != on ) {
+		m_pInstrument->set_apply_velocity( on );
+		Hydrogen::get_instance()->setIsModified( true );
+		selectedInstrumentChangedEvent();	// force an update
+	}
 }
 
 void InstrumentEditor::midiOutChannelChanged( double fValue ) {

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -630,11 +630,8 @@ int main(int argc, char *argv[])
 				pHydrogen->setIsModified( true );
 			}
 			else {
-				NsmClient::get_instance()->sendDirtyState( false );
-				pHydrogen->setIsModified( false );
+				NsmClient::get_instance()->sendDirtyState( pHydrogen->getIsModified() );
 			}
-#else
-			pHydrogen->setIsModified( false );
 #endif
 		}
 


### PR DESCRIPTION
Remove autosave files when user declines to restore from them
    
When Hydrogen starts up, if a file has been autosaved the user will
be offered the opportunity to restore from that file. If they decline
it, Hydrogen should delete the autosaved file; it may be soon overwritten anyway by new autosave data.
    
This avoids the annoying cycle I often find myself in:
   1. edit file
   2. quit Hydrogen discarding edits (but autosave remains)
   3. open Hydrogen
   4. hit "Don't Save" because I didn't want those edits
   5. listen to original file without modifying (hence no autosave, but old autosave remains)
   6. quit Hydrogen (silently)
   7. goto 3
    
Also, when opening a file and restoring from its autosave, Hydrogen
should count this as the song being Modified because the current
content is from the autosave and is not the same as the content of
the named file.

This change also removes spurious sets of `IsModified` in parts of the GUI, which would `setIsModified( true )` in the GUI initialisation despite not making any actual changes, as well as `setModified( false )` calls that were needed to work around these spurious sets after song loading completed.