### PR TITLE
PatternEditor: indicate whether notes will be played back

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -37,6 +37,9 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 			done using "instrument types".
 		- `<instrumentComponent>` and `<instrumentLayer>` elements in drumkit XML
 			definitions contain two new elements: `<isMuted>` and `<isSoloed>`.
+		- Notes not rendered by the audio engine are now highlighted in the pattern
+			editor (can be disabled in Preferences > Appearance > Interface >
+			Indicate note playback).
 	* Changed
 		- Drumkit handling was reworked. Each song will now hold a proper drumkit.
 			Tweaking its name, instruments etc. does not affect the kits in the Sound

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -731,16 +731,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1380,6 +1370,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4551,6 +4551,10 @@ La ruta a l&apos;Script i el nom del Script no poden tenir espais en blanc.</tra
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4549,6 +4549,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -733,16 +733,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation>Instrument konnte nicht geladen werden</translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation>an</translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>aus</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation>aktiv</translation>
@@ -1383,6 +1373,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation>H</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>An</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Aus</translation>
     </message>
 </context>
 <context>
@@ -4583,6 +4583,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>ανενεργό</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4585,6 +4585,10 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation></translation>
     </message>
 </context>
@@ -4534,6 +4534,10 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation></translation>
     </message>
 </context>
@@ -4534,6 +4534,10 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -733,16 +733,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation>No se puede cargar el instrumento</translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation>encendido</translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>apagado</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation>activado</translation>
@@ -1384,6 +1374,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation>B</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>Encendido</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Apagado</translation>
     </message>
 </context>
 <context>
@@ -4595,6 +4595,10 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -732,16 +732,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation>Impossible de charger l&apos;instrument</translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation>on</translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>off</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation>activé</translation>
@@ -1383,6 +1373,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation>Si</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>On</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Off</translation>
     </message>
 </context>
 <context>
@@ -4596,6 +4596,10 @@ Le chemin vers le script et le nom du script doivent être sans espaces.</transl
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>apagado</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4578,6 +4578,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4549,6 +4549,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4539,6 +4539,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation>Non è possibile caricare lo strumento</translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>off</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1380,6 +1370,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>On</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Off</translation>
     </message>
 </context>
 <context>
@@ -4553,6 +4553,10 @@ Il percorso dello script o il suo nome non devono contenere spazi.</translation>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -731,16 +731,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>オフ</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1381,6 +1371,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>オフ</translation>
     </message>
 </context>
 <context>
@@ -4576,6 +4576,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4546,6 +4546,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4542,6 +4542,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -733,16 +733,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation>Não é possível carregar o instrumento</translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation>ligado</translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>desligado</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation>ativado</translation>
@@ -1383,6 +1373,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation>B</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>Ligado</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Desligado</translation>
     </message>
 </context>
 <context>
@@ -4593,6 +4593,10 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>выкл</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4573,6 +4573,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>искљ</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1380,6 +1370,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>Укљ</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Искљ</translation>
     </message>
 </context>
 <context>
@@ -4574,6 +4574,10 @@ The path to the script and the scriptname must be without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1379,6 +1369,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4539,6 +4539,10 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>вимкн</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1380,6 +1370,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>Увімкн</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>Вимкн</translation>
     </message>
 </context>
 <context>
@@ -4579,6 +4579,10 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -730,16 +730,6 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
         <translation>无法加载乐器</translation>
     </message>
     <message>
-        <source>on</source>
-        <extracomment>Displayed within a status message when activating a widget.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>off</source>
-        <extracomment>Displayed within a status message when deactivating a widget.</extracomment>
-        <translation>关</translation>
-    </message>
-    <message>
         <source>enabled</source>
         <extracomment>Displayed within a status message when enabling a widget.</extracomment>
         <translation type="unfinished"></translation>
@@ -1381,6 +1371,16 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>B</source>
         <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
         <translation>B</translation>
+    </message>
+    <message>
+        <source>On</source>
+        <extracomment>Displayed within a status message when activating a widget as well as in * the preferences dialog as option to enable a setting.</extracomment>
+        <translation>开</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
+        <translation>关</translation>
     </message>
 </context>
 <context>
@@ -4579,6 +4579,10 @@ The path to the script and the scriptname must without whitespaces.</source>
     </message>
     <message>
         <source>Enable JACK &amp;Timebase support</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Indicate note playback</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/themes/default.h2theme
+++ b/data/themes/default.h2theme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hydrogen_theme xmlns="http://www.hydrogen-music.org/theme" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
- <version>1.3.0-alpha-'9f69fb9e3'</version>
+ <version>1.3.0-alpha-'05bec5f3a'</version>
  <colorTheme>
   <songEditor>
    <backgroundColor>128,134,152</backgroundColor>
@@ -134,6 +134,7 @@
   <SongEditor_pattern_color_48>67,96,131</SongEditor_pattern_color_48>
   <SongEditor_pattern_color_49>67,96,131</SongEditor_pattern_color_49>
   <SongEditor_visible_pattern_colors>18</SongEditor_visible_pattern_colors>
+  <indicate_note_playback>true</indicate_note_playback>
  </interfaceTheme>
  <fontTheme>
   <application_font_family>DejaVu Sans</application_font_family>

--- a/src/core/Preferences/Theme.cpp
+++ b/src/core/Preferences/Theme.cpp
@@ -781,7 +781,8 @@ InterfaceTheme::InterfaceTheme()
 	, m_uiScalingPolicy( InterfaceTheme::ScalingPolicy::Smaller )
 	, m_iconColor( InterfaceTheme::IconColor::Black )
 	, m_coloringMethod( InterfaceTheme::ColoringMethod::Custom )
