### PR TITLE
Fix issues found by address sanitization

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1448,9 +1448,10 @@ int AudioEngine::audioEngine_process( uint32_t nframes, void* /*arg*/ )
 	// For the JACK driver it is very important (#1867) to not do anything while
 	// the JACK client is stopped/closed. Otherwise it will segfault on mutex
 	// locking or message logging.
-	if ( ! ( pAudioEngine->getState() == AudioEngine::State::Ready ||
-			 pAudioEngine->getState() == AudioEngine::State::Playing ) &&
-		 dynamic_cast<JackAudioDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) {
+	if ( pAudioEngine->m_pAudioDriver == nullptr ||
+		 ( ! ( pAudioEngine->getState() == AudioEngine::State::Ready ||
+			   pAudioEngine->getState() == AudioEngine::State::Playing ) &&
+		   dynamic_cast<JackAudioDriver*>(pAudioEngine->m_pAudioDriver) != nullptr ) ) {
 		return 0;
 	}
 	timeval startTimeval = currentTime2();

--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -3056,8 +3056,9 @@ void AudioEngineTests::throwException( const QString& sMsg ) {
 
 	pAE->setState( AudioEngine::State::Ready );
 	pAE->unlock();
-	
-	throw std::runtime_error( sMsg.toLocal8Bit().data() );
+
+	const auto sMsgLocal8Bit = sMsg.toLocal8Bit();
+	throw std::runtime_error( sMsgLocal8Bit.data() );
 }
 
 	

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -730,7 +730,8 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 	};
 
 #if ARCHIVE_VERSION_NUMBER < 3000000
-	nRet = archive_read_open_file( a, sSourcePath.toUtf8().constData(), 10240 );
+	const auto sSourcePathUtf8 = sSourcePath.toUtf8();
+	nRet = archive_read_open_file( a, sSourcePathUtf8.constData(), 10240 );
 #else
   #ifdef WIN32
 	QString sSourcePathPadded = sSourcePath;
