### PR TITLE
Fix build pipeline

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -598,6 +598,7 @@ for:
           if not %job_name%==Windows32 c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-liblo
+          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-angleproject
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -598,7 +598,8 @@ for:
           if not %job_name%==Windows32 c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-jack2
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-ccache
           c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-liblo
-          c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-angleproject
+          REM *** The angleproject package does not seem to be available for 32bit Windows and Qt does not find its libGLESv2.dll anymore ***
+          if not %job_name%==Windows32 c:\msys64\usr\bin\pacman --noconfirm -S -q %MSYS_REPO%-angleproject
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-5.15.5-1-any.pkg.tar.zst
           c:\msys64\usr\bin\pacman --noconfirm --assume-installed %PACKAGE_PREFIX%-gettext -U https://repo.msys2.org/mingw/%MSYS_REPO%-qt5-tools-5.15.9-1-any.pkg.tar.zst
 
@@ -641,7 +642,12 @@ for:
           mkdir %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs
 
           REM *** Deploy Qt ***
-          %QTDIR%\bin\windeployqt.exe -xmlpatterns --no-patchqt --dir %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs src/gui/hydrogen.exe
+          set "DEPLOY_ARGS=-xmlpatterns --no-patchqt --dir %APPVEYOR_BUILD_FOLDER%\build\windows\extralibs"
+
+          REM *** No OpenGL ES support via pacman on 32bit Windows
+          if %job_name%==Windows32 set "DEPLOY_ARGS=%DEPLOY_ARGS% --no-angle"
+
+          %QTDIR%\bin\windeployqt.exe %DEPLOY_ARGS% src/gui/hydrogen.exe
 
           REM *** Deploy other libraries ***
           set PYTHON=C:\Python38\python


### PR DESCRIPTION
Since recently (https://ci.appveyor.com/project/mauser/hydrogen/builds/50262151 vs. https://ci.appveyor.com/project/mauser/hydrogen/builds/49314329) our Windows build pipeline fails because Qts `windeplyqt` fails to locate `libGLESv2.dll`.

I do not really understand what is going on here since I expect Qt to Vulkan and OpenGL ES is explicitly tailored for embedded systems - which we do not support. But whatever. Before risking to break things at some ends it is probably better to install a OpenGL ES implementation provided by `ANGLE`.

As for JACK2 there is also no `angleproject` package for 32bit Windows within the `pacman` repos. At least as far as queries from the CLI both locally and within AppVeyor are concerned. In the web interface the package seems to be still available.

This starts to smell like bit rot. Lets see how long we can provide 32bit support.