### PR TITLE
InstrumentEditor: fix pitch handling

### DIFF
--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -727,6 +727,11 @@ void InstrumentEditor::rotaryChanged( WidgetWithInput *ref)
 	Rotary* pRotary = static_cast<Rotary*>( ref );
 	auto pCoreActionController =
 		Hydrogen::get_instance()->getCoreActionController();
+
+	const auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
 	
 	float fVal = pRotary->getValue();
 
@@ -738,12 +743,14 @@ void InstrumentEditor::rotaryChanged( WidgetWithInput *ref)
 			//round fVal, since Coarse is the integer number of half steps
 			float fNewPitch = round( fVal ) + m_pPitchFineRotary->getValue();
 			pCoreActionController->setInstrumentPitch(
-				m_pInstrument->get_id(), fNewPitch );
+				pSong->getInstrumentList()->index( m_pInstrument ),
+				fNewPitch );
 		}
 		else if ( pRotary == m_pPitchFineRotary ) {
 			float fNewPitch = round( m_pPitchCoarseRotary->getValue() ) + fVal;
 			pCoreActionController->setInstrumentPitch(
-				m_pInstrument->get_id(), fNewPitch );
+				pSong->getInstrumentList()->index( m_pInstrument ),
+				fNewPitch );
 		}
 		else if ( pRotary == m_pCutoffRotary ) {
 			m_pInstrument->set_filter_cutoff( fVal );


### PR DESCRIPTION
the instrument the pitch is altered of must be specified using its index - its position within the `InstrumentList` - not using its ID.

In kits with IDs not matching the instrument order or when rearranging instruments in the sidebar of the pattern editor adjusting the pitch knob did result in very strange behavior