### PR TITLE
Fix lifetime issue with utf8 string in Drumkit::exportTo

### DIFF
--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -1047,7 +1047,8 @@ bool Drumkit::exportTo( const QString& sTargetDir, bool* pUtf8Encoded,
 	const auto targetPath = sTargetNamePadded.toStdWString();
 	nRet = archive_write_open_filename_w( a, targetPath.c_str() );
 #else
-	const auto targetPath = sTargetName.toUtf8().constData();
+	const auto targetPathUtf8 = sTargetName.toUtf8();
+	const auto targetPath = targetPathUtf8.constData();
 	nRet = archive_write_open_filename( a, targetPath );
 #endif
 	if ( nRet != ARCHIVE_OK ) {


### PR DESCRIPTION
The `QString::toUtf8()` function returns a `QByteArray` object. Previously, a reference to the contents of this was taken with `.constData()` but the object itself was transient and destroyed at the end of the statement, leaving a `const char*` pointing at freed memory.