### PR TITLE
SoundLibraryOnlineImportDialog: allow multiple drumkit/song/pattern downloads (#1143)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
-	* Release 1.3.0
+	* Release 2.0.0
 	* Added
 		- PortMidi driver does open a input/output port which can be
 		  discovered and connected to by other applications when port was
@@ -53,6 +53,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				  samples. Linked ones are not supported) as available as session kits
 				  in the Sound Library.
 				- New action in Main Menu to save kit to session folder.
+		- Online import dialog now allows for multiple downloads at once (#1143).
 	* Fixed
 		- Components can now carry arbitrary names and name duplication is handled
 			properly.

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -6010,9 +6010,9 @@ Overwrite the existing pattern?</source>
         <translation>Descarregant llibreria de sò...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -6008,9 +6008,9 @@ Overwrite the existing pattern?</source>
         <translation>Stahování knihovny zvuků...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -6066,9 +6066,9 @@ Soll sie überschrieben werden?</translation>
         <translation>Lade Soundbibliothek herunter...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -6070,9 +6070,9 @@ Overwrite the existing pattern?</source>
         <translation>Λαμβάνεται η ΒιβλιοθήκηΉχων...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -5992,9 +5992,9 @@ Overwrite the existing pattern?</source>
         <translation></translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -5992,9 +5992,9 @@ Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -6078,9 +6078,9 @@ Overwrite the existing pattern?</source>
         <translation>Descargando Librería de Sonidos...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -6078,9 +6078,9 @@ Overwrite the existing pattern?</source>
         <translation>Téléchargement de la bibliothèque de sons...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -6048,9 +6048,9 @@ Sobrescribir o patrón existente?</translation>
         <translation>Descargando biblioteca de son...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -6008,9 +6008,9 @@ Overwrite the existing pattern?</source>
         <translation>Skidanje zvučne knjižnice...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -5997,9 +5997,9 @@ Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -6013,9 +6013,9 @@ Sovrascrivere il modello esistente?</translation>
         <translation>Scaricamento libreria sonora...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -6046,9 +6046,9 @@ Overwrite the existing pattern?</source>
         <translation>サウンドライブラリーのダウンロード...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -6005,9 +6005,9 @@ Overwrite the existing pattern?</source>
         <translation>Geluid bibliotheek downloaden ...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -6001,9 +6001,9 @@ Overwrite the existing pattern?</source>
         <translation>Ściąganie Biblioteki Dźwięków...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -6076,9 +6076,9 @@ Sobrescrever o padrão existente?</translation>
         <translation>Baixando Biblioteca de Som</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -6039,9 +6039,9 @@ Overwrite the existing pattern?</source>
         <translation>Скачивается библиотека звуков...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -6057,9 +6057,9 @@ Overwrite the existing pattern?</source>
         <translation>Преузимам гарнитуру бубњева...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -5998,9 +5998,9 @@ Overwrite the existing pattern?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -6062,9 +6062,9 @@ Overwrite the existing pattern?</source>
         <translation>Звантаження бібліотеки звуків...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -6062,9 +6062,9 @@ Overwrite the existing pattern?</source>
         <translation>正在下载声音库...</translation>
     </message>
     <message>
-        <source>Drumkit
+        <source>Drumkits
 
-%1
+- %1
 
 imported into %2</source>
         <translation type="unfinished"></translation>

--- a/src/core/SoundLibrary/SoundLibraryInfo.cpp
+++ b/src/core/SoundLibrary/SoundLibraryInfo.cpp
@@ -33,6 +33,29 @@ SoundLibraryInfo::SoundLibraryInfo()
 	//default constructor
 }
 