-	, m_nVisiblePatternColors( 18 ) {
+	, m_nVisiblePatternColors( 18 )
+	, m_bIndicateNotePlayback( true ) {
 	m_patternColors.resize( nMaxPatternColors );
 
 	std::vector<QColor> defaultColors {
@@ -884,7 +885,9 @@ QString InterfaceTheme::toQString( const QString& sPrefix, bool bShort ) const {
 							.arg( ccolor.name() ) );
 		}
 		sOutput.append( QString( "%1%2]\n%1%2m_nVisiblePatternColors: %3\n" )
-						.arg( sPrefix ) .arg( s ).arg( m_nVisiblePatternColors ) );
+						.arg( sPrefix ) .arg( s ).arg( m_nVisiblePatternColors ) )
+			.append( QString( "%1%2m_bIndicateNotePlayback: %3\n" )
+					 .arg( sPrefix ) .arg( s ).arg( m_bIndicateNotePlayback ) );
 	}
 	else {
 		sOutput = QString( "[InterfaceTheme] " )
@@ -904,7 +907,9 @@ QString InterfaceTheme::toQString( const QString& sPrefix, bool bShort ) const {
 			sOutput.append( QString( "%1, " ).arg( ccolor.name() ) );
 		}
 		sOutput.append( QString( "], m_nVisiblePatternColors: %1" )
-						 .arg( m_nVisiblePatternColors ) );
+						 .arg( m_nVisiblePatternColors ) )
+			.append( QString( ", m_bIndicateNotePlayback: %1" )
+					 .arg( m_bIndicateNotePlayback ) );
 	}
 
 	return sOutput;
@@ -1082,7 +1087,11 @@ std::unique_ptr<Theme> Theme::importFrom( const QString& sPath ) {
 		interfaceTheme.m_nVisiblePatternColors = 50;
 	} else if ( interfaceTheme.m_nVisiblePatternColors < 0 ) {
 		interfaceTheme.m_nVisiblePatternColors = 0;
-	}									  
+	}
+
+	interfaceTheme.m_bIndicateNotePlayback = interfaceNode.read_bool(
+		"indicate_note_playback", true, /* inexistent_ok */ true,
+		/* empty_ok */ false );
 			
 	XMLNode fontNode = rootNode.firstChildElement( "fontTheme" );
 	if ( fontNode.isNull() ) {
@@ -1140,6 +1149,8 @@ bool Theme::exportTo( const QString& sPath ) const {
 	}
 	interfaceNode.write_int( "SongEditor_visible_pattern_colors",
 							 m_interface.m_nVisiblePatternColors );
+	interfaceNode.write_bool( "indicate_note_playback",
+							  m_interface.m_bIndicateNotePlayback );
 
 	XMLNode fontNode = rootNode.createNode( "fontTheme" );
 	fontNode.write_string( "application_font_family",

--- a/src/core/Preferences/Theme.h
+++ b/src/core/Preferences/Theme.h
@@ -195,6 +195,10 @@ public:
 	int	m_nVisiblePatternColors;
 	/** Not read from/written to disk */
 	static constexpr int nMaxPatternColors = 50;
+
+		/** Whether notes which will not be rendered by the audio engine be
+		 * highlighted in a distinct color. */
+		bool m_bIndicateNotePlayback;
 };
 	
 /** \ingroup docCore docConfiguration*/

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -338,10 +338,12 @@ CommonStrings::CommonStrings(){
 	  drumkit, MIDI etc. into a read-only folder.*/
 	m_sFileDialogMissingWritePermissions = tr( "You do not have permissions to write to the selected folder. Please select another one." );
 
-	/*: Displayed within a status message when activating a widget.*/
-	m_sStatusOn = tr( "on" );
-	/*: Displayed within a status message when deactivating a widget.*/
-	m_sStatusOff = tr( "off" );
+	/*: Displayed within a status message when activating a widget as well as in
+	 *  the preferences dialog as option to enable a setting.*/
+	m_sStatusOn = tr( "On" );
+	/*: Displayed within a status message when deactivating a widget as well as in
+	 *  the preferences dialog as option to disable a setting.*/
+	m_sStatusOff = tr( "Off" );
 	/*: Displayed within a status message when enabling a widget.*/
 	m_sStatusEnabled = tr( "enabled" );
 	/*: Displayed within a status message when disabling a widget.*/

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -209,9 +209,11 @@ std::vector<DrumPatternEditor::SelectionIndex> DrumPatternEditor::elementsInters
 	rNormalized += QMargins( 4, h/2, 4, h/2 );
 
 
-	// Calculate the first and last position values that this rect will intersect with
+	// Calculate the first and last position values that this rect will
+	// intersect with
 	int x_min = (rNormalized.left() - PatternEditor::nMargin - 1) / m_fGridWidth;
-	int x_max = (rNormalized.right() - PatternEditor::nMargin) / m_fGridWidth;
+	int x_max = (std::min( rNormalized.right(), m_nActiveWidth ) -
+				 PatternEditor::nMargin ) / m_fGridWidth;
 
 	const Pattern::notes_t* notes = pPattern->getNotes();
 

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1189,15 +1189,15 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 			// value is centered - draw circle
 			const int nY = static_cast<int>(std::round( height() * 0.5 ) );
 
-			if ( noteStyle & ( NoteStyle::Selected |
-							   NoteStyle::Hovered |
-							   NoteStyle::NoPlayback ) ) {
-				p.setPen( highlightPen );
-				p.setBrush( highlightBrush );
-				p.drawEllipse( nX - 7, nY - 7, 14, 14 );
-			}
-
 			if ( ! ( noteStyle & NoteStyle::Moved ) ) {
+				if ( noteStyle & ( NoteStyle::Selected |
+								   NoteStyle::Hovered |
+								   NoteStyle::NoPlayback ) ) {
+					p.setPen( highlightPen );
+					p.setBrush( highlightBrush );
+					p.drawEllipse( nX - 7, nY - 7, 14, 14 );
+				}
+
 				p.setPen( notePen );
 				p.setBrush( noteBrush );
 				p.drawEllipse( nX - 4, nY - 4, 8, 8);
@@ -1223,16 +1223,16 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 				nHeight = fValue;
 			}
 
-			if ( noteStyle & ( NoteStyle::Selected |
-							   NoteStyle::Hovered |
-							   NoteStyle::NoPlayback ) ) {
-				p.setPen( highlightPen );
-				p.setBrush( highlightBrush );
-				p.drawRoundedRect( nX - 1 - 4, nY - 4, nLineWidth + 8,
-								   nHeight + 8, 5, 5 );
-			}
-
 			if ( ! ( noteStyle & NoteStyle::Moved ) ) {
+				if ( noteStyle & ( NoteStyle::Selected |
+								   NoteStyle::Hovered |
+								   NoteStyle::NoPlayback ) ) {
+					p.setPen( highlightPen );
+					p.setBrush( highlightBrush );
+					p.drawRoundedRect( nX - 1 - 4, nY - 4, nLineWidth + 8,
+									   nHeight + 8, 5, 5 );
+				}
+
 				p.setPen( notePen );
 				p.setBrush( noteBrush );
 				p.drawRoundedRect( nX - 1 - 1, nY - 1,

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1138,21 +1138,7 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 		return;
 	}
 
-	const auto pPref = H2Core::Preferences::get_instance();
 	const int nLineWidth = 3;
-
-	QColor color;
-	if ( ! pNote->getNoteOff() ) {
-		color = PatternEditor::computeNoteColor( pNote->getVelocity() );
-	} else {
-		color = pPref->getTheme().m_color.m_patternEditor_noteOffColor;
-	}
-	const QColor noteColor(
-		pPref->getTheme().m_color.m_patternEditor_noteVelocityDefaultColor );
-	const QColor noteInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor.darker( 150 ) );
-	const QColor noteoffInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor );
 
 	const int nX = nOffsetX + PatternEditor::nMargin +
 		pNote->getPosition() * m_fGridWidth;
@@ -1164,32 +1150,19 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 			static_cast<NoteStyle>(noteStyle | NoteStyle::NoPlayback);
 	}
 
