### PR TITLE
Base `jackTimebaseStateChanged` on event value to support it in our shotlist

### DIFF
--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -891,9 +891,6 @@ bool CoreActionController::activateJackTimebaseControl( bool bActivate ) {
 	}
 	pHydrogen->getAudioEngine()->unlock();
 	
-	EventQueue::get_instance()->push_event( EVENT_JACK_TIMEBASE_STATE_CHANGED,
-											static_cast<int>(pHydrogen->getJackTimebaseState()) );
-	
 	return true;
 #else
 	ERRORLOG( "Unable to (de)activate JACK Timebase support. Your Hydrogen version was not compiled with JACK support." );

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -1491,6 +1491,17 @@ QString JackAudioDriver::TimebaseTrackingToQString( const TimebaseTracking& t ) 
 			return "Unknown";
 	}
 }
+JackAudioDriver::Timebase JackAudioDriver::TimebaseFromInt( int nState ) {
+	switch( nState ) {
+	case static_cast<int>(Timebase::Listener):
+		return Timebase::Listener;
+	case static_cast<int>(Timebase::Controller):
+		return Timebase::Controller;
+	case static_cast<int>(Timebase::None):
+	default:
+		return Timebase::None;
+	}
+}
 };
 
 #endif // H2CORE_HAVE_JACK

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -1305,7 +1305,10 @@ void JackAudioDriver::releaseTimebaseControl()
 	}
 
 	m_timebaseTracking = TimebaseTracking::Valid;
