### PR TITLE
SongEditorRuler: fix tempo marker highlighting

### DIFF
--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -3279,7 +3279,7 @@ void SongEditorPositionRuler::updatePosition()
 	const auto pTransportPos = m_pAudioEngine->getTransportPosition();
 	const auto pPatternGroupVector =
 		m_pHydrogen->getSong()->getPatternGroupVector();
-	const auto m_nColumn = std::max( pTransportPos->getColumn(), 0 );
+	m_nColumn = std::max( pTransportPos->getColumn(), 0 );
 
 	float fTick = static_cast<float>(m_nColumn);
 


### PR DESCRIPTION
and other side effects introduced in 1f0268ffa433404551b77c60a367e7c3a60184ad