+SoundLibraryInfo::SoundLibraryInfo( const QString& sName,
+									const QString& sURL,
+									const QString& sInfo,
+									const QString& sAuthor,
+									const QString& sCategory,
+									const QString& sType,
+									const License& license,
+									const QString& sImage,
+									const License& imageLicense,
+									const QString& sPath )
+	: m_sName( sName )
+	, m_sURL( sURL )
+	, m_sInfo( sInfo )
+	, m_sAuthor( sAuthor )
+	, m_sCategory( sCategory )
+	, m_sType( sType )
+	, m_license( license )
+	, m_sImage( sImage )
+	, m_imageLicense( imageLicense )
+	, m_sPath( sPath )
+{
+}
+
 bool SoundLibraryInfo::load( const QString& sPath ) {
 	setPath( sPath );
 

--- a/src/core/SoundLibrary/SoundLibraryInfo.h
+++ b/src/core/SoundLibrary/SoundLibraryInfo.h
@@ -48,6 +48,16 @@ class SoundLibraryInfo : public H2Core::Object<SoundLibraryInfo>
 	H2_OBJECT(SoundLibraryInfo)
 	public:
 		SoundLibraryInfo();
+		SoundLibraryInfo( const QString& sName,
+						  const QString& sURL,
+						  const QString& sInfo,
+						  const QString& sAuthor,
+						  const QString& sCategory,
+						  const QString& sType,
+						  const License& license,
+						  const QString& sImage,
+						  const License& imageLicense,
+						  const QString& sPath );
 		~SoundLibraryInfo();
 
 	/**

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -75,6 +75,15 @@ SoundLibraryOnlineImportDialog::SoundLibraryOnlineImportDialog( QWidget* pParent
 	SoundLibraryInfoLbl->setText( "" );
 	DownloadBtn->setEnabled( false );
 
+	UpdateListBtn->setSize( QSize( 105, 24 ) );
+	UpdateListBtn->setType( Button::Type::Push );
+	EditListBtn->setSize( QSize( 130, 24 ) );
+	EditListBtn->setType( Button::Type::Push );
+	DownloadBtn->setSize( QSize( 380, 24 ) );
+	DownloadBtn->setType( Button::Type::Push );
+	close_btn->setSize( QSize( 80, 24 ) );
+	close_btn->setType( Button::Type::Push );
+
 
 	updateRepositoryCombo();
 }

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -32,6 +32,7 @@
 #include <core/H2Exception.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Hydrogen.h>
+#include <core/License.h>
 #include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
@@ -58,6 +59,9 @@ SoundLibraryOnlineImportDialog::SoundLibraryOnlineImportDialog( QWidget* pParent
 					Qt::WindowMinMaxButtonsHint );
 
 	setWindowTitle( tr( "Sound Library import" ) );
+
+	m_sLabelInstalled = tr( "Installed" );
+	m_sLabelNew = tr( "New" );
 
 	QStringList headers;
 	headers << tr( "Sound library" ) << tr( "Status" );
@@ -105,21 +109,21 @@ SoundLibraryOnlineImportDialog::~SoundLibraryOnlineImportDialog()
 //update combo box
 void SoundLibraryOnlineImportDialog::updateRepositoryCombo()
 {
-	H2Core::Preferences* pref = H2Core::Preferences::get_instance();
+	H2Core::Preferences* pPref = H2Core::Preferences::get_instance();
 
 	/*
 		Read serverList from config and put servers into the comboBox
 	*/
 
-	if( pref->sServerList.size() == 0 ) {
-		pref->sServerList.push_back( "http://hydrogen-music.org/feeds/drumkit_list.php" );
+	if ( pPref->sServerList.size() == 0 ) {
+		pPref->sServerList.push_back(
+			"http://hydrogen-music.org/feeds/drumkit_list.php" );
 	}
 
 	repositoryCombo->clear();
 
-	std::list<QString>::const_iterator cur_Server;
-	for( cur_Server = pref->sServerList.begin(); cur_Server != pref->sServerList.end(); ++cur_Server ) {
-		repositoryCombo->insertItem( 0, *cur_Server );
+	for ( const auto& ssServer : pPref->sServerList ) {
+		repositoryCombo->insertItem( 0, ssServer );
 	}
 	reloadRepositoryData();
 }
@@ -170,18 +174,20 @@ void SoundLibraryOnlineImportDialog::clearImageCache()
 
 QString SoundLibraryOnlineImportDialog::getCachedFilename()
 {
-	QString cacheDir = H2Core::Filesystem::repositories_cache_dir();
-	QString serverMd5 = QString(QCryptographicHash::hash(( repositoryCombo->currentText().toLatin1() ),QCryptographicHash::Md5).toHex());
-	QString cacheFile = cacheDir + "/" + serverMd5;
-	return cacheFile;
+	const QString sCacheDir = H2Core::Filesystem::repositories_cache_dir();
+	const QString sServerMd5 = QString(
+		QCryptographicHash::hash( repositoryCombo->currentText().toLatin1(),
+								  QCryptographicHash::Md5 ).toHex() );
+	return sCacheDir + "/" + sServerMd5;
 }
 
 QString SoundLibraryOnlineImportDialog::getCachedImageFilename()
 {
-	QString cacheDir = H2Core::Filesystem::repositories_cache_dir();
-	QString kitNameMd5 = QString(QCryptographicHash::hash(( SoundLibraryNameLbl->text().toLatin1() ),QCryptographicHash::Md5).toHex());
-	QString cacheFile = cacheDir + "/" + kitNameMd5 + ".png";	
-	return cacheFile;
+	const QString sCacheDir = H2Core::Filesystem::repositories_cache_dir();
+	const QString sKitNameMd5 = QString(
+		QCryptographicHash::hash( SoundLibraryNameLbl->text().toLatin1(),
+								  QCryptographicHash::Md5 ).toHex() );
+	return sCacheDir + "/" + sKitNameMd5 + ".png";
 }
 
 
@@ -221,27 +227,21 @@ void SoundLibraryOnlineImportDialog::writeCachedImage( const QString& imageFile,
 	outFile.close();
 }
 
-QString SoundLibraryOnlineImportDialog::readCachedData(const QString& fileName)
-{
-	QString content;
-	QFile inFile( fileName );
-	if( !inFile.open( QIODevice::ReadOnly | QIODevice::Text ) )
-	{
-		ERRORLOG( QString("Failed to open file for reading: %1").arg( fileName ) );
-		return content;
+QString SoundLibraryOnlineImportDialog::readCachedData( const QString& sFileName ) {
+	QFile inFile( sFileName );
+	if ( ! inFile.open( QIODevice::ReadOnly | QIODevice::Text ) ) {
+		ERRORLOG( QString("Failed to open file for reading: %1").arg( sFileName ) );
+		return "";
 	}
 
 	QDomDocument document;
-	if( !document.setContent( &inFile ) )
-	{
+	if ( ! document.setContent( &inFile ) ) {
 		inFile.close();
-		return content;
+		return "";
 	}
 	inFile.close();
 
-	content = document.toString();
-
-	return content;
+	return document.toString();
 }
 
 QString SoundLibraryOnlineImportDialog::readCachedImage( const QString& imageFile )
@@ -261,80 +261,50 @@ QString SoundLibraryOnlineImportDialog::readCachedImage( const QString& imageFil
 void SoundLibraryOnlineImportDialog::reloadRepositoryData()
 {
 	QString sDrumkitXML;
-	QString cacheFile = getCachedFilename();
+	const QString sCacheFile = getCachedFilename();
 
-	if(H2Core::Filesystem::file_exists(cacheFile,true))
-	{
-		sDrumkitXML = readCachedData(cacheFile);
+	if ( H2Core::Filesystem::file_exists( sCacheFile, true ) ) {
+		sDrumkitXML = readCachedData( sCacheFile );
 	}
 
 	m_soundLibraryList.clear();
+
 	QDomDocument dom;
 	dom.setContent( sDrumkitXML );
+
+	auto setIfPresent = []( H2Core::SoundLibraryInfo& info,
+							const QDomNode& node, const QString& sLabel ) {
+		const QDomElement childNode = node.firstChildElement( sLabel );
+		if ( ! childNode.isNull() ) {
+			info.setName( childNode.text() );
+		}
+	};
+
 	QDomNode drumkitNode = dom.documentElement().firstChild();
-	while ( !drumkitNode.isNull() ) {
-		if( !drumkitNode.toElement().isNull() ) {
+	while ( ! drumkitNode.isNull() ) {
+		if ( ! drumkitNode.toElement().isNull() &&
+			 ( drumkitNode.toElement().tagName() == "drumkit" ||
+			   drumkitNode.toElement().tagName() == "song" ||
+			   drumkitNode.toElement().tagName() == "pattern" ) ) {
 
-			if ( drumkitNode.toElement().tagName() == "drumkit" || drumkitNode.toElement().tagName() == "song" || drumkitNode.toElement().tagName() == "pattern" ) {
-
-				H2Core::SoundLibraryInfo soundLibInfo;
-
-				if ( drumkitNode.toElement().tagName() =="song" ) {
-					soundLibInfo.setType( "song" );
-				}
-
-				if ( drumkitNode.toElement().tagName() =="drumkit" ) {
-					soundLibInfo.setType( "drumkit" );
-				}
-
-				if ( drumkitNode.toElement().tagName() =="pattern" ) {
-					soundLibInfo.setType( "pattern" );
-				}
-
-				QDomElement nameNode = drumkitNode.firstChildElement( "name" );
-				if ( !nameNode.isNull() ) {
-					soundLibInfo.setName( nameNode.text() );
-				}
-
-				QDomElement urlNode = drumkitNode.firstChildElement( "url" );
-				if ( !urlNode.isNull() ) {
-					soundLibInfo.setUrl( urlNode.text() );
-				}
-
-				QDomElement infoNode = drumkitNode.firstChildElement( "info" );
-				if ( !infoNode.isNull() ) {
-					soundLibInfo.setInfo( infoNode.text() );
-				}
-
-				QDomElement authorNode = drumkitNode.firstChildElement( "author" );
-				if ( !authorNode.isNull() ) {
-					soundLibInfo.setAuthor( authorNode.text() );
-				}
-
-				QDomElement licenseNode = drumkitNode.firstChildElement( "license" );
-				if ( !licenseNode.isNull() ) {
-					soundLibInfo.setLicense( licenseNode.text() );
-				}
-
-				QDomElement imageNode = drumkitNode.firstChildElement( "image" );
-				if ( !imageNode.isNull() ) {
-					soundLibInfo.setImage( imageNode.text() );
-				}
-
-				QDomElement imageLicenseNode = drumkitNode.firstChildElement( "imageLicense" );
-				if ( !imageLicenseNode.isNull() ) {
-					soundLibInfo.setImageLicense( imageLicenseNode.text() );
-				}
-
-
-				m_soundLibraryList.push_back( soundLibInfo );
-			}
+			m_soundLibraryList.push_back( H2Core::SoundLibraryInfo(
+				drumkitNode.firstChildElement( "name" ).text(),
+				drumkitNode.firstChildElement( "url" ).text(),
+				drumkitNode.firstChildElement( "info" ).text(),
+				drumkitNode.firstChildElement( "author" ).text(),
+				drumkitNode.firstChildElement( "category" ).text(),
+				drumkitNode.toElement().tagName(),
+				H2Core::License(
+					drumkitNode.firstChildElement( "license" ).text() ),
+				drumkitNode.firstChildElement( "image" ).text(),
+				H2Core::License(
+					drumkitNode.firstChildElement( "imageLicense" ).text() ),
+				"" ) );
 		}
 		drumkitNode = drumkitNode.nextSibling();
 	}
 
 	updateSoundLibraryList();
-
 }
 
 ///
@@ -504,94 +474,110 @@ void SoundLibraryOnlineImportDialog::showImage( const QPixmap& pixmap )
 }
 
 
-void SoundLibraryOnlineImportDialog::soundLibraryItemChanged( QTreeWidgetItem* current, QTreeWidgetItem* previous  )
+void SoundLibraryOnlineImportDialog::soundLibraryItemChanged( QTreeWidgetItem* pCurrentItem,
+															  QTreeWidgetItem*  )
 {
-	UNUSED( previous );
-	if ( current ) {
+	auto resetLabels = [=](){
+		SoundLibraryNameLbl->setText( "" );
+		SoundLibraryInfoLbl->setText( "" );
+		AuthorLbl->setText( "" );
+		LicenseLbl->setText( "" );
+	};
 
-		QString selected = current->text(0);
-		for ( uint i = 0; i < m_soundLibraryList.size(); ++i ) {
-			if ( m_soundLibraryList[ i ].getName() == selected ) {
-				H2Core::SoundLibraryInfo info = m_soundLibraryList[ i ];
+	if ( pCurrentItem == nullptr ) {
+		resetLabels();
+		return;
+	}
 
-				//bool alreadyInstalled = isSoundLibraryAlreadyInstalled( info.m_sURL );
+	if ( pCurrentItem == m_pDrumkitsItem || pCurrentItem == m_pSongItem ||
+		 pCurrentItem == m_pPatternItem ) {
+		resetLabels();
+		pCurrentItem->setSelected( false );
+		return;
+	}
 
-				SoundLibraryNameLbl->setText( info.getName() );
+	QString selected = pCurrentItem->text(0);
+	for ( uint i = 0; i < m_soundLibraryList.size(); ++i ) {
+		if ( m_soundLibraryList[ i ].getName() == selected ) {
+			H2Core::SoundLibraryInfo info = m_soundLibraryList[ i ];
 
-				if( info.getType() == "pattern" ){
-					SoundLibraryInfoLbl->setText("");
-				} else {
-					SoundLibraryInfoLbl->setText( info.getInfo() );
-				}
+			//bool alreadyInstalled = isSoundLibraryAlreadyInstalled( info.m_sURL );
 
-				AuthorLbl->setText( tr( "Author: %1" ).arg( info.getAuthor() ) );
+			SoundLibraryNameLbl->setText( info.getName() );
 
-				LicenseLbl->setText( tr( "Drumkit License: %1" )
-									 .arg( info.getLicense().getLicenseString() ) );
+			if( info.getType() == "pattern" ){
+				SoundLibraryInfoLbl->setText("");
+			} else {
+				SoundLibraryInfoLbl->setText( info.getInfo() );
+			}
 
-				ImageLicenseLbl->setText( tr("Image License: %1" )
-										  .arg( info.getImageLicense().getLicenseString() ) );
+			AuthorLbl->setText( tr( "Author: %1" ).arg( info.getAuthor() ) );
 
-				// Load the drumkit image
-				// Clear any image first
-				drumkitImageLabel->setPixmap( QPixmap() );
-				drumkitImageLabel->setText( info.getImage() );
+			LicenseLbl->setText( tr( "Drumkit License: %1" )
+								 .arg( info.getLicense().getLicenseString() ) );
 
-				if ( info.getImage().length() > 0 ) {
-					if ( isSoundLibraryItemAlreadyInstalled( info ) ) {
-						// get image file from local disk
-						QString sName = QFileInfo( info.getUrl() ).fileName();
-						sName = sName.left( sName.lastIndexOf( "." ) );
+			ImageLicenseLbl->setText( tr("Image License: %1" )
+									  .arg( info.getImageLicense().getLicenseString() ) );
 
-						auto pDrumkit = H2Core::Hydrogen::get_instance()
-							->getSoundLibraryDatabase()->getDrumkit( info.getPath() );
-						if ( pDrumkit != nullptr ) {
-							// get the image from the local filesystem
-							QPixmap pixmap ( pDrumkit->getPath() + "/" + pDrumkit->getImage() );
-							INFOLOG("Loaded image " + pDrumkit->getImage() + " from local filesystem");
-							showImage( pixmap );
-						}
-						else {
-							___ERRORLOG ( "Error loading the drumkit" );
-						}
+			// Load the drumkit image
+			// Clear any image first
+			drumkitImageLabel->setPixmap( QPixmap() );
+			drumkitImageLabel->setText( info.getImage() );
 
+			if ( info.getImage().length() > 0 ) {
+				if ( isSoundLibraryItemAlreadyInstalled( info ) ) {
+					// get image file from local disk
+					QString sName = QFileInfo( info.getUrl() ).fileName();
+					sName = sName.left( sName.lastIndexOf( "." ) );
+
+					auto pDrumkit = H2Core::Hydrogen::get_instance()
+						->getSoundLibraryDatabase()->getDrumkit( info.getPath() );
+					if ( pDrumkit != nullptr ) {
+						// get the image from the local filesystem
+						QPixmap pixmap ( pDrumkit->getPath() + "/" + pDrumkit->getImage() );
+						INFOLOG("Loaded image " + pDrumkit->getImage() + " from local filesystem");
+						showImage( pixmap );
 					}
 					else {
-						// Try from the cache
-						QString cachedFile = readCachedImage( info.getImage() );
-						
-						if ( cachedFile.length() > 0 ) {
-							QPixmap pixmap ( cachedFile );
-							showImage( pixmap );
-							INFOLOG( "Loaded image " + info.getImage() + " from cache (" + cachedFile + ")" );
-						}
-						else {
-							// Get the drumkit's directory name from URL
-							//
-							// Example: if the server repo URL is: http://www.hydrogen-music.org/feeds/drumkit_list.php
-							// and the image name from the XML is Roland_TR-808_drum_machine.jpg
-							// the URL for the image will be: http://www.hydrogen-music.org/feeds/images/Roland_TR-808_drum_machine.jpg
+						___ERRORLOG ( "Error loading the drumkit" );
+					}
 
-							if ( info.getImage().length() > 0 ) {
-								QString sImageUrl;
-								QString sLocalFile;
-								
-								sImageUrl = repositoryCombo->currentText().left( repositoryCombo->currentText().lastIndexOf( QString( "/" )) + 1 ) + info.getImage() ;
-								sLocalFile = QDir::tempPath() + "/" + QFileInfo( sImageUrl ).fileName();
+				}
+				else {
+					// Try from the cache
+					QString cachedFile = readCachedImage( info.getImage() );
 
-								DownloadWidget dl( this, tr( "" ), sImageUrl, sLocalFile );
-								dl.exec();
+					if ( cachedFile.length() > 0 ) {
+						QPixmap pixmap ( cachedFile );
+						showImage( pixmap );
+						INFOLOG( "Loaded image " + info.getImage() + " from cache (" + cachedFile + ")" );
+					}
+					else {
+						// Get the drumkit's directory name from URL
+						//
+						// Example: if the server repo URL is: http://www.hydrogen-music.org/feeds/drumkit_list.php
+						// and the image name from the XML is Roland_TR-808_drum_machine.jpg
+						// the URL for the image will be: http://www.hydrogen-music.org/feeds/images/Roland_TR-808_drum_machine.jpg
 
-								loadImage( sLocalFile );
-								// Delete the temporary file
-								QFile::remove( sLocalFile );
-							}
+						if ( info.getImage().length() > 0 ) {
+							QString sImageUrl;
+							QString sLocalFile;
+
+							sImageUrl = repositoryCombo->currentText().left( repositoryCombo->currentText().lastIndexOf( QString( "/" )) + 1 ) + info.getImage() ;
+							sLocalFile = QDir::tempPath() + "/" + QFileInfo( sImageUrl ).fileName();
+
+							DownloadWidget dl( this, tr( "" ), sImageUrl, sLocalFile );
+							dl.exec();
+
+							loadImage( sLocalFile );
+							// Delete the temporary file
+							QFile::remove( sLocalFile );
 						}
 					}
 				}
-				
-				return;
 			}
+
+			return;
 		}
 	}
 

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -655,28 +655,33 @@ void SoundLibraryOnlineImportDialog::on_DownloadBtn_clicked()
 				}
 
 				// Error message has been already displayed by DL widget
-				if ( ! bError && sType == "drumkit" ) {
-					if ( H2Core::Drumkit::install( sLocalFile ) ) {
-						// Success
-						QDir dir;
-						dir.remove( sLocalFile );
-						bUpdateDrumkits = true;
+				if ( ! bError ) {
+					// Success
+					ppItem->setText( 1, m_sLabelInstalled );
+					updateDownloadBtn();
 
-						installedDrumkits << sName;
-					}
-					else {
-						QApplication::restoreOverrideCursor();
-						if ( MainForm::checkDrumkitPathEncoding(
-								 sLocalFile,
-								 pCommonStrings->getImportDrumkitFailure() ) ) {
-							// In case it was not an encoding error, we have to
-							// create and std:: <<  << std::endl;or window ourselves.
-							QMessageBox::critical(
-								nullptr, "Hydrogen", QString( "%1\n\n%2" )
-								.arg( pCommonStrings->getImportDrumkitFailure() )
-								.arg( sName ) );
+					if ( sType == "drumkit" ) {
+						if ( H2Core::Drumkit::install( sLocalFile ) ) {
+							QDir dir;
+							dir.remove( sLocalFile );
+							bUpdateDrumkits = true;
+
+							installedDrumkits << sName;
 						}
-						QApplication::setOverrideCursor( Qt::WaitCursor );
+						else {
+							QApplication::restoreOverrideCursor();
+							if ( MainForm::checkDrumkitPathEncoding(
+									 sLocalFile,
+									 pCommonStrings->getImportDrumkitFailure() ) ) {
+								// In case it was not an encoding error, we have
+								// to create and show an error dialog ourselves.
+								QMessageBox::critical(
+									nullptr, "Hydrogen", QString( "%1\n\n%2" )
+									.arg( pCommonStrings->getImportDrumkitFailure() )
+									.arg( sName ) );
+							}
+							QApplication::setOverrideCursor( Qt::WaitCursor );
+						}
 					}
 				}
 
@@ -719,6 +724,10 @@ void SoundLibraryOnlineImportDialog::selectionChanged() {
 		pCurrentItem->setSelected( false );
 	}
 
+	updateDownloadBtn();
+}
+
+void SoundLibraryOnlineImportDialog::updateDownloadBtn() {
 	// Determine how many of the sSelected kits are not installed yet.
 	int nInstalledKits = 0;
 	for ( const auto& ppItem : m_pDrumkitTree->selectedItems() ) {

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -80,7 +80,7 @@ SoundLibraryOnlineImportDialog::SoundLibraryOnlineImportDialog( QWidget* pParent
 	UpdateListBtn->setType( Button::Type::Push );
 	EditListBtn->setSize( QSize( 130, 24 ) );
 	EditListBtn->setType( Button::Type::Push );
-	DownloadBtn->setSize( QSize( 380, 24 ) );
+	DownloadBtn->setSize( QSize( 215, 24 ) );
 	DownloadBtn->setType( Button::Type::Push );
 	close_btn->setSize( QSize( 80, 24 ) );
 	close_btn->setType( Button::Type::Push );

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -605,6 +605,10 @@ void SoundLibraryOnlineImportDialog::on_DownloadBtn_clicked()
 		}
 
 		const QString sSelected = ppItem->text(0);
+		if ( ppItem->text( 1 ) == m_sLabelInstalled ) {
+			// Item already installed. Skipping...
+			continue;
+		}
 
 		for ( int ii = 0; ii < m_soundLibraryList.size(); ++ii ) {
 			if ( m_soundLibraryList[ ii ].getName() == sSelected ) {

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -392,11 +392,11 @@ void SoundLibraryOnlineImportDialog::updateSoundLibraryList()
 		if( pDrumkitItem ) {
 			if ( isSoundLibraryItemAlreadyInstalled( m_soundLibraryList[ i ]  ) ) {
 				pDrumkitItem->setText( 0, sLibraryName );
-				pDrumkitItem->setText( 1, tr( "Installed" ) );
+				pDrumkitItem->setText( 1, m_sLabelInstalled );
 			}
 			else {
 				pDrumkitItem->setText( 0, sLibraryName );
-				pDrumkitItem->setText( 1, tr( "New" ) );
+				pDrumkitItem->setText( 1, m_sLabelNew );
 			}
 		}
 	}
@@ -695,13 +695,31 @@ void SoundLibraryOnlineImportDialog::on_close_btn_clicked() {
 }
 
 void SoundLibraryOnlineImportDialog::selectionChanged() {
-	if ( m_pDrumkitTree->selectedItems().size() == 0 ) {
+
+	// We do not take the root nodes into account.
+	auto pCurrentItem = m_pDrumkitTree->currentItem();
+	if ( pCurrentItem != nullptr && (
+			 pCurrentItem == m_pDrumkitsItem || pCurrentItem == m_pSongItem ||
+			 pCurrentItem == m_pPatternItem ) ) {
+		pCurrentItem->setSelected( false );
+	}
+
+	// Determine how many of the selected kits are not installed yet.
+	int nInstalledKits = 0;
+	for ( const auto& ppItem : m_pDrumkitTree->selectedItems() ) {
+		if ( ppItem != nullptr && ppItem->text( 1 ) == m_sLabelNew ) {
+			++nInstalledKits;
+		}
+	}
+
+	if ( nInstalledKits == 0 ) {
 		DownloadBtn->setIsActive( false );
 		DownloadBtn->setText( m_sDownloadBtnBase );
-	} else {
+	}
+	else {
 		DownloadBtn->setIsActive( true );
 		DownloadBtn->setText(
 			QString( "%1 (%2)" ).arg( m_sDownloadBtnBase )
-			.arg( m_pDrumkitTree->selectedItems().size() ) );
+			.arg( nInstalledKits ) );
 	}
 }

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.cpp
@@ -22,20 +22,17 @@
 
 #include "SoundLibraryOnlineImportDialog.h"
 #include "SoundLibraryRepositoryDialog.h"
-#include "SoundLibraryPanel.h"
 
-#include "../Widgets/DownloadWidget.h"
-#include "../Widgets/FileDialog.h"
+#include "../CommonStrings.h"
 #include "../HydrogenApp.h"
 #include "../MainForm.h"
-#include "../InstrumentRack.h"
-#include "../CommonStrings.h"
+#include "../Widgets/DownloadWidget.h"
 
-#include <core/H2Exception.h>
-#include <core/Preferences/Preferences.h>
 #include <core/Basics/Drumkit.h>
-#include <core/Hydrogen.h>
+#include <core/H2Exception.h>
 #include <core/Helpers/Filesystem.h>
+#include <core/Hydrogen.h>
+#include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
 #include <QTreeWidget>
@@ -68,12 +65,16 @@ SoundLibraryOnlineImportDialog::SoundLibraryOnlineImportDialog( QWidget* pParent
 	m_pDrumkitTree->setHeaderItem( header );
 	m_pDrumkitTree->header()->resizeSection( 0, 200 );
 
-	connect( m_pDrumkitTree, SIGNAL( currentItemChanged ( QTreeWidgetItem*, QTreeWidgetItem* ) ), this, SLOT( soundLibraryItemChanged( QTreeWidgetItem*, QTreeWidgetItem* ) ) );
-	connect( repositoryCombo, SIGNAL(currentIndexChanged(int)), this, SLOT( onRepositoryComboBoxIndexChanged(int) ));
+	connect( m_pDrumkitTree,
+			 SIGNAL( currentItemChanged ( QTreeWidgetItem*, QTreeWidgetItem* ) ),
+			 this,
+			 SLOT( soundLibraryItemChanged( QTreeWidgetItem*, QTreeWidgetItem* ) ) );
+	connect( repositoryCombo, SIGNAL(currentIndexChanged(int)),
+			 this, SLOT( onRepositoryComboBoxIndexChanged(int) ));
 
 	SoundLibraryNameLbl->setText( "" );
 	SoundLibraryInfoLbl->setText( "" );
-	DownloadBtn->setEnabled( false );
+	DownloadBtn->setIsActive( false );
 
 	UpdateListBtn->setSize( QSize( 105, 24 ) );
 	UpdateListBtn->setType( Button::Type::Push );
@@ -84,6 +85,9 @@ SoundLibraryOnlineImportDialog::SoundLibraryOnlineImportDialog( QWidget* pParent
 	close_btn->setSize( QSize( 80, 24 ) );
 	close_btn->setType( Button::Type::Push );
 
+	m_sDownloadBtnBase = DownloadBtn->text();
+	connect( m_pDrumkitTree, &QTreeWidget::itemSelectionChanged,
+			 this, &SoundLibraryOnlineImportDialog::selectionChanged );
 
 	updateRepositoryCombo();
 }
@@ -586,7 +590,6 @@ void SoundLibraryOnlineImportDialog::soundLibraryItemChanged( QTreeWidgetItem* c
 					}
 				}
 				
-				DownloadBtn->setEnabled( true );
 				return;
 			}
 		}
@@ -595,7 +598,6 @@ void SoundLibraryOnlineImportDialog::soundLibraryItemChanged( QTreeWidgetItem* c
 	SoundLibraryNameLbl->setText( "" );
 	SoundLibraryInfoLbl->setText( "" );
 	AuthorLbl->setText( "" );
-	DownloadBtn->setEnabled( false );
 }
 
 
@@ -704,4 +706,16 @@ void SoundLibraryOnlineImportDialog::on_DownloadBtn_clicked()
 
 void SoundLibraryOnlineImportDialog::on_close_btn_clicked() {
 	accept();
+}
+
+void SoundLibraryOnlineImportDialog::selectionChanged() {
+	if ( m_pDrumkitTree->selectedItems().size() == 0 ) {
+		DownloadBtn->setIsActive( false );
+		DownloadBtn->setText( m_sDownloadBtnBase );
+	} else {
+		DownloadBtn->setIsActive( true );
+		DownloadBtn->setText(
+			QString( "%1 (%2)" ).arg( m_sDownloadBtnBase )
+			.arg( m_pDrumkitTree->selectedItems().size() ) );
+	}
 }

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.h
@@ -73,6 +73,8 @@ class SoundLibraryOnlineImportDialog :  public QDialog,
 		QTreeWidgetItem* m_pPatternItem;
 
 		QString m_sDownloadBtnBase;
+		QString m_sLabelInstalled;
+		QString m_sLabelNew;
 
 		bool isSoundLibraryItemAlreadyInstalled( const H2Core::SoundLibraryInfo& sInfo );
 		void writeCachedData(const QString& fileName, const QString& data);

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.h
@@ -61,7 +61,9 @@ class SoundLibraryOnlineImportDialog :  public QDialog,
 		void soundLibraryItemChanged( QTreeWidgetItem*, QTreeWidgetItem* );
 		void onRepositoryComboBoxIndexChanged(int);
 
-
+		// Indicate the number of selected items in the download button and only
+		// active it in case at least one was selected.
+		void selectionChanged();
 
 	private:
 	std::vector<H2Core::SoundLibraryInfo> m_soundLibraryList;
@@ -69,6 +71,8 @@ class SoundLibraryOnlineImportDialog :  public QDialog,
 		QTreeWidgetItem* m_pDrumkitsItem;
 		QTreeWidgetItem* m_pSongItem;
 		QTreeWidgetItem* m_pPatternItem;
+
+		QString m_sDownloadBtnBase;
 
 		bool isSoundLibraryItemAlreadyInstalled( const H2Core::SoundLibraryInfo& sInfo );
 		void writeCachedData(const QString& fileName, const QString& data);

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog.h
@@ -89,7 +89,7 @@ class SoundLibraryOnlineImportDialog :  public QDialog,
 		void updateRepositoryCombo();
 		void showImage( const QPixmap& pixmap );
 		void loadImage( const QString& img );
-
+		void updateDownloadBtn();
 };
 
 #endif

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog_UI.ui
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog_UI.ui
@@ -87,14 +87,14 @@
                 </spacer>
                </item>
                <item>
-                <widget class="QPushButton" name="UpdateListBtn">
+                <widget class="Button" name="UpdateListBtn">
                  <property name="text">
                   <string>Update list</string>
                  </property>
                 </widget>
                </item>
                <item>
-                <widget class="QPushButton" name="EditListBtn">
+                <widget class="Button" name="EditListBtn">
                  <property name="text">
                   <string>Edit server list</string>
                  </property>
@@ -296,7 +296,7 @@
               </spacer>
              </item>
              <item>
-              <widget class="QPushButton" name="DownloadBtn">
+              <widget class="Button" name="DownloadBtn">
                <property name="text">
                 <string>Download and install</string>
                </property>
@@ -324,7 +324,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="close_btn">
+          <widget class="Button" name="close_btn">
            <property name="text">
             <string>Close</string>
            </property>
@@ -351,6 +351,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Button</class>
+   <extends>QPushButton</extends>
+   <header location="global">../src/Widgets/Button.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog_UI.ui
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog_UI.ui
@@ -283,24 +283,17 @@
               </widget>
              </item>
              <item>
-              <spacer name="centerSpacer">
+              <spacer name="horizontalSpacer">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>372</width>
-                 <height>21</height>
+                 <width>40</width>
+                 <height>20</height>
                 </size>
                </property>
               </spacer>
-             </item>
-             <item>
-              <widget class="Button" name="DownloadBtn">
-               <property name="text">
-                <string>Download and install</string>
-               </property>
-              </widget>
              </item>
             </layout>
            </item>
@@ -322,6 +315,13 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="Button" name="DownloadBtn">
+           <property name="text">
+            <string>Download and install</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="Button" name="close_btn">

--- a/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog_UI.ui
+++ b/src/gui/src/SoundLibrary/SoundLibraryOnlineImportDialog_UI.ui
@@ -126,6 +126,9 @@
                <property name="alternatingRowColors">
                 <bool>true</bool>
                </property>
+               <property name="selectionMode">
+                <enum>QAbstractItemView::MultiSelection</enum>
+               </property>
                <property name="indentation">
                 <number>15</number>
                </property>

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -54,13 +54,7 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 	, m_nBorderRadius( nBorderRadius )
 {
 	setFocusPolicy( Qt::NoFocus );
-	
-	if ( size.isNull() || size.isEmpty() ) {
-		m_size = sizeHint();
-	}
-	adjustSize();
-	setFixedSize( m_size );
-	resize( m_size );
+	setSize( size );
 
 	if ( ! sIcon.isEmpty() ) {
 		updateIcon();
@@ -68,16 +62,6 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 		setText( sText );
 	}
 
-	if ( m_nBorderRadius == -1 ) {
-		if ( size.width() <= 12 || size.height() <= 12 ) {
-			m_nBorderRadius = 0;
-		} else if ( size.width() <= 20 || size.height() <= 20 ) {
-			m_nBorderRadius = 3;
-		} else {
-			m_nBorderRadius = 5;
-		}
-	}
-	
 	if ( type == Type::Toggle ) {
 		setCheckable( true );
 	} else {
@@ -88,7 +72,6 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 		setFlat( true );
 	}
 
-	updateFont();
 	updateStyleSheet();
 	updateTooltip();
 	
@@ -367,12 +350,24 @@ void Button::updateTooltip() {
 }
 
 void Button::setSize( const QSize& size ) {
-	m_size = size;
-	
+	if ( size.isNull() || size.isEmpty() ) {
+		m_size = sizeHint();
+	} else {
+		m_size = size;
+	}
+
+	setFixedSize( m_size );
+	resize( m_size );
 	adjustSize();
-	if ( ! size.isNull() ) {
-		setFixedSize( size );
-		resize( size );
+
+	if ( m_nBorderRadius == -1 ) {
+		if ( m_size.width() <= 12 || m_size.height() <= 12 ) {
+			m_nBorderRadius = 0;
+		} else if ( m_size.width() <= 20 || m_size.height() <= 20 ) {
+			m_nBorderRadius = 3;
+		} else {
+			m_nBorderRadius = 5;
+		}
 	}
 
 	updateFont();


### PR DESCRIPTION
I implemented this feature a little different than suggested in #1143. Instead of having checkboxes for each item, one can now multiselect arbitrary items in `SoundLibraryOnlineImportDialog` and download them all at once. This is more touch friendly and faster (you left click-drag the tree to select all elements in a second).

![SLOID_multiselect](https://github.com/user-attachments/assets/16e0a0f2-36bb-41b6-8674-ca16ff8b29ea)


implements #1143