### PR TITLE
Fix crash due to undefined order of static initialisers

### DIFF
--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -122,7 +122,6 @@ QStringList Filesystem::__ladspa_paths;
 
 QString Filesystem::m_sPreferencesOverwritePath = "";
 
-/* TODO QCoreApplication is not instantiated */
 bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
 							const QString& sUserConfigPath,
 							const QString& sLogFile )
@@ -132,6 +131,9 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
 	} else {
 		return false;
 	}
+
+	// A QCoreApplication instance is needed for applicationDirPath etc.
+	assert( QCoreApplication::instance() != nullptr );
 
 #ifdef Q_OS_MACX
 #ifdef H2CORE_HAVE_BUNDLE

--- a/src/gui/src/Parser.cpp
+++ b/src/gui/src/Parser.cpp
@@ -38,10 +38,13 @@ Parser::~Parser() {
 }
 
 bool Parser::parse( int argc, char* argv[] ) {
-
-	QCoreApplication* pApp = new QCoreApplication( argc, argv );
-	pApp->setApplicationVersion(
-		QString::fromStdString( H2Core::get_version() ) );
+	QCoreApplication* pApp = nullptr;
+	if ( QCoreApplication::instance() == nullptr) {
+		pApp = new QCoreApplication( argc, argv );
+		pApp->setApplicationVersion(
+			QString::fromStdString( H2Core::get_version() ) );
+		assert( QCoreApplication::instance() == pApp );
+	}
 
 	QCommandLineParser parser;
 
@@ -132,7 +135,7 @@ bool Parser::parse( int argc, char* argv[] ) {
 	parser.addPositionalArgument( "file", "Song, playlist or Drumkit file" );
 
 	// Evaluate the options
-	parser.process( *pApp );
+	parser.process( *( QCoreApplication::instance() ) );
 
 	m_sAudioDriver = parser.value( audioDriverOption );
 	m_sPlaylistFilename = parser.value( playlistFileNameOption );
@@ -193,7 +196,9 @@ bool Parser::parse( int argc, char* argv[] ) {
 		}
 	}
 
-	delete pApp;
+	if ( pApp != nullptr ) {
+		delete pApp;
+	}
 
 	return true;
 }

--- a/src/gui/src/Reporter.cpp
+++ b/src/gui/src/Reporter.cpp
@@ -30,7 +30,7 @@
 
 
 QString Reporter::m_sPrefix = "Fatal error in: ";
-QString Reporter::m_sLogFile = H2Core::Filesystem::log_file_path();
+QString Reporter::m_sLogFile;
 
 std::set<QProcess *> Reporter::m_children;
 
@@ -67,6 +67,10 @@ Reporter::Reporter( QProcess *pChild )
 	assert( pChild != nullptr );
 	this->m_pChild = pChild;
 	m_children.insert( pChild );
+
+	if ( m_sLogFile.isEmpty() ) {
+		m_sLogFile = H2Core::Filesystem::log_file_path();
+	}
 
 	connect( pChild, &QProcess::readyReadStandardOutput,
 			 this, &Reporter::on_readyReadStandardOutput );

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -214,6 +214,8 @@ int main(int argc, char *argv[])
 		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
+		// Create bootstrap QApplication to get H2 Core set up with correct Filesystem paths before starting GUI application.
+		QCoreApplication *pBootStrApp = new QCoreApplication( argc, argv );
 
 		Parser parser;
 		if ( ! parser.parse( argc, argv ) ) {
@@ -304,6 +306,7 @@ int main(int argc, char *argv[])
 				H2Core::Preferences::parseAudioDriver( parser.getAudioDriver() );
 		}
 
+		delete pBootStrApp;
 		H2QApplication* pQApp = new H2QApplication( argc, argv );
 		pQApp->setApplicationName( "Hydrogen" );
 		pQApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );


### PR DESCRIPTION
`Filesystem::log_file_path` relies on a static-initialised value set in `Filesystem::__usr_log_path`. We should avoid calling this from static initializers because the order of execution of static initialisers is undefined.

Alternatively (or additionally) removing the dependency on static initializers in `Filesystem::log_file_path` would be benificial but ordering dependencies there are trickier