### PR TITLE
Add `userVersion` to XML files

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -66,6 +66,12 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				  in the Sound Library.
 				- New action in Main Menu to save kit to session folder.
 		- Online import dialog now allows for multiple downloads at once (#1143).
+		- `userVersion` element was added to `.h2song`, `.h2pattern`, and drumkit
+			files. It can be set using the corresponding properties dialog and can
+			help to tell different artifact versions apart.
+		- `formatVersion` element was added to `.h2song`, `.h2pattern`, `.h2playlist`,
+			drumkit and config files. This integer will be increment each time the
+			format will be changed.
 	* Fixed
 		- Components can now carry arbitrary names and name duplication is handled
 			properly.

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -1085,6 +1085,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -1087,6 +1087,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Version</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Έκδοση</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -1088,6 +1088,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Versión</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -1087,6 +1087,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Version</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Versione</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -1085,6 +1085,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -1087,6 +1087,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Versão</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Версия</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Издање</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -1084,6 +1084,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">Версія</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1085,6 +1085,11 @@ Are you sure?</source>
         <extracomment>Text displayed on an Apply button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version</source>
+        <extracomment>Label of the spin box in pattern/song/drumkit properties dialog to set * the version of the particular artifact.</extracomment>
+        <translation type="unfinished">版本</translation>
+    </message>
 </context>
 <context>
     <name>ComponentMixerLine</name>

--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -157,7 +157,7 @@
 			<xsd:element name="formatVersion"	type="xsd:nonNegativeInteger"
 						 minOccurs="0"	maxOccurs="1"/>
 			<xsd:element name="name"			type="xsd:string"/>
-			<xsd:element name="version"			type="xsd:nonNegativeInteger"
+			<xsd:element name="userVersion"			type="xsd:nonNegativeInteger"
 						 minOccurs="0"	maxOccurs="1"/>
 			<xsd:element name="author"			type="xsd:string"/>
 			<xsd:element name="info"			type="xsd:string"/>

--- a/data/xsd/drumkit.xsd
+++ b/data/xsd/drumkit.xsd
@@ -157,6 +157,8 @@
 			<xsd:element name="formatVersion"	type="xsd:nonNegativeInteger"
 						 minOccurs="0"	maxOccurs="1"/>
 			<xsd:element name="name"			type="xsd:string"/>
+			<xsd:element name="version"			type="xsd:nonNegativeInteger"
+						 minOccurs="0"	maxOccurs="1"/>
 			<xsd:element name="author"			type="xsd:string"/>
 			<xsd:element name="info"			type="xsd:string"/>
 			<xsd:element name="license"			type="xsd:string"/>

--- a/data/xsd/drumkit_pattern.xsd
+++ b/data/xsd/drumkit_pattern.xsd
@@ -68,7 +68,7 @@
 		<xsd:sequence>
 			<xsd:element name="formatVersion" type="xsd:nonNegativeInteger"
 						 minOccurs="0"		maxOccurs="1"/>
-			<xsd:element name="version" type="xsd:nonNegativeInteger"
+			<xsd:element name="userVersion" type="xsd:nonNegativeInteger"
 						 minOccurs="0"		maxOccurs="1"/>
 			<xsd:element name="name"		type="xsd:string"/>
 			<xsd:element name="info"		type="xsd:string"/>

--- a/data/xsd/drumkit_pattern.xsd
+++ b/data/xsd/drumkit_pattern.xsd
@@ -68,6 +68,8 @@
 		<xsd:sequence>
 			<xsd:element name="formatVersion" type="xsd:nonNegativeInteger"
 						 minOccurs="0"		maxOccurs="1"/>
+			<xsd:element name="version" type="xsd:nonNegativeInteger"
+						 minOccurs="0"		maxOccurs="1"/>
 			<xsd:element name="name"		type="xsd:string"/>
 			<xsd:element name="info"		type="xsd:string"/>
 			<xsd:element name="category"	type="xsd:string"/>

--- a/docs/decisions/0002-introduce-version-to-xml-files.md
+++ b/docs/decisions/0002-introduce-version-to-xml-files.md
@@ -4,7 +4,7 @@ date: 2024-08-11
 deciders: phil (theGreatWhiteShark)
 ---
 
-# AD: Introduce `version` to XML files
+# AD: Introduce `userVersion` to XML files
 
 ## Context and Problem Statement
 
@@ -38,7 +38,7 @@ way, like including topic, style, using semantic versioning, but since we can
 not compare them in a meaningful way, this would be effectively just another
 "name" element.
 
-I also decided to include `version` into `.h2song`, `.h2pattern`, and
+I also decided to include `userVersion` into `.h2song`, `.h2pattern`, and
 `drumkit.xml` file but not into `.h2playlist`, `hydrogen.conf`, and `.h2map`
 files. `hydrogen.conf` and `.h2map` are somewhat internal and not user-fronted
 files. These are more for us to ship and not for the user to share.
@@ -46,9 +46,15 @@ files. These are more for us to ship and not for the user to share.
 mostly it was an UX-driven decision to not include it there. For songs, kits,
 and patterns we already provide a properties dialog. But not for the playlist
 and it would be awkward to introduce one just to set the version.
+
+The name `userVersion` instead of plain `version` is required as there is
+already `version` element present in both `.h2song` and `hydrogen.conf` file
+indicating the semantic version of the Hydrogen installation the file was
+created with.
+
 ### Consequences
 
-* `version` elements will be introduced to `.h2song`, `.h2pattern`, and
+* `userVersion` elements will be introduced to `.h2song`, `.h2pattern`, and
   `drumkit.xml` files and the corresponding XSD files will be tweaked.
 * The initial version will be set to `0` and higher values will indicate newer
   versions.

--- a/docs/decisions/0002-introduce-version-to-xml-files.md
+++ b/docs/decisions/0002-introduce-version-to-xml-files.md
@@ -1,0 +1,56 @@
+---
+status: accepted
+date: 2024-08-11
+deciders: phil (theGreatWhiteShark)
+---
+
+# AD: Introduce `version` to XML files
+
+## Context and Problem Statement
+
+None of our XML files allows the user to introduce some proper way of
+versioning. In the `.h2drumkit` files we host on SourceForge this is done by
+adding a "_VX" suffix to file and kit name. But this does not allow for an
+automated way of checking for a newer version.
+
+## Decision Drivers
+
+Since starting with v2.0 of Hydrogen patterns and songs are independent of
+drumkits and it finally makes sense to share them and e.g. provide a central
+repo. There are no plans to do so (yet) but since all XML definitions are
+touched anyway, this is a good time to introduce a more solid base for such
+endeavor. An upgrade path to the latest version of a provided artifact would be
+of much help.
+
+## Considered Options
+
+1. No versioning
+2. Integer version
+2. String version
+
+## Decision Outcome
+
+It feels wrong (at least a little) to introduce a feature that is currently not required. But in the long run versioning is most probably a lot more helpful than no versioning (and we do not break anything).
+
+I decided to go for integer versions as they are easy to understand and come
+with an inherent way of comparison. Strings would be allow for a more flexible
+way, like including topic, style, using semantic versioning, but since we can
+not compare them in a meaningful way, this would be effectively just another
+"name" element.
+
+I also decided to include `version` into `.h2song`, `.h2pattern`, and
+`drumkit.xml` file but not into `.h2playlist`, `hydrogen.conf`, and `.h2map`
+files. `hydrogen.conf` and `.h2map` are somewhat internal and not user-fronted
+files. These are more for us to ship and not for the user to share.
+`.h2playlist` is more tricky. I think there is less use in sharing those. But
+mostly it was an UX-driven decision to not include it there. For songs, kits,
+and patterns we already provide a properties dialog. But not for the playlist
+and it would be awkward to introduce one just to set the version.
+### Consequences
+
+* `version` elements will be introduced to `.h2song`, `.h2pattern`, and
+  `drumkit.xml` files and the corresponding XSD files will be tweaked.
+* The initial version will be set to `0` and higher values will indicate newer
+  versions.
+* `PatternPropertiesDialog`, `SongPropertiesDialog`, and
+  `DrumkitPropertiesDialog` have to be extended with a corresponding spin box.

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -57,19 +57,20 @@
 namespace H2Core
 {
 
-Drumkit::Drumkit() : m_bSamplesLoaded( false ),
-					 m_pInstruments( nullptr ),
-					 m_context( Context::User ),
+Drumkit::Drumkit() : m_context( Context::User ),
 					 m_sName( "empty" ),
+					 m_nVersion( 0 ),
 					 m_sAuthor( "undefined author" ),
 					 m_sInfo( "No information available." ),
 					 m_license( License() ),
-					 m_imageLicense( License() )
+					 m_sImage( "" ),
+					 m_imageLicense( License() ),
+					 m_bSamplesLoaded( false ),
+					 m_pInstruments( std::make_shared<InstrumentList>() ),
+					 m_pComponents( std::make_shared<std::vector<std::shared_ptr<DrumkitComponent>>>() )
 {
 	QDir usrDrumkitPath( Filesystem::usr_drumkits_dir() );
 	m_sPath = usrDrumkitPath.filePath( m_sName );
-	m_pComponents = std::make_shared<std::vector<std::shared_ptr<DrumkitComponent>>>();
-	m_pInstruments = std::make_shared<InstrumentList>();
 }
 
 Drumkit::Drumkit( std::shared_ptr<Drumkit> other ) :
@@ -77,6 +78,7 @@ Drumkit::Drumkit( std::shared_ptr<Drumkit> other ) :
 	m_context( other->getContext() ),
 	m_sPath( other->getPath() ),
 	m_sName( other->getName() ),
+	m_nVersion( other->m_nVersion ),
 	m_sAuthor( other->getAuthor() ),
 	m_sInfo( other->getInfo() ),
 	m_license( other->getLicense() ),
@@ -186,6 +188,8 @@ std::shared_ptr<Drumkit> Drumkit::loadFrom( const XMLNode& node,
 
 	pDrumkit->m_sPath = sDrumkitPath;
 	pDrumkit->m_sName = sDrumkitName;
+	pDrumkit->m_nVersion = node.read_int(
+		"version", pDrumkit->m_nVersion, true, false, bSilent );
 	pDrumkit->m_sAuthor = node.read_string( "author", "undefined author",
 											true, true, true );
 	pDrumkit->m_sInfo = node.read_string( "info", "No information available.",
@@ -442,6 +446,7 @@ void Drumkit::saveTo( XMLNode& node,
 {
 	node.write_int( "formatVersion", nCurrentFormatVersion );
 	node.write_string( "name", m_sName );
+	node.write_int( "version", m_nVersion );
 	node.write_string( "author", m_sAuthor );
 	node.write_string( "info", m_sInfo );
 	node.write_string( "license", m_license.getLicenseString() );
@@ -1711,6 +1716,8 @@ QString Drumkit::toQString( const QString& sPrefix, bool bShort ) const {
 					 .arg( ContextToString( m_context ) ) )
 			.append( QString( "%1%2path: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sPath ) )
 			.append( QString( "%1%2name: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sName ) )
+			.append( QString( "%1%2m_nVersion: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( m_nVersion ) )
 			.append( QString( "%1%2author: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sAuthor ) )
 			.append( QString( "%1%2info: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sInfo ) )
 			.append( QString( "%1%2license: %3\n" ).arg( sPrefix ).arg( s ).arg( m_license.toQString() ) )
@@ -1732,6 +1739,7 @@ QString Drumkit::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( " context: %1" ).arg( ContextToString( m_context ) ) )
 			.append( QString( ", path: %1" ).arg( m_sPath ) )
 			.append( QString( ", name: %1" ).arg( m_sName ) )
+			.append( QString( ", version: %1" ).arg( m_nVersion ) )
 			.append( QString( ", author: %1" ).arg( m_sAuthor ) )
 			.append( QString( ", info: %1" ).arg( m_sInfo ) )
 			.append( QString( ", license: %1" ).arg( m_license.toQString() ) )

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -189,7 +189,7 @@ std::shared_ptr<Drumkit> Drumkit::loadFrom( const XMLNode& node,
 	pDrumkit->m_sPath = sDrumkitPath;
 	pDrumkit->m_sName = sDrumkitName;
 	pDrumkit->m_nVersion = node.read_int(
-		"version", pDrumkit->m_nVersion, true, false, bSilent );
+		"userVersion", pDrumkit->m_nVersion, true, false, bSilent );
 	pDrumkit->m_sAuthor = node.read_string( "author", "undefined author",
 											true, true, true );
 	pDrumkit->m_sInfo = node.read_string( "info", "No information available.",
@@ -446,7 +446,7 @@ void Drumkit::saveTo( XMLNode& node,
 {
 	node.write_int( "formatVersion", nCurrentFormatVersion );
 	node.write_string( "name", m_sName );
-	node.write_int( "version", m_nVersion );
+	node.write_int( "userVersion", m_nVersion );
 	node.write_string( "author", m_sAuthor );
 	node.write_string( "info", m_sInfo );
 	node.write_string( "license", m_license.getLicenseString() );

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -269,6 +269,8 @@ class Drumkit : public H2Core::Object<Drumkit>
 		/** #m_sName accessor */
 		const QString& getName() const;
 		/** #m_sAuthor setter */
+		int getVersion() const;
+		void setVersion( int nVersion );
 		void setAuthor( const QString& author );
 		/** #m_sAuthor accessor */
 		const QString& getAuthor() const;
@@ -357,6 +359,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 		Context m_context;
 		QString m_sPath;					///< absolute drumkit path
 		QString m_sName;					///< drumkit name
+		int m_nVersion;
 		QString m_sAuthor;				///< drumkit author
 		QString m_sInfo;					///< drumkit free text
 		License m_license;				///< drumkit license description
@@ -443,6 +446,12 @@ inline void Drumkit::setName( const QString& name )
 inline const QString& Drumkit::getName() const
 {
 	return m_sName;
+}
+inline int Drumkit::getVersion() const {
+	return m_nVersion;
+}
+inline void Drumkit::setVersion( int nVersion ) {
+	m_nVersion = nVersion;
 }
 
 inline void Drumkit::setAuthor( const QString& author )

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -150,7 +150,7 @@ Pattern* Pattern::load_from( const XMLNode& node, const QString& sDrumkitName,
 	);
 
 	pPattern->m_nVersion = node.read_int(
-		"version", pPattern->m_nVersion, false, false, bSilent );
+		"userVersion", pPattern->m_nVersion, false, false, bSilent );
 	pPattern->setDrumkitName( sDrumkitName );
 	pPattern->setAuthor( sAuthor );
 	pPattern->setLicense( license );
@@ -237,7 +237,7 @@ void Pattern::save_to( XMLNode& node, const std::shared_ptr<Instrument> pInstrum
 {
 	XMLNode pattern_node =  node.createNode( "pattern" );
 	pattern_node.write_int( "formatVersion", nCurrentFormatVersion );
-	pattern_node.write_int( "version", m_nVersion );
+	pattern_node.write_int( "userVersion", m_nVersion );
 	pattern_node.write_string( "name", __name );
 	pattern_node.write_string( "info", __info );
 	pattern_node.write_string( "category", __category );

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -37,7 +37,8 @@ namespace H2Core
 {
 
 Pattern::Pattern( const QString& name, const QString& info, const QString& sCategory, int length, int denominator )
-	: __length( length )
+	: m_nVersion( 0 )
+	, __length( length )
 	, __denominator( denominator)
 	, __name( name )
 	, __info( info )
@@ -52,7 +53,8 @@ Pattern::Pattern( const QString& name, const QString& info, const QString& sCate
 }
 
 Pattern::Pattern( Pattern* other )
-	: __length( other->get_length() )
+	: m_nVersion( other->m_nVersion )
+	, __length( other->get_length() )
 	, __denominator( other->get_denominator() )
 	, __name( other->get_name() )
 	, __info( other->get_info() )
@@ -147,6 +149,8 @@ Pattern* Pattern::load_from( const XMLNode& node, const QString& sDrumkitName,
 	    node.read_int( "denominator", 4, false, false )
 	);
 
+	pPattern->m_nVersion = node.read_int(
+		"version", pPattern->m_nVersion, false, false, bSilent );
 	pPattern->setDrumkitName( sDrumkitName );
 	pPattern->setAuthor( sAuthor );
 	pPattern->setLicense( license );
@@ -233,6 +237,7 @@ void Pattern::save_to( XMLNode& node, const std::shared_ptr<Instrument> pInstrum
 {
 	XMLNode pattern_node =  node.createNode( "pattern" );
 	pattern_node.write_int( "formatVersion", nCurrentFormatVersion );
+	pattern_node.write_int( "version", m_nVersion );
 	pattern_node.write_string( "name", __name );
 	pattern_node.write_string( "info", __info );
 	pattern_node.write_string( "category", __category );
@@ -519,6 +524,8 @@ QString Pattern::toQString( const QString& sPrefix, bool bShort ) const {
 	if ( ! bShort ) {
 		sOutput = QString( "%1[Pattern]\n" ).arg( sPrefix )
 			.append( QString( "%1%2name: %3\n" ).arg( sPrefix ).arg( s ).arg( __name ) )
+			.append( QString( "%1%2m_nVersion: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_nVersion ) )
 			.append( QString( "%1%2m_sDrumkitName: %3\n" ).arg( sPrefix )
 					 .arg( s ).arg( m_sDrumkitName ) )
 			.append( QString( "%1%2m_sAuthor: %3\n" ).arg( sPrefix ).arg( s )
@@ -556,6 +563,7 @@ QString Pattern::toQString( const QString& sPrefix, bool bShort ) const {
 
 		sOutput = QString( "[Pattern]" )
 			.append( QString( " name: %1" ).arg( __name ) )
+			.append( QString( ", m_nVersion: %1" ).arg( m_nVersion ) )
 			.append( QString( ", m_sDrumkitName: %1" ).arg( m_sDrumkitName ) )
 			.append( QString( ", m_sAuthor: %1" ).arg( m_sAuthor ) )
 			.append( QString( ", m_license: %1" )

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -111,6 +111,8 @@ class Pattern : public H2Core::Object<Pattern>
 		 */
 		bool save_file( const QString& drumkit_name, const QString& author, const License& license, const QString& pattern_path, bool overwrite=false ) const;
 
+		void setVersion( int nVersion );
+		int getVersion() const;
 		void setDrumkitName( const QString& sDrumkitName );
 		const QString& getDrumkitName() const;
 		void setAuthor( const QString& sAuthor );
@@ -262,6 +264,7 @@ class Pattern : public H2Core::Object<Pattern>
 		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
 
 	private:
+		int m_nVersion;
 		/** Name of the kit using which the pattern was written. This is mainly
 		 * used for backward compatibility. */
 		QString m_sDrumkitName;
@@ -337,6 +340,12 @@ class Pattern : public H2Core::Object<Pattern>
 	for( Pattern::notes_it_t _it=(_notes)->lower_bound((_bound)); (_it)!=(_notes)->end() && (_it)->first == (_bound) && (_it)->first < (_pattern)->get_length(); (_it)++ )
 
 // DEFINITIONS
+inline void Pattern::setVersion( int nVersion ) {
+	m_nVersion = nVersion;
+}
+inline int Pattern::getVersion() const {
+	return m_nVersion;
+}
 inline void Pattern::setDrumkitName( const QString& sDrumkitName ) {
 	m_sDrumkitName = sDrumkitName;
 }

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -67,6 +67,7 @@ Song::Song( const QString& sName, const QString& sAuthor, float fBpm, float fVol
 	, m_bIsMuted( false )
 	, m_resolution( nDefaultResolution )
 	, m_fBpm( fBpm )
+	, m_nVersion( 0 )
 	, m_sName( sName )
 	, m_sAuthor( sAuthor )
 	, m_fVolume( fVolume )
@@ -242,6 +243,9 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sF
 												 false, false, bSilent ) );
 
 	std::shared_ptr<Song> pSong = std::make_shared<Song>( sName, sAuthor, fBpm, fVolume );
+
+	pSong->m_nVersion = rootNode.read_int(
+		"version", pSong->m_nVersion, true, false, bSilent );
 
 	pSong->setIsMuted( rootNode.read_bool( "isMuted", false, true, false,
 											 bSilent ) );
@@ -721,6 +725,7 @@ void Song::saveTo( XMLNode& rootNode, bool bLegacy, bool bSilent ) const {
 	rootNode.write_float( "volume", m_fVolume );
 	rootNode.write_bool( "isMuted", m_bIsMuted );
 	rootNode.write_float( "metronomeVolume", m_fMetronomeVolume );
+	rootNode.write_int( "version", m_nVersion );
 	rootNode.write_string( "name", m_sName );
 	rootNode.write_string( "author", m_sAuthor );
 	rootNode.write_string( "notes", m_sNotes );
@@ -1346,6 +1351,8 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 					 .arg( m_resolution ) )
 			.append( QString( "%1%2m_fBpm: %3\n" ).arg( sPrefix ).arg( s )
 					 .arg( m_fBpm ) )
+			.append( QString( "%1%2m_nVersion: %3\n" ).arg( sPrefix ).arg( s )
+					 .arg( m_nVersion ) )
 			.append( QString( "%1%2m_sName: %3\n" ).arg( sPrefix ).arg( s )
 					 .arg( m_sName ) )
 			.append( QString( "%1%2m_sAuthor: %3\n" ).arg( sPrefix ).arg( s )
@@ -1423,6 +1430,7 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", m_bIsMuted: %1" ).arg( m_bIsMuted ) )
 			.append( QString( ", m_resolution: %1" ).arg( m_resolution ) )
 			.append( QString( ", m_fBpm: %1" ).arg( m_fBpm ) )
+			.append( QString( ", m_nVersion: %1" ).arg( m_nVersion ) )
 			.append( QString( ", m_sName: %1" ).arg( m_sName ) )
 			.append( QString( ", m_sAuthor: %1" ).arg( m_sAuthor ) )
 			.append( QString( ", m_fVolume: %1" ).arg( m_fVolume ) )

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -245,7 +245,7 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sF
 	std::shared_ptr<Song> pSong = std::make_shared<Song>( sName, sAuthor, fBpm, fVolume );
 
 	pSong->m_nVersion = rootNode.read_int(
-		"version", pSong->m_nVersion, true, false, bSilent );
+		"userVersion", pSong->m_nVersion, true, false, bSilent );
 
 	pSong->setIsMuted( rootNode.read_bool( "isMuted", false, true, false,
 											 bSilent ) );
@@ -725,7 +725,7 @@ void Song::saveTo( XMLNode& rootNode, bool bLegacy, bool bSilent ) const {
 	rootNode.write_float( "volume", m_fVolume );
 	rootNode.write_bool( "isMuted", m_bIsMuted );
 	rootNode.write_float( "metronomeVolume", m_fMetronomeVolume );
-	rootNode.write_int( "version", m_nVersion );
+	rootNode.write_int( "userVersion", m_nVersion );
 	rootNode.write_string( "name", m_sName );
 	rootNode.write_string( "author", m_sAuthor );
 	rootNode.write_string( "notes", m_sNotes );

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -152,7 +152,7 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 	 *
 	 * @param sFilename Absolute path to write the song to.
 	 * @param bLegacy Whether the current format containing a proper
-	 *   #H2Core::Drumkit or the legacy format (prior to version 1.3.0)
+	 *   #H2Core::Drumkit or the legacy format (prior to version 2.0.0)
 	 *   containing only selected drumkit parts should be used.
 	 * \param bSilent if set to true, all log messages except of errors and
 	 *   warnings are suppressed.

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -176,6 +176,9 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		float getBpm() const;
 		void setBpm( float fBpm );
 
+		int getVersion() const;
+		void setVersion( int nVersion );
+
 		const QString& getName() const;
 		void setName( const QString& sName );
 		
@@ -335,6 +338,8 @@ private:
 		 * different tempo instances work.
 		 */
 		float m_fBpm;
+
+		int m_nVersion;
 		
 		///< song name
 		QString m_sName;
@@ -497,6 +502,14 @@ inline float Song::getBpm() const
 {
 	return m_fBpm;
 }
+
+inline void Song::setVersion( int nVersion ) {
+	m_nVersion = nVersion;
+}
+inline int Song::getVersion() const {
+	return m_nVersion;
+}
+
 
 inline void Song::setName( const QString& sName )
 {

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -401,6 +401,9 @@ CommonStrings::CommonStrings(){
 	m_sSavingChanges = tr( "Do you want to save the changes?" );
 
 	m_sMutableDialog = tr( "Don't show this message again" );
+	/*: Label of the spin box in pattern/song/drumkit properties dialog to set
+	 *  the version of the particular artifact. */
+	m_sVersionDialog = tr( "Version" );
 	
 	// Not used yet.
 	/*: Displayed in the Open dialog window if the selected song could

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -166,6 +166,7 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getSavingChanges() const { return m_sSavingChanges; }
 
 	const QString& getMutableDialog() const { return m_sMutableDialog; }
+	const QString& getVersionDialog() const { return m_sVersionDialog; }
 
 	// const QString& getDialogSongLoadError() const { return m_sDialogSongLoadError; }
 	// const QString& getDialogUnsavedChangesH1() const { return m_sDialogUnsavedChangedH1; }
@@ -355,6 +356,7 @@ private:
 	QString m_sSavingChanges;
 	
 	QString m_sMutableDialog;
+	QString m_sVersionDialog;
 	
 	// Not used yet. A redesign of the GUI startup is required first
 	// since these strings are required _before_ HydrogenApp was

--- a/src/gui/src/PatternPropertiesDialog.cpp
+++ b/src/gui/src/PatternPropertiesDialog.cpp
@@ -38,8 +38,17 @@ PatternPropertiesDialog::PatternPropertiesDialog(QWidget* parent, Pattern *patte
 	setupUi( this );
 	setWindowTitle( tr( "Pattern properties" ) );
 
+	// Show and enable maximize button. This is key when enlarging the
+	// application using a scaling factor and allows the OS to force its size
+	// beyond the minimum and make the scrollbars appear.
+	setWindowFlags( windowFlags() | Qt::CustomizeWindowHint |
+					Qt::WindowMinMaxButtonsHint );
+
 	this->pattern = pattern;
 
+	// Remove size constraints
+	versionSpinBox->setFixedSize( QWIDGETSIZE_MAX, QWIDGETSIZE_MAX );
+	versionSpinBox->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
 	patternNameTxt->setText( pattern->get_name() );
 	patternNameTxt->selectAll();
 
@@ -63,7 +72,16 @@ PatternPropertiesDialog::PatternPropertiesDialog(QWidget* parent, Pattern *patte
 	}
 
 	defaultNameCheck( pattern->get_name(), savepattern );
-	okBtn->setEnabled(true);
+
+	okBtn->setFixedFontSize( 12 );
+	okBtn->setSize( QSize( 70, 23 ) );
+	okBtn->setBorderRadius( 3 );
+	okBtn->setType( Button::Type::Push );
+	okBtn->setIsActive( true );
+	cancelBtn->setFixedFontSize( 12 );
+	cancelBtn->setSize( QSize( 70, 23 ) );
+	cancelBtn->setBorderRadius( 3 );
+	cancelBtn->setType( Button::Type::Push );
 }
 
 

--- a/src/gui/src/PatternPropertiesDialog.cpp
+++ b/src/gui/src/PatternPropertiesDialog.cpp
@@ -49,6 +49,9 @@ PatternPropertiesDialog::PatternPropertiesDialog(QWidget* parent, Pattern *patte
 	// Remove size constraints
 	versionSpinBox->setFixedSize( QWIDGETSIZE_MAX, QWIDGETSIZE_MAX );
 	versionSpinBox->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+	versionLabel->setText(
+		HydrogenApp::get_instance()->getCommonStrings()->getVersionDialog() );
+
 	patternNameTxt->setText( pattern->get_name() );
 	patternNameTxt->selectAll();
 

--- a/src/gui/src/PatternPropertiesDialog_UI.ui
+++ b/src/gui/src/PatternPropertiesDialog_UI.ui
@@ -6,112 +6,191 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>311</width>
-    <height>274</height>
+    <width>315</width>
+    <height>277</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="TextLabel1">
-         <property name="text">
-          <string>New Pattern Name</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="patternNameTxt"/>
-       </item>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Pattern description</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTextEdit" name="patternDescTxt"/>
-       </item>
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Pattern category</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="categoryComboBox">
-         <property name="editable">
-          <bool>true</bool>
-         </property>
-        </widget>
+  <layout class="QVBoxLayout" name="overallLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaContent">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>313</width>
+        <height>275</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>311</width>
+        <height>274</height>
+       </size>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="QLabel" name="TextLabel1">
+             <property name="text">
+              <string>New Pattern Name</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="LCDDisplay" name="patternNameTxt"/>
+           </item>
+           <item>
+            <widget class="QLabel" name="versionLabel">
+            </widget>
+           </item>
+           <item>
+            <widget class="LCDSpinBox" name="versionSpinBox"/>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Pattern description</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="LCDTextEdit" name="patternDescTxt"/>
+           </item>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Pattern category</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="LCDCombo" name="categoryComboBox">
+             <property name="editable">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>37</width>
+               <height>28</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="Button" name="cancelBtn">
+             <property name="text">
+              <string>&amp;Cancel</string>
+             </property>
+             <property name="shortcut">
+              <string>Alt+C</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Button" name="okBtn">
+             <property name="text">
+              <string>&amp;OK</string>
+             </property>
+             <property name="shortcut">
+              <string>Alt+O</string>
+             </property>
+             <property name="default">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>37</width>
+               <height>28</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
       </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>37</width>
-           <height>28</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="cancelBtn">
-         <property name="text">
-          <string>&amp;Cancel</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+C</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="okBtn">
-         <property name="text">
-          <string>&amp;OK</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+O</string>
-         </property>
-         <property name="default">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>37</width>
-           <height>28</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </item>
-    </layout>
+     </widget>
+    </widget>
    </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>Button</class>
+   <extends>QPushButton</extends>
+   <header location="global">../src/Widgets/Button.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDCombo</class>
+   <extends>QComboBox</extends>
+   <header location="global">../src/Widgets/LCDCombo.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDDisplay</class>
+   <extends>QLineEdit</extends>
+   <header location="global">../src/Widgets/LCDDisplay.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header location="global">../src/Widgets/LCDSpinBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header location="global">../src/Widgets/LCDTextEdit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1624,9 +1624,11 @@ void SongEditorPatternList::inlineEditingEntered()
 	QString patternName = pPatternList->find_unused_pattern_name( m_pLineEdit->text(), m_pPatternBeingEdited );
 
 	SE_modifyPatternPropertiesAction *action =
-		new SE_modifyPatternPropertiesAction( m_pPatternBeingEdited->get_name(),
+		new SE_modifyPatternPropertiesAction( m_pPatternBeingEdited->getVersion(),
+											  m_pPatternBeingEdited->get_name(),
 											  m_pPatternBeingEdited->get_info(),
 											  m_pPatternBeingEdited->get_category(),
+											  m_pPatternBeingEdited->getVersion(),
 											  patternName,
 											  m_pPatternBeingEdited->get_info(),
 											  m_pPatternBeingEdited->get_category(),
@@ -2029,7 +2031,8 @@ void SongEditorPatternList::patternPopup_properties()
 }
 
 
-void SongEditorPatternList::acceptPatternPropertiesDialogSettings( const QString& newPatternName,
+void SongEditorPatternList::acceptPatternPropertiesDialogSettings( const int nNewVersion,
+																   const QString& newPatternName,
 																   const QString& newPatternInfo,
 																   const QString& newPatternCategory,
 																   int patternNr )
@@ -2038,6 +2041,7 @@ void SongEditorPatternList::acceptPatternPropertiesDialogSettings( const QString
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	PatternList *patternList = pSong->getPatternList();
 	H2Core::Pattern *pattern = patternList->get( patternNr );
+	pattern->setVersion( nNewVersion );
 	pattern->set_name( newPatternName );
 	pattern->set_info( newPatternInfo );
 	pattern->set_category( newPatternCategory );
@@ -2048,7 +2052,8 @@ void SongEditorPatternList::acceptPatternPropertiesDialogSettings( const QString
 }
 
 
-void SongEditorPatternList::revertPatternPropertiesDialogSettings( const QString& oldPatternName,
+void SongEditorPatternList::revertPatternPropertiesDialogSettings( const int nOldVersion,
+																   const QString& oldPatternName,
 																   const QString& oldPatternInfo,
 																   const QString& oldPatternCategory,
 																   int patternNr)
@@ -2057,6 +2062,7 @@ void SongEditorPatternList::revertPatternPropertiesDialogSettings( const QString
 	std::shared_ptr<Song> pSong = pHydrogen->getSong();
 	PatternList *patternList = pSong->getPatternList();
 	H2Core::Pattern *pattern = patternList->get( patternNr );
+	pattern->setVersion( nOldVersion );
 	pattern->set_name( oldPatternName );
 	pattern->set_category( oldPatternCategory );
 	pHydrogen->setIsModified( true );

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -275,11 +275,13 @@ class SongEditorPatternList :  public QWidget
 		void createBackground();
 		void invalidateBackground();
 		void movePatternLine( int, int );
-		void acceptPatternPropertiesDialogSettings( const QString& newPatternName,
+		void acceptPatternPropertiesDialogSettings( const int nNewVersion,
+													const QString& newPatternName,
 													const QString& newPatternInfo,
 													const QString& newPatternCategory,
 													int patternNr );
-		void revertPatternPropertiesDialogSettings( const QString& oldPatternName,
+		void revertPatternPropertiesDialogSettings( const int nOldVersion,
+													const QString& oldPatternName,
 													const QString& oldPatternInfo,
 													const QString& oldPatternCategory,
 													int patternNr);

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -38,9 +38,11 @@ SongPropertiesDialog::SongPropertiesDialog(QWidget* parent)
 	
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
-	adjustSize();
-	setMaximumSize( width(), height() );
-	setMinimumSize( width(), height() );
+	// Show and enable maximize button. This is key when enlarging the
+	// application using a scaling factor and allows the OS to force its size
+	// beyond the minimum and make the scrollbars appear.
+	setWindowFlags( windowFlags() | Qt::CustomizeWindowHint |
+					Qt::WindowMinMaxButtonsHint );
 
 	setWindowTitle( tr( "Song properties" ) );
 

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -46,30 +46,49 @@ SongPropertiesDialog::SongPropertiesDialog(QWidget* parent)
 
 	setWindowTitle( tr( "Song properties" ) );
 
-	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
-	songNameTxt->setText( pSong->getName() );
+	// Remove size constraints
+	versionSpinBox->setFixedSize( QWIDGETSIZE_MAX, QWIDGETSIZE_MAX );
+	versionSpinBox->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+	// Arbitrary high number.
+	versionSpinBox->setMaximum( 300 );
+	versionLabel->setText( pCommonStrings->getVersionDialog() );
 
-	authorTxt->setText( pSong->getAuthor() );
-	notesTxt->append( pSong->getNotes() );
+	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
+
+	if ( pSong != nullptr ) {
+		versionSpinBox->setValue( pSong->getVersion() );
+		songNameTxt->setText( pSong->getName() );
+
+		authorTxt->setText( pSong->getAuthor() );
+		notesTxt->append( pSong->getNotes() );
+
+		licenseComboBox->setCurrentIndex(
+			static_cast<int>( pSong->getLicense().getType() ) );
+		licenseStringTxt->setText( pSong->getLicense().getLicenseString() );
+		if ( pSong->getLicense().getType() == License::Unspecified ) {
+			licenseStringTxt->hide();
+		}
+	}
 	connect( licenseComboBox, SIGNAL( currentIndexChanged( int ) ),
 			 this, SLOT( licenseComboBoxChanged( int ) ) );
 
 	setupLicenseComboBox( licenseComboBox );
-	
+
 	licenseComboBox->setToolTip( pCommonStrings->getLicenseComboToolTip() );
 	licenseStringTxt->setToolTip( pCommonStrings->getLicenseStringToolTip() );
-	
-	licenseComboBox->setCurrentIndex( static_cast<int>( pSong->getLicense().getType() ) );
-	licenseStringTxt->setText( pSong->getLicense().getLicenseString() );
-	if ( pSong->getLicense().getType() == License::Unspecified ) {
-		licenseStringTxt->hide();
-	}
+
+	okBtn->setFixedFontSize( 12 );
+	okBtn->setSize( QSize( 70, 23 ) );
+	okBtn->setBorderRadius( 3 );
+	okBtn->setType( Button::Type::Push );
+	okBtn->setIsActive( true );
+	cancelBtn->setFixedFontSize( 12 );
+	cancelBtn->setSize( QSize( 70, 23 ) );
+	cancelBtn->setBorderRadius( 3 );
+	cancelBtn->setType( Button::Type::Push );
 }
 
-
-
-SongPropertiesDialog::~SongPropertiesDialog()
-{
+SongPropertiesDialog::~SongPropertiesDialog() {
 }
 
 void SongPropertiesDialog::licenseComboBoxChanged( int ) {
@@ -96,6 +115,10 @@ void SongPropertiesDialog::on_okBtn_clicked()
 	auto pSong = pHydrogen->getSong();
 
 	bool bIsModified = false;
+	if ( versionSpinBox->value() != pSong->getVersion() ) {
+		pSong->setVersion( versionSpinBox->value() );
+		bIsModified = true;
+	}
 	if ( songNameTxt->text() != pSong->getName() ) {
 		pSong->setName( songNameTxt->text() );
 		bIsModified = true;

--- a/src/gui/src/SongPropertiesDialog_UI.ui
+++ b/src/gui/src/SongPropertiesDialog_UI.ui
@@ -49,50 +49,8 @@
         <height>378</height>
        </size>
       </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="0" colspan="2">
-        <widget class="QLineEdit" name="songNameTxt"/>
-       </item>
-       <item row="11" column="0">
-        <widget class="QPushButton" name="cancelBtn">
-         <property name="text">
-          <string>&amp;Cancel</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+C</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="2">
-        <widget class="QLineEdit" name="authorTxt"/>
-       </item>
-       <item row="10" column="0" colspan="2">
-        <widget class="QTextEdit" name="notesTxt"/>
-       </item>
-       <item row="9" column="0" colspan="2">
-        <widget class="QLabel" name="TextLabel2">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>20</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Notes</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0" colspan="2">
-        <widget class="QComboBox" name="licenseComboBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="2">
+      <layout class="QVBoxLayout" name="mainLayout">
+       <item>
         <widget class="QLabel" name="TextLabel1">
          <property name="minimumSize">
           <size>
@@ -105,43 +63,16 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
-        <widget class="QLabel" name="TextLabel1_3">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>20</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>License</string>
-         </property>
-        </widget>
+       <item>
+        <widget class="LCDDisplay" name="songNameTxt"/>
        </item>
-       <item row="11" column="1">
-        <widget class="QPushButton" name="okBtn">
-         <property name="text">
-          <string> &amp;OK</string>
-         </property>
-         <property name="shortcut">
-          <string>Alt+O</string>
-         </property>
-         <property name="default">
-          <bool>true</bool>
-         </property>
-        </widget>
+       <item>
+        <widget class="QLabel" name="versionLabel"/>
        </item>
-       <item row="8" column="0" colspan="2">
-        <widget class="QLineEdit" name="licenseStringTxt"/>
+       <item>
+        <widget class="LCDSpinBox" name="versionSpinBox"/>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>TextLabel</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0" colspan="2">
+       <item>
         <widget class="QLabel" name="TextLabel1_2">
          <property name="minimumSize">
           <size>
@@ -154,15 +85,142 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QSpinBox" name="spinBox"/>
+       <item>
+        <widget class="LCDDisplay" name="authorTxt"/>
        </item>
+       <item>
+        <widget class="QLabel" name="TextLabel1_3">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>License</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="LCDCombo" name="licenseComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="LCDDisplay" name="licenseStringTxt"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="TextLabel2">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Notes</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="LCDTextEdit" name="notesTxt"/>
+       </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>37</width>
+               <height>28</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="Button" name="cancelBtn">
+             <property name="text">
+              <string>&amp;Cancel</string>
+             </property>
+             <property name="shortcut">
+              <string>Alt+C</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Button" name="okBtn">
+             <property name="text">
+              <string>&amp;OK</string>
+             </property>
+             <property name="shortcut">
+              <string>Alt+O</string>
+             </property>
+             <property name="default">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>37</width>
+               <height>28</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
       </layout>
      </widget>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Button</class>
+   <extends>QPushButton</extends>
+   <header location="global">../src/Widgets/Button.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDCombo</class>
+   <extends>QComboBox</extends>
+   <header location="global">../src/Widgets/LCDCombo.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDDisplay</class>
+   <extends>QLineEdit</extends>
+   <header location="global">../src/Widgets/LCDDisplay.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header location="global">../src/Widgets/LCDSpinBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header location="global">../src/Widgets/LCDTextEdit.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <layoutdefault spacing="6" margin="11"/>
  <resources/>
  <connections/>

--- a/src/gui/src/SongPropertiesDialog_UI.ui
+++ b/src/gui/src/SongPropertiesDialog_UI.ui
@@ -6,109 +6,159 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>290</width>
-    <height>378</height>
+    <width>295</width>
+    <height>383</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="TextLabel1">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Song name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLineEdit" name="songNameTxt"/>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLineEdit" name="authorTxt"/>
-   </item>
-   <item row="9" column="1">
-    <widget class="QPushButton" name="okBtn">
-     <property name="text">
-      <string> &amp;OK</string>
-     </property>
-     <property name="shortcut">
-      <string>Alt+O</string>
-     </property>
-     <property name="default">
+  <layout class="QVBoxLayout" name="overallLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QLabel" name="TextLabel1_3">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>License</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QLabel" name="TextLabel1_2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Author</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QTextEdit" name="notesTxt"/>
-   </item>
-   <item row="9" column="0">
-    <widget class="QPushButton" name="cancelBtn">
-     <property name="text">
-      <string>&amp;Cancel</string>
-     </property>
-     <property name="shortcut">
-      <string>Alt+C</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QLabel" name="TextLabel2">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Notes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QLineEdit" name="licenseStringTxt"/>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QComboBox" name="licenseComboBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+     <widget class="QWidget" name="scrollAreaContent">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>293</width>
+        <height>381</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>290</width>
+        <height>378</height>
+       </size>
+      </property>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="0" colspan="2">
+        <widget class="QLineEdit" name="songNameTxt"/>
+       </item>
+       <item row="11" column="0">
+        <widget class="QPushButton" name="cancelBtn">
+         <property name="text">
+          <string>&amp;Cancel</string>
+         </property>
+         <property name="shortcut">
+          <string>Alt+C</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QLineEdit" name="authorTxt"/>
+       </item>
+       <item row="10" column="0" colspan="2">
+        <widget class="QTextEdit" name="notesTxt"/>
+       </item>
+       <item row="9" column="0" colspan="2">
+        <widget class="QLabel" name="TextLabel2">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Notes</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="2">
+        <widget class="QComboBox" name="licenseComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="TextLabel1">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Song name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QLabel" name="TextLabel1_3">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>License</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QPushButton" name="okBtn">
+         <property name="text">
+          <string> &amp;OK</string>
+         </property>
+         <property name="shortcut">
+          <string>Alt+O</string>
+         </property>
+         <property name="default">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="2">
+        <widget class="QLineEdit" name="licenseStringTxt"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QLabel" name="TextLabel1_2">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Author</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QSpinBox" name="spinBox"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/gui/src/SongPropertiesDialog_UI.ui
+++ b/src/gui/src/SongPropertiesDialog_UI.ui
@@ -158,7 +158,7 @@
            <item>
             <widget class="Button" name="okBtn">
              <property name="text">
-              <string>&amp;OK</string>
+              <string> &amp;OK</string>
              </property>
              <property name="shortcut">
               <string>Alt+O</string>

--- a/src/gui/src/SoundLibrary/DrumkitPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/DrumkitPropertiesDialog.cpp
@@ -68,6 +68,13 @@ DrumkitPropertiesDialog::DrumkitPropertiesDialog( QWidget* pParent,
 	setupLicenseComboBox( licenseComboBox );
 	setupLicenseComboBox( imageLicenseComboBox );
 
+	// Remove size constraints
+	versionSpinBox->setFixedSize( QWIDGETSIZE_MAX, QWIDGETSIZE_MAX );
+	versionSpinBox->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Fixed );
+	// Arbitrary high number.
+	versionSpinBox->setMaximum( 300 );
+	versionLabel->setText( pCommonStrings->getVersionDialog() );
+
 	if ( bSaveToNsmSession &&
 		 ! Hydrogen::get_instance()->isUnderSessionManagement() ) {
 		ERRORLOG( "NSM session export request while there is no active NSM session. Saving to Sound Library instead." );
@@ -78,6 +85,7 @@ DrumkitPropertiesDialog::DrumkitPropertiesDialog( QWidget* pParent,
 	//display the current drumkit infos into the qlineedit
 	if ( pDrumkit != nullptr ){
 
+		versionSpinBox->setValue( pDrumkit->getVersion() );
 		auto drumkitContext = pDrumkit->getContext();
 		if ( drumkitContext == Drumkit::Context::User ||
 			 drumkitContext == Drumkit::Context::SessionReadWrite ||
@@ -590,6 +598,9 @@ void DrumkitPropertiesDialog::on_saveBtn_clicked()
 		m_pDrumkit->setName( nameTxt->text() );
 		m_pDrumkit->setPath( H2Core::Filesystem::usr_drumkits_dir() +
 							  nameTxt->text() );
+	}
+	if ( m_pDrumkit->getVersion() != versionSpinBox->value() ) {
+		m_pDrumkit->setVersion( versionSpinBox->value() );
 	}
 	m_pDrumkit->setAuthor( authorTxt->text() );
 	m_pDrumkit->setInfo( infoTxt->toHtml() );

--- a/src/gui/src/SoundLibrary/DrumkitPropertiesDialog_UI.ui
+++ b/src/gui/src/SoundLibrary/DrumkitPropertiesDialog_UI.ui
@@ -45,7 +45,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>752</width>
+        <width>755</width>
         <height>923</height>
        </rect>
       </property>
@@ -55,449 +55,453 @@
         <height>919</height>
        </size>
       </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="sizeConstraint">
-    <enum>QLayout::SetDefaultConstraint</enum>
-   </property>
-   <item>
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="tabGeneral">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <attribute name="title">
-       <string>General</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Information</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="imageLicenseLbl">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+       <item>
+        <widget class="QTabWidget" name="tabWidget">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>Image License</string>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
+         <property name="currentIndex">
+          <number>0</number>
          </property>
+         <widget class="QWidget" name="tabGeneral">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <attribute name="title">
+           <string>General</string>
+          </attribute>
+          <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+           <item row="4" column="1">
+            <widget class="LCDDisplay" name="licenseStringTxt">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="licenseStringLbl">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="1">
+            <widget class="LCDDisplay" name="imageLicenseStringTxt">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QLabel" name="imageLicenseStringLbl">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Information</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="1">
+            <widget class="QLabel" name="drumkitImageLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>75</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>320</height>
+              </size>
+             </property>
+             <property name="palette">
+              <palette>
+               <active>
+                <colorrole role="WindowText">
+                 <brush brushstyle="SolidPattern">
+                  <color alpha="0">
+                   <red>34</red>
+                   <green>31</green>
+                   <blue>30</blue>
+                  </color>
+                 </brush>
+                </colorrole>
+               </active>
+               <inactive>
+                <colorrole role="WindowText">
+                 <brush brushstyle="SolidPattern">
+                  <color alpha="0">
+                   <red>34</red>
+                   <green>31</green>
+                   <blue>30</blue>
+                  </color>
+                 </brush>
+                </colorrole>
+               </inactive>
+               <disabled>
+                <colorrole role="WindowText">
+                 <brush brushstyle="SolidPattern">
+                  <color alpha="255">
+                   <red>144</red>
+                   <green>141</green>
+                   <blue>139</blue>
+                  </color>
+                 </brush>
+                </colorrole>
+               </disabled>
+              </palette>
+             </property>
+             <property name="autoFillBackground">
+              <bool>true</bool>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="scaledContents">
+              <bool>false</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="LCDDisplay" name="authorTxt">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1">
+            <widget class="LCDTextEdit" name="infoTxt">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>46</height>
+              </size>
+             </property>
+             <property name="styleSheet">
+              <string notr="true"/>
+             </property>
+             <property name="acceptRichText">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="LCDCombo" name="imageLicenseComboBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="licenseLbl">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Drumkit License</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Name</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Author</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="imageLicenseLbl">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Image License</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_3">
+             <item>
+              <widget class="LCDDisplay" name="imageText">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>370</width>
+                 <height>21</height>
+                </size>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="Button" name="imageBrowsePushButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Browse</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>Image</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="LCDDisplay" name="nameTxt">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="LCDCombo" name="licenseComboBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="versionLabel">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="LCDSpinBox" name="versionSpinBox"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="tabTypes">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <attribute name="title">
+           <string>Types</string>
+          </attribute>
+          <layout class="QVBoxLayout" name="tabTypesLayout">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="TypesTable" name="typesTable">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="tabLicenses">
+          <attribute name="title">
+           <string>Licenses</string>
+          </attribute>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QTableWidget" name="licensesTable"/>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
-       <item row="6" column="1">
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <layout class="QHBoxLayout">
          <item>
-          <widget class="LCDDisplay" name="imageText">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
-           <property name="minimumSize">
+           <property name="sizeHint" stdset="0">
             <size>
-             <width>370</width>
-             <height>21</height>
+             <width>40</width>
+             <height>20</height>
             </size>
            </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="Button" name="saveBtn">
            <property name="text">
-            <string/>
+            <string>Save </string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="Button" name="imageBrowsePushButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
+          <widget class="Button" name="m_cancelBtn">
            <property name="text">
-            <string>Browse</string>
+            <string>Cancel</string>
            </property>
           </widget>
          </item>
         </layout>
        </item>
-       <item row="4" column="1">
-        <widget class="LCDTextEdit" name="infoTxt">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>46</height>
-          </size>
-         </property>
-         <property name="styleSheet">
-          <string notr="true"/>
-         </property>
-         <property name="acceptRichText">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="LCDDisplay" name="authorTxt">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="LCDCombo" name="imageLicenseComboBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="licenseLbl">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Drumkit License</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="LCDDisplay" name="licenseStringTxt">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Author</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="LCDDisplay" name="nameTxt">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="LCDDisplay" name="imageLicenseStringTxt">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Image</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="LCDCombo" name="licenseComboBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QLabel" name="drumkitImageLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>75</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>320</height>
-          </size>
-         </property>
-         <property name="palette">
-          <palette>
-           <active>
-            <colorrole role="WindowText">
-             <brush brushstyle="SolidPattern">
-              <color alpha="0">
-               <red>34</red>
-               <green>31</green>
-               <blue>30</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </active>
-           <inactive>
-            <colorrole role="WindowText">
-             <brush brushstyle="SolidPattern">
-              <color alpha="0">
-               <red>34</red>
-               <green>31</green>
-               <blue>30</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </inactive>
-           <disabled>
-            <colorrole role="WindowText">
-             <brush brushstyle="SolidPattern">
-              <color alpha="255">
-               <red>144</red>
-               <green>141</green>
-               <blue>139</blue>
-              </color>
-             </brush>
-            </colorrole>
-           </disabled>
-          </palette>
-         </property>
-         <property name="autoFillBackground">
-          <bool>true</bool>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="scaledContents">
-          <bool>false</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="imageLicenseStringLbl">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="licenseStringLbl">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tabTypes">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <attribute name="title">
-       <string>Types</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="tabTypesLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="TypesTable" name="typesTable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tabLicenses">
-      <attribute name="title">
-       <string>Licenses</string>
-      </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QTableWidget" name="licensesTable"/>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="Button" name="saveBtn">
-       <property name="text">
-        <string>Save </string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Button" name="m_cancelBtn">
-       <property name="text">
-        <string>Cancel</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-    </item>
-    </layout>
-    </widget>
     </widget>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>LCDDisplay</class>
-   <extends>QLineEdit</extends>
-   <header location="global">../src/Widgets/LCDDisplay.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>LCDTextEdit</class>
-   <extends>QTextEdit</extends>
-   <header location="global">../src/Widgets/LCDTextEdit.h</header>
+   <class>Button</class>
+   <extends>QPushButton</extends>
+   <header location="global">../src/Widgets/Button.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -507,9 +511,21 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>Button</class>
-   <extends>QPushButton</extends>
-   <header location="global">../src/Widgets/Button.h</header>
+   <class>LCDDisplay</class>
+   <extends>QLineEdit</extends>
+   <header location="global">../src/Widgets/LCDDisplay.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header location="global">../src/Widgets/LCDSpinBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDTextEdit</class>
+   <extends>QTextEdit</extends>
+   <header location="global">../src/Widgets/LCDTextEdit.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -159,17 +159,21 @@ private:
 class SE_modifyPatternPropertiesAction : public QUndoCommand
 {
 public:
-	SE_modifyPatternPropertiesAction( const QString& oldPatternName,
+	SE_modifyPatternPropertiesAction( const int nOldVersion,
+									  const QString& oldPatternName,
 									  const QString& oldPatternInfo,
 									  const QString& oldPatternCategory,
+									  const int nNewVersion,
 									  const QString& newPatternName,
 									  const QString& newPatternInfo,
 									  const QString& newPatternCategory,
 									  int patternNr ){
 		setText( QObject::tr( "Modify pattern properties" ) );
+		m_nOldVersion =  nOldVersion;
 		__oldPatternName =  oldPatternName;
 		__oldPatternCategory = oldPatternCategory;
 		__oldPatternInfo = oldPatternInfo;
+		m_nNewVersion =  nNewVersion;
 		__newPatternName = newPatternName;
 		__newPatternInfo = newPatternInfo;
 		__newPatternCategory = newPatternCategory;
@@ -179,20 +183,28 @@ public:
 	{
 		//qDebug() << "Modify pattern properties undo";
 		HydrogenApp* h2app = HydrogenApp::get_instance();
-		h2app->getSongEditorPanel()->getSongEditorPatternList()->revertPatternPropertiesDialogSettings( __oldPatternName, __oldPatternInfo, __oldPatternCategory, __patternNr );
+		h2app->getSongEditorPanel()->getSongEditorPatternList()
+			->revertPatternPropertiesDialogSettings(
+				m_nOldVersion, __oldPatternName, __oldPatternInfo,
+				__oldPatternCategory, __patternNr );
 	}
 
 	virtual void redo()
 	{
 		//qDebug() << "Modify pattern properties redo" ;
 		HydrogenApp* h2app = HydrogenApp::get_instance();
-		h2app->getSongEditorPanel()->getSongEditorPatternList()->acceptPatternPropertiesDialogSettings( __newPatternName, __newPatternInfo, __newPatternCategory, __patternNr );
+		h2app->getSongEditorPanel()->getSongEditorPatternList()
+			->acceptPatternPropertiesDialogSettings(
+				m_nNewVersion, __newPatternName, __newPatternInfo,
+				__newPatternCategory, __patternNr );
 	}
 private:
+		int m_nOldVersion;
 	QString __oldPatternName;
 	QString __oldPatternInfo;
 	QString __oldPatternCategory;
 
+		int m_nNewVersion;
 	QString __newPatternName;
 	QString __newPatternInfo;
 	QString __newPatternCategory;

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -359,7 +359,7 @@ void LCDSpinBox::paintEvent( QPaintEvent *ev ) {
 		pen.setColor( colorHighlightActive );
 		pen.setWidth( 3 );
 		painter.setPen( pen );
-		painter.drawRoundedRect( QRect( 0, 0, m_size.width(), m_size.height() ), 3, 3 );
+		painter.drawRoundedRect( QRect( 0, 0, width(), height() ), 3, 3 );
 	}
 }
 

--- a/src/tests/data/drumkits/format-integrity/drumkit.xml
+++ b/src/tests/data/drumkits/format-integrity/drumkit.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<drumkit_info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.hydrogen-music.org/drumkit">
+<drumkit_info xmlns="http://www.hydrogen-music.org/drumkit" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <formatVersion>2</formatVersion>
  <name>H2 test DK</name>
+ <version>0</version>
  <author>Zurcher Jérémy</author>
  <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 &lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">

--- a/src/tests/data/drumkits/format-integrity/drumkit.xml
+++ b/src/tests/data/drumkits/format-integrity/drumkit.xml
@@ -2,7 +2,7 @@
 <drumkit_info xmlns="http://www.hydrogen-music.org/drumkit" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <formatVersion>2</formatVersion>
  <name>H2 test DK</name>
- <version>0</version>
+ <userVersion>0</userVersion>
  <author>Zurcher Jérémy</author>
  <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 &lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">

--- a/src/tests/data/pattern/empty.h2pattern
+++ b/src/tests/data/pattern/empty.h2pattern
@@ -5,7 +5,7 @@
  <license>CC0</license>
  <pattern>
   <formatVersion>2</formatVersion>
-  <version>0</version>
+  <userVersion>0</userVersion>
   <name>test</name>
   <info>ladida</info>
   <category>not_categorized</category>

--- a/src/tests/data/pattern/empty.h2pattern
+++ b/src/tests/data/pattern/empty.h2pattern
@@ -5,6 +5,7 @@
  <license>CC0</license>
  <pattern>
   <formatVersion>2</formatVersion>
+  <version>0</version>
   <name>test</name>
   <info>ladida</info>
   <category>not_categorized</category>

--- a/src/tests/data/pattern/pattern.h2pattern
+++ b/src/tests/data/pattern/pattern.h2pattern
@@ -5,7 +5,7 @@
  <license>CC0</license>
  <pattern>
   <formatVersion>2</formatVersion>
-  <version>0</version>
+  <userVersion>0</userVersion>
   <name>pat</name>
   <info></info>
   <category>unknown</category>

--- a/src/tests/data/pattern/pattern.h2pattern
+++ b/src/tests/data/pattern/pattern.h2pattern
@@ -5,6 +5,7 @@
  <license>CC0</license>
  <pattern>
   <formatVersion>2</formatVersion>
+  <version>0</version>
   <name>pat</name>
   <info></info>
   <category>unknown</category>

--- a/src/tests/data/song/constructor.h2song
+++ b/src/tests/data/song/constructor.h2song
@@ -27,6 +27,7 @@
  <drumkit_info>
   <formatVersion>2</formatVersion>
   <name>empty</name>
+  <version>0</version>
   <author>undefined author</author>
   <info>No information available.</info>
   <license>undefined license</license>

--- a/src/tests/data/song/constructor.h2song
+++ b/src/tests/data/song/constructor.h2song
@@ -6,6 +6,7 @@
  <volume>0.5</volume>
  <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
+ <version>0</version>
  <name>Untitled Song</name>
  <author>hydrogen</author>
  <notes></notes>

--- a/src/tests/data/song/constructor.h2song
+++ b/src/tests/data/song/constructor.h2song
@@ -6,7 +6,7 @@
  <volume>0.5</volume>
  <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
- <version>0</version>
+ <userVersion>0</userVersion>
  <name>Untitled Song</name>
  <author>hydrogen</author>
  <notes></notes>
@@ -28,7 +28,7 @@
  <drumkit_info>
   <formatVersion>2</formatVersion>
   <name>empty</name>
-  <version>0</version>
+  <userVersion>0</userVersion>
   <author>undefined author</author>
   <info>No information available.</info>
   <license>undefined license</license>

--- a/src/tests/data/song/current.h2song
+++ b/src/tests/data/song/current.h2song
@@ -6,6 +6,7 @@
  <volume>0.5</volume>
  <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
+ <version>0</version>
  <name>Untitled Song</name>
  <author>hydrogen</author>
  <notes>...</notes>

--- a/src/tests/data/song/current.h2song
+++ b/src/tests/data/song/current.h2song
@@ -2416,6 +2416,7 @@ p, li { white-space: pre-wrap; }
  <patternList>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 1</name>
    <info></info>
    <category>not_categorized</category>
@@ -2517,6 +2518,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 2</name>
    <info></info>
    <category>not_categorized</category>
@@ -2526,6 +2528,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 3</name>
    <info></info>
    <category>not_categorized</category>
@@ -2535,6 +2538,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 4</name>
    <info></info>
    <category>not_categorized</category>
@@ -2544,6 +2548,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 5</name>
    <info></info>
    <category>not_categorized</category>
@@ -2553,6 +2558,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 6</name>
    <info></info>
    <category>not_categorized</category>
@@ -2562,6 +2568,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 7</name>
    <info></info>
    <category>not_categorized</category>
@@ -2571,6 +2578,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 8</name>
    <info></info>
    <category>not_categorized</category>
@@ -2580,6 +2588,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 9</name>
    <info></info>
    <category>not_categorized</category>
@@ -2589,6 +2598,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 10</name>
    <info></info>
    <category>not_categorized</category>

--- a/src/tests/data/song/current.h2song
+++ b/src/tests/data/song/current.h2song
@@ -6,7 +6,7 @@
  <volume>0.5</volume>
  <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
- <version>0</version>
+ <userVersion>0</userVersion>
  <name>Untitled Song</name>
  <author>hydrogen</author>
  <notes>...</notes>
@@ -28,7 +28,7 @@
  <drumkit_info>
   <formatVersion>2</formatVersion>
   <name>GMRockKit</name>
-  <version>0</version>
+  <userVersion>0</userVersion>
   <author>Glen MacArthur / Sebastian Moors</author>
   <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 &lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
@@ -2417,7 +2417,7 @@ p, li { white-space: pre-wrap; }
  <patternList>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 1</name>
    <info></info>
    <category>not_categorized</category>
@@ -2519,7 +2519,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 2</name>
    <info></info>
    <category>not_categorized</category>
@@ -2529,7 +2529,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 3</name>
    <info></info>
    <category>not_categorized</category>
@@ -2539,7 +2539,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 4</name>
    <info></info>
    <category>not_categorized</category>
@@ -2549,7 +2549,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 5</name>
    <info></info>
    <category>not_categorized</category>
@@ -2559,7 +2559,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 6</name>
    <info></info>
    <category>not_categorized</category>
@@ -2569,7 +2569,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 7</name>
    <info></info>
    <category>not_categorized</category>
@@ -2579,7 +2579,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 8</name>
    <info></info>
    <category>not_categorized</category>
@@ -2589,7 +2589,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 9</name>
    <info></info>
    <category>not_categorized</category>
@@ -2599,7 +2599,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 10</name>
    <info></info>
    <category>not_categorized</category>

--- a/src/tests/data/song/current.h2song
+++ b/src/tests/data/song/current.h2song
@@ -27,6 +27,7 @@
  <drumkit_info>
   <formatVersion>2</formatVersion>
   <name>GMRockKit</name>
+  <version>0</version>
   <author>Glen MacArthur / Sebastian Moors</author>
   <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 &lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">

--- a/src/tests/data/song/empty.h2song
+++ b/src/tests/data/song/empty.h2song
@@ -6,6 +6,7 @@
  <volume>0.5</volume>
  <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
+ <version>0</version>
  <name>Untitled Song</name>
  <author>hydrogen</author>
  <notes>...</notes>

--- a/src/tests/data/song/empty.h2song
+++ b/src/tests/data/song/empty.h2song
@@ -6,7 +6,7 @@
  <volume>0.5</volume>
  <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
- <version>0</version>
+ <userVersion>0</userVersion>
  <name>Untitled Song</name>
  <author>hydrogen</author>
  <notes>...</notes>
@@ -28,7 +28,7 @@
  <drumkit_info>
   <formatVersion>2</formatVersion>
   <name>GMRockKit</name>
-  <version>0</version>
+  <userVersion>0</userVersion>
   <author>Glen MacArthur / Sebastian Moors</author>
   <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 &lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
@@ -2216,7 +2216,7 @@ p, li { white-space: pre-wrap; }
  <patternList>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 1</name>
    <info></info>
    <category>not_categorized</category>
@@ -2226,7 +2226,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 2</name>
    <info></info>
    <category>not_categorized</category>
@@ -2236,7 +2236,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 3</name>
    <info></info>
    <category>not_categorized</category>
@@ -2246,7 +2246,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 4</name>
    <info></info>
    <category>not_categorized</category>
@@ -2256,7 +2256,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 5</name>
    <info></info>
    <category>not_categorized</category>
@@ -2266,7 +2266,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 6</name>
    <info></info>
    <category>not_categorized</category>
@@ -2276,7 +2276,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 7</name>
    <info></info>
    <category>not_categorized</category>
@@ -2286,7 +2286,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 8</name>
    <info></info>
    <category>not_categorized</category>
@@ -2296,7 +2296,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 9</name>
    <info></info>
    <category>not_categorized</category>
@@ -2306,7 +2306,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
-   <version>0</version>
+   <userVersion>0</userVersion>
    <name>Pattern 10</name>
    <info></info>
    <category>not_categorized</category>

--- a/src/tests/data/song/empty.h2song
+++ b/src/tests/data/song/empty.h2song
@@ -2215,6 +2215,7 @@ p, li { white-space: pre-wrap; }
  <patternList>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 1</name>
    <info></info>
    <category>not_categorized</category>
@@ -2224,6 +2225,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 2</name>
    <info></info>
    <category>not_categorized</category>
@@ -2233,6 +2235,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 3</name>
    <info></info>
    <category>not_categorized</category>
@@ -2242,6 +2245,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 4</name>
    <info></info>
    <category>not_categorized</category>
@@ -2251,6 +2255,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 5</name>
    <info></info>
    <category>not_categorized</category>
@@ -2260,6 +2265,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 6</name>
    <info></info>
    <category>not_categorized</category>
@@ -2269,6 +2275,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 7</name>
    <info></info>
    <category>not_categorized</category>
@@ -2278,6 +2285,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 8</name>
    <info></info>
    <category>not_categorized</category>
@@ -2287,6 +2295,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 9</name>
    <info></info>
    <category>not_categorized</category>
@@ -2296,6 +2305,7 @@ p, li { white-space: pre-wrap; }
   </pattern>
   <pattern>
    <formatVersion>2</formatVersion>
+   <version>0</version>
    <name>Pattern 10</name>
    <info></info>
    <category>not_categorized</category>

--- a/src/tests/data/song/empty.h2song
+++ b/src/tests/data/song/empty.h2song
@@ -27,6 +27,7 @@
  <drumkit_info>
   <formatVersion>2</formatVersion>
   <name>GMRockKit</name>
+  <version>0</version>
   <author>Glen MacArthur / Sebastian Moors</author>
   <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
 &lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">


### PR DESCRIPTION
`userVersion` element was added to `.h2song`, `.h2pattern`, and `drumkit.xml`. It can be set using the corresponding properties dialog and can help to tell different artifact versions apart.

See 89548951bde6532a98e5b8a0ad4cd72f2b1a33ef for further details.