### PR TITLE
Timeline: update default BPM

### DIFF
--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -141,6 +141,10 @@ void Song::setBpm( float fBpm ) {
 	} else {
 		m_fBpm = fBpm;
 	}
+
+	if ( m_pTimeline != nullptr ) {
+		m_pTimeline->setDefaultBpm( m_fBpm );
+	}
 }
 
 void Song::setActionMode( Song::ActionMode actionMode ) {

--- a/src/core/Timeline.cpp
+++ b/src/core/Timeline.cpp
@@ -44,6 +44,10 @@ void Timeline::activate() {
 
 void Timeline::deactivate() {
 }
+
+void Timeline::setDefaultBpm( float fDefaultBpm ) {
+	m_fDefaultBpm = fDefaultBpm;
+}
 	
 void Timeline::addTempoMarker( int nColumn, float fBpm ) {
 	if ( fBpm < MIN_BPM ) {

--- a/src/core/Timeline.h
+++ b/src/core/Timeline.h
@@ -113,6 +113,8 @@ public:
 	 */
 	void deactivate();
 
+		void setDefaultBpm( float fDefaultBpm );
+
 	/** Adds a TempoMarker to the Timeline.
 	 *
 	 * Fails if there is already a #TempoMarker present at @a nColumn.


### PR DESCRIPTION
within the `Timeline` we have to so called "special tempo marker": in case no tempo marker is set in the first column, the overall bpm of the current song (the one set via the BPM widget in `PlayerControl`) is used at the beginning of the song till the encounter of the first actual tempo marker.

The value for the bpm of the `Song` is cached in `Timeline` and was only updated when activating the `Timeline` again. This lead to inconsistencies when not having a tempo marker at first column but at a later one, switching to Pattern mode, adjusting speed, and changing back to Song mode.