### PR TITLE
Fix UTF-8 support in `Drumkit` import and export using `libarchive` (#1957)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -42,9 +42,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix synchronization problems while using JACK Timebase support (#1953).
 		- Fix compilation error on macOS with case-sensitive filesystem (#1938).
 		- Fix usability with large QT_SCALE_FACTOR (#1933).
-		- Fix MIDI, WAV, and LilyPond export with with non-ASCII filenames on
-			Windows (#1957). Import and export of drumkits can, however, still fail if
-			system encoding is not UTF-8.
+		- Fix MIDI, WAV, and LilyPond export as well as drumkit import and export
+			with with non-ASCII filenames (#1957).
 		- Paths to songs and scripts are now properly saved relative to a
 			`.h2playlist` file (in case the corresponding option was set).
 		- Fix grid line rendering with resolution set to `off` (#2015).

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -586,6 +586,11 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 	
 #ifdef H2CORE_HAVE_LIBARCHIVE
 	int nRet;
+
+	if ( nullptr == setlocale( LC_ALL, "en_US.UTF-8" ) ) {
+		INFOLOG( "No en_US.UTF-8 locale not available on this system" );
+	}
+
 	struct archive* a;
 	struct archive_entry* entry;
 

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -1068,9 +1068,13 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 			return false;
 		}
 
+#if defined(WIN32) and ARCHIVE_VERSION_NUMBER >= 3005000
 		if ( bUseUtf8Encoding ) {
 			archive_entry_set_pathname_utf8(entry, sTargetFilename.toUtf8().constData());
 		} else {
+#else
+		{
+#endif
 			archive_entry_set_pathname(entry, sTargetFilename.toUtf8().constData());
 		}
 		archive_entry_set_size(entry, st.st_size);

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -566,8 +566,17 @@ bool Drumkit::remove( const QString& sDrumkitDir )
 }
 	
 bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
+					   QString* pInstalledPath, bool* pEncodingIssuesDetected,
 					   bool bSilent )
 {
+	// Ensure variables are always set/initialized.
+	if ( pInstalledPath != nullptr ) {
+		*pInstalledPath = "";
+	}
+	if ( pEncodingIssuesDetected != nullptr ) {
+		*pEncodingIssuesDetected = false;
+	}
+
 	if ( sTargetPath.isEmpty() ) {
 		if ( ! bSilent ) {
 			INFOLOG( QString( "Install drumkit [%1]" ).arg( sSourcePath ) );
@@ -587,8 +596,10 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 #ifdef H2CORE_HAVE_LIBARCHIVE
 	int nRet;
 
+	bool bUseUtf8Encoding = true;
 	if ( nullptr == setlocale( LC_ALL, "en_US.UTF-8" ) ) {
 		INFOLOG( "No en_US.UTF-8 locale not available on this system" );
+		bUseUtf8Encoding = false;
 	}
 
 	struct archive* a;
@@ -679,6 +690,29 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 		}
 		sNewPath.prepend( sDrumkitDir );
 
+		if ( ! bUseUtf8Encoding ) {
+			// In case `libarchive` is not able to support UTF-8 on the system,
+			// we remove all characters outside of the Latin-1 range. Else they
+			// will be represented by wacky characters and the calling routine
+			// would have no idea where the resulting kit did end up.
+			const auto sNewPathTrimmed = Filesystem::removeUtf8Characters( sNewPath );
+			if ( sNewPathTrimmed != sNewPath ) {
+				if ( pEncodingIssuesDetected != nullptr ) {
+					ERRORLOG( QString( "Encoding error (no UTF-8 available)! File was renamed [%1] -> [%2]" )
+							  .arg( sNewPath ).arg( sNewPathTrimmed ) );
+					*pEncodingIssuesDetected = true;
+				}
+				sNewPath = sNewPathTrimmed;
+			}
+		}
+
+		if ( pInstalledPath != nullptr &&
+			 sNewPath.contains( Filesystem::drumkit_xml() ) ) {
+			// This file must be part of every kit and allows us to set this
+			// variable only once.
+			QFileInfo installInfo( sNewPath );
+			*pInstalledPath = installInfo.absoluteDir().absolutePath();
+		}
 		QByteArray newpath = sNewPath.toUtf8();
 
 		archive_entry_set_pathname( entry, newpath.data() );
@@ -773,10 +807,10 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 }
 
 bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName,
-						bool bRecentVersion, bool* bUtf8Encoded, bool bSilent ) {
-	if ( bUtf8Encoded != nullptr ) {
+						bool bRecentVersion, bool* pUtf8Encoded, bool bSilent ) {
+	if ( pUtf8Encoded != nullptr ) {
 		// Ensure the variable is always set/initialized.
-		*bUtf8Encoded = false;
+		*pUtf8Encoded = false;
 	}
 
 	if ( ! Filesystem::path_usable( sTargetDir, true, false ) ) {
@@ -962,8 +996,8 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	int nBytesRead, nRet;
 
 	// Write it back for the calling routine.
-	if ( bUtf8Encoded != nullptr ) {
-		*bUtf8Encoded = bUseUtf8Encoding;
+	if ( pUtf8Encoded != nullptr ) {
+		*pUtf8Encoded = bUseUtf8Encoding;
 	}
 
 	a = archive_write_new();

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -688,23 +688,23 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 		if ( sNewPath.isEmpty() ) {
 			sNewPath = QString( archive_entry_pathname( entry ) );
 		}
-		sNewPath.prepend( sDrumkitDir );
 
 		if ( ! bUseUtf8Encoding ) {
 			// In case `libarchive` is not able to support UTF-8 on the system,
-			// we remove all characters outside of the Latin-1 range. Else they
-			// will be represented by wacky characters and the calling routine
-			// would have no idea where the resulting kit did end up.
+			// we remove (a lot of) characters. Else they will be represented by
+			// wacky ones and the calling routine would have no idea where the
+			// resulting kit did end up.
 			const auto sNewPathTrimmed = Filesystem::removeUtf8Characters( sNewPath );
 			if ( sNewPathTrimmed != sNewPath ) {
+				ERRORLOG( QString( "Encoding error (no UTF-8 available)! File was renamed [%1] -> [%2]" )
+						  .arg( sNewPath ).arg( sNewPathTrimmed ) );
 				if ( pEncodingIssuesDetected != nullptr ) {
-					ERRORLOG( QString( "Encoding error (no UTF-8 available)! File was renamed [%1] -> [%2]" )
-							  .arg( sNewPath ).arg( sNewPathTrimmed ) );
 					*pEncodingIssuesDetected = true;
 				}
 				sNewPath = sNewPathTrimmed;
 			}
 		}
+		sNewPath.prepend( sDrumkitDir );
 
 		if ( pInstalledPath != nullptr &&
 			 sNewPath.contains( Filesystem::drumkit_xml() ) ) {

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -945,6 +945,12 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 	char buff[ nBufferSize ];
 	int nBytesRead, nRet;
 
+	bool bUseUtf8Encoding = true;
+	if ( NULL == setlocale( LC_ALL, "en_US.UTF-8" ) ) {
+		ERRORLOG( "No en_US.UTF-8 locale not available on this system" );
+		bUseUtf8Encoding = false;
+	}
+
 	a = archive_write_new();
 	if ( a == nullptr ) {
 		ERRORLOG( "Unable to create new archive" );
@@ -1012,10 +1018,12 @@ bool Drumkit::exportTo( const QString& sTargetDir, const QString& sComponentName
 			set_name( sOldDrumkitName );
 			return false;
 		}
-		// IMPORTANT: for now do _not_ use archive_entry_set_pathname_utf8()!
-		// This leads to segfaults in some libarchive versions, like 3.7.2 and
-		// 3.6.2.
-		archive_entry_set_pathname(entry, sTargetFilename.toUtf8().constData());
+
+		if ( bUseUtf8Encoding ) {
+			archive_entry_set_pathname_utf8(entry, sTargetFilename.toUtf8().constData());
+		} else {
+			archive_entry_set_pathname(entry, sTargetFilename.toUtf8().constData());
+		}
 		archive_entry_set_size(entry, st.st_size);
 		archive_entry_set_filetype(entry, AE_IFREG);
 		archive_entry_set_perm(entry, 0644);

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -147,7 +147,8 @@ class Drumkit : public H2Core::Object<Drumkit>
 		 *   kit was installed to. In most cases this will coincide with a
 		 *   folder within @a sTargetPath named like the kit itself. But in case
 		 *   the system does not support UTF-8 encoding and @a sTargetPath
-		 *   contains non-Latin1 characters, those might be omitted and the
+		 *   contains characters other than those whitelisted in
+		 *   #Filesystem::removeUtf8Characters, those might be omitted and the
 		 *   directory and files created using `libarchive` might differ.
 		 * \param pEncodingIssuesDetected will be set to `true` in case at least
 		 *   one filepath of extracted kit had to be altered in order to not run

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -140,15 +140,27 @@ class Drumkit : public H2Core::Object<Drumkit>
 		 * Extract a .h2drumkit file.
 		 *
 		 * \param sSourcePath Absolute path to the new drumkit archive
-		 * \param sTargetPath Absolute path to where the new drumkit
-		 * should be extracted to. If left empty, the user's drumkit
-		 * folder will be used.
-		 * \param bSilent Whether debug and info messages should be
-		 * logged.
+		 * \param sTargetPath Absolute path to where the new drumkit should be
+		 *   extracted to. If left empty, the user's drumkit folder will be
+		 *   used.
+		 * \param pInstalledPath Will contain the actual name of the folder the
+		 *   kit was installed to. In most cases this will coincide with a
+		 *   folder within @a sTargetPath named like the kit itself. But in case
+		 *   the system does not support UTF-8 encoding and @a sTargetPath
+		 *   contains non-Latin1 characters, those might be omitted and the
+		 *   directory and files created using `libarchive` might differ.
+		 * \param pEncodingIssuesDetected will be set to `true` in case at least
+		 *   one filepath of extracted kit had to be altered in order to not run
+		 *   into UTF-8 issues.
+		 * \param bSilent Whether debug and info messages should be logged.
 		 *
 		 * \return true on success
 		 */
-	static bool install( const QString& sSourcePath, const QString& sTargetPath = "", bool bSilent = false );
+	static bool install( const QString& sSourcePath,
+						 const QString& sTargetPath = "",
+						 QString* pInstalledPath = nullptr,
+						 bool* pEncodingIssuesDetected = nullptr,
+						 bool bSilent = false );
 
 	/**
 	 * Compresses the drumkit into a .h2drumkit file.
@@ -166,7 +178,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 	 * \param bRecentVersion Whether the drumkit format should be supported by
 	 *   Hydrogen 0.9.7 or higher (whether it should be composed of
 	 *   DrumkitComponents).
-	 * \param bUtf8Encoded will be set to true in case we were able to enforce
+	 * \param pUtf8Encoded will be set to true in case we were able to enforce
 	 *   'UTF-8' as system locale in `libarchive`. If this didn't work, export
 	 *   will be done using classic Latin1 encoded filenames.
 	 * \param bSilent Whether debug and info messages should be logged.
@@ -174,7 +186,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 	 * \return true on success 
 	 */
 	bool exportTo( const QString& sTargetDir, const QString& sComponentName = "",
-				   bool bRecentVersion = true, bool* bUtf8Encoded = nullptr,
+				   bool bRecentVersion = true, bool* pUtf8Encoded = nullptr,
 				   bool bSilent = false );
 		/**
 		 * remove a drumkit from the disk

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -153,25 +153,29 @@ class Drumkit : public H2Core::Object<Drumkit>
 	/**
 	 * Compresses the drumkit into a .h2drumkit file.
 	 *
-	 * The name of the created file will be a concatenation of #__name
-	 * and Filesystem::drumkit_ext.
+	 * The name of the created file will be a concatenation of #__name and
+	 * Filesystem::drumkit_ext.
 	 *
-	 * exportTo() ? well, export is a protected name within C++. So,
-	 * we needed a less obvious name. 
+	 * exportTo() ? well, export is a protected name within C++. So, we needed a
+	 * less obvious name.
 	 *
-	 * \param sTargetDir Folder which will contain the resulting
-	 * .h2drumkit file.
-	 * \param sComponentName Name of a particular component used in
-	 * case just a single component should be exported.
-	 * \param bRecentVersion Whether the drumkit format should be
-	 * supported by Hydrogen 0.9.7 or higher (whether it should be
-	 * composed of DrumkitComponents).
-	 * \param bSilent Whether debug and info messages should be
-	 * logged.
+	 * \param sTargetDir Folder which will contain the resulting .h2drumkit
+	 *   file.
+	 * \param sComponentName Name of a particular component used in case just a
+	 *   single component should be exported.
+	 * \param bRecentVersion Whether the drumkit format should be supported by
+	 *   Hydrogen 0.9.7 or higher (whether it should be composed of
+	 *   DrumkitComponents).
+	 * \param bUtf8Encoded will be set to true in case we were able to enforce
+	 *   'UTF-8' as system locale in `libarchive`. If this didn't work, export
+	 *   will be done using classic Latin1 encoded filenames.
+	 * \param bSilent Whether debug and info messages should be logged.
 	 *
 	 * \return true on success 
 	 */
-	bool exportTo( const QString& sTargetDir, const QString& sComponentName = "", bool bRecentVersion = true, bool bSilent = false );
+	bool exportTo( const QString& sTargetDir, const QString& sComponentName = "",
+				   bool bRecentVersion = true, bool* bUtf8Encoded = nullptr,
+				   bool bSilent = false );
 		/**
 		 * remove a drumkit from the disk
 		 *

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1259,6 +1259,11 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 	// function is intended to be used for validating or upgrading
 	// drumkits via CLI or OSC command. It should always refer to the
 	// latest copy found on disk.
+	if ( bIsCompressed == nullptr || sTemporaryFolder == nullptr ||
+		 sDrumkitDir == nullptr ) {
+		ERRORLOG( "Invalid input" );
+		return nullptr;
+	}
 
 	*bIsCompressed = false;
 	*sTemporaryFolder = "";
@@ -1312,7 +1317,8 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 
 		// Providing the path to a compressed .h2drumkit file. It will
 		// be extracted to a temporary folder and loaded from there.
-		if ( ! Drumkit::install( sDrumkitPath, tmpDir.path(), true ) ) {
+		if ( ! Drumkit::install( sDrumkitPath, tmpDir.path(), sDrumkitDir,
+								 nullptr, true ) ) {
 			ERRORLOG( QString( "Unabled to extract provided drumkit [%1] into [%2]" )
 					  .arg( sDrumkitPath ).arg( tmpDir.path() ) );
 			return nullptr;
@@ -1340,8 +1346,6 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 			return nullptr;
 		}
 
-		*sDrumkitDir = tmpDir.path() + "/" + extractedFolders[0];
-		
 		pDrumkit = Drumkit::load( *sDrumkitDir, false, true );
 		
 	} else {
@@ -1353,7 +1357,13 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 	return pDrumkit;
 }
 
-bool CoreActionController::extractDrumkit( const QString& sDrumkitPath, const QString& sTargetDir ) {
+bool CoreActionController::extractDrumkit( const QString& sDrumkitPath,
+										   const QString& sTargetDir,
+										   QString* pInstalledPath ) {
+	// Ensure variables are always set/initialized.
+	if ( pInstalledPath != nullptr ) {
+		*pInstalledPath = "";
+	}
 
 	QString sTarget;
 	bool bInstall = false;
@@ -1381,7 +1391,8 @@ bool CoreActionController::extractDrumkit( const QString& sDrumkitPath, const QS
 		return false;
 	}
 
-	if ( ! Drumkit::install( sDrumkitPath, sTarget, true ) ) {
+	if ( ! Drumkit::install( sDrumkitPath, sTarget, pInstalledPath, nullptr,
+							 true ) ) {
 		ERRORLOG( QString( "Unabled to extract provided drumkit [%1] into [%2]" )
 				  .arg( sDrumkitPath ).arg( sTarget ) );
 		return false;

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1303,8 +1303,7 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 		
 		// Temporary folder used to extract a compressed drumkit (
 		// .h2drumkit ).
-		QString sTemplateName( Filesystem::tmp_dir() + "/" +
-							   sourceFileInfo.baseName() + "_XXXXXX" );
+		QString sTemplateName( Filesystem::tmp_dir() + "/XXXXXX" );
 		QTemporaryDir tmpDir( sTemplateName );
 		tmpDir.setAutoRemove( false );
 		if ( ! tmpDir.isValid() ) {
@@ -1359,10 +1358,14 @@ std::shared_ptr<Drumkit> CoreActionController::retrieveDrumkit( const QString& s
 
 bool CoreActionController::extractDrumkit( const QString& sDrumkitPath,
 										   const QString& sTargetDir,
-										   QString* pInstalledPath ) {
+										   QString* pInstalledPath,
+										   bool* pEncodingIssuesDetected ) {
 	// Ensure variables are always set/initialized.
 	if ( pInstalledPath != nullptr ) {
 		*pInstalledPath = "";
+	}
+	if ( pEncodingIssuesDetected != nullptr ) {
+		*pEncodingIssuesDetected = false;
 	}
 
 	QString sTarget;
@@ -1391,8 +1394,8 @@ bool CoreActionController::extractDrumkit( const QString& sDrumkitPath,
 		return false;
 	}
 
-	if ( ! Drumkit::install( sDrumkitPath, sTarget, pInstalledPath, nullptr,
-							 true ) ) {
+	if ( ! Drumkit::install( sDrumkitPath, sTarget, pInstalledPath,
+							 pEncodingIssuesDetected, true ) ) {
 		ERRORLOG( QString( "Unabled to extract provided drumkit [%1] into [%2]" )
 				  .arg( sDrumkitPath ).arg( sTarget ) );
 		return false;

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1152,7 +1152,7 @@ bool CoreActionController::upgradeDrumkit( const QString& sDrumkitPath, const QS
 			sExportPath = sourceFileInfo.dir().absolutePath();
 		}
 		
-		if ( ! pDrumkit->exportTo( sExportPath, "", true, false ) ) {
+		if ( ! pDrumkit->exportTo( sExportPath, "", true, nullptr, false ) ) {
 			ERRORLOG( QString( "Unable to export upgrade drumkit to [%1]" )
 					  .arg( sExportPath ) );
 			return false;

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -332,12 +332,17 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 *   kit was installed to. In most cases this will coincide with a
 		 *   folder within @a sTargetPath named like the kit itself. But in case
 		 *   the system does not support UTF-8 encoding and @a sTargetPath
-		 *   contains non-Latin1 characters, those might be omitted and the
+		 *   contains characters other than those whitelisted in
+		 *   #Filesystem::removeUtf8Characters, those might be omitted and the
 		 *   directory and files created using `libarchive` might differ.
+		 * \param pEncodingIssuesDetected will be set to `true` in case at least
+		 *   one filepath of extracted kit had to be altered in order to not run
+		 *   into UTF-8 issues.
 		 */
 		bool extractDrumkit( const QString& sDrumkitPath,
 							 const QString& sTargetDir = "",
-							 QString* pInstalledPath = nullptr );
+							 QString* pInstalledPath = nullptr,
+							 bool* pEncodingIssuesDetected = nullptr );
 		/** Relocates transport to the beginning of a particular
 		 * column/Pattern group.
 		 * 

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -314,23 +314,30 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 	 *   definition or also all previous versions should be checked.
 	 */
 	bool validateDrumkit( const QString& sDrumkitPath, bool bCheckLegacyVersions = false );
-	/**
-	 * Extracts the compressed .h2drumkit file in @a sDrumkitPath into
-	 * @a sTargetDir.
-	 *
-	 * The function does not automatically load the extracted kit into
-	 * the current Hydrogen session in case a custom @a sTargetDir was
-	 * supplied. To do so, the name of the folder contained in the
-	 * tarball is required (might differ from the name of the tarball)
-	 * and it is not easily obtained.
-	 *
-	 * \param sDrumkitPath Tar-compressed drumkit with .h2drumkit
-	 * extension
-	 * \param sTargetDir Folder to extract the drumkit to. If the
-	 * folder is not present yet, it will be created. If left empty,
-	 * the drumkit will be installed to the users drumkit data folder.
-	 */
-	bool extractDrumkit( const QString& sDrumkitPath, const QString& sTargetDir = "" );
+		/**
+		 * Extracts the compressed .h2drumkit file in @a sDrumkitPath into @a
+		 * sTargetDir.
+		 *
+		 * The function does not automatically load the extracted kit into the
+		 * current Hydrogen session in case a custom @a sTargetDir was supplied.
+		 * To do so, the name of the folder contained in the tarball is required
+		 * (might differ from the name of the tarball) and it is not easily
+		 * obtained.
+		 *
+		 * \param sDrumkitPath Tar-compressed drumkit with .h2drumkit extension
+		 * \param sTargetDir Folder to extract the drumkit to. If the folder is
+		 *   not present yet, it will be created. If left empty, the drumkit
+		 *   will be installed to the users drumkit data folder.
+		 * \param pInstalledPath Will contain the actual name of the folder the
+		 *   kit was installed to. In most cases this will coincide with a
+		 *   folder within @a sTargetPath named like the kit itself. But in case
+		 *   the system does not support UTF-8 encoding and @a sTargetPath
+		 *   contains non-Latin1 characters, those might be omitted and the
+		 *   directory and files created using `libarchive` might differ.
+		 */
+		bool extractDrumkit( const QString& sDrumkitPath,
+							 const QString& sTargetDir = "",
+							 QString* pInstalledPath = nullptr );
 		/** Relocates transport to the beginning of a particular
 		 * column/Pattern group.
 		 * 

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -1142,14 +1142,8 @@ QString Filesystem::rerouteDrumkitPath( const QString& sDrumkitPath ) {
 }
 
 QString Filesystem::removeUtf8Characters( const QString &sEncodedString ) {
-	QString sCleaned;
-	for ( const auto& cchar : sEncodedString ) {
-		if ( cchar.toLatin1() != 0 ) {
-			sCleaned.append( cchar );
-		}
-	}
-
-	return sCleaned;
+	QString sCleaned( sEncodedString );
+	return sCleaned.remove( QRegExp( "[^a-zA-Z0-9._/]" ) );
 }
 };
 

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -1140,6 +1140,17 @@ QString Filesystem::rerouteDrumkitPath( const QString& sDrumkitPath ) {
 	return sDrumkitPath;
 #endif
 }
+
+QString Filesystem::removeUtf8Characters( const QString &sEncodedString ) {
+	QString sCleaned;
+	for ( const auto& cchar : sEncodedString ) {
+		if ( cchar.toLatin1() != 0 ) {
+			sCleaned.append( cchar );
+		}
+	}
+
+	return sCleaned;
+}
 };
 
 /* vim: set softtabstop=4 noexpandtab: */

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -494,6 +494,10 @@ namespace H2Core
 		 */
 		static QString rerouteDrumkitPath( const QString& sDrumkitPath );
 
+			/** Removes all characters not within the Latin-1 range of @a
+			 * sEncodedString. */
+			static QString removeUtf8Characters( const QString& sEncodedString );
+
 	private:
 		static Logger* __logger;                    ///< a pointer to the logger
 		static bool check_sys_paths();              ///< returns true if the system path is consistent

--- a/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryImportDialog.cpp
@@ -722,7 +722,11 @@ void SoundLibraryImportDialog::on_InstallBtn_clicked()
 	QString sError = tr( "An error occurred importing the SoundLibrary."  );
 	
 	try {
-		if ( ! H2Core::Drumkit::install( SoundLibraryPathTxt->text() ) ) {
+		QString sImportedPath;
+		bool bEncodingIssues;
+		if ( ! H2Core::Drumkit::install(
+				 SoundLibraryPathTxt->text(), "", &sImportedPath,
+				 &bEncodingIssues, false ) ) {
 			QApplication::restoreOverrideCursor();
 			
 			// Check whether encoding might be the problem in here.
@@ -741,12 +745,22 @@ void SoundLibraryImportDialog::on_InstallBtn_clicked()
 					 
 			return;
 		}
+
 		// update the drumkit list
 		H2Core::Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
 		QApplication::restoreOverrideCursor();
-		QMessageBox::information( this, "Hydrogen",
-								  QString( tr( "SoundLibrary imported in %1" )
-										   .arg( H2Core::Filesystem::usr_data_path() )  ) );
+		if ( ! bEncodingIssues ) {
+			QMessageBox::information( this, "Hydrogen",
+									  QString( tr( "SoundLibrary imported in %1" )
+											   .arg( sImportedPath ) ) );
+		}
+		else {
+			QMessageBox::warning(
+				this, "Hydrogen",
+				QString( tr( "SoundLibrary imported in %1" )
+						 .arg( sImportedPath ) )
+				.append( tr( "\nBut there were encoding issues.\n\nPlease set your system's locale to UTF-8!" ) ) );
+		}
 	}
 	catch( H2Core::H2Exception ex ) {
 		QApplication::restoreOverrideCursor();

--- a/src/tests/DrumkitExportTest.cpp
+++ b/src/tests/DrumkitExportTest.cpp
@@ -141,10 +141,6 @@ void DrumkitExportTest::testDrumkitExportAndImportUtf8() {
 	}
 
 	// Load the kit and export it.
-	//
-	// This is not supposed to work yet. There is an issue with libarchive UTF8
-	// support that needs to be addressed upstream first. But if for some reason
-	// it miraculously starts to work, we want the test to inform us .
 	CPPUNIT_ASSERT( pDrumkit->exportTo( Filesystem::tmp_dir() ) );
 
 	// Bitwise comparison of the (!extracted!) original drumkit and the one we

--- a/src/tests/DrumkitExportTest.cpp
+++ b/src/tests/DrumkitExportTest.cpp
@@ -45,8 +45,12 @@ void DrumkitExportTest::setUp() {
 
 	// We do not check return value as the folder should not exist in the first
 	// place.
-	Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitName ), true, true );
-	Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 ), true, true );
+	if ( Filesystem::dir_exists( Filesystem::drumkit_usr_path( m_sTestKitName ) ) ) {
+		Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitName ), true, true );
+	}
+	if ( Filesystem::dir_exists( Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 ) ) ) {
+		Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 ), true, true );
+	}
 
 	Hydrogen::get_instance()->getCoreActionController()->openSong(
 		H2TEST_FILE( "functional/test.h2song" ) );
@@ -54,8 +58,12 @@ void DrumkitExportTest::setUp() {
 
 void DrumkitExportTest::tearDown() {
 	// Remove the test kit from the system.
-	Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitName ), true, true );
-	Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 ), true, true );
+	if ( Filesystem::dir_exists( Filesystem::drumkit_usr_path( m_sTestKitName ) ) ) {
+		Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitName ), true, true );
+	}
+	if ( Filesystem::dir_exists( Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 ) ) ) {
+		Filesystem::rm( Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 ), true, true );
+	}
 
 	// Discard all changes to the test song.
 	Hydrogen::get_instance()->getCoreActionController()->openSong(

--- a/src/tests/DrumkitExportTest.cpp
+++ b/src/tests/DrumkitExportTest.cpp
@@ -126,14 +126,14 @@ void DrumkitExportTest::testDrumkitExportAndImportUtf8() {
 						sTestKitPath, false ) );
 
 	// Import test kit into Hydrogen.
