### PR TITLE
Show reporter on normal child exit if exit code non-zero

### DIFF
--- a/src/gui/src/Reporter.cpp
+++ b/src/gui/src/Reporter.cpp
@@ -132,7 +132,8 @@ void Reporter::on_finished( int exitCode, QProcess::ExitStatus exitStatus )
 	on_readyReadStandardError();
 	on_readyReadStandardOutput();
 
-	if ( m_pChild->exitStatus() != QProcess::NormalExit ) {
+	if ( m_pChild->exitStatus() != QProcess::NormalExit
+		 || m_pChild->exitCode() != 0 ) {
 
 		char *argv[] = { (char *)"-" };
 		int argc = 1;


### PR DESCRIPTION
On Windows, `QProcess::exitStatus()` returns `Normal` for many circumstances that would be `CrashExit` on other operating systems. So check the exit *code* as well, which will be non-zero on most Windows abnormal exits.