-	QPen highlightPen;
-	QBrush highlightBrush;
-	applyHighlightColor( &highlightPen, &highlightBrush, noteStyle );
+	QPen notePen, highlightPen, movingPen;
+	QBrush noteBrush, highlightBrush, movingBrush;
+	applyColor( pNote, &notePen, &noteBrush, &highlightPen, &highlightBrush,
+				&movingPen, &movingBrush, noteStyle );
 
-	QBrush noteBrush( color );
-	QPen notePen( noteColor );
-	if ( noteStyle & NoteStyle::Background ) {
-
-		if ( nX >= m_nActiveWidth ) {
-			notePen.setColor( noteInactiveColor );
-		}
-
-		noteBrush.setStyle( Qt::Dense4Pattern );
-		notePen.setStyle( Qt::DotLine );
-	}
 	p.setPen( notePen );
 	p.setRenderHint( QPainter::Antialiasing );
 
 	// Silhouette to show when a note is selected and moved to a different
 	// position (in another editor!).
 	auto pEditor = m_pPatternEditorPanel->getVisibleEditor();
-	QPen movingPen( noteColor );
 	QPoint movingOffset, delta;
 	if ( noteStyle & NoteStyle::Moved ) {
-		movingPen.setStyle( Qt::DotLine );
-		movingPen.setWidth( 2 );
 		delta = pEditor->movingGridOffset();
 		movingOffset = QPoint( delta.x() * m_fGridWidth, 0 );
 	}
@@ -1268,7 +1241,7 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 			}
 			else {
 				p.setPen( movingPen );
-				p.setBrush( Qt::NoBrush );
+				p.setBrush( movingBrush );
 				p.drawRoundedRect( movingOffset.x() + nX - 1 - 2, nY - 2,
 								   nLineWidth + 4, nHeight + 4, 5, 5 );
 			}
