### PR TITLE
PatternEditor: Fix editing with resolution set to `off` (#2015)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -29,6 +29,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 			argument.
 		- `h2cli` long option for `-k` is renamed `--drumkit` -> `kit` in order to
 			align the naming with the one used in `hydrogen` CLI options.
+		- Smaller keyboard cursor size with resolution set to `off`.
 	* Fixed
 		- Fix potential segfault on ill-formated notes in .h2song files.
 		- Fix buzzing sound during startup when using Port Audio (#1932).

--- a/ChangeLog
+++ b/ChangeLog
@@ -32,7 +32,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Fixed
 		- Fix potential segfault on ill-formated notes in .h2song files.
 		- Fix buzzing sound during startup when using Port Audio (#1932).
-		- Fix build failure without precompiled headers (e.g. on Gentoo) (#1944)
+		- Fix build failure without precompiled headers (e.g. on Gentoo) (#1944).
 		- Fix persistent of hihat pressure group settings while changing/restarting
 			MIDI drivers.
 		- Fix mapping of `NOTE_OFF` MIDI messages in hihat pressure groups.
@@ -40,12 +40,13 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 			after removing rows above it from the table.
 		- Fix synchronization problems while using JACK Timebase support (#1953).
 		- Fix compilation error on macOS with case-sensitive filesystem (#1938).
-		- Fix usability with large QT_SCALE_FACTOR (#1933)
+		- Fix usability with large QT_SCALE_FACTOR (#1933).
 		- Fix MIDI, WAV, and LilyPond export with with non-ASCII filenames on
 			Windows (#1957). Import and export of drumkits can, however, still fail if
 			system encoding is not UTF-8.
 		- Paths to songs and scripts are now properly saved relative to a
 			`.h2playlist` file (in case the corresponding option was set).
+		- Fix grid line rendering with resolution set to `off` (#2015).
 	* Removed
 		- Dropped `JACK` support in provided Windows 32 binaries (as the upstream
 			jack2 MSYS package was dropped)

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -1322,7 +1322,7 @@ void DrumPatternEditor::paintEvent( QPaintEvent* ev )
 		painter.setPen( p );
 		painter.setBrush( Qt::NoBrush );
 		painter.setRenderHint( QPainter::Antialiasing );
-		painter.drawRoundedRect( QRect( x-m_fGridWidth*3, y+2, m_fGridWidth*6, m_nGridHeight-3 ), 4, 4 );
+		painter.drawRoundedRect( getKeyboardCursorRect(), 4, 4 );
 	}
 
 }

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -865,10 +865,21 @@ std::vector<DrumPatternEditor::SelectionIndex> DrumPatternEditor::elementsInters
 QRect DrumPatternEditor::getKeyboardCursorRect()
 {
 
-	uint x = PatternEditor::nMargin + m_pPatternEditorPanel->getCursorPosition() * m_fGridWidth;
-	int nSelectedInstrument = Hydrogen::get_instance()->getSelectedInstrumentNumber();
-	uint y = nSelectedInstrument * m_nGridHeight;
-	return QRect( x-m_fGridWidth*3, y+2, m_fGridWidth*6, m_nGridHeight-3 );
+	const uint x = PatternEditor::nMargin +
+		m_pPatternEditorPanel->getCursorPosition() * m_fGridWidth;
+	const int nSelectedInstrument =
+		Hydrogen::get_instance()->getSelectedInstrumentNumber();
+	const uint y = nSelectedInstrument * m_nGridHeight;
+	float fHalfWidth;
+	if ( m_nResolution != MAX_NOTES ) {
+		// Corresponds to the distance between grid lines on 1/64 resolution.
+		fHalfWidth = m_fGridWidth * 3;
+	} else {
+		// Corresponds to the distance between grid lines set to resolution
+		// "off".
+		fHalfWidth = m_fGridWidth;
+	}
+	return QRect( x - fHalfWidth, y + 2, fHalfWidth * 2, m_nGridHeight - 3 );
 
 }
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -695,8 +695,6 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 		QColor( pPref->getColorTheme()->m_windowTextColor.darker( 250 ) ),
 	};
 
-	int nGranularity = granularity() * m_nResolution;
-
 	if ( !m_bUseTriplets ) {
 
 		// Draw vertical lines. To minimise pen colour changes (and
@@ -713,7 +711,7 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 		// First, quarter note markers. All the quarter note markers must be
 		// drawn. These will be drawn on all resolutions.
 		const int nRes = 4;
-		float fStep = nGranularity / nRes * m_fGridWidth;
+		float fStep = MAX_NOTES / nRes * m_fGridWidth;
 		float x = PatternEditor::nMargin;
 		p.setPen( QPen( colorsActive[ 0 ], 1, style ) );
 		while ( x < m_nActiveWidth ) {
@@ -739,7 +737,7 @@ void PatternEditor::drawGridLines( QPainter &p, Qt::PenStyle style ) const
 				break;
 			}
 
-			fStep = nGranularity / nnRes * m_fGridWidth;
+			fStep = MAX_NOTES / nnRes * m_fGridWidth;
 			float x = PatternEditor::nMargin + fStep;
 			p.setPen( QPen( colorsActive[ std::min( nColour, static_cast<int>(colorsActive.size()) - 1 ) ],
 							1, style ) );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -702,18 +702,62 @@ void PatternEditorPanel::gridResolutionChanged( int nSelected )
 	int nResolution;
 	bool bUseTriplets = false;
 
-	if ( nSelected == 11 ) {
-		nResolution = MAX_NOTES;
-	}
-	else if ( nSelected > 4 ) {
+	switch( nSelected ) {
+	case 0:
+		// 1/4
+		nResolution = 4;
+		bUseTriplets = false;
+		break;
+	case 1:
+		// 1/8
+		nResolution = 8;
+		bUseTriplets = false;
+		break;
+	case 2:
+		// 1/16
+		nResolution = 16;
+		bUseTriplets = false;
+		break;
+	case 3:
+		// 1/32
+		nResolution = 32;
+		bUseTriplets = false;
+		break;
+	case 4:
+		// 1/64
+		nResolution = 64;
+		bUseTriplets = false;
+		break;
+	case 6:
+		// 1/4T
+		nResolution = 8;
 		bUseTriplets = true;
-		nResolution = 0x1 << ( nSelected - 3 );
+		break;
+	case 7:
+		// 1/8T
+		nResolution = 16;
+		bUseTriplets = true;
+		break;
+	case 8:
+		// 1/16T
+		nResolution = 32;
+		bUseTriplets = true;
+		break;
+	case 9:
+		// 1/32T
+		nResolution = 64;
+		bUseTriplets = true;
+		break;
+	case 11:
+		// off
+		nResolution = MAX_NOTES;
+		bUseTriplets = false;
+		break;
+	default:
+		ERRORLOG( QString( "Invalid resolution selection [%1]" )
+				  .arg( nSelected ) );
+		return;
 	}
-	else {
-		nResolution = 0x1 << ( nSelected + 2 );
-	}
-
-	// INFOLOG( QString("idx %1 -> %2 resolution").arg( nSelected ).arg( nResolution ) );
 
 	m_pDrumPatternEditor->setResolution( nResolution, bUseTriplets );
 	m_pPianoRollEditor->setResolution( nResolution, bUseTriplets );

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -175,8 +175,7 @@ void PianoRollEditor::paintEvent(QPaintEvent *ev)
 		painter.setPen( pen );
 		painter.setBrush( Qt::NoBrush );
 		painter.setRenderHint( QPainter::Antialiasing );
-		painter.drawRoundedRect( QRect( pos.x() - m_fGridWidth*3, pos.y()-2,
-										m_fGridWidth*6, m_nGridHeight+3 ), 4, 4 );
+		painter.drawRoundedRect( getKeyboardCursorRect(), 4, 4 );
 	}
 }
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -1239,9 +1239,18 @@ std::vector<PianoRollEditor::SelectionIndex> PianoRollEditor::elementsIntersecti
 ///
 QRect PianoRollEditor::getKeyboardCursorRect()
 {
-	QPoint pos = cursorPosition();
-	return QRect( pos.x() - m_fGridWidth*3, pos.y()-2,
-				  m_fGridWidth*6, m_nGridHeight+3 );
+	const QPoint pos = cursorPosition();
+	float fHalfWidth;
+	if ( m_nResolution != MAX_NOTES ) {
+		// Corresponds to the distance between grid lines on 1/64 resolution.
+		fHalfWidth = m_fGridWidth * 3;
+	} else {
+		// Corresponds to the distance between grid lines set to resolution
+		// "off".
+		fHalfWidth = m_fGridWidth;
+	}
+	return QRect( pos.x() - fHalfWidth, pos.y()-2,
+				  fHalfWidth * 2, m_nGridHeight+3 );
 }
 
 void PianoRollEditor::onPreferencesChanged( H2Core::Preferences::Changes changes )


### PR DESCRIPTION
Drawing grid lines with resolution set to `off` was off. Instead of introducing two new grid lines in the space between those already existing for 1/64 (because resolution increased to 1/64*3=1/192) just a single line was added. Right in the center where no note could be added.

In addition, there was a problem with cursor size. The default one is twice the distance between grid line in 1/64 resolution. This is nice, because it allows both for precise keyboard-selection and is still big enough to properly see it.

But when setting resolution to `off` things change. Resolution is now 1/192 and the cursor is just too big. It is impossible to select individual notes in densly populated patterns using keyboard.

Instead, now the size of the cursor is decreased in case resolution is set to `off` to cover twice the distance between grid lines. This yields the same UX as for 1/64 and allows to properly select individual notes.

Closes #2015 