### PR TITLE
NotePropertiesRuler: support Delete key

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -28,6 +28,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 			is required on your system for MP3 support. (#2023)
 		- `X-NSM-Exec` entry added to `org.hydrogenmusic.Hydrogen.desktop` by
 			@grammoboy2 (#2042).
+		- Delete key does now remove selected notes and notes under cursor in
+			NotePropertiesRuler.
 	* Changed
 		- Brazilian translation updated.
 		- Grid lines in the Song Editor are now rendered dotted to emphasize that

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -656,6 +656,21 @@ void NotePropertiesRuler::keyPressEvent( QKeyEvent *ev )
 		// |<--
 		m_pPatternEditorPanel->setCursorPosition(0);
 
+	} else if ( ev->key() == Qt::Key_Delete ) {
+		// Key: Delete / Backspace: delete selected notes, or note under keyboard cursor
+		bUnhideCursor = false;
+		if ( m_selection.begin() != m_selection.end() ) {
+			// Delete selected notes if any
+			m_pPatternEditorPanel->getDrumPatternEditor()->
+				deleteSelection();
+		} else {
+			// Delete note under the keyboard cursor.
+			m_pPatternEditorPanel->getDrumPatternEditor()->
+				addOrRemoveNote( m_pPatternEditorPanel->getCursorPosition(), -1,
+								 pHydrogen->getSelectedInstrumentNumber(),
+								 /*bDoAdd=*/false, /*bDoDelete=*/true );
+		}
+
 	} else {
 
 		// Value adjustments


### PR DESCRIPTION
<kbd>Del</kbd> key does now remove selected notes and notes under cursor in `NotePropertiesRuler`.

It is a good idea to not remove the note when clicking it, like in the DrumPatternEditor. But <kbd>Del</kbd> is pressed with a pretty clear intent and I was puzzled at first to not find it already working.

It's especially useful when deleting all notes with a specific property. Say, duplicating a pattern and removing all notes panned to the right in the original and all panned to the left in the copy.