@@ -1300,6 +1273,7 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 
 		if ( ! ( noteStyle & NoteStyle::Moved ) ) {
 			// paint the octave
+			p.setPen( notePen );
 			p.setBrush( noteBrush );
 			p.drawEllipse( QPoint( nX, nOctaveY ), nRadiusOctave, nRadiusOctave );
 
@@ -1330,7 +1304,7 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 
 			if ( bDrawMoveSilhouettes ) {
 				p.setPen( movingPen );
-				p.setBrush( Qt::NoBrush );
+				p.setBrush( movingBrush );
 				p.drawEllipse( QPoint( movingOffset.x() + nX, nMovedOctaveY ),
 							   nRadiusOctave + 1, nRadiusOctave + 1 );
 

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1156,6 +1156,7 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 				&movingPen, &movingBrush, noteStyle );
 
 	p.setPen( notePen );
+	p.setBrush( noteBrush );
 	p.setRenderHint( QPainter::Antialiasing );
 
 	// Silhouette to show when a note is selected and moved to a different

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1157,6 +1157,13 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 	const int nX = nOffsetX + PatternEditor::nMargin +
 		pNote->getPosition() * m_fGridWidth;
 
+	// NoPlayback is handled in here in order to not bloat calling routines
+	// (since it has to be calculated for every note drawn).
+	if ( ! checkNotePlayback( pNote ) ) {
+		noteStyle =
+			static_cast<NoteStyle>(noteStyle | NoteStyle::NoPlayback);
+	}
+
 	QPen highlightPen;
 	QBrush highlightBrush;
 	applyHighlightColor( &highlightPen, &highlightBrush, noteStyle );
@@ -1209,7 +1216,9 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 			// value is centered - draw circle
 			const int nY = static_cast<int>(std::round( height() * 0.5 ) );
 
-			if ( noteStyle & ( NoteStyle::Selected | NoteStyle::Hovered ) ) {
+			if ( noteStyle & ( NoteStyle::Selected |
+							   NoteStyle::Hovered |
+							   NoteStyle::NoPlayback ) ) {
 				p.setPen( highlightPen );
 				p.setBrush( highlightBrush );
 				p.drawEllipse( nX - 7, nY - 7, 14, 14 );
@@ -1241,7 +1250,9 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 				nHeight = fValue;
 			}
 
-			if ( noteStyle & ( NoteStyle::Selected | NoteStyle::Hovered ) ) {
+			if ( noteStyle & ( NoteStyle::Selected |
+							   NoteStyle::Hovered |
+							   NoteStyle::NoPlayback ) ) {
 				p.setPen( highlightPen );
 				p.setBrush( highlightBrush );
 				p.drawRoundedRect( nX - 1 - 4, nY - 4, nLineWidth + 8,
@@ -1274,7 +1285,9 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 			  NotePropertiesRuler::nKeyLineHeight );
 
 		// Paint selection outlines
-		if ( noteStyle & ( NoteStyle::Selected | NoteStyle::Hovered ) ) {
+		if ( noteStyle & ( NoteStyle::Selected |
+						   NoteStyle::Hovered |
+						   NoteStyle::NoPlayback ) ) {
 			p.setPen( highlightPen );
 			p.setBrush( highlightBrush );
 			// Octave

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1569,6 +1569,10 @@ void NotePropertiesRuler::drawPattern() {
 				continue;
 			}
 
+			if ( nnPos >= ppPattern->getLength() ) {
+				break;
+			}
+
 			if ( nLastPos != nnPos ) {
 				nLastPos = nnPos;
 				sortAndDrawNotes( p, notes, baseStyle );

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -3898,6 +3898,11 @@ void PatternEditor::popupTeardown() {
 }
 
 bool PatternEditor::checkNotePlayback( std::shared_ptr<H2Core::Note> pNote ) const {
+	if ( ! Preferences::get_instance()->
+		 getTheme().m_interface.m_bIndicateNotePlayback ) {
+		return true;
+	}
+
 	const auto row = m_pPatternEditorPanel->getRowDB(
 		m_pPatternEditorPanel->findRowDB( pNote ) );
 	return row.bPlaysBackAudio;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "PatternEditor.h"
+
 #include "PatternEditorRuler.h"
 #include "PatternEditorSidebar.h"
 #include "PatternEditorPanel.h"
@@ -46,6 +47,7 @@
 #include <core/AudioEngine/AudioEngine.h>
 #include <core/Helpers/Xml.h>
 
+#include <QtMath>
 
 using namespace std;
 using namespace H2Core;
@@ -337,11 +339,36 @@ void PatternEditor::drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
 		else {
 			p.setPen( movingPen );
 			p.setBrush( movingBrush );
-			p.drawEllipse( movingOffset.x() + nX -4 -2, movingOffset.y() + nY -2 , w + 4, h + 4 );
 
-			// Moving tail
-			if ( pNote->getLength() != LENGTH_ENTIRE_SAMPLE ) {
-				p.drawRoundedRect( movingOffset.x() + nX-2, movingOffset.y() + nY, width+4, 3+4, 4, 4 );
+			if ( pNote->getLength() == LENGTH_ENTIRE_SAMPLE ) {
+				p.drawEllipse( movingOffset.x() + nX -4 -2,
+							   movingOffset.y() + nY -2 , w + 4, h + 4 );
+			}
+			else {
+				// Moving note with tail
+
+				const int nDiameterNote = w + 4;
+				const int nHeightTail = 7;
+				// Angle of triangle at note center with note radius as hypotenuse
+				// and half the tail height as opposite.
+				const int nAngleIntersection = static_cast<int>(
+					std::round( qRadiansToDegrees(
+									qAsin( static_cast<qreal>(nHeightTail) /
+										   static_cast<qreal>(nDiameterNote) ) ) ) );
+
+				const int nMoveX = movingOffset.x() + nX;
+				const int nMoveY = movingOffset.y() + nY;
+
+				p.drawArc( nMoveX - 4 - 2, nMoveY - 2, nDiameterNote, nDiameterNote,
+						   nAngleIntersection * 16,
+						   ( 360 - 2 * nAngleIntersection ) * 16 );
+
+				p.drawLine( nMoveX + w - 2, nMoveY,
+							nMoveX + width + 2, nMoveY );
+				p.drawLine( nMoveX + width + 2, nMoveY,
+							nMoveX + width + 2, nMoveY + nHeightTail );
+				p.drawLine( nMoveX + w - 2, nMoveY + nHeightTail,
+							nMoveX + width + 2, nMoveY + nHeightTail );
 			}
 		}
 	}

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1627,7 +1627,13 @@ void PatternEditor::applyHighlightColor( QPen* pPen, QBrush* pBrush,
 
 	if ( pBrush != nullptr ) {
 		pBrush->setColor( color );
-		pBrush->setStyle( Qt::SolidPattern );
+
+		if ( noteStyle & NoteStyle::Background ) {
+			pBrush->setStyle( Qt::Dense4Pattern );
+		}
+		else {
+			pBrush->setStyle( Qt::SolidPattern );
+		}
 	}
 
 	if ( pPen != nullptr ) {
@@ -1637,6 +1643,10 @@ void PatternEditor::applyHighlightColor( QPen* pPen, QBrush* pBrush,
 			pPen->setColor( Qt::black );
 		} else {
 			pPen->setColor( Qt::white );
+		}
+
+		if ( noteStyle & NoteStyle::Background ) {
+			pPen->setStyle( Qt::DotLine );
 		}
 	}
 }

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -251,7 +251,8 @@ void PatternEditor::drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
 	if ( pNote->getNoteOff() == false ) {
 		int width = w;
 
-		if ( noteStyle & ( NoteStyle::Selected |
+		if ( ! ( noteStyle & NoteStyle::Moved) &&
+			 noteStyle & ( NoteStyle::Selected |
 						   NoteStyle::Hovered |
 						   NoteStyle::NoPlayback ) ) {
 			p.setPen( highlightPen );
@@ -295,25 +296,26 @@ void PatternEditor::drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
 			width = m_fGridWidth * nLength / fStep;
 			width = width - 1;	// lascio un piccolo spazio tra una nota ed un altra
 
-			if ( noteStyle & ( NoteStyle::Selected |
-							   NoteStyle::Hovered |
-							   NoteStyle::NoPlayback ) ) {
-				p.setPen( highlightPen );
-				p.setBrush( highlightBrush );
-				// Tail highlight
-				p.drawRect( nX - 3, nY - 1, width + 6, 3 + 6 );
-				p.drawEllipse( nX - 4 - 3, nY - 3, w + 6, h + 6 );
-				p.fillRect( nX - 4, nY, width, 3 + 4, highlightBrush );
-			}
+			// Since the note body is transparent for an inactive note, we
+			// try to start the tail at its boundary. For regular notes we
+			// do not care about an overlap, as it ensures that there are no
+			// white artifacts between tail and note body regardless of the
+			// scale factor.
 			if ( ! ( noteStyle & NoteStyle::Moved ) ) {
+				if ( noteStyle & ( NoteStyle::Selected |
+								   NoteStyle::Hovered |
+								   NoteStyle::NoPlayback ) ) {
+					p.setPen( highlightPen );
+					p.setBrush( highlightBrush );
+					// Tail highlight
+					p.drawRect( nX - 3, nY - 1, width + 6, 3 + 6 );
+					p.drawEllipse( nX - 4 - 3, nY - 3, w + 6, h + 6 );
+					p.fillRect( nX - 4, nY, width, 3 + 4, highlightBrush );
+				}
+
 				p.setPen( notePen );
 				p.setBrush( noteBrush );
 
-				// Since the note body is transparent for an inactive note, we
-				// try to start the tail at its boundary. For regular notes we
-				// do not care about an overlap, as it ensures that there are no
-				// white artifacts between tail and note body regardless of the
-				// scale factor.
 				int nRectOnsetX = nX;
 				int nRectWidth = width;
 				if ( noteStyle & NoteStyle::Background ) {
@@ -345,16 +347,17 @@ void PatternEditor::drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
 	}
 	else if ( pNote->getNoteOff() ) {
 
-		if ( noteStyle & ( NoteStyle::Selected |
-						   NoteStyle::Hovered |
-						   NoteStyle::NoPlayback ) ) {
-			p.setPen( highlightPen );
-			p.setBrush( highlightBrush );
-			p.drawEllipse( nX - 4 - 3, nY - 3, w + 6, h + 6 );
-			p.setBrush( Qt::NoBrush );
-		}
-
 		if ( ! ( noteStyle & NoteStyle::Moved ) ) {
+
+			if ( noteStyle & ( NoteStyle::Selected |
+							   NoteStyle::Hovered |
+							   NoteStyle::NoPlayback ) ) {
+				p.setPen( highlightPen );
+				p.setBrush( highlightBrush );
+				p.drawEllipse( nX - 4 - 3, nY - 3, w + 6, h + 6 );
+				p.setBrush( Qt::NoBrush );
+			}
+
 			p.setPen( notePen );
 			p.setBrush( noteBrush );
 			p.drawEllipse( nX -4 , nY, w, h );

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -2233,8 +2233,8 @@ void PatternEditor::leaveEvent( QEvent *ev ) {
 	m_bEntered = false;
 
 	if ( m_pPatternEditorPanel->getHoveredNotes().size() > 0 ) {
-		std::map< std::shared_ptr<Pattern>,
-				  std::vector< std::shared_ptr<Note> > > empty;
+		std::vector< std::pair< std::shared_ptr<Pattern>,
+								std::vector< std::shared_ptr<Note> > > > empty;
 		// Takes care of the update.
 		m_pPatternEditorPanel->setHoveredNotesMouse( empty );
 	}
@@ -3706,8 +3706,8 @@ void PatternEditor::updateHoveredNotesMouse( QMouseEvent* pEvent,
 	// notes, the left one wins.
 	int nLastPosition = -1;
 
-	std::map< std::shared_ptr<Pattern>,
-			  std::vector< std::shared_ptr<Note> > > hovered;
+	std::vector< std::pair< std::shared_ptr<Pattern>,
+							std::vector< std::shared_ptr<Note> > > > hovered;
 	// We do not highlight hovered notes during a property drag. Else, the
 	// hovered ones would appear in front of the dragged one in the ruler,
 	// hiding the newly adjusted value.
@@ -3727,7 +3727,7 @@ void PatternEditor::updateHoveredNotesMouse( QMouseEvent* pEvent,
 				}
 
 				if ( hoveredNotes[ 0 ]->getPosition() == nLastPosition ) {
-					hovered[ ppPattern ] = hoveredNotes;
+					hovered.push_back( std::make_pair( ppPattern, hoveredNotes ) );
 				}
 			}
 		}
@@ -3736,8 +3736,8 @@ void PatternEditor::updateHoveredNotesMouse( QMouseEvent* pEvent,
 }
 
 void PatternEditor::updateHoveredNotesKeyboard( bool bUpdateEditors ) {
-	std::map< std::shared_ptr<Pattern>,
-			  std::vector< std::shared_ptr<Note> > > hovered;
+	std::vector< std::pair< std::shared_ptr<Pattern>,
+							std::vector< std::shared_ptr<Note> > > > hovered;
 	if ( ! HydrogenApp::get_instance()->hideKeyboardCursor() ) {
 		// cursor visible
 
@@ -3758,7 +3758,7 @@ void PatternEditor::updateHoveredNotesKeyboard( bool bUpdateEditors ) {
 			const auto hoveredNotes =
 				pEditor->getElementsAtPoint( point, 0, ppPattern );
 			if ( hoveredNotes.size() > 0 ) {
-				hovered[ ppPattern ] = hoveredNotes;
+				hovered.push_back( std::make_pair( ppPattern, hoveredNotes ) );
 			}
 		}
 	}

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -3594,6 +3594,7 @@ std::vector< std::shared_ptr<Note> > PatternEditor::getElementsAtPoint(
 		  it != notes->end() && it->first <= nRealColumnUpper; ++it ) {
 		const auto ppNote = it->second;
 		if ( ppNote != nullptr &&
+			 ppNote->getPosition() < pPattern->getLength() &&
 			 ppNote->getInstrumentId() == row.nInstrumentID &&
 			 ppNote->getType() == row.sType ) {
 

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -295,6 +295,8 @@ protected:
 			/** Note is in a transient state while being moved to another
 			 * location. A silhouette will be rendered at the new position. */
 			Moved = 0x008,
+			/** Note won't be played back by the audio engine. */
+			NoPlayback = 0x010,
 		};
 
 		/** Scaling factor by which the background colors will be made darker in
@@ -456,6 +458,11 @@ protected:
 		void updateHoveredNotesMouse( QMouseEvent* pEvent,
 									  bool bUpdateEditors = true );
 		void updateHoveredNotesKeyboard( bool bUpdateEditors = true );
+
+		/** Checks whether the note would be played back when picked up by the
+		 * audio engine. */
+		bool checkNotePlayback( std::shared_ptr<H2Core::Note> pNote ) const;
+
 };
 
 #endif // PATERN_EDITOR_H

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -361,9 +361,11 @@ protected:
 	//! Draw lines for note grid.
 	void drawGridLines( QPainter &p, const Qt::PenStyle& style = Qt::SolidLine ) const;
 
-	//! Colour to use for outlining notes
-	void applyHighlightColor( QPen* pPen, QBrush* pBrush,
-							  NoteStyle noteStyle ) const;
+	//! Colour to use for rendering and outlining notes
+	void applyColor( std::shared_ptr<H2Core::Note> pNote, QPen* pNotePen,
+					 QBrush* pNoteBrush, QPen* pHighlightPen,
+					 QBrush* pHighlightBrush, QPen* pMovingPen,
+					 QBrush* pMovingBrush, NoteStyle noteStyle ) const;
 
 	/**
 	 * Draw a note

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1670,6 +1670,9 @@ void PatternEditorPanel::onPreferencesChanged( const H2Core::Preferences::Change
 		updateStyleSheet();
 		updateEditors();
 	}
+	else if ( changes & H2Core::Preferences::Changes::AppearanceTab ) {
+		updateEditors( true );
+	}
 }
 
 void PatternEditorPanel::updateStyleSheet() {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1893,17 +1893,22 @@ void PatternEditorPanel::updateDB() {
 		return;
 	}
 
+	const auto pInstrumentList = pSong->getDrumkit()->getInstruments();
+
 	int nnRow = 0;
 
 	std::set<int> kitIds;
 	// First we add all instruments of the current drumkit in the order author
 	// of the kit intended.
-	for ( const auto& ppInstrument : *pSong->getDrumkit()->getInstruments() ) {
+	for ( const auto& ppInstrument : *pInstrumentList ) {
 		if ( ppInstrument != nullptr ) {
+			const bool bNoPlayback = ppInstrument->is_muted() ||
+				( pInstrumentList->isAnyInstrumentSoloed() &&
+				  ! ppInstrument->is_soloed() );
+
 			m_db.push_back(
 				DrumPatternRow( ppInstrument->get_id(), ppInstrument->getType(),
-								nnRow % 2 != 0, true,
-								! ppInstrument->is_muted() ) );
+								nnRow % 2 != 0, true, ! bNoPlayback ) );
 			kitIds.insert( ppInstrument->get_id() );
 			++nnRow;
 		}

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -24,8 +24,9 @@
 #ifndef PATTERN_EDITOR_PANEL_H
 #define PATTERN_EDITOR_PANEL_H
 
-#include <vector>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <core/Basics/Note.h>
 #include <core/Object.h>
@@ -311,16 +312,18 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		void updateDB();
 
 		/** Returns both notex hovered by mouse and keyboard. */
-		const std::map< std::shared_ptr<H2Core::Pattern>,
-						std::vector< std::shared_ptr<H2Core::Note> > >&
-			getHoveredNotes() const;
+		const std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+									  std::vector< std::shared_ptr<H2Core::Note> > >
+						   >& getHoveredNotes() const;
 		void setHoveredNotesMouse(
-			std::map< std::shared_ptr<H2Core::Pattern>,
-			  std::vector< std::shared_ptr<H2Core::Note> > > hoveredNotes,
+			std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+								    std::vector< std::shared_ptr<H2Core::Note> > >
+					   > hoveredNotes,
 			bool bUpdateEditors = true );
 		void setHoveredNotesKeyboard(
-			std::map< std::shared_ptr<H2Core::Pattern>,
-			  std::vector< std::shared_ptr<H2Core::Note> > > hoveredNotes,
+			std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+								    std::vector< std::shared_ptr<H2Core::Note> > >
+					   > hoveredNotes,
 			bool bUpdateEditors = true );
 
 		/** @returns `true` in case any of the child editors or sidebar has
@@ -472,12 +475,15 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		void updateHoveredNotes();
 		/** Combined version of both #m_hoveredNotesMouse and
 		 * #m_hoveredNotesKeyboard. */
-		std::map< std::shared_ptr<H2Core::Pattern>,
-				  std::vector< std::shared_ptr<H2Core::Note> > > m_hoveredNotes;
-		std::map< std::shared_ptr<H2Core::Pattern>,
-			std::vector< std::shared_ptr<H2Core::Note> > > m_hoveredNotesMouse;
-		std::map< std::shared_ptr<H2Core::Pattern>,
-			std::vector< std::shared_ptr<H2Core::Note> > > m_hoveredNotesKeyboard;
+		std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+								std::vector< std::shared_ptr<H2Core::Note> > >
+					 > m_hoveredNotes;
+		std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+								std::vector< std::shared_ptr<H2Core::Note> > >
+					 > m_hoveredNotesMouse;
+		std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+								std::vector< std::shared_ptr<H2Core::Note> > >
+					 > m_hoveredNotesKeyboard;
 
 		virtual void dragEnterEvent(QDragEnterEvent *event) override;
 		virtual void dropEvent(QDropEvent *event) override;
@@ -501,9 +507,9 @@ inline int PatternEditorPanel::getResolution() const {
 inline bool PatternEditorPanel::isUsingTriplets() const {
 	return m_bIsUsingTriplets;
 }
-inline const std::map< std::shared_ptr<H2Core::Pattern>,
-	std::vector< std::shared_ptr<H2Core::Note> > >&
-	PatternEditorPanel::getHoveredNotes() const {
+inline const std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
+									 std::vector< std::shared_ptr<H2Core::Note> > >
+						  >& PatternEditorPanel::getHoveredNotes() const {
 	return m_hoveredNotes;
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -63,7 +63,8 @@ struct DrumPatternRow {
 
 	explicit DrumPatternRow() noexcept;
 	explicit DrumPatternRow( int nId, const QString& sType,
-							 bool bAlternate, bool bMappedToDrumkit ) noexcept;
+							 bool bAlternate, bool bMappedToDrumkit,
+							 bool bPlaysBackAudio ) noexcept;
 
 	/** Associated #H2Core::Instrument::__id in the current #H2Core::Drumkit.
 	 *
@@ -103,6 +104,12 @@ struct DrumPatternRow {
 	/** Whether the row is associated with an instrument of the current
 	 * drumkit. If note won't be played back. */
 	bool bMappedToDrumkit;
+
+	/** Whether the row is associated with an instrument currently rendering
+	 * sounds (not muted, not shadowed by soloing another instrment). The notes
+	 * contained, however, could be muted regardless of this variable due to
+	 * e.g. mute group settings of the corresponding instrument. */
+	bool bPlaysBackAudio;
 
 	QString toQString( const QString& sPrefix = "", bool bShort = true ) const;
 };
@@ -167,6 +174,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 	virtual void patternEditorLockedEvent() override;
 	virtual void stateChangedEvent( const H2Core::AudioEngine::State& ) override;
 	virtual void relocationEvent() override;
+		virtual void instrumentMuteSoloChangedEvent( int ) override;
 		// ~ Implements EventListener interface
 
 		std::shared_ptr<H2Core::Pattern> getPattern() const;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -799,9 +799,11 @@ std::vector<PianoRollEditor::SelectionIndex> PianoRollEditor::elementsIntersecti
 		rNormalized += QMargins( 2, 2, 2, 2 );
 	}
 
-	// Calculate the first and last position values that this rect will intersect with
+	// Calculate the first and last position values that this rect will
+	// intersect with
 	int x_min = (rNormalized.left() - w - PatternEditor::nMargin) / m_fGridWidth;
-	int x_max = (rNormalized.right() + w - PatternEditor::nMargin) / m_fGridWidth;
+	int x_max = (std::min( rNormalized.right(), m_nActiveWidth ) + w -
+				 PatternEditor::nMargin) / m_fGridWidth;
 
 	const Pattern::notes_t* pNotes = pPattern->getNotes();
 

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -496,6 +496,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	uiScalingPolicyComboBox->setSize( appearanceTabWidgetSize );
 	iconColorComboBox->setSize( appearanceTabWidgetSize );
 	coloringMethodAuxSpinBox->setSize( appearanceTabWidgetSize );
+	indicateNotePlaybackComboBox->setSize( appearanceTabWidgetSize );
 
 	connect( styleComboBox, SIGNAL( activated(int) ), this,
 			 SLOT( styleComboBoxActivated(int) ) );
@@ -507,7 +508,8 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 			 SLOT( mixerFalloffComboBoxCurrentIndexChanged(int) ) );
 	connect( iconColorComboBox, SIGNAL(currentIndexChanged(int)), this,
 			 SLOT( onIconColorChanged(int)) );
-	connect( coloringMethodAuxSpinBox, SIGNAL( valueChanged(int)), this, SLOT( onColorNumberChanged( int ) ) );
+	connect( coloringMethodAuxSpinBox, SIGNAL( valueChanged(int)),
+			 this, SLOT( onColorNumberChanged( int ) ) );
 
 	m_colorSelectionButtons = std::vector<ColorSelectionButton*>( InterfaceTheme::nMaxPatternColors );
 	int nButtonSize = fontSizeComboBox->height();
@@ -537,7 +539,15 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	coloringMethodCombo->clear();
 	coloringMethodCombo->addItem(tr("Automatic"));
 	coloringMethodCombo->addItem(tr("Custom"));
-	connect( coloringMethodCombo, SIGNAL( currentIndexChanged(int) ), this, SLOT( onColoringMethodChanged(int) ) );
+	connect( coloringMethodCombo, SIGNAL( currentIndexChanged(int) ),
+			 this, SLOT( onColoringMethodChanged(int) ) );
+
+	indicateNotePlaybackComboBox->clear();
+	indicateNotePlaybackComboBox->addItem( pCommonStrings->getStatusOn() );
+	indicateNotePlaybackComboBox->addItem( pCommonStrings->getStatusOff() );
+	indicateNotePlaybackComboBox->setCurrentIndex( 0 );
+	connect( indicateNotePlaybackComboBox, SIGNAL( currentIndexChanged(int) ),
+			 this, SLOT( onIndicateNotePlaybackChanged(int) ) );
 
 	// Appearance tab - Colors
 	colorButton->setAutoFillBackground(true);
@@ -1682,6 +1692,20 @@ void PreferencesDialog::onColoringMethodChanged( int nIndex ) {
 			m_changes | H2Core::Preferences::Changes::AppearanceTab );
 	
 	HydrogenApp::get_instance()->changePreferences( H2Core::Preferences::Changes::AppearanceTab );
+}
+
+void PreferencesDialog::onIndicateNotePlaybackChanged( int ) {
+	const bool bNew = indicateNotePlaybackComboBox->currentIndex() == 0 ?
+		true : false;
+	m_currentTheme.m_interface.m_bIndicateNotePlayback = bNew;
+	Preferences::get_instance()->
+		getThemeWritable().m_interface.m_bIndicateNotePlayback = bNew;
+
+	m_changes = static_cast<H2Core::Preferences::Changes>(
+		m_changes | H2Core::Preferences::Changes::AppearanceTab );
+
+	HydrogenApp::get_instance()->changePreferences(
+		H2Core::Preferences::Changes::AppearanceTab );
 }
 
 void PreferencesDialog::mixerFalloffComboBoxCurrentIndexChanged( int nIndex ) {

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.h
@@ -132,6 +132,7 @@ class PreferencesDialog :  public QDialog, private Ui_PreferencesDialog_UI,  pub
 	void onColorNumberChanged( int nIndex );
 	void onColorSelectionClicked();
 	void onColoringMethodChanged( int nIndex );
+		void onIndicateNotePlaybackChanged( int );
 	// void onCustomizePaletteClicked();
 	void colorTreeSelectionChanged();
 	void colorButtonChanged();

--- a/src/gui/src/PreferencesDialog/PreferencesDialog_UI.ui
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog_UI.ui
@@ -1196,6 +1196,17 @@
                  <item row="13" column="2">
                   <layout class="QGridLayout" name="colorSelectionGrid"/>
                  </item>
+                 <item row="6" column="0">
+                  <widget class="QLabel" name="indicateNotePlaybackLabel">
+                   <property name="text">
+                    <string>Indicate note playback</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="6" column="2">
+                  <widget class="LCDCombo" name="indicateNotePlaybackComboBox">
+                  </widget>
+                 </item>
                 </layout>
                </item>
                <item>

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -1132,7 +1132,8 @@ void SongEditorPanel::setTimelineActive( bool bActive ){
 
 	QString sMessage = QString( "%1 = %2" )
 		.arg( pCommonStrings->getTimelineBigButton() )
-		.arg( bActive ? pCommonStrings->getStatusOn() : pCommonStrings->getStatusOff() );
+		.arg( bActive ? pCommonStrings->getStatusOn() :
+			  pCommonStrings->getStatusOff() );
 	HydrogenApp::get_instance()->showStatusBarMessage( sMessage );
 }
 


### PR DESCRIPTION
Using this patch a note in the pattern editor is highlighted in case

- the corresponding instrument is muted
- another instrument but not the one of the note is soloed
- the note is not corresponding to an instrument of the current drumkit

![2025-01-30-204403_3840x2280_scrot](https://github.com/user-attachments/assets/a73fa19b-bd20-4a0e-ac1a-2f725dfe9c06)

The highlighting color is based on the color of the (pressed) mute button and will adopt to changes of the corresponding "button red" color.

This should both highlight the nature of notes residing in rows not associated to the current kit and does lay the foundation for missing visual feedback of some of Hydrogen's older features: when using mute groups or stop notes/note-off within a chord (multiple notes of different pitch for the same instrument at the same time) or in a background pattern being played as well, the user does not see if a note will be rendered or not. The latter will be implemented in another PR.

In case the user does not like the new highlighting feature, it can be turned of in Preferences > Appearance > Interface > Indicate note playback.

Addresses #2079 