### PR TITLE
Add option to always show type labels in PatternEditorSidebar

### DIFF
--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -84,6 +84,7 @@
   <patternEditorGridHeight>21</patternEditorGridHeight>
   <patternEditorGridWidth>3</patternEditorGridWidth>
   <patternEditorUsingTriplets>false</patternEditorUsingTriplets>
+  <patternEditorAlwaysShowTypeLabels>false</patternEditorAlwaysShowTypeLabels>
   <songEditorGridHeight>18</songEditorGridHeight>
   <songEditorGridWidth>16</songEditorGridWidth>
   <showInstrumentPeaks>true</showInstrumentPeaks>

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -1382,6 +1382,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -1384,6 +1384,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Aus</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Apagado</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -1384,6 +1384,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Off</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Off</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -1382,6 +1382,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>オフ</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -1384,6 +1384,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Desligado</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Искљ</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -1381,6 +1381,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>Вимкн</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1382,6 +1382,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Displayed within a status message when deactivating a widget as well as in * the preferences dialog as option to disable a setting.</extracomment>
         <translation>关</translation>
     </message>
+    <message>
+        <source>Settings</source>
+        <extracomment>Indicates a menu section in which behavioural customizations can be * done.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Director</name>

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -157,6 +157,7 @@ Preferences::Preferences()
 	, m_bShowInstrumentPeaks( true )
 	, m_nPatternEditorGridResolution( 8 )
 	, m_bPatternEditorUsingTriplets( false )
+	, m_bPatternEditorAlwaysShowTypeLabels( false )
 	, m_bIsFXTabVisible( true )
 	, m_bHideKeyboardCursor( false )
 	, m_bShowPlaybackTrack( false )
@@ -341,6 +342,7 @@ Preferences::Preferences( std::shared_ptr<Preferences> pOther )
 	, m_bShowInstrumentPeaks( pOther->m_bShowInstrumentPeaks )
 	, m_nPatternEditorGridResolution( pOther->m_nPatternEditorGridResolution )
 	, m_bPatternEditorUsingTriplets( pOther->m_bPatternEditorUsingTriplets )
+	, m_bPatternEditorAlwaysShowTypeLabels( pOther->m_bPatternEditorAlwaysShowTypeLabels )
 	, m_bIsFXTabVisible( pOther->m_bIsFXTabVisible )
 	, m_bHideKeyboardCursor( pOther->m_bHideKeyboardCursor )
 	, m_bShowPlaybackTrack( pOther->m_bShowPlaybackTrack )