-	CPPUNIT_ASSERT( pCoreActionController->extractDrumkit( sTestKitPath ) );
+	QString sInstalledPath;
+	CPPUNIT_ASSERT( pCoreActionController->extractDrumkit(
+						sTestKitPath, "", &sInstalledPath ) );
 
 	// Check whether import worked, the UTF-8 path and name was read properly,
 	// and all samples are present.
 	const auto pDB = pHydrogen->getSoundLibraryDatabase();
-	const QString sExtractedKit =
-		Filesystem::drumkit_usr_path( m_sTestKitNameUtf8 );
-	const auto pDrumkit = pDB->getDrumkit( sExtractedKit, true );
+	const auto pDrumkit = pDB->getDrumkit( sInstalledPath, true );
 	CPPUNIT_ASSERT( pDrumkit != nullptr );
 	CPPUNIT_ASSERT( pDrumkit->get_name() == m_sTestKitNameUtf8 );
 	for ( const auto& ppInstrument : *pDrumkit->get_instruments() ) {
@@ -162,10 +162,11 @@ void DrumkitExportTest::testDrumkitExportAndImportUtf8() {
 	CPPUNIT_ASSERT( pCoreActionController->extractDrumkit(
 						sExportPath, exportValidation.path() ) );
 
-	H2TEST_ASSERT_DIRS_EQUAL( exportValidation.path(), sExtractedKit );
+	H2TEST_ASSERT_DIRS_EQUAL( exportValidation.path(), sInstalledPath );
 
 	// Cleanup
 	H2Core::Filesystem::rm( exportValidation.path(), true, true );
+	H2Core::Filesystem::rm( sInstalledPath, true, true );
 
 	___INFOLOG( "passed" );
 }

--- a/src/tests/DrumkitExportTest.cpp
+++ b/src/tests/DrumkitExportTest.cpp
@@ -141,7 +141,16 @@ void DrumkitExportTest::testDrumkitExportAndImportUtf8() {
 	}
 
 	// Load the kit and export it.
-	CPPUNIT_ASSERT( pDrumkit->exportTo( Filesystem::tmp_dir() ) );
+	bool bUtf8SupportOnSystem;
+	const auto bDrumkitExportSuccessful = pDrumkit->exportTo(
+		Filesystem::tmp_dir(), "", true, &bUtf8SupportOnSystem );
+	if ( ! bUtf8SupportOnSystem ) {
+		___WARNINGLOG( "UTF-8 support couldn't be enforced. Unit test not applicable." )
+		___INFOLOG( "skipped" );
+		return;
+	}
+
+	CPPUNIT_ASSERT( bDrumkitExportSuccessful );
 
 	// Bitwise comparison of the (!extracted!) original drumkit and the one we
 	// just exported.

--- a/src/tests/DrumkitExportTest.cpp
+++ b/src/tests/DrumkitExportTest.cpp
@@ -127,8 +127,10 @@ void DrumkitExportTest::testDrumkitExportAndImportUtf8() {
 
 	// Import test kit into Hydrogen.
 	QString sInstalledPath;
+	bool bEncodingIssuesDetected;
 	CPPUNIT_ASSERT( pCoreActionController->extractDrumkit(
-						sTestKitPath, "", &sInstalledPath ) );
+						sTestKitPath, "", &sInstalledPath,
+						&bEncodingIssuesDetected ) );
 
 	// Check whether import worked, the UTF-8 path and name was read properly,
 	// and all samples are present.
