### PR TITLE
rework libsndfile error logging

### DIFF
--- a/src/core/Basics/Sample.cpp
+++ b/src/core/Basics/Sample.cpp
@@ -180,7 +180,7 @@ bool Sample::load( float fBpm )
 		ERRORLOG( QString( "Error loading file [%1] with format [%2]: %3" )
 				  .arg( get_filepath() )
 				  .arg( sndfileFormatToQString( sound_info.format ) )
-				  .arg( sndfileErrorToQString( sf_error( nullptr ) ) ) );
+				  .arg( sf_strerror( file ) ) );
 		return false;
 	}
 	
@@ -745,7 +745,7 @@ bool Sample::write( const QString& path, int format )
 		ERRORLOG( QString( "Unable to create file [%1] with format [%2]: %3" )
 				  .arg( path )
 				  .arg( sndfileFormatToQString( format ) )
-				  .arg( sndfileErrorToQString( sf_error( nullptr ) ) ) );
+				  .arg( sf_strerror( sf_file ) ) );
 		sf_close( sf_file );
 		delete[] obuf;
 		return false;
@@ -830,23 +830,6 @@ QString Sample::toQString( const QString& sPrefix, bool bShort ) const {
 	}
 	
 	return sOutput;
-}
-
-QString Sample::sndfileErrorToQString( int nError ) {
-	switch( nError ) {
-	case 0:
-		return QString( "No error" );
-	case 1:
-		return QString( "Unrecognized format" );
-	case 2:
-		return QString( "System" );
-	case 3:
-		return QString( "Malformed file" );
-	case 4:
-		return QString( "Unsupported encoding" );
-	}
-
-	return QString( "Unknown error code [%1]" ).arg( nError );
 }
 
 QString Sample::sndfileFormatToQString( int nFormat ) {

--- a/src/core/Basics/Sample.h
+++ b/src/core/Basics/Sample.h
@@ -129,7 +129,6 @@ class Sample : public H2Core::Object<Sample>
 				QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 		};
 
-	static QString sndfileErrorToQString( int nError );
 	static QString sndfileFormatToQString( int nFormat );
 
 		/**

--- a/src/core/IO/DiskWriterDriver.cpp
+++ b/src/core/IO/DiskWriterDriver.cpp
@@ -192,7 +192,7 @@ void* diskWriterDriver_thread( void* param )
 					.arg( pDriver->m_sFilename )
 					.arg( Sample::sndfileFormatToQString( soundInfo.format ) )
 					.arg( sf_version_string() )
-					.arg( Sample::sndfileErrorToQString( sf_error( nullptr ) ) ) );
+					.arg( sf_strerror( pSndfile ) ) );
 		pDriver->m_bDoneWriting = true;
 		pDriver->m_bWritingFailed = true;
 		EventQueue::get_instance()->push_event( EVENT_PROGRESS, 100 );
@@ -207,7 +207,7 @@ void* diskWriterDriver_thread( void* param )
 		if ( sf_command( pSndfile, SFC_SET_BITRATE_MODE, &nBitrateMode,
 						 sizeof(int) ) != SF_TRUE ) {
 			___WARNINGLOG( QString( "Unable to set variable bitrate for MP3 encoding: %1" )
-						  .arg( Sample::sndfileErrorToQString( sf_error( nullptr ) ) ) );
+						  .arg( sf_strerror( pSndfile ) ) );
 		}
 	}
 #endif
@@ -223,7 +223,7 @@ void* diskWriterDriver_thread( void* param )
 						 sizeof(double) ) != SF_TRUE ) {
 			___WARNINGLOG( QString( "Unable to set compression level [%1]: %2" )
 						  .arg( pDriver->m_fCompressionLevel )
-						  .arg( Sample::sndfileErrorToQString( sf_error( nullptr ) ) ) );
+						  .arg( sf_strerror( pSndfile ) ) );
 		}
 	}
 #endif


### PR DESCRIPTION
In its documentation `libsndfile` notes to only handle the first five error bits. All other can be subject to changes http://www.mega-nerd.com/libsndfile/api.html\#error .

This is what we do till now. But in case something gets wrong one most of the time just gets an "unknown error number".

Instead, we now use `sf_strerror()`. It provides string representation a lot (all?) error numbers including the internal ones. As it is part of the `libsndfile` codebase I will most probably handle changing error numbers in future `libsndfile` versions well.