### PR TITLE
MainForm: fix redo after shortcut modification

### DIFF
--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -436,36 +436,31 @@ void MainForm::createMenuBar()
 	// VIEW MENU
 	m_pViewMenu = pMenubar->addMenu( tr( "&View" ) );
 
-	m_pViewPlaylistEditorAction =
-		m_pViewMenu->addAction( tr("Play&list Editor"), this,
-								SLOT( action_window_showPlaylistEditor() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowPlaylist ) );
+	m_pViewPlaylistEditorAction = m_pViewMenu->addAction(
+		tr("Play&list Editor"), this, SLOT( action_window_showPlaylistEditor() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowPlaylist ) );
 	m_pViewPlaylistEditorAction->setCheckable( true );
-	m_pViewDirectorAction =
-		m_pViewMenu->addAction( tr("&Director"), this,
-								SLOT( action_window_show_DirectorWidget() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowDirector ) );
+	m_pViewDirectorAction = m_pViewMenu->addAction(
+		tr("&Director"), this, SLOT( action_window_show_DirectorWidget() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowDirector ) );
 	m_pViewDirectorAction->setCheckable( true );
 
 	m_pFileMenu->addSeparator();
-	m_pViewMixerAction =
-		m_pViewMenu->addAction( tr("&Mixer"), this,
-								SLOT( action_window_showMixer() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowMixer ) );
+	m_pViewMixerAction = m_pViewMenu->addAction(
+		tr("&Mixer"), this, SLOT( action_window_showMixer() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowMixer ) );
 	m_pViewMixerAction->setCheckable( true );
 	update_mixer_checkbox();						// if checkbox need to be checked.
 
-	m_pViewMixerInstrumentRackAction =
-		m_pViewMenu->addAction( tr("&Instrument Rack"), this,
-								SLOT( action_window_showInstrumentRack() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowInstrumentRack ) );
+	m_pViewMixerInstrumentRackAction = m_pViewMenu->addAction(
+		tr("&Instrument Rack"), this, SLOT( action_window_showInstrumentRack() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowInstrumentRack ) );
 	m_pViewMixerInstrumentRackAction->setCheckable( true );
 	update_instrument_checkbox( pPref->getInstrumentRackProperties().visible );
 
-	m_pViewAutomationPathAction =
-		m_pViewMenu->addAction( tr("&Automation Path"), this,
-								SLOT( action_window_showAutomationArea() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowAutomation ) );
+	m_pViewAutomationPathAction = m_pViewMenu->addAction(
+		tr("&Automation Path"), this, SLOT( action_window_showAutomationArea() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowAutomation ) );
 	m_pViewAutomationPathAction->setCheckable( true );
 	if ( pPref->getShowAutomationArea() ){
 		m_pViewAutomationPathAction->setChecked(true);	
@@ -475,16 +470,14 @@ void MainForm::createMenuBar()
 
 	m_pViewMenu->addSeparator();				// -----
 
-	m_pViewTimelineAction =
-		m_pViewMenu->addAction( tr("&Timeline"), this,
-								SLOT( action_window_showTimeline() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowTimeline ) );
+	m_pViewTimelineAction = m_pViewMenu->addAction(
+		tr("&Timeline"), this, SLOT( action_window_showTimeline() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowTimeline ) );
 	m_pViewTimelineAction->setCheckable( true );
 	
-	m_pViewPlaybackTrackAction =
-		m_pViewMenu->addAction( tr("&Playback Track"), this,
-								SLOT( action_window_showPlaybackTrack() ),
-								pShortcuts->getKeySequence( Shortcuts::Action::ShowPlaybackTrack ) );
+	m_pViewPlaybackTrackAction = m_pViewMenu->addAction(
+		tr("&Playback Track"), this, SLOT( action_window_showPlaybackTrack() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::ShowPlaybackTrack ) );
 	m_pViewPlaybackTrackAction->setCheckable( true );
 
 	m_pViewPlaybackTrackActionGroup = new QActionGroup( this );
@@ -509,16 +502,14 @@ void MainForm::createMenuBar()
 	m_pOptionsMenu = pMenubar->addMenu( tr( "&Options" ));
 
 	m_pInputModeMenu = m_pOptionsMenu->addMenu( tr( "Input &Mode" ) );
-	m_pInstrumentAction =
-		m_pInputModeMenu->addAction( tr( "&Instrument" ), this,
-									 SLOT( action_inputMode_instrument() ),
-									 pShortcuts->getKeySequence( Shortcuts::Action::InputInstrument ) );
+	m_pInstrumentAction = m_pInputModeMenu->addAction(
+		tr( "&Instrument" ), this, SLOT( action_inputMode_instrument() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::InputInstrument ) );
 	m_pInstrumentAction->setCheckable( true );
 
-	m_pDrumkitAction =
-		m_pInputModeMenu->addAction( tr( "&Drumkit" ), this,
-									 SLOT( action_inputMode_drumkit() ),
-									 pShortcuts->getKeySequence( Shortcuts::Action::InputDrumkit ) );
+	m_pDrumkitAction = m_pInputModeMenu->addAction(
+		tr( "&Drumkit" ), this, SLOT( action_inputMode_drumkit() ),
+		pShortcuts->getKeySequence( Shortcuts::Action::InputDrumkit ) );
 	m_pDrumkitAction->setCheckable( true );
 
 	if ( pPref->m_bPlaySelectedInstrument ) {

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -378,11 +378,11 @@ void MainForm::createMenuBar()
 	m_pUndoAction = m_pUndoMenu->addAction(
 		pCommonStrings->getUndoMenuUndo(), this, SLOT( action_undo() ),
 		pShortcuts->getKeySequence( Shortcuts::Action::Undo ) );
-	m_pUndoAction->setEnabled( false );
+	m_pUndoAction->setEnabled( h2app->m_pUndoStack->canUndo() );
 	m_pRedoAction = m_pUndoMenu->addAction(
 		pCommonStrings->getUndoMenuRedo(), this, SLOT( action_redo() ),
 		pShortcuts->getKeySequence( Shortcuts::Action::Redo ) );
-	m_pRedoAction->setEnabled( false );
+	m_pRedoAction->setEnabled( h2app->m_pUndoStack->canRedo() );
 
 	m_pUndoMenu->addAction( pCommonStrings->getUndoMenuHistory(), this,
 							SLOT( openUndoStack() ),

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -274,6 +274,8 @@ public slots:
 		QAction *	m_pRecentFileAction4;
 
 		QUndoView *	m_pUndoView;
+		QAction*	m_pUndoAction;
+		QAction*	m_pRedoAction;
 
 	void startAutosaveTimer();
 		QTimer		m_AutosaveTimer;


### PR DESCRIPTION
This led to segfaults on `master` when setting a shortcut in the `PreferencesDialog` and triggering anything which can be undone afterwards.

Since changing the Preferences triggers `MainForm::createMenuBar` - to update the shown shortcuts - we have to be very careful to enabling/disabling the proper undo/redo actions based on the current stack position.

Also, it is important to only connect these once. Else the property will be set over and over again.