@@ -136,8 +138,13 @@ void DrumkitExportTest::testDrumkitExportAndImportUtf8() {
 	const auto pDrumkit = pDB->getDrumkit( sInstalledPath, true );
 	CPPUNIT_ASSERT( pDrumkit != nullptr );
 	CPPUNIT_ASSERT( pDrumkit->get_name() == m_sTestKitNameUtf8 );
-	for ( const auto& ppInstrument : *pDrumkit->get_instruments() ) {
-		CPPUNIT_ASSERT( ! ppInstrument->has_missing_samples() );
+	if ( ! bEncodingIssuesDetected ) {
+		// This can cause file names of sample files to extracted from the tar
+		// ball to get altered. But as we do not touch the drumkit definition
+		// itself, they will be considered a missing sample.
+		for ( const auto& ppInstrument : *pDrumkit->get_instruments() ) {
+			CPPUNIT_ASSERT( ! ppInstrument->has_missing_samples() );
+		}
 	}
 
 	// Load the kit and export it.

--- a/src/tests/DrumkitExportTest.h
+++ b/src/tests/DrumkitExportTest.h
@@ -33,9 +33,7 @@ class DrumkitExportTest : public CppUnit::TestCase {
 	CPPUNIT_TEST_SUITE( DrumkitExportTest );
 #ifdef H2CORE_HAVE_LIBARCHIVE
 		CPPUNIT_TEST( testDrumkitExportAndImport );
-		// Do not activate unless proper UTF-8 support is introduced via
-		// `libarchive`.
-		// CPPUNIT_TEST( testDrumkitExportAndImportUtf8 );
+		CPPUNIT_TEST( testDrumkitExportAndImportUtf8 );
 #endif
 	CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
I finally got word from somebody at `libarchive` and it turns out one has to enforce UTF-8 encoding [1] in order to avoid segfaults in some versions when encountering non-Latin1 characters. Using this patch we can also support UTF-8 drumkit import and export.

Enforcing the locale works fine on systems not having the proper locale for the provided characters set. (It sounds like an edge case but we had several issues and discussions regarding this).

But what still needs to be properly handled is the case UTF-8 can not be enforced since the locale is not available on the system in the first place. Then, we just strip everything except of Roman letters and Arabic numbers of the name/path, import the kit into this location, and popup a dialog telling about the alternate location and that there was an encoding error + that they should set their system locale. Export is less problematic in this case.

Unfortunately, this is not it. `libarchive` is quite a pain. Our build pipeline (a real life safer in this one) caught an export failure on Ubuntu 20.04 - which I was able to reproduce locally. Well, at least a bit. The problem seems to be this one [2] but it is only occurring with `libarchive` installed from Canonicals package repos. Building the same sources with the same options and patches (https://launchpad.net/ubuntu/focal/amd64/libarchive13/3.4.0-2ubuntu1) I was not able to reproduce it.

But the result of this bug is quite severe. Not just UTF-8 support is affected, Hydrogen is not able to export drumkits at all anymore.

Since the original issue (https://github.com/hydrogen-music/hydrogen/issues/1957) only affects systems having their locale set up improperly and it was only reported to appear on Windows, I will be a little more conservative in here. The UTF-8 export patch is now only affecting Windows systems with `libarchive` >= 3.5.0. The latter should be guaranteed as we ship the corresponding DLL ourselves.

[1] github.com/libarchive/ libarchive/issues/2233
[2] github.com/libarchive/ libarchive/pull/1389/commits/c30f279475e2afd39f380622d2b53b157eb746d8