### PR TITLE
org.hydrogenmusic.Hydrogen.desktop, add X-NSM-Exec: when used in NSM,…

### DIFF
--- a/linux/org.hydrogenmusic.Hydrogen.desktop
+++ b/linux/org.hydrogenmusic.Hydrogen.desktop
@@ -28,3 +28,4 @@ StartupNotify=true
 
 Icon=org.hydrogenmusic.Hydrogen
 X-NSM-Capable=true
+X-NSM-Exec=hydrogen


### PR DESCRIPTION
… hydrogen can't be opened with a file, as it should wait for the open message from the NSM daemon

X-NSM-Capable, is used to detect if the application has NSM support. It should ideally become false if the application is build without NSM support.
X-NSM-Exec, is the exec name of the application when used in NSM. It can't contain a path (not /usr/bin/ for example) or command line arguments like %f.