### PR TITLE
NotePropertiesRuler: avoid superfluous undo

### DIFF
--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -395,6 +395,7 @@ void NotePropertiesRuler::prepareUndoAction( int x )
 		ERRORLOG( "No instrument selected" );
 		return;
 	}
+	const int nColumn = getColumn( x );
 
 	if ( m_selection.begin() != m_selection.end() ) {
 		// If there is a selection, preserve the initial state of all the selected notes.
@@ -405,8 +406,8 @@ void NotePropertiesRuler::prepareUndoAction( int x )
 		}
 
 	} else {
-		// No notes are selected. The target notes to adjust are all those at column given by 'x', so we preserve these.
-		int nColumn = getColumn( x );
+		// No notes are selected. The target notes to adjust are all those at
+		// column given by 'x', so we preserve these.
 		FOREACH_NOTE_CST_IT_BOUND_LENGTH( m_pPattern->get_notes(), it,
 										  nColumn, m_pPattern ) {
 			Note *pNote = it->second;
@@ -415,6 +416,8 @@ void NotePropertiesRuler::prepareUndoAction( int x )
 			}
 		}
 	}
+
+	m_nDragPreviousColumn = nColumn;
 }
 
 //! Update notes for a property adjust drag, in response to the mouse moving. This modifies the values of the


### PR DESCRIPTION
clicking a single column to edit the properties of a single note caused two undo/redo actions being queued: one during drag update and one during drag end. The former is now only triggered in case the column did change. This way all property edits can be redone in a single undo