### PR TITLE
Add shared parser between `hydrogen` main routine and `Reporter`

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -292,7 +292,8 @@ int main(int argc, char *argv[])
 		Logger* pLogger = Logger::bootstrap( logLevelOpt,
 											sLogFile, true, bLogTimestamps );
 		Base::bootstrap( pLogger, pLogger->should_log( Logger::Debug ) );
-		H2Core::Filesystem::bootstrap( pLogger, sSysDataPath, sConfigFilePath );
+		H2Core::Filesystem::bootstrap(
+			pLogger, sSysDataPath, sConfigFilePath, sLogFile );
 		MidiMap::create_instance();
 		Preferences::create_instance();
 		Preferences* preferences = Preferences::get_instance();

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -124,7 +124,8 @@ QString Filesystem::m_sPreferencesOverwritePath = "";
 
 /* TODO QCoreApplication is not instantiated */
 bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
-							const QString& sUserConfigPath )
+							const QString& sUserConfigPath,
+							const QString& sLogFile )
 {
 	if( __logger==nullptr && logger!=nullptr ) {
 		__logger = logger;
@@ -164,6 +165,12 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
 		INFOLOG( QString( "Using custom user-level config file [%1]" )
 				 .arg( sUserConfigPath ) );
 		__usr_cfg_path = sUserConfigPath;
+	}
+
+	if ( ! sLogFile.isEmpty() ) {
+		// No need for an info log. This is done within the bootstrap of the
+		// logger.
+		Filesystem::__usr_log_path = sLogFile;
 	}
 
 	if( !dir_readable( __sys_data_path ) ) {

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -89,15 +89,17 @@ namespace H2Core
 		/**
 		 * check user and system filesystem usability
 		 *
-		 * If either @a sSysDataPath or @a sUserConfigFile are not provided or
-		 * empty, the corresponding default values will be used
+		 * If either @a sSysDataPath, @a sLogFile, or @a sUserConfigFile are not
+		 * provided or empty, the corresponding default values will be used
 		 *
 		 * \param logger is a pointer to the logger instance which will be used
 		 * \param sSysDataPath path to an alternate system data folder
 		 * \param sUserConfigFile path to an alternate hydrogen.conf config file
+		 * \param sLogFile path to alternate log file
 		 */
 		static bool bootstrap( Logger* logger, const QString& sSysDataPath = "",
-							   const QString& sUserConfigFile = "" );
+							   const QString& sUserConfigFile = "",
+							   const QString& sLogFile = "" );
 
 		/** returns system data path */
 		static const QString& sys_data_path();

--- a/src/gui/src/Parser.cpp
+++ b/src/gui/src/Parser.cpp
@@ -1,0 +1,199 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2024 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+#include "Parser.h"
+
+#include <QtGui>
+#include <QtWidgets>
+#include <QCommandLineParser>
+#include <QCoreApplication>
+#include <QStringList>
+#include <iostream>
+
+#include <core/Helpers/Filesystem.h>
+#include <core/Preferences/Preferences.h>
+#include <core/Version.h>
+
+Parser::Parser() {
+}
+
+Parser::~Parser() {
+}
+
+bool Parser::parse( int argc, char* argv[] ) {
+
+	QCoreApplication* pApp = new QCoreApplication( argc, argv );
+	pApp->setApplicationVersion(
+		QString::fromStdString( H2Core::get_version() ) );
+
+	QCommandLineParser parser;
+
+	parser.setApplicationDescription( H2Core::getAboutText() );
+
+	QStringList availableAudioDrivers;
+	for ( const auto& ddriver : H2Core::Preferences::getSupportedAudioDrivers() ) {
+		availableAudioDrivers <<
+			H2Core::Preferences::audioDriverToQString( ddriver );
+	}
+	availableAudioDrivers << H2Core::Preferences::audioDriverToQString(
+		H2Core::Preferences::AudioDriver::Auto );
+
+	QCommandLineOption audioDriverOption(
+		QStringList() << "d" << "driver",
+		QString( "Use the selected audio driver (%1)" )
+		.arg( availableAudioDrivers.join( ", " ) ), "Audiodriver");
+	QCommandLineOption playlistFileNameOption(
+		QStringList() << "p" <<
+		"playlist", "Load a playlist (*.h2playlist) at startup", "File" );
+	QCommandLineOption songFileOption(
+		QStringList() << "s" <<
+		"song", "Load a song (*.h2song) at startup", "File" );
+	QCommandLineOption kitOption(
+		QStringList() << "k" << "kit", "Load a drumkit at startup", "DrumkitName" );
+
+	QCommandLineOption installDrumkitOption(
+		QStringList() << "i" <<
+		"install", "Install a drumkit (*.h2drumkit)", "File");
+
+	QCommandLineOption verboseOption(
+		QStringList() << "V" <<
+		"verbose", "Level, if present, may be None, Error, Warning, Info, Debug, Constructors, Locks, or 0xHHHH", "Level" );
+	QCommandLineOption logFileOption(
+		QStringList() << "L" << "log-file", "Alternative log file path", "Path" );
+	QCommandLineOption logTimestampsOption(
+		QStringList() << "T" <<
+		"log-timestamps", "Add timestamps to all log messages" );
+
+	QCommandLineOption systemDataPathOption(
+		QStringList() << "P" <<
+		"data", "Use an alternate system data path", "Path" );
+	QCommandLineOption configFileOption(
+		QStringList() << "config", "Use an alternate config file", "Path" );
+	QCommandLineOption uiLayoutOption(
+		QStringList() << "layout", "UI layout ('tabbed' or 'single')", "Layout" );
+#ifdef H2CORE_HAVE_OSC
+	QCommandLineOption oscPortOption(
+		QStringList() << "O" <<
+		"osc-port", "Custom port for OSC connections", "int" );
+#endif
+	QCommandLineOption noSplashScreenOption(
+		QStringList() << "n" << "nosplash", "Hide splash screen" );
+
+	QCommandLineOption shotListOption(
+		QStringList() << "t" <<
+		"shotlist", "Shot list of widgets to grab", "ShotList" );
+
+	QCommandLineOption noReporterOption(
+		QStringList() << "child", "Child process (no crash reporter)");
+
+	parser.addHelpOption();
+	parser.addVersionOption();
+
+	parser.addOption( audioDriverOption );
+	parser.addOption( playlistFileNameOption );
+	parser.addOption( songFileOption );
+	parser.addOption( kitOption );
+
+	parser.addOption( installDrumkitOption );
+
+	parser.addOption( verboseOption );
+	parser.addOption( logFileOption );
+	parser.addOption( logTimestampsOption );
+
+	parser.addOption( systemDataPathOption );
+	parser.addOption( configFileOption );
+	parser.addOption( uiLayoutOption );
+#ifdef H2CORE_HAVE_OSC
+	parser.addOption( oscPortOption );
+#endif
+	parser.addOption( noSplashScreenOption );
+
+	parser.addOption( shotListOption );
+
+	parser.addOption( noReporterOption );
+
+	parser.addPositionalArgument( "file", "Song, playlist or Drumkit file" );
+
+	// Evaluate the options
+	parser.process( *pApp );
+
+	m_sAudioDriver = parser.value( audioDriverOption );
+	m_sPlaylistFilename = parser.value( playlistFileNameOption );
+	m_sSongFilename = parser.value ( songFileOption );
+	m_sDrumkitToLoad = parser.value( kitOption );
+
+	m_sInstallDrumkitPath = parser.value( installDrumkitOption );
+
+	QString sVerbosityString = parser.value( verboseOption );
+	m_logLevel = H2Core::Logger::Error;
+	if ( parser.isSet( verboseOption ) ) {
+		if ( ! sVerbosityString.isEmpty() ) {
+			m_logLevel =  H2Core::Logger::parse_log_level(
+				sVerbosityString.toLocal8Bit() );
+		} else {
+			m_logLevel = H2Core::Logger::Error | H2Core::Logger::Warning;
+		}
+	}
+	m_sLogFile = parser.value( logFileOption );
+	m_bLogTimestamps = parser.isSet( logTimestampsOption );
+
+	m_sSysDataPath = parser.value( systemDataPathOption );
+	m_sConfigFilePath = parser.value( configFileOption );
+	m_sUiLayout = parser.value( uiLayoutOption );
+	m_nOscPort = -1;
+#ifdef H2CORE_HAVE_OSC
+	QString sOscPort = parser.value( oscPortOption );
+	if ( ! sOscPort.isEmpty() ) {
+		bool bOk;
+		m_nOscPort = sOscPort.toInt( &bOk, 10 );
+		if ( ! bOk ) {
+			std::cerr << "Unable to parse 'osc-port' option. Please provide an integer value"
+					  << std::endl;
+			return false;
+		}
+	}
+#endif
+
+	m_bNoSplashScreen = parser.isSet( noSplashScreenOption );
+
+	m_sShotList = parser.value( shotListOption );
+
+	m_bNoReporter = parser.isSet( noReporterOption );
+
+	// Operating system GUIs typically pass documents to open as simple
+	// positional arguments to the process command line. Handling this here
+	// enables "Open with" as well as default document bindings to work.
+	QString sArg;
+	foreach ( sArg, parser.positionalArguments() ) {
+		if ( sArg.endsWith( H2Core::Filesystem::songs_ext ) ) {
+			m_sSongFilename = sArg;
+		}
+		if ( sArg.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
+			m_sInstallDrumkitPath = sArg;
+		}
+		if ( sArg.endsWith( H2Core::Filesystem::playlist_ext ) ) {
+			m_sPlaylistFilename = sArg;
+		}
+	}
+
+	delete pApp;
+
+	return true;
+}

--- a/src/gui/src/Parser.h
+++ b/src/gui/src/Parser.h
@@ -1,0 +1,113 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2024 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#ifndef PARSER_H
+#define PARSER_H
+
+#include <QString>
+
+/** Reusable parser for provided command line arguments.
+ *
+ * In our current design we have to access the CLI arguments of the `hydrogen`
+ * program at two different points (`h2cli` and `h2player` have other CLI
+ * options and are not covered in here): 1. In #Reporter and 2. in the main
+ * routine it spawns.
+ *
+ * Some CLI args, like the path to a custom log file, are important for the
+ * #Reporter as well. But it can not access them through the child process but
+ * has to retrieve it from the CLI args itself. Here it is crucial to a) perform
+ * the parsing in the same way in order to avoid inconsistencies and b) keep the
+ * parsing with the one in the main routine in sync as QCommandLineParser will
+ * complain about arguments unknown to it. That's why we abstract it in a
+ * separate class.
+ *
+ * Note that this is not a H2_OBJECT. It get's invoked way ahead of
+ * #H2Core::Logger::bootstrap() and #H2Core::Base::bootstrap() and could not be
+ * used with our usual logging macros etc.
+ * */
+class Parser {
+	public:
+
+		Parser();
+		~Parser();
+
+		bool parse( int argc, char* argv[] );
+
+		const QString& getAudioDriver() const {
+			return m_sAudioDriver; }
+		const QString& getPlaylistFilename() const {
+			return m_sPlaylistFilename; }
+		const QString& getSongFilename() const {
+			return m_sSongFilename; }
+		const QString& getDrumkitToLoad() const {
+			return m_sDrumkitToLoad; }
+
+		const QString& getInstallDrumkitPath() const {
+			return m_sInstallDrumkitPath; }
+
+		unsigned getLogLevel() const {
+			return m_logLevel; }
+		const QString& getLogFile() const {
+			return m_sLogFile; }
+		bool getLogTimestamps() const {
+			return m_bLogTimestamps; }
+
+		const QString& getSysDataPath() const {
+			return m_sSysDataPath; }
+		const QString& getConfigFilePath() const {
+			return m_sConfigFilePath; }
+		const QString& getUiLayout() const {
+			return m_sUiLayout; }
+		int getOscPort() const {
+			return m_nOscPort; }
+		bool getNoSplashScreen() const {
+			return m_bNoSplashScreen; }
+
+		const QString& getShotList() const {
+			return m_sShotList; }
+
+		bool getNoReporter() const {
+			return m_bNoReporter; }
+
+	private:
+		QString  m_sAudioDriver;
+		QString  m_sPlaylistFilename;
+		QString  m_sSongFilename;
+		QString  m_sDrumkitToLoad;
+
+		QString  m_sInstallDrumkitPath;
+
+		unsigned m_logLevel;
+		QString  m_sLogFile;
+		bool     m_bLogTimestamps;
+
+		QString  m_sSysDataPath;
+		QString  m_sConfigFilePath;
+		QString  m_sUiLayout;
+		int      m_nOscPort;
+		bool     m_bNoSplashScreen;
+
+		QString  m_sShotList;
+
+		bool     m_bNoReporter;
+};
+
+#endif

--- a/src/gui/src/Reporter.h
+++ b/src/gui/src/Reporter.h
@@ -60,6 +60,7 @@ class Reporter : public QObject
 
 	static QString m_sPrefix;
 	QString m_sContext;
+	static QString m_sLogFile;
 
 	void addLine( const QString& s );
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -36,6 +36,7 @@
 #include "SplashScreen.h"
 #include "HydrogenApp.h"
 #include "MainForm.h"
+#include "Parser.h"
 #include "PlaylistEditor/PlaylistEditor.h"
 #include "Skin.h"
 #include "Reporter.h"
@@ -215,126 +216,15 @@ int main(int argc, char *argv[])
 		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
 
-		// Create bootstrap QApplication to get H2 Core set up with correct Filesystem paths before starting GUI application.
-		QCoreApplication *pBootStrApp = new QCoreApplication( argc, argv );
-		pBootStrApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );
-
-		
-		QCommandLineParser parser;
-		
-		parser.setApplicationDescription( H2Core::getAboutText() );
-
-		QStringList availableAudioDrivers;
-		for ( const auto& ddriver : H2Core::Preferences::getSupportedAudioDrivers() ) {
-			availableAudioDrivers << H2Core::Preferences::audioDriverToQString( ddriver );
-		}
-		availableAudioDrivers << H2Core::Preferences::audioDriverToQString(
-			H2Core::Preferences::AudioDriver::Auto );
-		
-		QCommandLineOption audioDriverOption( QStringList() << "d" << "driver",
-											  QString( "Use the selected audio driver (%1)" )
-											  .arg( availableAudioDrivers.join( ", " ) ),
-											  "Audiodriver");
-		QCommandLineOption installDrumkitOption( QStringList() << "i" << "install", "Install a drumkit (*.h2drumkit)" , "File");
-		QCommandLineOption noSplashScreenOption( QStringList() << "n" << "nosplash", "Hide splash screen" );
-		QCommandLineOption playlistFileNameOption( QStringList() << "p" << "playlist", "Load a playlist (*.h2playlist) at startup", "File" );
-		QCommandLineOption systemDataPathOption( QStringList() << "P" << "data", "Use an alternate system data path", "Path" );
-		QCommandLineOption configFileOption(
-			QStringList() << "config", "Use an alternate config file", "Path" );
-		QCommandLineOption songFileOption( QStringList() << "s" << "song", "Load a song (*.h2song) at startup", "File" );
-		QCommandLineOption kitOption( QStringList() << "k" << "kit", "Load a drumkit at startup", "DrumkitName" );
-		QCommandLineOption verboseOption( QStringList() << "V" << "verbose", "Level, if present, may be None, Error, Warning, Info, Debug, Constructors, Locks, or 0xHHHH", "Level" );
-		QCommandLineOption logFileOption( QStringList() << "L" << "log-file",
-										  "Alternative log file path", "Path" );
-		QCommandLineOption logTimestampsOption(
-			QStringList() << "T" << "log-timestamps",
-			"Add timestamps to all log messages" );
-		QCommandLineOption shotListOption( QStringList() << "t" << "shotlist", "Shot list of widgets to grab", "ShotList" );
-		QCommandLineOption uiLayoutOption( QStringList() << "layout", "UI layout ('tabbed' or 'single')", "Layout" );
-		QCommandLineOption noReporterOption( QStringList() << "child", "Child process (no crash reporter)");
-#ifdef H2CORE_HAVE_OSC
-		QCommandLineOption oscPortOption( QStringList() << "O" << "osc-port",
-										  "Custom port for OSC connections", "int" );
-#endif
-		
-		parser.addHelpOption();
-		parser.addVersionOption();
-		parser.addOption( audioDriverOption );
-		parser.addOption( installDrumkitOption );
-		parser.addOption( noSplashScreenOption );
-		parser.addOption( playlistFileNameOption );
-		parser.addOption( systemDataPathOption );
-		parser.addOption( configFileOption );
-		parser.addOption( songFileOption );
-		parser.addOption( kitOption );
-		parser.addOption( verboseOption );
-		parser.addOption( logFileOption );
-		parser.addOption( logTimestampsOption );
-		parser.addOption( shotListOption );
-		parser.addOption( uiLayoutOption );
-		parser.addOption( noReporterOption );
-#ifdef H2CORE_HAVE_OSC
-		parser.addOption( oscPortOption );
-#endif
-		parser.addPositionalArgument( "file", "Song, playlist or Drumkit file" );
-		
-		// Evaluate the options
-		parser.process( *pBootStrApp );
-		QString sSelectedDriver = parser.value( audioDriverOption );
-		QString sDrumkitName = parser.value( installDrumkitOption );
-		bool	bNoSplash = parser.isSet( noSplashScreenOption );
-		QString sPlaylistFilename = parser.value( playlistFileNameOption );
-		QString sSysDataPath = parser.value( systemDataPathOption );
-		const QString sConfigFilePath = parser.value( configFileOption );
-		QString sSongFilename = parser.value ( songFileOption );
-		QString sDrumkitToLoad = parser.value( kitOption );
-		QString sVerbosityString = parser.value( verboseOption );
-		QString sShotList = parser.value( shotListOption );
-		QString sUiLayout = parser.value( uiLayoutOption );
-		QString sLogFile = parser.value( logFileOption );
-		bool bLogTimestamps = parser.isSet( logTimestampsOption );
-
-		unsigned logLevelOpt = H2Core::Logger::Error;
-		if( parser.isSet(verboseOption) ){
-			if( !sVerbosityString.isEmpty() )
-			{
-				logLevelOpt =  H2Core::Logger::parse_log_level( sVerbosityString.toLocal8Bit() );
-			} else {
-				logLevelOpt = H2Core::Logger::Error|H2Core::Logger::Warning;
-			}
+		Parser parser;
+		if ( ! parser.parse( argc, argv ) ) {
+			std::cerr << "Error: Unable to parse CLI arguments. Abort..."
+					  << std::endl;
+			exit( 1 );
 		}
 
-		int nOscPort = -1;
-#ifdef H2CORE_HAVE_OSC
-		QString sOscPort = parser.value( oscPortOption );
-		if ( ! sOscPort.isEmpty() ) {
-			bool bOk;
-			nOscPort = sOscPort.toInt( &bOk, 10 );
-			if ( ! bOk ) {
-				std::cerr << "Unable to parse 'osc-port' option. Please provide an integer value"
-						  << std::endl;
-				exit( 1 );
-			}
-		}
-#endif
+		QString sSongFilename = parser.getSongFilename();
 
-		// Operating system GUIs typically pass documents to open as
-		// simple positional arguments to the process command
-		// line. Handling this here enables "Open with" as well as
-		// default document bindings to work.
-		QString sArg;
-		foreach ( sArg, parser.positionalArguments() ) {
-			if ( sArg.endsWith( H2Core::Filesystem::songs_ext ) ) {
-				sSongFilename = sArg;
-			}
-			if ( sArg.endsWith( H2Core::Filesystem::drumkit_ext ) ) {
-				sDrumkitName = sArg;
-			}
-			if ( sArg.endsWith( H2Core::Filesystem::playlist_ext ) ) {
-				sPlaylistFilename = sArg;
-			}
-		}
-		
 		std::cout << H2Core::getAboutText().toStdString();
 		
 		setup_unix_signal_handlers();
@@ -342,11 +232,15 @@ int main(int argc, char *argv[])
 		H2Core::Logger::setCrashContext( &sInitialisingCrashContext );
 
 		// Man your battle stations... this is not a drill.
-		auto pLogger = H2Core::Logger::bootstrap( logLevelOpt, sLogFile,
-												  true, bLogTimestamps );
-		H2Core::Base::bootstrap( pLogger, pLogger->should_log(H2Core::Logger::Debug) );
+		auto pLogger = H2Core::Logger::bootstrap(
+			parser.getLogLevel(), parser.getLogFile(), true,
+			parser.getLogTimestamps() );
+		H2Core::Base::bootstrap(
+			pLogger, pLogger->should_log( H2Core::Logger::Debug ) );
 
-		H2Core::Filesystem::bootstrap( pLogger, sSysDataPath, sConfigFilePath );
+		H2Core::Filesystem::bootstrap(
+			pLogger, parser.getSysDataPath(), parser.getConfigFilePath(),
+			parser.getLogFile() );
 		MidiMap::create_instance();
 		H2Core::Preferences::create_instance();
 		// See below for H2Core::Hydrogen.
@@ -378,8 +272,8 @@ int main(int argc, char *argv[])
 #endif
 
 		// Force layout
-		if ( !sUiLayout.isEmpty() ) {
-			if ( sUiLayout == "tabbed" ) {
+		if ( ! parser.getUiLayout().isEmpty() ) {
+			if ( parser.getUiLayout() == "tabbed" ) {
 				pPref->getThemeWritable().m_interface.m_layout =
 					H2Core::InterfaceTheme::Layout::Tabbed;
 			} else {
@@ -388,8 +282,8 @@ int main(int argc, char *argv[])
 			}
 		}
 
-		if ( nOscPort != -1 ) {
-			pPref->m_nOscTemporaryPort = nOscPort;
+		if ( parser.getOscPort() != -1 ) {
+			pPref->m_nOscTemporaryPort = parser.getOscPort();
 		}
 
 #ifdef H2CORE_HAVE_LASH
@@ -398,22 +292,20 @@ int main(int argc, char *argv[])
 		LashClient* pLashClient = LashClient::get_instance();
 
 #endif
-		if( ! sDrumkitName.isEmpty() ){
-			if ( ! H2Core::Drumkit::install( sDrumkitName ) ) {
+		if( ! parser.getInstallDrumkitPath().isEmpty() ){
+			if ( ! H2Core::Drumkit::install( parser.getInstallDrumkitPath() ) ) {
 				___ERRORLOG( QString( "Unable to install drumkit [%1]" )
-							 .arg( sDrumkitName ) );
+							 .arg( parser.getInstallDrumkitPath() ) );
 				exit( 1  );
 			}
 			exit( 0 );
 		}
 
-		if ( ! sSelectedDriver.isEmpty() ) {
+		if ( ! parser.getAudioDriver().isEmpty() ) {
 			pPref->m_audioDriver =
-				H2Core::Preferences::parseAudioDriver( sSelectedDriver );
+				H2Core::Preferences::parseAudioDriver( parser.getAudioDriver() );
 		}
 
-		// Bootstrap is complete, start GUI
-		delete pBootStrApp;
 		H2QApplication* pQApp = new H2QApplication( argc, argv );
 		pQApp->setApplicationName( "Hydrogen" );
 		pQApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );
@@ -525,7 +417,7 @@ int main(int argc, char *argv[])
 #ifdef H2CORE_HAVE_OSC
 		// Check for being under session management without the
 		// NsmClient class available yet.
-		if ( bNoSplash ||  getenv( "NSM_URL" ) ) {
+		if ( parser.getNoSplashScreen() ||  getenv( "NSM_URL" ) ) {
 			pSplash->hide();
 		}
 		else {
@@ -584,14 +476,15 @@ int main(int argc, char *argv[])
 		}
 
 		MainForm *pMainForm =
-			new MainForm( pQApp, sSongFilename, sPlaylistFilename );
+			new MainForm( pQApp, sSongFilename,
+						  parser.getPlaylistFilename() );
 		auto pHydrogenApp = HydrogenApp::get_instance();
 		pMainForm->show();
 		
 		pSplash->finish( pMainForm );
 
-		if( ! sDrumkitToLoad.isEmpty() ) {
-			H2Core::CoreActionController::setDrumkit( sDrumkitToLoad );
+		if( ! parser.getDrumkitToLoad().isEmpty() ) {
+			H2Core::CoreActionController::setDrumkit( parser.getDrumkitToLoad() );
 		}
 
 		// Write the changes in the Preferences to disk to make them
@@ -603,8 +496,8 @@ int main(int argc, char *argv[])
 		// Tell the core that the GUI is now fully loaded and ready.
 		pHydrogen->setGUIState( H2Core::Hydrogen::GUIState::ready );
 
-		if ( sShotList != QString() ) {
-			ShotList *sl = new ShotList( sShotList );
+		if ( ! parser.getShotList().isEmpty() ) {
+			ShotList *sl = new ShotList( parser.getShotList() );
 			sl->shoot();
 		}
 


### PR DESCRIPTION
Since the introduction of the CLI arg `-L` to use a custom log file we are in a somewhat inconsistent state. The `Reporter` is trying to open the log file after a crash using `Filesystem::log_file_path`. But since this is accessing a static variable of the `Filesystem` class it is not enough to just parse the log file in the child process. This one will be lost and the Reporter can not do anything than accessing the default log file.

So, `Reporter` needs to set the custom log file as well. Here we are a bit in a pickle. I do not want to resort to manually or "old school" CLI arg parsing like the one I just modernized in `h2cli`. On the other side, we do not want to duplicate all the CLI options in Reporter but we would have to for Qt-style parsing. Else the parser might reject some valid options we missed to add and `hydrogen` would not start up anymore (unless combined with `--child`). Therefore, I decided to move all the parsing into a separate class - `Parser` - used in both places.