### PR TITLE
PatternEditor: take note lead-lag into account

### DIFF
--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1184,7 +1184,9 @@ void DrumPatternEditor::drawNote( Note *note, QPainter& p, bool bIsForeground )
 		return;
 	}
 
-	QPoint pos ( PatternEditor::nMargin + note->get_position() * m_fGridWidth,
+	QPoint pos ( PatternEditor::nMargin +
+				 ( note->get_lead_lag() * AudioEngine::getLeadLagInTicks() +
+				   note->get_position() ) * m_fGridWidth,
 				 ( nInstrument * m_nGridHeight) + (m_nGridHeight / 2) - 3 );
 
 	drawNoteSymbol( p, pos, note, bIsForeground );

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -380,7 +380,9 @@ void PianoRollEditor::drawNote( Note *pNote, QPainter *pPainter, bool bIsForegro
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	if ( pNote != nullptr && pNote->get_instrument() != nullptr &&
 		 pNote->get_instrument() == pHydrogen->getSelectedInstrument() ) {
-		QPoint pos ( PatternEditor::nMargin + pNote->get_position() * m_fGridWidth,
+		QPoint pos ( PatternEditor::nMargin +
+					 ( pNote->get_lead_lag() * AudioEngine::getLeadLagInTicks() +
+					   pNote->get_position() ) * m_fGridWidth,
 					 m_nGridHeight * pitchToLine( pNote->get_notekey_pitch() ) + 1);
 		drawNoteSymbol( *pPainter, pos, pNote, bIsForeground );
 	}


### PR DESCRIPTION
Instead of placing notes at their defined position, both `DrumPatternEditor` and `PianoRollEditor` do now take the lead-lag of each note into account and displace them accordingly. Altering the lead-lag in `NotePropertiesRuler` results in an immediate position update in the editor.

As the lead/lag of a node is an integer between [-1,1] scaling the maximum allowed value of `5` **ticks** we do not run in any trouble, like rescaling lead/lag on different tempo and sample rates, since the editors themselves are tick-based too.

Current UI when creating a chord/flam (both as the actual chord and the individual notes dragged into a diagonal to see their lead-lag values):
![pre](https://github.com/user-attachments/assets/e2f75380-db81-43b4-8ef5-c3ed1b60a288)

With this patch it will look like this:
![post](https://github.com/user-attachments/assets/ef0e063a-cc82-48cb-8c90-544d8c392aa1)

I like it a lot. Previously the amount of lead/lag always felt a little bit esoteric. Now one can really see what is going on.

But the first thing that came to my mind is that it is now able to place on top of each other (three of them in `64` resolution). On the other hand, this is not a real issue as it was possible the whole time. It's just the first time you actually see it.

Nevertheless, there are a number of UX changes that are required
- [ ] lead/lag has to be taken into account in `NotePropertiesRuler` as well (easy)
- [ ] select/drag/drop must also account for the displacement (in `NotePropertiesRuler` too)
- [ ] I found editing of properties of multiple notes stacked on top of each other to be quite glitchy. At least when subset of notes in a chord is selected, all changes should only affect these.
- [ ] in case multiple notes have been moved to the exact same position, do we use the `2x` symbols to indicate this? Selection will be tricky in such a case. I would suggest rectangles with starting points (`Note::__position`) to the right of the notes will select the note with the right-most onset first and require another nudge for the note starting left of it and vice versa.

But there a couple of other things I need to address first.

@cme what do you think.

Addresses #2010 