@@ -738,7 +739,8 @@ bool Drumkit::install( const QString& sSourcePath, const QString& sTargetPath,
 	auto sourcePathW = sSourcePathPadded.toStdWString();
 	nRet = archive_read_open_filename_w( a, sourcePathW.c_str(), 10240 );
   #else
-	nRet = archive_read_open_filename( a, sSourcePath.toUtf8().constData(),
+	const auto sSourcePathUtf8 = sSourcePath.toUtf8();
+	nRet = archive_read_open_filename( a, sSourcePathUtf8.constData(),
 									   10240 );
   #endif
 #endif
@@ -1073,7 +1075,8 @@ bool Drumkit::exportTo( const QString& sTargetDir, bool* pUtf8Encoded,
 			return false;
 		}
 
-		stat( sFilename.toUtf8().constData(), &st );
+		const auto sFilenameUtf8 = sFilename.toUtf8();
+		stat( sFilenameUtf8.constData(), &st );
 		entry = archive_entry_new();
 		if ( entry == nullptr ) {
 			ERRORLOG( "Unable to create new archive entry" );
@@ -1081,14 +1084,16 @@ bool Drumkit::exportTo( const QString& sTargetDir, bool* pUtf8Encoded,
 			return false;
 		}
 
+		const auto sTargetFilenameUtf8 = sTargetFilename.toUtf8();
 #if defined(WIN32) and ARCHIVE_VERSION_NUMBER >= 3005000
 		if ( bUseUtf8Encoding ) {
-			archive_entry_set_pathname_utf8(entry, sTargetFilename.toUtf8().constData());
+			archive_entry_set_pathname_utf8(
+				entry, sTargetFilenameUtf8.constData());
 		} else {
 #else
 		{
 #endif
-			archive_entry_set_pathname(entry, sTargetFilename.toUtf8().constData());
+			archive_entry_set_pathname(entry, sTargetFilenameUtf8.constData());
 		}
 		archive_entry_set_size(entry, st.st_size);
 		archive_entry_set_filetype(entry, AE_IFREG);

--- a/src/core/Basics/Sample.cpp
+++ b/src/core/Basics/Sample.cpp
@@ -762,7 +762,8 @@ bool Sample::write( const QString& path, int format ) const
 								   &sf_info );
 	delete encodedFilename;
 #else
-	SNDFILE* sf_file = sf_open( path.toLocal8Bit().data(), SFM_WRITE, &sf_info );
+	const auto sPathLocal8Bit = path.toLocal8Bit();
+	SNDFILE* sf_file = sf_open( sPathLocal8Bit.data(), SFM_WRITE, &sf_info );
 #endif
 
 	if ( sf_file == nullptr ) {

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -423,7 +423,8 @@ bool Filesystem::write_to_file( const QString& dst, const QString& content )
 		ERRORLOG( QString( "unable to write to %1" ).arg( dst ) );
 		return false;
 	}
-	file.write( content.toUtf8().data() );
+	const auto contentUtf8 = content.toUtf8();
+	file.write( contentUtf8.data() );
 	file.close();
 
 	return true;

--- a/src/core/IO/AlsaAudioDriver.cpp
+++ b/src/core/IO/AlsaAudioDriver.cpp
@@ -164,10 +164,16 @@ QStringList AlsaAudioDriver::getDevices()
 			*sIOID = snd_device_name_get_hint( *pHint, "IOID");
 
 		if ( sIOID && QString( sIOID ) != "Output") {
+			free( (void *)sIOID );
+
+			if ( sName ) {
+				free( (void *)sName );
+			}
+
 			continue;
 		}
 
-		QString sDev = QString( sName );
+		const QString sDev = QString( sName );
 		if ( sName ) {
 			free( (void *)sName );
 		}

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -1042,7 +1042,8 @@ int JackAudioDriver::init( unsigned bufferSize )
 	if ( pPreferences->useLash() ){
 		LashClient* lashClient = LashClient::get_instance();
 		if ( lashClient->isConnected() ) {
-			lashClient->setJackClientName(sClientName.toLocal8Bit().constData());
+			const auto sClientNameLocal8Bit = sClientName.toLocal8Bit();
+			lashClient->setJackClientName(sClientNameLocal8Bit.constData());
 		}
 	}
 #endif

--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -205,14 +205,16 @@ void PortMidiDriver::open()
 		}
 		else {
 			if ( pInfo->input == TRUE ) {
-				if ( strcmp( pInfo->name, sMidiPortName.toLocal8Bit().constData() ) == 0 &&
+				const auto sMidiPortNameLocal8Bit = sMidiPortName.toLocal8Bit();
+				if ( strcmp( pInfo->name, sMidiPortNameLocal8Bit.constData() ) == 0 &&
 					 sMidiPortName != Preferences::getNullMidiPort() ) {
 					nDeviceId = i;
 				}
 			}
 	
 			if ( pInfo->output == TRUE ) {
-				if ( strcmp( pInfo->name, sMidiOutputPortName.toLocal8Bit().constData() ) == 0 &&
+				const auto sMidiOutputPortNameLocal8Bit = sMidiOutputPortName.toLocal8Bit();
+				if ( strcmp( pInfo->name, sMidiOutputPortNameLocal8Bit.constData() ) == 0 &&
 					 sMidiOutputPortName != Preferences::getNullMidiPort() ) {
 					nOutDeviceId = i;
 				}

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -106,11 +106,6 @@ Sampler::~Sampler()
 	m_pPlaybackTrackInstrument = nullptr;
 }
 
-/** set default k for pan law with -4.5dB center compensation, given L^k + R^k = const
- * it is the mean compromise between constant sum and constant power
- */
-float const Sampler::K_NORM_DEFAULT = 1.33333333333333;
-
 void Sampler::process( uint32_t nFrames )
 {
 	auto pHydrogen = Hydrogen::get_instance();

--- a/src/core/Sampler/Sampler.h
+++ b/src/core/Sampler/Sampler.h
@@ -119,11 +119,10 @@ public:
 		QUADRATIC_CONST_K_NORM
 	};
 	
-	/** default k for pan law with such that L^k + R^k = const
-	 * must be initialised in Sampler.cpp
+	/** default k for pan law with -4.5dB center compensation, given L^k + R^k =
+	 * const it is the mean compromise between constant sum and constant power
 	 */
-	static const float K_NORM_DEFAULT;
-	
+	static constexpr float K_NORM_DEFAULT = 1.33333333333333;
 
 	// pan law functions
 	static float ratioStraightPolygonalPanLaw( float fPan );

--- a/src/gui/src/ShotList.cpp
+++ b/src/gui/src/ShotList.cpp
@@ -54,7 +54,8 @@ ShotList::~ShotList() {
 }
 
 QWidget *ShotList::findWidgetInheriting( QObject *pObject, const QString& sName ) {
-	if ( pObject->inherits( sName.toLocal8Bit().data() ) ) {
+	const auto sNameLocal8Bit = sName.toLocal8Bit();
+	if ( pObject->inherits( sNameLocal8Bit.data() ) ) {
 		return dynamic_cast< QWidget *>( pObject );
 	}
 	for ( QObject *pC : pObject->children() ) {
@@ -184,21 +185,26 @@ void ShotList::shoot( const QString& s ) {
 			if ( pWidget ) {
 				___INFOLOG( QString( "Invoking '%1' on '%2'" ).arg( sMethodName, sWidgetName ) );
 				bool bSuccess = false;
+				const auto sMethodNameLocal8Bit = sMethodName.toLocal8Bit();
 				switch ( words.size() ) {
 				case 3:
-					bSuccess = QMetaObject::invokeMethod( pWidget, sMethodName.toLocal8Bit().data(), Qt::DirectConnection );
+					bSuccess = QMetaObject::invokeMethod(
+						pWidget, sMethodNameLocal8Bit.data(), Qt::DirectConnection );
 					break;
 				case 4:
-					bSuccess = QMetaObject::invokeMethod( pWidget, sMethodName.toLocal8Bit().data(), Qt::DirectConnection,
-														  Arg( words[3] ) );
+					bSuccess = QMetaObject::invokeMethod(
+						pWidget, sMethodNameLocal8Bit.data(), Qt::DirectConnection,
+						Arg( words[3] ) );
 					break;
 				case 5:
-					bSuccess = QMetaObject::invokeMethod( pWidget, sMethodName.toLocal8Bit().data(), Qt::DirectConnection,
-														  Arg( words[3] ), Arg( words[4] ) );
+					bSuccess = QMetaObject::invokeMethod(
+						pWidget, sMethodNameLocal8Bit.data(), Qt::DirectConnection,
+						Arg( words[3] ), Arg( words[4] ) );
 					break;
 				case 6:
-					bSuccess = QMetaObject::invokeMethod( pWidget, sMethodName.toLocal8Bit().data(), Qt::DirectConnection,
-														  Arg( words[3] ), Arg( words[4] ), Arg( words[5] ) );
+					bSuccess = QMetaObject::invokeMethod(
+						pWidget, sMethodNameLocal8Bit.data(), Qt::DirectConnection,
+						Arg( words[3] ), Arg( words[4] ), Arg( words[5] ) );
 					break;
 				default:
 					___ERRORLOG( "Unsupported number of arguments in %0" );

--- a/src/tests/OscServerTest.cpp
+++ b/src/tests/OscServerTest.cpp
@@ -96,8 +96,9 @@ void OscServerTest::testSessionManagement(){
 	lo::Address hydrogenOSC("localhost", "7362" );
 	
 	// Create the new song.
+	const auto sValidPathLocal8Bit = m_sValidPath.toLocal8Bit();
 	hydrogenOSC.send("/Hydrogen/NEW_SONG", "s", 
-					 m_sValidPath.toLocal8Bit().data());
+					 sValidPathLocal8Bit.data());
 	
 	// Store it to disk so we can retrieve it later on.
 	hydrogenOSC.send("/Hydrogen/SAVE_SONG");
@@ -105,15 +106,16 @@ void OscServerTest::testSessionManagement(){
 	CPPUNIT_ASSERT( m_sValidPath == m_pHydrogen->getSong()->getFilename() );
 
 	// Store a copy in another file.
+	const auto sValidPath2Local8Bit = m_sValidPath2.toLocal8Bit();
 	hydrogenOSC.send("/Hydrogen/SAVE_SONG_AS", "s",
-					 m_sValidPath2.toLocal8Bit().data());	
+					 sValidPath2Local8Bit.data());
 	WAIT(m_sValidPath2 == m_pHydrogen->getSong()->getFilename());
 	CPPUNIT_ASSERT( m_sValidPath2 == m_pHydrogen->getSong()->getFilename() );
 	
 	// Load the first song. This will only be successful if the
 	// SAVE_SONG did work.
 	hydrogenOSC.send("/Hydrogen/OPEN_SONG", "s",
-					 m_sValidPath.toLocal8Bit().data());
+					 sValidPathLocal8Bit.data());
 	WAIT(m_sValidPath == m_pHydrogen->getSong()->getFilename());
 	CPPUNIT_ASSERT( m_sValidPath == m_pHydrogen->getSong()->getFilename() );
 	___INFOLOG( "passed" );

--- a/src/tests/assertions/AudioFile.cpp
+++ b/src/tests/assertions/AudioFile.cpp
@@ -29,9 +29,10 @@ static constexpr qint64 BUFFER_SIZE = 4096;
 
 void H2Test::checkAudioFilesEqual(const QString& sExpected, const QString& sActual, CppUnit::SourceLine sourceLine)
 {
+	const auto sExpectedLocal8Bit = sExpected.toLocal8Bit();
 	SF_INFO info1 = {0};
 	std::unique_ptr<SNDFILE, decltype(&sf_close)>
-		f1{ sf_open( sExpected.toLocal8Bit().data(), SFM_READ, &info1), sf_close };
+		f1{ sf_open( sExpectedLocal8Bit.data(), SFM_READ, &info1), sf_close };
 	if ( f1 == nullptr ) {
 		CppUnit::Message msg(
 			QString( "Can't open reference file [%1]" ).arg( sExpected )
@@ -41,9 +42,10 @@ void H2Test::checkAudioFilesEqual(const QString& sExpected, const QString& sActu
 		throw CppUnit::Exception(msg, sourceLine);
 	}
 
+	const auto sActualLocal8Bit = sActual.toLocal8Bit();
 	SF_INFO info2 = {0};
 	std::unique_ptr<SNDFILE, decltype(&sf_close)>
-		f2{ sf_open( sActual.toLocal8Bit().data(), SFM_READ, &info2), sf_close };
+		f2{ sf_open( sActualLocal8Bit.data(), SFM_READ, &info2), sf_close };
 	if ( f2 == nullptr ) {
 		CppUnit::Message msg(
 			QString( "Can't open results file [%1]" ).arg( sActual )
@@ -96,9 +98,10 @@ void H2Test::checkAudioFilesEqual(const QString& sExpected, const QString& sActu
 
 void H2Test::checkAudioFilesDataEqual(const QString& sExpected, const QString& sActual, CppUnit::SourceLine sourceLine)
 {
+	const auto sExpectedLocal8Bit = sExpected.toLocal8Bit();
 	SF_INFO expectedInfo = {0};
 	std::unique_ptr<SNDFILE, decltype(&sf_close)>
-		f1{ sf_open( sExpected.toLocal8Bit().data(), SFM_READ, &expectedInfo), sf_close };
+		f1{ sf_open( sExpectedLocal8Bit.data(), SFM_READ, &expectedInfo), sf_close };
 	if ( f1 == nullptr ) {
 		CppUnit::Message msg(
 			QString( "Can't open reference file [%1]" ).arg( sExpected )
@@ -108,9 +111,10 @@ void H2Test::checkAudioFilesDataEqual(const QString& sExpected, const QString& s
 		throw CppUnit::Exception(msg, sourceLine);
 	}
 
+	const auto sActualLocal8Bit = sActual.toLocal8Bit();
 	SF_INFO actualInfo = {0};
 	std::unique_ptr<SNDFILE, decltype(&sf_close)>
-		f2{ sf_open( sActual.toLocal8Bit().data(), SFM_READ, &actualInfo), sf_close };
+		f2{ sf_open( sActualLocal8Bit.data(), SFM_READ, &actualInfo), sf_close };
 	if ( f2 == nullptr ) {
 		CppUnit::Message msg(
 			QString( "Can't open results file [%1]" ).arg( sActual )


### PR DESCRIPTION
Using the option `-fsanitize=address` for `gcc` I was able to spot a number of memory issues. 

However, the search for memory leaks is just too detailed. I got a lot of errors we can do nothing about, like the destructor of `ServerThread` in `liblo`, the loading of `QXmlSchema` in `Qt5`, things in `libasound2` (ALSA), PortAudio, JACK.... Using preprocessor macros to blacklist functions calling the affected routines does not work either (the flag is probably not propagated and just sticks to the symbol. But I have no idea about compilers and probably writing nonsense). That's why using an address sanitizer within our build pipeline is off the table.