### PR TITLE
NotePropertiesRuler: add proper sidebar (#2051)

### DIFF
--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -1322,6 +1322,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2889,54 +2949,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2887,54 +2947,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -1324,6 +1324,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation>C</translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation>C#</translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation>D</translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation>D#</translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation>F</translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation>F#</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation>G</translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation>G#</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation>A</translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation>A#</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation>H</translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2925,54 +2985,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Clear selection</source>
         <translation>Lösche Selektion</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation>A#</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation>G#</translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation>F#</translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation>D#</translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation>C#</translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation>C</translation>
     </message>
     <message>
         <source>Edit [%1] property of [%2] notes</source>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2916,54 +2976,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2876,54 +2936,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2876,54 +2936,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -1325,6 +1325,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation>C</translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation>C#</translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation>D</translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation>D#</translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation>F</translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation>F#</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation>G</translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation>G#</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation>A</translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation>A#</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation>B</translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2931,54 +2991,6 @@ Debería funcionar correctamente mientras utilices el GMRockKit, y no uses tresi
     <message>
         <source>Clear selection</source>
         <translation>Limpiar selección</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation>A#</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation>G#</translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation>F#</translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation>D#</translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation>C#</translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation>C</translation>
     </message>
     <message>
         <source>Edit [%1] property of [%2] notes</source>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -1324,6 +1324,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation>Do</translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation>Do#</translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation>Ré</translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation>Ré#</translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation>Mi</translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation>Fa</translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation>Fa#</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation>Sol</translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation>Sol#</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation>La</translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation>La#</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation>Si</translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2925,54 +2985,6 @@ L&apos;exportation LilyPond est une fonctionnalité expérimentale.
 </context>
 <context>
     <name>NotePropertiesRuler</name>
-    <message>
-        <source>B</source>
-        <translation>Si</translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation>La#</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>La</translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation>Sol#</translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation>Sol</translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation>Fa#</translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation>Fa</translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation>Mi</translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation>Ré#</translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation>Ré</translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation>Do#</translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation>Do</translation>
-    </message>
     <message>
         <source>Select &amp;all</source>
         <translation>&amp;Tout sélectionner</translation>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2915,54 +2975,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2887,54 +2947,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2881,54 +2941,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2891,54 +2951,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Clear selection</source>
         <translation>Pulisci selezione</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Edit [%1] property of [%2] notes</source>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -1322,6 +1322,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2913,54 +2973,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2888,54 +2948,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2884,54 +2944,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -1324,6 +1324,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation>C</translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation>C#</translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation>D</translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation>D#</translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation>F</translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation>F#</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation>G</translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation>G#</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation>A</translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation>A#</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation>B</translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2929,54 +2989,6 @@ Deveria funcionar corretamente dado que você usou o GMRockKit e que você não 
     <message>
         <source>Clear selection</source>
         <translation>Limpar seleção</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation>A#</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation>G#</translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation>F#</translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation>D#</translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation>C#</translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation>C</translation>
     </message>
     <message>
         <source>Edit [%1] property of [%2] notes</source>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2913,54 +2973,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2909,54 +2969,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2881,54 +2941,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -1321,6 +1321,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2914,54 +2974,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Clear selection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1322,6 +1322,66 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Instrument types must be unique!</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>C</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C. It is designed to hold a single character.</extracomment>
+        <translation>C</translation>
+    </message>
+    <message>
+        <source>C#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note C#. It is designed to hold two characters.</extracomment>
+        <translation>C#</translation>
+    </message>
+    <message>
+        <source>D</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D. It is designed to hold a single character.</extracomment>
+        <translation>D</translation>
+    </message>
+    <message>
+        <source>D#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note D#. It is designed to hold two characters.</extracomment>
+        <translation>D#</translation>
+    </message>
+    <message>
+        <source>E</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note E. It is designed to hold a single character.</extracomment>
+        <translation>E</translation>
+    </message>
+    <message>
+        <source>F</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F. It is designed to hold a single character.</extracomment>
+        <translation>F</translation>
+    </message>
+    <message>
+        <source>F#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note F#. It is designed to hold two characters.</extracomment>
+        <translation>F#</translation>
+    </message>
+    <message>
+        <source>G</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G. It is designed to hold a single character.</extracomment>
+        <translation>G</translation>
+    </message>
+    <message>
+        <source>G#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note G#. It is designed to hold two characters.</extracomment>
+        <translation>G#</translation>
+    </message>
+    <message>
+        <source>A</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A. It is designed to hold a single character.</extracomment>
+        <translation>A</translation>
+    </message>
+    <message>
+        <source>A#</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note A#. It is designed to hold two characters.</extracomment>
+        <translation>A#</translation>
+    </message>
+    <message>
+        <source>B</source>
+        <extracomment>Label used in the sidebar of the pattern editor for a pitch * corresponding to note B. It is designed to hold a single character.</extracomment>
+        <translation>B</translation>
+    </message>
 </context>
 <context>
     <name>Director</name>
@@ -2915,54 +2975,6 @@ LilyPond 导出是一项实验性功能。
     <message>
         <source>Clear selection</source>
         <translation>清除选择</translation>
-    </message>
-    <message>
-        <source>B</source>
-        <translation>B</translation>
-    </message>
-    <message>
-        <source>A#</source>
-        <translation>A#</translation>
-    </message>
-    <message>
-        <source>A</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <source>G#</source>
-        <translation>G#</translation>
-    </message>
-    <message>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <source>F#</source>
-        <translation>F#</translation>
-    </message>
-    <message>
-        <source>F</source>
-        <translation>F</translation>
-    </message>
-    <message>
-        <source>E</source>
-        <translation>E</translation>
-    </message>
-    <message>
-        <source>D#</source>
-        <translation>D#</translation>
-    </message>
-    <message>
-        <source>D</source>
-        <translation>D</translation>
-    </message>
-    <message>
-        <source>C#</source>
-        <translation>C#</translation>
-    </message>
-    <message>
-        <source>C</source>
-        <translation>C</translation>
     </message>
     <message>
         <source>Edit [%1] property of [%2] notes</source>

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -706,6 +706,43 @@ CommonStrings::CommonStrings(){
 	 *  DrumPatternEditor and PianoRollEditor. */
 	m_sNotePropertyLength = tr( "Length" );
 
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note C. It is designed to hold a single character. */
+	m_sNotePitchC = tr( "C" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note C#. It is designed to hold two characters. */
+	m_sNotePitchCSharp = tr( "C#" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note D. It is designed to hold a single character. */
+	m_sNotePitchD = tr( "D" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note D#. It is designed to hold two characters. */
+	m_sNotePitchDSharp = tr( "D#" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note E. It is designed to hold a single character. */
+	m_sNotePitchE = tr( "E" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note F. It is designed to hold a single character. */
+	m_sNotePitchF = tr( "F" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note F#. It is designed to hold two characters. */
+	m_sNotePitchFSharp = tr( "F#" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note G. It is designed to hold a single character. */
+	m_sNotePitchG = tr( "G" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note G#. It is designed to hold two characters. */
+	m_sNotePitchGSharp = tr( "G#" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note A. It is designed to hold a single character. */
+	m_sNotePitchA = tr( "A" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note A#. It is designed to hold two characters. */
+	m_sNotePitchASharp = tr( "A#" );
+	/*: Label used in the sidebar of the pattern editor for a pitch
+	 *  corresponding to note B. It is designed to hold a single character. */
+	m_sNotePitchB = tr( "B" );
+
 	/*: Displayed in a warning message in case the user tries to read
 	 * or write data to a file/path Hydrogen can not handle in the
 	 * current encoding.*/

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -307,6 +307,19 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 		const QString& getNotePropertyLength() const {
 			return m_sNotePropertyLength; }
 
+		const QString& getNotePitchC() const { return m_sNotePitchC; }
+		const QString& getNotePitchCSharp() const { return m_sNotePitchCSharp; }
+		const QString& getNotePitchD() const { return m_sNotePitchD; }
+		const QString& getNotePitchDSharp() const { return m_sNotePitchDSharp; }
+		const QString& getNotePitchE() const { return m_sNotePitchE; }
+		const QString& getNotePitchF() const { return m_sNotePitchF; }
+		const QString& getNotePitchFSharp() const { return m_sNotePitchFSharp; }
+		const QString& getNotePitchG() const { return m_sNotePitchG; }
+		const QString& getNotePitchGSharp() const { return m_sNotePitchGSharp; }
+		const QString& getNotePitchA() const { return m_sNotePitchA; }
+		const QString& getNotePitchASharp() const { return m_sNotePitchASharp; }
+		const QString& getNotePitchB() const { return m_sNotePitchB; }
+
 		const QString& getErrorNotFound() const { return m_sErrorNotFound; }
 		const QString& getErrorNotFoundShort() const {
 			return m_sErrorNotFoundShort; }
@@ -554,6 +567,19 @@ private:
 		QString m_sNotePropertyKeyOctave;
 		QString m_sNotePropertyProbability;
 		QString m_sNotePropertyLength;
+
+		QString m_sNotePitchC;
+		QString m_sNotePitchCSharp;
+		QString m_sNotePitchD;
+		QString m_sNotePitchDSharp;
+		QString m_sNotePitchE;
+		QString m_sNotePitchF;
+		QString m_sNotePitchFSharp;
+		QString m_sNotePitchG;
+		QString m_sNotePitchGSharp;
+		QString m_sNotePitchA;
+		QString m_sNotePitchASharp;
+		QString m_sNotePitchB;
 
 	QString m_sEncodingError;
 };

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -36,9 +36,11 @@
 
 using namespace H2Core;
 
+// +1 to fit all the labels and another +1 to have enough room to show the focus
+// at the bottom of the editor.
 int NotePropertiesRuler::nKeyOctaveHeight =
 	NotePropertiesRuler::nOctaveHeight +
-	NotePropertiesRuler::nKeyLineHeight * KEYS_PER_OCTAVE + 1 -
+	NotePropertiesRuler::nKeyLineHeight * KEYS_PER_OCTAVE + 2 -
 	std::floor( NotePropertiesRuler::nKeyLineHeight / 2 );
 
 KeyOctaveLabel::KeyOctaveLabel( QWidget* pParent, const QString& sText, int nY,
@@ -48,10 +50,10 @@ KeyOctaveLabel::KeyOctaveLabel( QWidget* pParent, const QString& sText, int nY,
 {
 	setText( sText );
 
-	move( 0, nY );
+	move( 1, nY );
 	setAlignment( Qt::AlignLeft );
 	setIndent( 4 );
-	setFixedSize( PatternEditor::nMarginSidebar,
+	setFixedSize( PatternEditor::nMarginSidebar - 1,
 				  NotePropertiesRuler::nKeyLineHeight );
 
 	updateColors();
@@ -1244,8 +1246,9 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 		const int nOctaveY = ( 4 - pNote->getOctave() ) *
 			NotePropertiesRuler::nKeyLineHeight;
 		const int nRadiusKey = 5;
-		const int nKeyY = NotePropertiesRuler::nKeyOctaveHeight -
-			( ( pNote->getKey() + 1 ) * NotePropertiesRuler::nKeyLineHeight );
+		const int nKeyY = NotePropertiesRuler::nOctaveHeight +
+			( ( KEYS_PER_OCTAVE - pNote->getKey() - 1 ) *
+			  NotePropertiesRuler::nKeyLineHeight );
 
 		// Paint selection outlines
 		if ( noteStyle & ( NoteStyle::Selected | NoteStyle::Hovered ) ) {

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -38,7 +38,8 @@ using namespace H2Core;
 
 int NotePropertiesRuler::nKeyOctaveHeight =
 	NotePropertiesRuler::nOctaveHeight +
-	NotePropertiesRuler::nKeyLineHeight * KEYS_PER_OCTAVE;
+	NotePropertiesRuler::nKeyLineHeight * KEYS_PER_OCTAVE + 1 -
+	std::floor( NotePropertiesRuler::nKeyLineHeight / 2 );
 
 KeyOctaveLabel::KeyOctaveLabel( QWidget* pParent, const QString& sText, int nY,
 								bool bAlternateBackground )

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1184,6 +1184,7 @@ void NotePropertiesRuler::drawNote( QPainter& p,
 
 void NotePropertiesRuler::createBackground()
 {
+	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	const auto pPref = H2Core::Preferences::get_instance();
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 
@@ -1270,18 +1271,18 @@ void NotePropertiesRuler::createBackground()
 
 			// Annotate with note class names
 			static QStringList noteNames = QStringList()
-				<< tr( "B" )
-				<< tr( "A#" )
-				<< tr( "A" )
-				<< tr( "G#" )
-				<< tr( "G" )
-				<< tr( "F#" )
-				<< tr( "F" )
-				<< tr( "E" )
-				<< tr( "D#" )
-				<< tr( "D" )
-				<< tr( "C#" )
-				<< tr( "C" );
+				<< pCommonStrings->getNotePitchB()
+				<< pCommonStrings->getNotePitchASharp()
+				<< pCommonStrings->getNotePitchA()
+				<< pCommonStrings->getNotePitchGSharp()
+				<< pCommonStrings->getNotePitchG()
+				<< pCommonStrings->getNotePitchFSharp()
+				<< pCommonStrings->getNotePitchF()
+				<< pCommonStrings->getNotePitchE()
+				<< pCommonStrings->getNotePitchDSharp()
+				<< pCommonStrings->getNotePitchD()
+				<< pCommonStrings->getNotePitchCSharp()
+				<< pCommonStrings->getNotePitchC();
 
 			QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
 						getPointSize( pPref->getTheme().m_font.m_fontSize ) );

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -41,8 +41,14 @@ class KeyOctaveLabel : public QLabel, public H2Core::Object<KeyOctaveLabel>
 	Q_OBJECT
 
 	public:
+
+		enum class Type {
+			Key,
+			Octave
+		};
+
 		KeyOctaveLabel( QWidget* pParent, const QString& sText, int nY,
-						bool bAlternateBackground );
+						bool bAlternateBackground, Type type );
 		~KeyOctaveLabel();
 
 		void updateColors();
@@ -52,6 +58,7 @@ class KeyOctaveLabel : public QLabel, public H2Core::Object<KeyOctaveLabel>
 		virtual void paintEvent( QPaintEvent* pEvent ) override;
 
 		bool m_bAlternateBackground;
+		Type m_type;
 		QColor m_backgroundColor;
 };
 

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -35,6 +35,26 @@
 
 #include "PatternEditor.h"
 
+class KeyOctaveLabel : public QLabel, public H2Core::Object<KeyOctaveLabel>
+{
+	H2_OBJECT(KeyOctaveLabel)
+	Q_OBJECT
+
+	public:
+		KeyOctaveLabel( QWidget* pParent, const QString& sText, int nY,
+						bool bAlternateBackground );
+		~KeyOctaveLabel();
+
+		void updateColors();
+		void updateFont();
+
+	private:
+		virtual void paintEvent( QPaintEvent* pEvent ) override;
+
+		bool m_bAlternateBackground;
+		QColor m_backgroundColor;
+};
+
 /** \ingroup docGUI*/
 //! NotePropertiesEditor is (currently) a single class instantiated in different "modes" to select
 //! which property it edits. There are individual instances for each property which are hidden and
@@ -51,11 +71,27 @@ class NotePropertiesRuler : public PatternEditor,
 			KeyOctave,
 		};
 
+		/** Height of a single line in the key section. */
+		static constexpr int nKeyLineHeight = 10;
+		/** Height of the whole octave section. */
+		static constexpr int nOctaveHeight = 90;
+		/** Height of the non-interactive space in KeyOctave editor between
+		 * octave and key section. It is contained within the octave part. */
+		static constexpr int nKeyOctaveSpaceHeight = 10;
+		/** The height of the overall KeyOctave Editor. It will be calculated
+		 * during runtime using the other constexprs. */
+		static int nKeyOctaveHeight;
+		/** Height of all editors except the KeyOctave one. */
+		static constexpr int nDefaultHeight = 100;
+
 		NotePropertiesRuler( QWidget *parent, Property property, Layout layout );
 		~NotePropertiesRuler();
 		
 		NotePropertiesRuler(const NotePropertiesRuler&) = delete;
 		NotePropertiesRuler& operator=( const NotePropertiesRuler& rhs ) = delete;
+
+		void updateColors();
+		void updateFont();
 
 		//! @name Property draw (right-click drag) gestures
 		//! 
@@ -89,19 +125,6 @@ class NotePropertiesRuler : public PatternEditor,
 
 	private:
 
-		/** Height of a single line in the key section. */
-		static constexpr int nKeyLineHeight = 10;
-		/** Height of the whole octave section. */
-		static constexpr int nOctaveHeight = 90;
-		/** Height of the non-interactive space in KeyOctave editor between
-		 * octave and key section. It is contained within the octave part. */
-		static constexpr int nKeyOctaveSpaceHeight = 10;
-		/** The height of the overall KeyOctave Editor. It will be calculated
-		 * during runtime using the other constexprs. */
-		static int nKeyOctaveHeight;
-		/** Height of all editors except the KeyOctave one. */
-		static constexpr int nDefaultHeight = 100;
-
 		void createBackground() override;
 	void drawDefaultBackground( QPainter& painter, int nHeight = 0, int nIncrement = 0 );
 		void drawPattern() override;
@@ -113,6 +136,8 @@ class NotePropertiesRuler : public PatternEditor,
 		void keyPressEvent( QKeyEvent *ev ) override;
 		void addUndoAction( const QString& sUndoContext );
 		void prepareUndoAction( QMouseEvent* pEvent );
+
+		std::vector<KeyOctaveLabel*> m_labels;
 
 		//! Map of notes currently in the pattern -> old notes with their
 		//! properties. Populated at the beginning of a properties editing

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -614,7 +614,8 @@ void PatternEditorPanel::createEditors() {
 		NotePropertiesRuler::Property::KeyOctave,
 		NotePropertiesRuler::Layout::KeyOctave );
 	m_pNoteKeyOctaveScrollView->setWidget( m_pNoteKeyOctaveEditor );
-	m_pNoteKeyOctaveScrollView->setFixedHeight( 210 );
+	m_pNoteKeyOctaveScrollView->setFixedHeight(
+		NotePropertiesRuler::nKeyOctaveHeight );
 	connect( m_pNoteKeyOctaveScrollView->horizontalScrollBar(), SIGNAL( valueChanged( int ) ),
 			 this, SLOT( on_patternEditorHScroll( int ) ) );
 	connect( m_pNoteKeyOctaveScrollView->horizontalScrollBar(), SIGNAL( valueChanged( int ) ),

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1648,6 +1648,7 @@ void PatternEditorPanel::onPreferencesChanged( const H2Core::Preferences::Change
 		m_pTabBar->setFont( boldFont );
 
 		m_pPianoRollEditor->updateFont();
+		m_pNoteKeyOctaveEditor->updateFont();
 		m_pSidebar->updateFont();
 		updateEditors();
 	}
@@ -1709,6 +1710,7 @@ QWidget#pRec {\
 	m_pSizeResol->setStyleSheet( sWidgetTopStyleSheet );
 	m_pRec->setStyleSheet( sWidgetTopStyleSheet );
 	m_pPianoRollEditor->updateStyleSheet();
+	m_pNoteKeyOctaveEditor->updateColors();
 	m_pSidebar->updateStyleSheet();
 }
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -233,18 +233,30 @@ PitchSidebar::PitchSidebar( QWidget *parent, int nHeight, int nGridHeight )
 	int nnActualOctave = 5;
 	int nnIndex = 0;
 	for ( int nnOctave = 0; nnOctave < OCTAVE_NUMBER; ++nnOctave ) {
-		createLabel( QString( "B%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "A#%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "A%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "G#%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "G%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "F#%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "F%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "E%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "D#%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "D%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "C#%1" ).arg( nnActualOctave ) , &nnIndex );
-		createLabel( QString( "C%1" ).arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchB() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchASharp() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchA() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchGSharp() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchG() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchFSharp() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchF() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchE() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchDSharp() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchD() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchCSharp() )
+					 .arg( nnActualOctave ) , &nnIndex );
+		createLabel( QString( "%1%2" ).arg( pCommonStrings->getNotePitchC() )
+					 .arg( nnActualOctave ) , &nnIndex );
 		--nnActualOctave;
 	}
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -632,7 +632,7 @@ void PianoRollEditor::createBackground()
 	p.setPen( QPen( lineColor, 1, Qt::DotLine ) );
 	for ( uint row = 0; row < ( KEYS_PER_OCTAVE * OCTAVE_NUMBER ); ++row ) {
 		unsigned y = row * m_nGridHeight;
-		p.drawLine( 0, y, m_nActiveWidth, y );
+		p.drawLine( PatternEditor::nMarginSidebar, y, m_nActiveWidth, y );
 	}
 
 	if ( m_nActiveWidth + 1 < m_nEditorWidth ) {


### PR DESCRIPTION
Previously, `NotePropertiesRuler` did only feature labels for its key section. But their alignment was slightly off and they did not integrate well.

![old](https://github.com/user-attachments/assets/39aa74e1-bcfe-457c-9e65-7cb034a452ba)

This patch introduce proper sidebar labels. 

![new](https://github.com/user-attachments/assets/184105e6-027f-482b-ba74-b6b2663eb6f2)

The ones in the key section resemble those used in `PianoRollEditor`. But there is no popup menu.

The labels of the octave section are done differently to emphasize that those two are different entities.