### PR TITLE
Logger: ensure log folder exists

### DIFF
--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -122,6 +122,23 @@ void* loggerThread_func( void* param ) {
 Logger* Logger::bootstrap( unsigned msk, const QString& sLogFilePath,
 						   bool bUseStdout, bool bLogTimestamps ) {
 	Logger::set_bit_mask( msk );
+
+	// When starting Hydrogen after a fresh install with no user-level .hydrogen
+	// folder, opening the log file will fail as the .hydrogen folder as whole
+	// does not exist yet. It is created as part of the bootstrap of
+	// `Filesystem`.
+	QFileInfo logFileInfo;
+	if ( ! sLogFilePath.isEmpty() ) {
+		logFileInfo = QFileInfo( sLogFilePath );
+	}
+	else {
+		logFileInfo = QFileInfo( Filesystem::log_file_path() );
+	}
+	const auto dir = logFileInfo.absoluteDir();
+	if ( ! dir.exists() ) {
+		Filesystem::mkdir( dir.absolutePath() );
+	}
+
 	return Logger::create_instance( sLogFilePath, bUseStdout, bLogTimestamps );
 }
 


### PR DESCRIPTION
in case the provided log file is located in a folder that does not exist yet or during the first time Hydrogen is starting up, the log file can not be written because its parent folder does not exist yet.

The `Logger` is bootstrapped _before_ `Filesystem` while the latter takes care of ensuring that all relevant files and folders exist