### PR TITLE
gui/main: fix exception handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Fixed
 		- Fix compilation with LASH support enabled (#2076).
 		- Fix Hue slider in Preferences > Appearance > Color (#2081)
+		- Show the Crash Reporter and exit with return code `1` on unhandled
+			exceptions.
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -561,9 +561,11 @@ int main(int argc, char *argv[])
 	}
 	catch ( const H2Core::H2Exception& ex ) {
 		std::cerr << "[main] Exception: " << ex.what() << std::endl;
+		return 1;
 	}
 	catch (...) {
 		std::cerr << "[main] Unknown exception X-(" << std::endl;
+		return 1;
 	}
 
 	return 0;


### PR DESCRIPTION
when provoking an exception during debugging I was quite surprised we did neither show the `Reporter` nor return with a non-zero exit code.