@@ -787,6 +789,10 @@ std::shared_ptr<Preferences> Preferences::load( const QString& sPath, const bool
 		pPref->m_bPatternEditorUsingTriplets = guiNode.read_bool(
 			"patternEditorUsingTriplets",
 			pPref->m_bPatternEditorUsingTriplets, false, false, bSilent );
+		pPref->m_bPatternEditorAlwaysShowTypeLabels = guiNode.read_bool(
+			"patternEditorAlwaysShowTypeLabels",
+			pPref->m_bPatternEditorAlwaysShowTypeLabels,
+			/* inexistent_ok */true, /* empty_ok */false, bSilent );
 				
 		pPref->m_bShowInstrumentPeaks = guiNode.read_bool(
 			"showInstrumentPeaks",
@@ -1266,6 +1272,8 @@ bool Preferences::saveTo( const QString& sPath, const bool bSilent ) const {
 		guiNode.write_int( "patternEditorGridHeight", m_nPatternEditorGridHeight );
 		guiNode.write_int( "patternEditorGridWidth", m_nPatternEditorGridWidth );
 		guiNode.write_bool( "patternEditorUsingTriplets", m_bPatternEditorUsingTriplets );
+		guiNode.write_bool( "patternEditorAlwaysShowTypeLabels",
+							m_bPatternEditorAlwaysShowTypeLabels );
 		guiNode.write_int( "songEditorGridHeight", m_nSongEditorGridHeight );
 		guiNode.write_int( "songEditorGridWidth", m_nSongEditorGridWidth );
 		guiNode.write_bool( "showInstrumentPeaks", m_bShowInstrumentPeaks );
@@ -1797,6 +1805,8 @@ QString Preferences::toQString( const QString& sPrefix, bool bShort ) const {
 					 .arg( s ).arg( m_nPatternEditorGridResolution ) )
 			.append( QString( "%1%2m_bPatternEditorUsingTriplets: %3\n" ).arg( sPrefix )
 					 .arg( s ).arg( m_bPatternEditorUsingTriplets ) )
+			.append( QString( "%1%2m_bPatternEditorAlwaysShowTypeLabels: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_bPatternEditorAlwaysShowTypeLabels ) )
 			.append( QString( "%1%2m_bIsFXTabVisible: %3\n" ).arg( sPrefix )
 					 .arg( s ).arg( m_bIsFXTabVisible ) )
 			.append( QString( "%1%2m_bHideKeyboardCursor: %3\n" ).arg( sPrefix )
@@ -2045,6 +2055,8 @@ QString Preferences::toQString( const QString& sPrefix, bool bShort ) const {
 					 .arg( m_nPatternEditorGridResolution ) )
 			.append( QString( ", m_bPatternEditorUsingTriplets: %1" )
 					 .arg( m_bPatternEditorUsingTriplets ) )
+			.append( QString( ", m_bPatternEditorAlwaysShowTypeLabels: %1" )
+					 .arg( m_bPatternEditorAlwaysShowTypeLabels ) )
 			.append( QString( ", m_bIsFXTabVisible: %1" )
 					 .arg( m_bIsFXTabVisible ) )
 			.append( QString( ", m_bHideKeyboardCursor: %1" )

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -478,6 +478,9 @@ public:
 	bool			isPatternEditorUsingTriplets() const;
 	void			setPatternEditorUsingTriplets( bool value );
 
+		bool		getPatternEditorAlwaysShowTypeLabels() const;
+		void		setPatternEditorAlwaysShowTypeLabels( bool bNew );
+
 	bool			isFXTabVisible() const;
 	void			setFXTabVisible( bool value );
 
@@ -671,6 +674,8 @@ private:
 	bool					m_bShowInstrumentPeaks;
 	int						m_nPatternEditorGridResolution;
 	bool					m_bPatternEditorUsingTriplets;
+		bool				m_bPatternEditorAlwaysShowTypeLabels;
+
 	bool					m_bIsFXTabVisible;
 	bool					m_bHideKeyboardCursor;
 	bool					m_bShowPlaybackTrack;
@@ -1045,6 +1050,12 @@ inline bool Preferences::isPatternEditorUsingTriplets() const {
 }
 inline void Preferences::setPatternEditorUsingTriplets( bool value ) {
 	m_bPatternEditorUsingTriplets = value;
+}
+inline bool Preferences::getPatternEditorAlwaysShowTypeLabels() const {
+	return m_bPatternEditorAlwaysShowTypeLabels;
+}
+inline void Preferences::setPatternEditorAlwaysShowTypeLabels( bool bNew ) {
+	m_bPatternEditorAlwaysShowTypeLabels = bNew;
 }
 
 inline bool Preferences::isFXTabVisible() const {

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -749,6 +749,10 @@ CommonStrings::CommonStrings(){
 	 * or write data to a file/path Hydrogen can not handle in the
 	 * current encoding.*/
 	m_sEncodingError = tr( "The provided filename can not be handled by your current encoding" );
+
+	/*: Indicates a menu section in which behavioural customizations can be
+	 *  done. */
+	m_sSettings = tr( "Settings" );
 }
 
 CommonStrings::~CommonStrings(){}

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -326,6 +326,7 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 		const QString& getErrorEmptyType() const { return m_sErrorEmptyType; }
 		const QString& getErrorUniqueTypes() const {return m_sErrorUniqueTypes; }
 
+		const QString& getSettings() const { return m_sSettings; }
 private:
 	QString m_sSmallSoloButton;
 	QString m_sSmallMuteButton;
@@ -582,5 +583,7 @@ private:
 		QString m_sNotePitchB;
 
 	QString m_sEncodingError;
+
+		QString m_sSettings;
 };
 #endif

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -654,15 +654,17 @@ void PatternEditorPanel::createEditors() {
 	m_pPropertiesPanel = new PixmapWidget( nullptr );
 	m_pPropertiesPanel->setObjectName( "PropertiesPanel" );
 	m_pPropertiesPanel->setColor( QColor( 58, 62, 72 ) );
+	m_pPropertiesPanel->setFixedHeight( 100 );
+	m_pPropertiesPanel->setMaximumWidth( PatternEditorSidebar::m_nWidth );
 
-	m_pPropertiesPanel->setFixedSize( PatternEditorSidebar::m_nWidth, 100 );
 
 	QVBoxLayout *pPropertiesVBox = new QVBoxLayout( m_pPropertiesPanel );
 	pPropertiesVBox->setSpacing( 0 );
 	pPropertiesVBox->setMargin( 0 );
 
-	m_pPropertiesCombo = new LCDCombo(
-		nullptr, QSize( PatternEditorSidebar::m_nWidth, 18 ), false );
+	m_pPropertiesCombo = new LCDCombo( nullptr, QSize( 0, 0 ), false );
+	m_pPropertiesCombo->setFixedHeight( 18 );
+	m_pPropertiesCombo->setMaximumWidth( PatternEditorSidebar::m_nWidth );
 	m_pPropertiesCombo->setFocusPolicy( Qt::ClickFocus );
 	m_pPropertiesCombo->setToolTip( tr( "Select note properties" ) );
 	m_pPropertiesCombo->addItem( pCommonStrings->getNotePropertyVelocity() );
@@ -1992,12 +1994,31 @@ void PatternEditorPanel::updateTypeLabelVisibility() {
 		return;
 	}
 
+	// Update visibility
+	bool bVisible;
 	if ( Preferences::get_instance()->getPatternEditorAlwaysShowTypeLabels() ) {
-		m_pSidebar->updateTypeLabelVisibility( true );
+		bVisible = true;
 	}
 	else {
-		m_pSidebar->updateTypeLabelVisibility( m_bTypeLabelsMustBeVisible );
+		bVisible = m_bTypeLabelsMustBeVisible;
 	}
+
+	// Update the width of the sidebar.
+	int nWidth;
+	if ( ! bVisible ) {
+		nWidth = PatternEditorSidebar::m_nWidth - SidebarRow::m_nTypeLblWidth;
+	}
+	else {
+		nWidth = PatternEditorSidebar::m_nWidth;
+	}
+
+	m_pDrumkitLabel->setFixedWidth( nWidth );
+	m_pSidebar->setFixedWidth( nWidth );
+	m_pSidebarScrollView->setFixedWidth( nWidth );
+	m_pPropertiesPanel->setFixedWidth( nWidth );
+	m_pPropertiesCombo->setFixedWidth( nWidth );
+
+	m_pSidebar->updateTypeLabelVisibility( bVisible );
 }
 
 void PatternEditorPanel::setHoveredNotesMouse(

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -105,6 +105,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	, m_pPattern( nullptr )
 	, m_bArmPatternSizeSpinBoxes( true )
 	, m_bPatternSelectedViaTab( false )
+	, m_bTypeLabelsMustBeVisible( false )
 {
 	setAcceptDrops(true);
 
@@ -714,6 +715,7 @@ void PatternEditorPanel::createEditors() {
 	pVBox->addWidget( pMainPanel );
 
 	updateStyleSheet();
+	updateTypeLabelVisibility();
 }
 
 void PatternEditorPanel::updateDrumkitLabel( )
@@ -1170,7 +1172,6 @@ void PatternEditorPanel::zoomOutBtnClicked()
 
 	updateEditors();
 	resizeEvent( nullptr );
-	DEBUGLOG( "DONE" );
 }
 
 void PatternEditorPanel::updatePatternInfo() {
@@ -1310,6 +1311,7 @@ void PatternEditorPanel::updateEditors( bool bPatternOnly ) {
 	m_pPianoRollEditor->updateEditor( bPatternOnly );
 	m_pDrumPatternEditor->updateEditor( bPatternOnly );
 	m_pSidebar->updateEditor();
+	updateTypeLabelVisibility();
 }
 
 void PatternEditorPanel::patternModifiedEvent() {
@@ -1976,6 +1978,25 @@ void PatternEditorPanel::updateDB() {
 		// instrument -> no type-only rows. We selected the bottom-most
 		// instrument instead.
 		setSelectedRowDB( m_db.size() - 1 );
+	}
+
+	if ( additionalIds.size() > 0 || additionalTypes.size() > 0 ) {
+		m_bTypeLabelsMustBeVisible = true;
+	} else {
+		m_bTypeLabelsMustBeVisible = false;
+	}
+}
+
+void PatternEditorPanel::updateTypeLabelVisibility() {
+	if ( m_pSidebar == nullptr ) {
+		return;
+	}
+
+	if ( Preferences::get_instance()->getPatternEditorAlwaysShowTypeLabels() ) {
+		m_pSidebar->updateTypeLabelVisibility( true );
+	}
+	else {
+		m_pSidebar->updateTypeLabelVisibility( m_bTypeLabelsMustBeVisible );
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -311,6 +311,11 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		/** Update #m_db based on #H2Core::Song::m_pDrumkit and #m_pPattern. */
 		void updateDB();
 
+		/** If set by the user, type labels in the sidebar will only be shown in
+		 * case there is a note not associated with the current drumkit in
+		 * #m_pPattern. */
+		void updateTypeLabelVisibility();
+
 		/** Returns both notex hovered by mouse and keyboard. */
 		const std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 									  std::vector< std::shared_ptr<H2Core::Note> > >
@@ -471,6 +476,8 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		bool m_bIsUsingTriplets;
 
 		bool m_bPatternSelectedViaTab;
+
+		bool m_bTypeLabelsMustBeVisible;
 
 		void updateHoveredNotes();
 		/** Combined version of both #m_hoveredNotesMouse and

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -724,7 +724,14 @@ void SidebarRow::setSelected( bool bSelected )
 
 	m_bIsSelected = bSelected;
 
-	m_pTypeLbl->setShowCursor( bSelected );
+	if ( m_pTypeLbl->isVisible() ) {
+		m_pTypeLbl->setShowCursor( bSelected );
+		m_pInstrumentNameLbl->setShowCursor( false );
+	}
+	else {
+		m_pInstrumentNameLbl->setShowCursor( bSelected );
+		m_pTypeLbl->setShowCursor( false );
+	}
 
 	updateStyleSheet();
 
@@ -786,6 +793,18 @@ void SidebarRow::updateTypeLabelVisibility( bool bVisible ) {
 		m_pTypeLbl->show();
 	} else {
 		m_pTypeLbl->hide();
+	}
+
+	// Update label on which the cursor is shown
+	if ( m_bIsSelected ) {
+		if ( bVisible ) {
+			m_pInstrumentNameLbl->setShowCursor( false );
+			m_pTypeLbl->setShowCursor( true );
+		}
+		else {
+			m_pInstrumentNameLbl->setShowCursor( true );
+			m_pTypeLbl->setShowCursor( false );
+		}
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -382,8 +382,7 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 			   SidebarRow::m_nTypeLblWidth, nHeight ),
 		"", PatternEditorSidebar::m_nMargin );
 	m_pInstrumentNameLbl->setFont( nameFont );
-	m_pInstrumentNameLbl->setSizePolicy(
-		QSizePolicy::Fixed, QSizePolicy::Fixed );
+	m_pInstrumentNameLbl->setSizePolicy( QSizePolicy::Fixed, QSizePolicy::Fixed );
 	pHBox->addWidget( m_pInstrumentNameLbl );
 
 	// Play back a sample of specific velocity based on the horizontal position
@@ -936,14 +935,24 @@ PatternEditorSidebar::PatternEditorSidebar( QWidget *parent )
 	HydrogenApp::get_instance()->addEventListener( this );
 	const auto pPref = H2Core::Preferences::get_instance();
 
-	//INFOLOG("INIT");
 	m_pPatternEditorPanel = HydrogenApp::get_instance()->getPatternEditorPanel();
 
+	auto pVBoxLayout = new QVBoxLayout( this );
+	pVBoxLayout->setSpacing( 0 );
+	pVBoxLayout->setMargin( 0 );
+
+	setLayout( pVBoxLayout );
 
 	m_nEditorHeight = pPref->getPatternEditorGridHeight() *
 		m_pPatternEditorPanel->getRowNumberDB();
 
-	resize( PatternEditorSidebar::m_nWidth, m_nEditorHeight );
+	if ( pPref->getPatternEditorAlwaysShowTypeLabels() ) {
+		resize( PatternEditorSidebar::m_nWidth, m_nEditorHeight );
+	}
+	else {
+		resize( PatternEditorSidebar::m_nWidth -
+				SidebarRow::m_nTypeLblWidth, m_nEditorHeight );
+	}
 
 	setAcceptDrops(true);
 
@@ -1025,9 +1034,8 @@ void PatternEditorSidebar::updateRows()
 		else {
 			// row in DB does not has its counterpart in the sidebar yet. Create
 			// it.
-			auto pRow = std::make_shared<SidebarRow>( this, rrow );
-			pRow->move( 0, pPref->getPatternEditorGridHeight() * nnIndex + 1 );
-			pRow->show();
+			auto pRow = new SidebarRow( this, rrow );
+			layout()->addWidget( pRow );
 			pRow->setDimed( bPianoRollShown );
 			m_rows.push_back( pRow );
 		}
@@ -1037,7 +1045,10 @@ void PatternEditorSidebar::updateRows()
 	const int nRows = m_pPatternEditorPanel->getRowNumberDB();
 	while ( nRows < m_rows.size() && m_rows.size() > 0 ) {
 		// There are rows not required anymore
+		auto pRow = *( m_rows.end() - 1 );
+		layout()->removeWidget( pRow );
 		m_rows.pop_back();
+		delete pRow;
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -934,13 +934,14 @@ PatternEditorSidebar::PatternEditorSidebar( QWidget *parent )
  {
 
 	HydrogenApp::get_instance()->addEventListener( this );
+	const auto pPref = H2Core::Preferences::get_instance();
 
 	//INFOLOG("INIT");
 	m_pPatternEditorPanel = HydrogenApp::get_instance()->getPatternEditorPanel();
 
-	m_nGridHeight = Preferences::get_instance()->getPatternEditorGridHeight();
 
-	m_nEditorHeight = m_nGridHeight * m_pPatternEditorPanel->getRowNumberDB();
+	m_nEditorHeight = pPref->getPatternEditorGridHeight() *
+		m_pPatternEditorPanel->getRowNumberDB();
 
 	resize( PatternEditorSidebar::m_nWidth, m_nEditorHeight );
 
@@ -1000,10 +1001,12 @@ void PatternEditorSidebar::dimRows( bool bDim ) {
 ///
 void PatternEditorSidebar::updateRows()
 {
-	if ( m_nEditorHeight !=
-		 m_nGridHeight * m_pPatternEditorPanel->getRowNumberDB() ) {
-		m_nEditorHeight = m_nGridHeight * m_pPatternEditorPanel->getRowNumberDB();
-		resize( PatternEditorSidebar::m_nWidth, m_nEditorHeight );
+	const auto pPref = H2Core::Preferences::get_instance();
+	if ( m_nEditorHeight != pPref->getPatternEditorGridHeight() *
+		 m_pPatternEditorPanel->getRowNumberDB() ) {
+		m_nEditorHeight = pPref->getPatternEditorGridHeight() *
+			m_pPatternEditorPanel->getRowNumberDB();
+		resize( width(), m_nEditorHeight );
 	}
 
 	bool bPianoRollShown = false;
@@ -1023,7 +1026,7 @@ void PatternEditorSidebar::updateRows()
 			// row in DB does not has its counterpart in the sidebar yet. Create
 			// it.
 			auto pRow = std::make_shared<SidebarRow>( this, rrow );
-			pRow->move( 0, m_nGridHeight * nnIndex + 1 );
+			pRow->move( 0, pPref->getPatternEditorGridHeight() * nnIndex + 1 );
 			pRow->show();
 			pRow->setDimed( bPianoRollShown );
 			m_rows.push_back( pRow );
@@ -1065,6 +1068,7 @@ void PatternEditorSidebar::dropEvent(QDropEvent *event)
 		return;
 	}
 
+	const auto pPref = H2Core::Preferences::get_instance();
 	auto pHydrogenApp = HydrogenApp::get_instance();
 	const auto pCommonStrings = pHydrogenApp->getCommonStrings();
 
@@ -1086,7 +1090,7 @@ void PatternEditorSidebar::dropEvent(QDropEvent *event)
 		nPosY = event->pos().y();
 	}
 
-	int nTargetRow = nPosY / m_nGridHeight;
+	int nTargetRow = nPosY / pPref->getPatternEditorGridHeight();
 
 	// There might be rows in the pattern editor not corresponding to the
 	// current kit. Since we only support rearranging rows corresponding to
@@ -1203,7 +1207,9 @@ void PatternEditorSidebar::mouseMoveEvent(QMouseEvent *event)
 		return;
 	}
 
-	if ( abs( event->pos().y() - m_nDragStartY ) < m_nGridHeight ) {
+	const auto pPref = H2Core::Preferences::get_instance();
+	if ( abs( event->pos().y() - m_nDragStartY ) <
+		 pPref->getPatternEditorGridHeight() ) {
 		// Still within the same row.
 		return;
 	}

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.h
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.h
@@ -205,7 +205,7 @@ class PatternEditorSidebar : public QWidget,
 	protected:
 		PatternEditorPanel* m_pPatternEditorPanel;
 		uint m_nEditorHeight;
-		std::vector<std::shared_ptr<SidebarRow>> m_rows;
+		std::vector<SidebarRow*> m_rows;
 		DragScroller *m_pDragScroller;
 
 		/** Vertical position the drag event started at. In case there is no

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.h
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.h
@@ -120,12 +120,14 @@ class SidebarRow : public PixmapWidget
 	public:
 		explicit SidebarRow( QWidget* pParent, const DrumPatternRow& row );
 
+
 		void set( const DrumPatternRow& row );
 		void setSelected( bool isSelected );
 		void setDimed( bool bDimed );
 
 		void updateFont();
 		void updateStyleSheet();
+		void updateTypeLabelVisibility( bool bVisible );
 
 		static constexpr int m_nButtonWidth = 18;
 		static constexpr int m_nTypeLblWidth = 100;
@@ -145,6 +147,7 @@ public slots:
 		QMenu *m_pFunctionPopupSub;
 		QAction* m_pRenameInstrumentAction;
 		QAction* m_pDeleteInstrumentAction;
+		QAction* m_pTypeLabelVisibilityAction;
 		SidebarLabel* m_pInstrumentNameLbl;
 		SidebarLabel* m_pTypeLbl;
 		bool m_bIsSelected;
@@ -189,6 +192,7 @@ class PatternEditorSidebar : public QWidget,
 		void updateEditor();
 		void updateFont();
 		void updateStyleSheet();
+		void updateTypeLabelVisibility( bool bVisible );
 
 		void dimRows( bool bDim );
 

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.h
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.h
@@ -204,7 +204,6 @@ class PatternEditorSidebar : public QWidget,
 
 	protected:
 		PatternEditorPanel* m_pPatternEditorPanel;
-		uint m_nGridHeight;
 		uint m_nEditorHeight;
 		std::vector<std::shared_ptr<SidebarRow>> m_rows;
 		DragScroller *m_pDragScroller;

--- a/src/tests/data/preferences/current.conf
+++ b/src/tests/data/preferences/current.conf
@@ -102,6 +102,7 @@
   <patternEditorGridHeight>21</patternEditorGridHeight>
   <patternEditorGridWidth>1</patternEditorGridWidth>
   <patternEditorUsingTriplets>false</patternEditorUsingTriplets>
+  <patternEditorAlwaysShowTypeLabels>false</patternEditorAlwaysShowTypeLabels>
   <songEditorGridHeight>18</songEditorGridHeight>
   <songEditorGridWidth>17</songEditorGridWidth>
   <showInstrumentPeaks>true</showInstrumentPeaks>


### PR DESCRIPTION
Previously, these labels have always been shown. Even in case all notes in a pattern do correspond to an instrument of the current kit (in which case type labels are somewhat redundant).

This patch introduces an option stored in `Preferences` and accessible via the right-click popup menu in the sidebar of the pattern editor using which the visibility of the instrument type labels can be controlled. If "Always show type labels" is checked, they will always be shown. If unchecked, they will be hidden in case all notes correspond to an instrument of the current kit.

Per default this new option is unchecked/off. I am not a 100% sure whether this works fine. Further testing and development will tell