### PR TITLE
AppVeyor: fix AppImage and Windows32 pipelines

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -589,7 +589,7 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-cppunit
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portaudio
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libwinpthread-git
+          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-winpthreads-git
           REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
           c:\msys64\usr\bin\pacman --noconfirm -S -y -q %MSYS_REPO%-ladspa-sdk
           if not %job_name%==Windows32 c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -258,7 +258,7 @@ for:
          exit 0
       fi
 
-      cache_tag=usr_cache_appimage_fresh # this can be modified to rebuild deps
+      cache_tag=usr_cache_appimage_fresh_2 # this can be modified to rebuild deps
 
       ## Since we use a different Linux image we, unfortunately, have
       ## to use a separate cache.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -65,7 +65,7 @@ environment:
       MSYS_REPO: 'mingw64/mingw-w64-x86_64'
       PACKAGE_PREFIX: 'mingw-w64-x86_64'
       BUILD_TYPE: "Release"
-      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON"
+      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=ON -DWANT_JACK=ON"
       appveyor_build_worker_image: Visual Studio 2019
       LIBSSL: libssl-3-x64.dll
       LIBCRYPTO: libcrypto-3-x64.dll
@@ -76,7 +76,7 @@ environment:
       MSYS_REPO: 'mingw32/mingw-w64-i686'
       PACKAGE_PREFIX: 'mingw-w64-i686'
       BUILD_TYPE: "Release"
-      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF"
+      CMAKE_FLAGS: "-DWANT_DEBUG:BOOL=OFF -DWIN64:BOOL=OFF -DWANT_JACK=OFF"
       appveyor_build_worker_image: Visual Studio 2019
       LIBSSL: libssl-3.dll
       LIBCRYPTO: libcrypto-3.dll
@@ -590,9 +590,9 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portaudio
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libwinpthread-git
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
           c:\msys64\usr\bin\pacman --noconfirm -S -y -q %MSYS_REPO%-ladspa-sdk
+          if not %job_name%==Windows32 c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-liblo
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -583,6 +583,9 @@ for:
           cmake --version
           g++ --version
 
+          REM *** Update pacman cache ***
+          c:\msys64\usr\bin\pacman --noconfirm -S -y
+
           REM *** Install dependencies ***
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libarchive
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-libsndfile
@@ -590,8 +593,8 @@ for:
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portaudio
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-portmidi
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-winpthreads-git
-          REM *** As of 2022-20-09 the package database refresh (-y) is required to get the newest qt package and to avoid a critical bug in less recent ones. In addition, the refresh _must_ take place _after_ installing libwinpthread (which otherwise fails). ***
-          c:\msys64\usr\bin\pacman --noconfirm -S -y -q %MSYS_REPO%-ladspa-sdk
+          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ladspa-sdk
+          REM *** The jack2 package does not seem to be available for 32bit Windows anymore ***
           if not %job_name%==Windows32 c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-liblo

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ GTAGS
 
 # Ignore compiled (binary) translation artifacts of `msgfmt`.
 *.mo
+
+# Ignore cache folder of clangd used in LSP editor support.
+.cache/

--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,9 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix mapping of `NOTE_OFF` MIDI messages in hihat pressure groups.
 		- Fix segfault when using MIDI sense button in table of Preferences > MIDI
 			after removing rows above it from the table.
+	* Removed
+		- Dropped `JACK` support in provided Windows 32 binaries (as the upstream
+			jack2 MSYS package was dropped)
 
 2024-01-12 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.3

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2653,15 +2653,15 @@ void AudioEngine::checkJackSupport() {
 	// importing the file) or by passing the `-d jack` CLI option.
 	if ( Preferences::get_instance()->m_sAudioDriver != "JACK" ) {
 		if ( ! JackAudioDriver::checkSupport() ) {
-			AE_WARNINGLOG( "JACK support disabled." );
+			WARNINGLOG( "JACK support disabled." );
 			m_bJackSupported = false;
 			return;
 		}
 
-		AE_INFOLOG( "JACK support enabled." );
+		INFOLOG( "JACK support enabled." );
 	}
 	else {
-		AE_INFOLOG( "Dynamic JACK support skipped. JACK support enabled." );
+		INFOLOG( "Dynamic JACK support skipped. JACK support enabled." );
 	}
   #endif
 
@@ -2669,7 +2669,7 @@ void AudioEngine::checkJackSupport() {
 	return;
 
 #else
-	AE_INFOLOG( "Hydrogen was compiled without JACK support." );
+	INFOLOG( "Hydrogen was compiled without JACK support." );
 	m_bJackSupported = false;
 	return;
 #endif


### PR DESCRIPTION
Unfortunately, the `JACK` support for Windows32 has to be dropped. I do still see a `mingw-w64-i686-jack2` package in https://repo.msys2.org/mingw/mingw32/. But both locally and in the AppVeyor pipeline the package can not be installed and querring  does yield no results. We have no choice but to disable JACK support for the Windows 32bit build for now.

We now use `winpthreads-git` over `libwinpthred-git` in the Windows pipeline. By doing so we do not encounter conflicts and the library is installed along `winpthreads-git` as a dependency anyway.

The `pacman` cache is now updated before any installation does happen in the Windows pipeline. This way, hopefully, individual packages do not get out of sync (so fast) anymore and make the pipeline crash.

The cache of the `AppImage` pipeline needed a refresh. Only `libsndfile.a` instead of `libsndfile.so` was found causing the build to fail. (Maybe the cache was somehow damaged?)