-	if ( m_JackTransportPos.valid & JackPositionBBT ) {
+	if ( m_JackTransportPos.valid & JackPositionBBT &&
+		 m_timebaseState != Timebase::Controller ) {
+		// Having an external controller while this function is called should be
+		// rarely the case. But we still have to handle it.
 		m_timebaseState = Timebase::Listener;
 	}
 	else {

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -115,6 +115,7 @@ public:
 		None = -1
 	};
 	static QString TimebaseToQString( const Timebase& t );
+		static Timebase TimebaseFromInt( int nState );
 	
 	/** 
 	 * Object holding the external client session with the JACK
@@ -660,6 +661,7 @@ public:
 		None = -1
 	};
 	static QString TimebaseToQString( const Timebase& t ) { return "Not supported"; };
+		static Timebase TimebaseFromInt( int nState ) { return Timebase::None; };
 	/**
 	 * Fallback version of the JackAudioDriver in case
 	 * #H2CORE_HAVE_JACK was not defined during the configuration

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -51,7 +51,7 @@ class EventListener
 		virtual void timelineActivationEvent(){}
 		virtual void timelineUpdateEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void jackTransportActivationEvent(){}
-		virtual void jackTimebaseStateChangedEvent(){}
+		virtual void jackTimebaseStateChangedEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void songModeActivationEvent(){}
 		virtual void stackedModeActivationEvent( int nValue ){ UNUSED( nValue ); }
 		virtual void loopModeActivationEvent(){}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -838,7 +838,7 @@ void HydrogenApp::onEventQueueTimer()
 				break;
 
 			case EVENT_JACK_TIMEBASE_STATE_CHANGED:
-				pListener->jackTimebaseStateChangedEvent();
+				pListener->jackTimebaseStateChangedEvent( event.value );
 				break;
 				
 			case EVENT_SONG_MODE_ACTIVATION:

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -714,7 +714,8 @@ void PlayerControl::updateSongEvent( int nValue ) {
 		loopModeActivationEvent();
 		timelineActivationEvent();
 		jackTransportActivationEvent();
-		jackTimebaseStateChangedEvent();
+		jackTimebaseStateChangedEvent(
+			static_cast<int>(Hydrogen::get_instance()->getJackTimebaseState()) );
 		updatePlayerControl();
 	}
 }
@@ -1101,7 +1102,8 @@ void PlayerControl::driverChangedEvent() {
 		m_pJackTransportBtn->show();
 		m_pJackTimebaseBtn->show();
 
-		jackTimebaseStateChangedEvent();
+		jackTimebaseStateChangedEvent(
+			static_cast<int>(Hydrogen::get_instance()->getJackTimebaseState() ));
 		jackTransportActivationEvent();
 	}
 	else {
@@ -1124,7 +1126,8 @@ void PlayerControl::jackTransportActivationEvent( )
 
 		if ( pPref->m_bJackTimebaseEnabled ) {
 			m_pJackTimebaseBtn->setIsActive( true );
-			jackTimebaseStateChangedEvent();
+			jackTimebaseStateChangedEvent(
+				static_cast<int>(Hydrogen::get_instance()->getJackTimebaseState()) );
 		}
 	}
 	else {
@@ -1138,7 +1141,7 @@ void PlayerControl::jackTransportActivationEvent( )
 	}
 }
 
-void PlayerControl::jackTimebaseStateChangedEvent()
+void PlayerControl::jackTimebaseStateChangedEvent( int nState )
 {
 	auto pPref = Preferences::get_instance();
 	if ( ! pPref->m_bJackTimebaseEnabled ) {
@@ -1146,11 +1149,11 @@ void PlayerControl::jackTimebaseStateChangedEvent()
 	}
 	
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	auto pHydrogen = Hydrogen::get_instance();
 
 	QString sMessage = tr("JACK Timebase mode" ) + QString( " = " );
+	const auto state = JackAudioDriver::TimebaseFromInt( nState );
 	
-	switch( pHydrogen->getJackTimebaseState() ) {
+	switch( state ) {
 	case JackAudioDriver::Timebase::Controller:
 
 		if ( ! m_pJackTimebaseBtn->isDown() ) {
@@ -1194,11 +1197,13 @@ void PlayerControl::onPreferencesChanged( H2Core::Preferences::Changes changes )
 	if ( changes & H2Core::Preferences::Changes::AudioTab ) {
 		auto pPref = Preferences::get_instance();
 		auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+		auto pHydrogen = Hydrogen::get_instance();
 
 		if ( pPref->m_bJackTimebaseEnabled ) {
-			if ( Hydrogen::get_instance()->hasJackTransport() ) {
+			if ( pHydrogen->hasJackTransport() ) {
 				m_pJackTimebaseBtn->setIsActive( true );
-				jackTimebaseStateChangedEvent();
+				jackTimebaseStateChangedEvent(
+					static_cast<int>(pHydrogen->getJackTimebaseState()) );
 			}
 			else {
 				m_pJackTimebaseBtn->setToolTip( pCommonStrings->getJackTimebaseTooltip() );

--- a/src/gui/src/PlayerControl.h
+++ b/src/gui/src/PlayerControl.h
@@ -60,7 +60,6 @@ public:
 	virtual void timelineActivationEvent() override;
 	virtual void tempoChangedEvent( int nValue ) override;
 	virtual void jackTransportActivationEvent() override;
-	virtual void jackTimebaseStateChangedEvent() override;
 	/**
 	 * Shared GUI update when activating Song or Pattern mode via
 	 * button click or via OSC command.
@@ -78,6 +77,7 @@ public:
 public slots:
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 	void activateSongMode( bool bActivate );
+	virtual void jackTimebaseStateChangedEvent( int nState ) override;
 
 private slots:
 	void recBtnClicked();

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2783,7 +2783,7 @@ void SongEditorPositionRuler::timelineActivationEvent() {
 	update();
 }
 
-void SongEditorPositionRuler::jackTimebaseStateChangedEvent() {
+void SongEditorPositionRuler::jackTimebaseStateChangedEvent( int nState ) {
 	invalidateBackground();
 	update();
 }

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -384,7 +384,6 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 	
 	virtual void timelineActivationEvent() override;
 	virtual void timelineUpdateEvent( int nValue ) override;
-	virtual void jackTimebaseStateChangedEvent() override;
 
 	static int tickToColumn( float fTick, uint nGridWidth );
 		static constexpr int m_nMinimumHeight = 50;
@@ -396,6 +395,7 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 		void onPreferencesChanged( H2Core::Preferences::Changes changes );
 		void createBackground();
 		void invalidateBackground();
+		virtual void jackTimebaseStateChangedEvent( int nState ) override;
 
 	private:
 		H2Core::Hydrogen* 		m_pHydrogen;

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -752,7 +752,8 @@ void SongEditorPanel::updateSongEvent( int nValue ) {
 	if ( nValue == 0 ) { // different song opened
 		actionModeChangeEvent( 0 );
 		stackedModeActivationEvent( 0 );
-		jackTimebaseStateChangedEvent();
+		jackTimebaseStateChangedEvent(
+			static_cast<int>(Hydrogen::get_instance()->getJackTimebaseState()) );
 		// Calls patternEditorLockedEvent() internally.
 		songModeActivationEvent();
 		timelineActivationEvent();
@@ -1054,10 +1055,11 @@ void SongEditorPanel::toggleAutomationAreaVisibility()
 }
 
 
-void SongEditorPanel::jackTimebaseStateChangedEvent() {
+void SongEditorPanel::jackTimebaseStateChangedEvent( int nState ) {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	auto pHydrogen = Hydrogen::get_instance();
-	if ( pHydrogen->getJackTimebaseState() == JackAudioDriver::Timebase::Listener ) {
+	const auto state = JackAudioDriver::TimebaseFromInt( nState );
+	if ( state == JackAudioDriver::Timebase::Listener ) {
 		setTimelineEnabled( false );
 		m_pTimelineBtn->setToolTip(
 			pCommonStrings->getTimelineDisabledTimebaseListener() );

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -98,8 +98,6 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 		virtual void gridCellToggledEvent() override;
 	virtual void patternModifiedEvent() override;
 
-		virtual void jackTimebaseStateChangedEvent() override;
-
 		virtual void playingPatternsChangedEvent() override;
 
 	virtual void patternEditorLockedEvent() override;
@@ -120,6 +118,8 @@ class SongEditorPanel :  public QWidget, public EventListener,  public H2Core::O
 			timelineBtnClicked();
 		}
 		void toggleAutomationAreaVisibility();
+		virtual void jackTimebaseStateChangedEvent( int nState ) override;
+
 
 	private slots:
 		void vScrollTo( int value );


### PR DESCRIPTION
instead on relying on the current state found in the `JackAudioDriver` instance.

This is done to allow the shotlist of our documentation to take shots of all possible states of the Timebase button - including the red one.

In addition, it fixes the initial state of the button. When being timebase controller while quitting, Hydrogen remembers and register itself during the next startup. Previously, this was not reflected by the GUI.