### PR TITLE
Director: clear 'next' tag when tags are the same

### DIFF
--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -306,7 +306,7 @@ void Director::paintEvent( QPaintEvent* ev )
 	painter.drawText( r2, Qt::AlignCenter, QString("%1").arg( m_nBeat) );
 
 	if( m_sTagNext == m_sTagCurrent ){
-		m_sTagCurrent = "";
+		m_sTagNext = "";
 	}
 	
 	//draw current bar tag


### PR DESCRIPTION
Fixes an issue apparently introduced in commit d27917977b when some
variables were renamed. In the Director window, when the 'current' and
'next' tags are the same, it's the 'next' tag that should be cleared,
not the 'current' one.
