### PR TITLE
Fix separate track Song export

### DIFF
--- a/src/core/AudioEngine/AudioEngineTests.cpp
+++ b/src/core/AudioEngine/AudioEngineTests.cpp
@@ -1201,7 +1201,7 @@ void AudioEngineTests::testNoteEnqueuingTimeline() {
 				 notesInSongQueue[ ii ]->getKey(),
 				 notesInSongQueue[ ii ]->getOctave() ) ) {
 		AudioEngineTests::throwException(
-			QString( "Mismatch at note [%1] between song [%2] and song queue [%3]" )
+			QString( "Mismatch at note [%1] between song [%2]\n and song queue [%3]" )
 			.arg( ii )
 			.arg( notesInSong[ ii ]->toQString() )
 			.arg( notesInSongQueue[ ii ]->toQString() ) );
@@ -1212,7 +1212,7 @@ void AudioEngineTests::testNoteEnqueuingTimeline() {
 				 notesInSamplerQueue[ ii ]->getKey(),
 				 notesInSamplerQueue[ ii ]->getOctave() ) ) {
 		AudioEngineTests::throwException(
-			QString( "Mismatch at note [%1] between song [%2] and sampler queue [%3]" )
+			QString( "Mismatch at note [%1] between song [%2]\n and sampler queue [%3]" )
 			.arg( ii )
 			.arg( notesInSong[ ii ]->toQString() )
 			.arg( notesInSamplerQueue[ ii ]->toQString() ) );

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -314,6 +314,16 @@ const bool Drumkit::areSamplesLoaded() const {
 	return m_pInstruments->isAnyInstrumentSampleLoaded();
 }
 
+bool Drumkit::hasMissingSamples() const {
+	for ( const auto& ppInstrument : *m_pInstruments ) {
+		if ( ppInstrument != nullptr && ppInstrument->has_missing_samples() ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 QString Drumkit::getExportName() const {
 	return Filesystem::validateFilePath( m_sName );
 }

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -176,6 +176,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 		void unloadSamples();
 		/** return true if the samples are loaded */
 		const bool areSamplesLoaded() const;
+		bool hasMissingSamples() const;
 
 	/**
 	 * Returns the base name used when exporting the drumkit.

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -322,6 +322,13 @@ class Note : public H2Core::Object<Note>
 		static bool compare( const std::shared_ptr<Note> pNote1,
 							 const std::shared_ptr<Note> pNote2 );
 
+		/** Like compare() but in reverse order.
+		 *
+		 * Just negating the output of compare() doesn't not work in the macOS
+		 * pipeline for some reason. */
+		static bool compareAscending( const std::shared_ptr<Note> pNote1,
+									  const std::shared_ptr<Note> pNote2 );
+
 		/** Performs a comparison based on starting position of the note.
 		 *
 		 * Note that this start has to be calculated first and involves random
@@ -735,6 +742,20 @@ inline bool Note::compare( const std::shared_ptr<Note> pNote1,
 	}
 	else {
 		return pNote1->getTotalPitch() > pNote2->getTotalPitch();
+	}
+}
+
+inline bool Note::compareAscending( const std::shared_ptr<Note> pNote1,
+									const std::shared_ptr<Note> pNote2 ) {
+	if ( pNote1 == nullptr || pNote2 == nullptr ) {
+		return false;
+	}
+
+	if ( pNote1->getPosition() != pNote2->getPosition() ) {
+		return pNote1->getPosition() < pNote2->getPosition();
+	}
+	else {
+		return pNote1->getTotalPitch() < pNote2->getTotalPitch();
 	}
 }
 

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1120,11 +1120,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 		nColumnStartTick += ppColumn->longest_pattern_length();
 	}
 
-	auto ascending = []( const std::shared_ptr<Note> pNote1,
-						 const std::shared_ptr<Note> pNote2 ) {
-		return ! Note::compare( pNote1, pNote2 );
-	};
-	std::sort( notes.begin(), notes.end(), ascending );
+	std::sort( notes.begin(), notes.end(), Note::compareAscending );
 
 	return notes;
 }

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -1059,44 +1059,72 @@ void Song::setPanLawKNorm( float fKNorm ) {
 
 std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 
-	std::vector<std::shared_ptr<Note>> notes;
+	std::vector< std::shared_ptr<Note> > notes;
+	std::set< std::shared_ptr<Pattern> > encounteredPattern;
+
+	auto addNotes = [&notes]( std::shared_ptr<Note> pNote,
+							  int nColumnStartTick ) {
+		if ( pNote != nullptr ) {
+			// Use the copy constructor to not mess
+			// with the song itself.
+			auto pNoteCopied = std::make_shared<Note>( pNote );
+
+			// The position property of the note specifies its position within
+			// the pattern. All we need to do is to add the pattern start tick.
+			pNoteCopied->setPosition( pNoteCopied->getPosition() +
+									  nColumnStartTick );
+			notes.push_back( pNoteCopied );
+		}
+	};
 
 	long nColumnStartTick = 0;
-	for ( int ii = 0; ii < m_pPatternGroupSequence->size(); ++ii ) {
-
-		auto pColumn = (*m_pPatternGroupSequence)[ ii ];
-
-		if ( pColumn->size() == 0 ) {
+	for ( const auto& ppColumn : *m_pPatternGroupSequence ) {
+		if ( ppColumn == nullptr || ppColumn->size() == 0 ) {
 			// An empty column with no patterns selected (but not the
 			// end of the song).
 			nColumnStartTick += MAX_NOTES;
 			continue;
 		}
-		else {
-			for ( const auto& ppattern : *pColumn ) {
-				if ( ppattern != nullptr ) {
-					FOREACH_NOTE_CST_IT_BEGIN_LENGTH( ppattern->getNotes(), it, ppattern ) {
-						if ( it->second != nullptr ) {
-							// Use the copy constructor to not mess
-							// with the song itself.
-							std::shared_ptr<Note> pNote =
-								std::make_shared<Note>( it->second );
 
-							// The position property of the note
-							// specifies its position within the
-							// pattern. All we need to do is to add
-							// the pattern start tick.
-							pNote->setPosition( pNote->getPosition() +
-												 nColumnStartTick );
-							notes.push_back( pNote );
-						}
+		for ( const auto& ppPattern : *ppColumn ) {
+			if ( ppPattern == nullptr ) {
+				continue;
+			}
+
+			// Add all notes of this pattern.
+			for ( const auto& [ _, ppNote ] : *ppPattern->getNotes() ) {
+				addNotes( ppNote, nColumnStartTick );
+			}
+			encounteredPattern.insert( ppPattern );
+
+			// Add notes of contained virtual patterns as well.
+			if ( ppPattern->isVirtual() ) {
+				for ( const auto& ppVirtualPattern :
+						  *ppPattern->getFlattenedVirtualPatterns() ) {
+					// A pattern could be part of several patterns as well as
+					// activated directly. We only need to take it into account
+					// once.
+					if ( encounteredPattern.find( ppVirtualPattern ) !=
+						 encounteredPattern.end() ) {
+						continue;
+					}
+					encounteredPattern.insert( ppVirtualPattern );
+
+					for ( const auto& [ _, ppNote ] : *ppVirtualPattern->getNotes() ) {
+						addNotes( ppNote, nColumnStartTick );
 					}
 				}
 			}
-
-			nColumnStartTick += pColumn->longest_pattern_length();
 		}
+
+		nColumnStartTick += ppColumn->longest_pattern_length();
 	}
+
+	auto ascending = []( const std::shared_ptr<Note> pNote1,
+						 const std::shared_ptr<Note> pNote2 ) {
+		return ! Note::compare( pNote1, pNote2 );
+	};
+	std::sort( notes.begin(), notes.end(), ascending );
 
 	return notes;
 }

--- a/src/gui/src/ExportSongDialog.h
+++ b/src/gui/src/ExportSongDialog.h
@@ -71,7 +71,7 @@ private:
 	void		setResamplerMode(int index);
 	bool		checkUseOfRubberband();
 
-	bool		currentInstrumentHasNotes();
+	bool		instrumentHasNotes( int nInstrumentId );
 	QString		findUniqueExportFilenameForInstrument( std::shared_ptr<H2Core::Instrument> pInstrument );
 
 	void		exportTracks();

--- a/src/tests/AudioBenchmark.cpp
+++ b/src/tests/AudioBenchmark.cpp
@@ -219,11 +219,7 @@ void AudioBenchmark::audioBenchmark(void)
 
 	/* Load song and prepare */
 	std::shared_ptr<Song> pSong = Song::load( songFile );
-	CPPUNIT_ASSERT( pSong != nullptr );
-
-	if ( !pSong ) {
-		return;
-	}
+	ASSERT_SONG( pSong );
 
 	pHydrogen->setSong( pSong );
 
@@ -243,11 +239,7 @@ void AudioBenchmark::audioBenchmark(void)
 
 	out << "Now with ADSR" << Qt::endl;
 	pSong = Song::load( songADSRFile );
-	CPPUNIT_ASSERT( pSong != nullptr );
-
-	if( !pSong ) {
-		return;
-	}
+	ASSERT_SONG( pSong );
 
 	pHydrogen->setSong( pSong );
 	pInstrumentList = pSong->getDrumkit()->getInstruments();

--- a/src/tests/NoteTest.cpp
+++ b/src/tests/NoteTest.cpp
@@ -78,12 +78,7 @@ class NoteTest : public CppUnit::TestCase {
 			}
 
 			// Ascending order based on position
-			auto ascending = []( const std::shared_ptr<Note> pNote1,
-								 const std::shared_ptr<Note> pNote2 ) {
-				return ! Note::compare( pNote1, pNote2 );
-			};
-
-			std::sort( notes2.begin(), notes2.end(), ascending );
+			std::sort( notes2.begin(), notes2.end(), Note::compareAscending );
 			for ( int ii = 1; ii < notes2.size(); ++ii ) {
 				CPPUNIT_ASSERT( notes2[ ii - 1 ]->getPosition() <=
 								notes2[ ii ]->getPosition() );

--- a/src/tests/NoteTest.cpp
+++ b/src/tests/NoteTest.cpp
@@ -20,26 +20,97 @@
  *
  */
 
+#include "TestHelper.h"
+
 #include <cppunit/extensions/HelperMacros.h>
 #include <core/Basics/Drumkit.h>
 #include <core/Basics/Instrument.h>
 #include <core/Basics/InstrumentList.h>
 #include <core/Basics/Note.h>
+#include <core/Basics/Song.h>
+#include <core/CoreActionController.h>
 #include <core/IO/MidiCommon.h>
 #include <core/Preferences/Shortcuts.h>
 #include <core/Helpers/Xml.h>
 #include <QDomDocument>
 
+#include <algorithm>
+
 using namespace H2Core;
 
 class NoteTest : public CppUnit::TestCase {
 		CPPUNIT_TEST_SUITE( NoteTest );
+		CPPUNIT_TEST( testComparison );
 		CPPUNIT_TEST( testMidiDefaultOffset );
 		CPPUNIT_TEST( testPitchConversions );
 		CPPUNIT_TEST( testVirtualKeyboard );
 		CPPUNIT_TEST( testProbability );
 		CPPUNIT_TEST( testSerializeProbability );
 		CPPUNIT_TEST_SUITE_END();
+
+		void testComparison() {
+			___INFOLOG( "" );
+
+			// Setup example vectors.
+			std::vector< std::shared_ptr<H2Core::Note> > notes1, notes2, notes3;
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 283 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 0 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 22 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 284 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 283 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 282 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 130 ) );
+			notes1.push_back( std::make_shared<H2Core::Note>( nullptr, 803 ) );
+
+			for ( const auto& ppNote : notes1 ) {
+				notes2.push_back( std::make_shared<H2Core::Note>( ppNote ) );
+
+				auto pNoteStart = std::make_shared<H2Core::Note>( ppNote );
+				pNoteStart->computeNoteStart();
+				notes3.push_back( pNoteStart );
+			}
+
+			// Descending order based on position
+			std::sort( notes1.begin(), notes1.end(), Note::compare );
+			for ( int ii = 1; ii < notes1.size(); ++ii ) {
+				CPPUNIT_ASSERT( notes1[ ii - 1 ]->getPosition() >=
+								notes1[ ii ]->getPosition() );
+			}
+
+			// Ascending order based on position
+			auto ascending = []( const std::shared_ptr<Note> pNote1,
+								 const std::shared_ptr<Note> pNote2 ) {
+				return ! Note::compare( pNote1, pNote2 );
+			};
+
+			std::sort( notes2.begin(), notes2.end(), ascending );
+			for ( int ii = 1; ii < notes2.size(); ++ii ) {
+				CPPUNIT_ASSERT( notes2[ ii - 1 ]->getPosition() <=
+								notes2[ ii ]->getPosition() );
+			}
+
+			// Descending based on note start
+			std::sort( notes3.begin(), notes3.end(), Note::compareStart );
+			for ( int ii = 1; ii < notes3.size(); ++ii ) {
+				CPPUNIT_ASSERT( notes3[ ii - 1 ]->getPosition() >=
+								notes3[ ii ]->getPosition() );
+				CPPUNIT_ASSERT( notes3[ ii - 1 ]->getNoteStart() >=
+								notes3[ ii ]->getNoteStart() );
+			}
+
+			// Full size example
+			auto pSong = Song::load(
+				H2TEST_FILE( "song/AE_noteEnqueuingTimeline.h2song" ) );
+			CPPUNIT_ASSERT( pSong != nullptr );
+
+			const auto songNotes = pSong->getAllNotes();
+			for ( int ii = 1; ii < songNotes.size(); ++ii ) {
+				CPPUNIT_ASSERT( songNotes[ ii - 1 ]->getPosition() <=
+								songNotes[ ii ]->getPosition() );
+			}
+
+			___INFOLOG( "passed" );
+		}
 
 	void testMidiDefaultOffset() {
 		___INFOLOG( "" );

--- a/src/tests/TestHelper.h
+++ b/src/tests/TestHelper.h
@@ -112,5 +112,10 @@ inline QString TestHelper::getTestFile(const QString& file) const
 }
 
 #define H2TEST_FILE(name) TestHelper::get_instance()->getTestFile(name)
+#define ASSERT_SONG(pSong) {                                                    \
+	CPPUNIT_ASSERT( pSong != nullptr );				                            \
+	CPPUNIT_ASSERT( pSong->getDrumkit() != nullptr );                           \
+	CPPUNIT_ASSERT( ! pSong->getDrumkit()->hasMissingSamples() );               \
+}
 
 #endif

--- a/src/tests/TransportTest.cpp
+++ b/src/tests/TransportTest.cpp
@@ -59,7 +59,7 @@ void TransportTest::testFrameToTickConversion() {
 	___INFOLOG( "" );
 	auto pSongDemo = Song::load( QString( "%1/GM_kit_demo3.h2song" )
 								   .arg( Filesystem::demos_dir() ) );
-	CPPUNIT_ASSERT( pSongDemo != nullptr );
+	ASSERT_SONG( pSongDemo );
 	H2Core::CoreActionController::setSong( pSongDemo );
 
 	const std::vector<int> indices{ 0, 5, 7, 12 };
@@ -74,7 +74,7 @@ void TransportTest::testTransportProcessing() {
 	___INFOLOG( "" );
 	auto pSongDemo = Song::load( QString( "%1/GM_kit_demo3.h2song" )
 								   .arg( Filesystem::demos_dir() ) );
-	CPPUNIT_ASSERT( pSongDemo != nullptr );
+	ASSERT_SONG( pSongDemo );
 	H2Core::CoreActionController::setSong( pSongDemo );
 
 	const std::vector<int> indices{ 1, 9, 14 };
@@ -89,7 +89,7 @@ void TransportTest::testTransportProcessingTimeline() {
 	___INFOLOG( "" );
 	auto pSongTransportProcessingTimeline =
 		Song::load( QString( H2TEST_FILE( "song/AE_transportProcessingTimeline.h2song" ) ) );
-	CPPUNIT_ASSERT( pSongTransportProcessingTimeline != nullptr );
+	ASSERT_SONG( pSongTransportProcessingTimeline );
 	H2Core::CoreActionController::
 		setSong( pSongTransportProcessingTimeline );
 
@@ -105,7 +105,7 @@ void TransportTest::testTransportRelocation() {
 	___INFOLOG( "" );
 	auto pSongDemo = Song::load( QString( "%1/GM_kit_demo3.h2song" )
 								   .arg( Filesystem::demos_dir() ) );
-	CPPUNIT_ASSERT( pSongDemo != nullptr );
+	ASSERT_SONG( pSongDemo );
 	H2Core::CoreActionController::setSong( pSongDemo );
 	
 	H2Core::CoreActionController::activateTimeline( true );
@@ -135,7 +135,7 @@ void TransportTest::testLoopMode() {
 	const QString sSongFile = H2TEST_FILE( "song/AE_loopMode.h2song" );
 
 	auto pSong = H2Core::Song::load( sSongFile );
-	CPPUNIT_ASSERT( pSong != nullptr );
+	ASSERT_SONG( pSong );
 
 	H2Core::CoreActionController::setSong( pSong );
 	
@@ -151,7 +151,7 @@ void TransportTest::testSongSizeChange() {
 	___INFOLOG( "" );
 	auto pSongSizeChanged =
 		Song::load( QString( H2TEST_FILE( "song/AE_songSizeChanged.h2song" ) ) );
-	CPPUNIT_ASSERT( pSongSizeChanged != nullptr );
+	ASSERT_SONG( pSongSizeChanged );
 	H2Core::CoreActionController::setSong( pSongSizeChanged );
 
 	// Depending on buffer size and sample rate transport might be
@@ -182,7 +182,7 @@ void TransportTest::testSongSizeChangeInLoopMode() {
 	___INFOLOG( "" );
 	auto pSongDemo = Song::load( QString( "%1/GM_kit_demo3.h2song" )
 								   .arg( Filesystem::demos_dir() ) );
-	CPPUNIT_ASSERT( pSongDemo != nullptr );
+	ASSERT_SONG( pSongDemo );
 	H2Core::CoreActionController::setSong( pSongDemo );
 
 	const std::vector<int> indices{ 0, 5, 7, 13 };
@@ -217,8 +217,7 @@ void TransportTest::testSampleConsistency() {
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 
 	auto pSong = H2Core::Song::load( sSongFile );
-
-	CPPUNIT_ASSERT( pSong != nullptr );
+	ASSERT_SONG( pSong );
 		
 	pHydrogen->setSong( pSong );
 
@@ -240,7 +239,8 @@ void TransportTest::testNoteEnqueuing() {
 
 	auto pSongNoteEnqueuing =
 		Song::load( QString( H2TEST_FILE( "song/AE_noteEnqueuing.h2song" ) ) );
-	CPPUNIT_ASSERT( pSongNoteEnqueuing != nullptr );
+	ASSERT_SONG( pSongNoteEnqueuing );
+
 	H2Core::CoreActionController::setSong( pSongNoteEnqueuing );
 
 	// This test is quite time consuming.
@@ -256,8 +256,7 @@ void TransportTest::testNoteEnqueuingTimeline() {
 	___INFOLOG( "" );
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = Song::load( QString( H2TEST_FILE( "song/AE_noteEnqueuingTimeline.h2song" ) ) );
-
-	CPPUNIT_ASSERT( pSong != nullptr );
+	ASSERT_SONG( pSong );
 
 	H2Core::CoreActionController::setSong( pSong );
 
@@ -277,7 +276,7 @@ void TransportTest::testHumanization() {
 
 	auto pSongHumanization =
 		Song::load( QString( H2TEST_FILE( "song/AE_humanization.h2song" ) ) );
-	CPPUNIT_ASSERT( pSongHumanization != nullptr );
+	ASSERT_SONG( pSongHumanization );
 	H2Core::CoreActionController::setSong( pSongHumanization );
 
 	// This test is quite time consuming.

--- a/src/tests/data/song/AE_noteEnqueuing.h2song
+++ b/src/tests/data/song/AE_noteEnqueuing.h2song
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <song>
- <version>1.1.1-'be336a1d'</version>
+ <version>2.0.0-pre-alpha-'d69b209bf'</version>
+ <formatVersion>2</formatVersion>
  <bpm>100</bpm>
  <volume>0.73</volume>
+ <isMuted>false</isMuted>
  <metronomeVolume>0.5</metronomeVolume>
+ <userVersion>0</userVersion>
  <name>Untitled Song</name>
  <author>Unknown</author>
  <notes>Empty song.</notes>
- <license>Unknown license</license>
+ <license>undefined license</license>
  <loopEnabled>false</loopEnabled>
  <patternModeMode>true</patternModeMode>
  <playbackTrackFilename></playbackTrackFilename>
@@ -22,2167 +25,2403 @@
  <humanize_time>0.07</humanize_time>
  <humanize_velocity>0.1</humanize_velocity>
  <swing_factor>0</swing_factor>
- <last_loaded_drumkit>/usr/local/share/hydrogen/data/drumkits/GMRockKit</last_loaded_drumkit>
- <last_loaded_drumkit_name>GMRockKit</last_loaded_drumkit_name>
- <componentList>
-  <drumkitComponent>
-   <id>0</id>
-   <name>Main</name>
-   <volume>1</volume>
-  </drumkitComponent>
- </componentList>
- <instrumentList>
-  <instrument>
-   <id>0</id>
-   <name>Kick</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>999</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>36</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+ <drumkit_info>
+  <formatVersion>2</formatVersion>
+  <name>GMRockKit</name>
+  <userVersion>0</userVersion>
+  <author>Glen MacArthur / Sebastian Moors</author>
+  <info>&lt;!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+&lt;html>&lt;head>&lt;meta name="qrichtext" content="1" />&lt;style type="text/css">
+p, li { white-space: pre-wrap; }
+&lt;/style>&lt;/head>&lt;body style=" font-family:'Lucida Grande'; font-size:10pt; font-weight:400; font-style:normal;">
+&lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">A Sampled 5pc Pearl DX Series Drumkit.&lt;/p>&lt;/body>&lt;/html></info>
+  <license>GPL</license>
+  <image></image>
+  <imageLicense>undefined license</imageLicense>
+  <instrumentList>
+   <instrument>
+    <id>0</id>
+    <name>Kick</name>
+    <type>Kick</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Kick-Softest.wav</filename>
-     <min>0</min>
-     <max>0.202899</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>999</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>36</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Kick-Soft.wav</filename>
-     <min>0.202899</min>
-     <max>0.369565</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Kick-Med.wav</filename>
-     <min>0.369565</min>
-     <max>0.731884</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Kick-Hard.wav</filename>
-     <min>0.731884</min>
-     <max>0.865942</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Kick-Hardest.wav</filename>
-     <min>0.865942</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>1</id>
-   <name>Stick</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.99569</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.7</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>37</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Softest.wav</filename>
+      <min>0</min>
+      <max>0.202899</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Soft.wav</filename>
+      <min>0.202899</min>
+      <max>0.369565</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Med.wav</filename>
+      <min>0.369565</min>
+      <max>0.731884</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Hard.wav</filename>
+      <min>0.731884</min>
+      <max>0.865942</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Hardest.wav</filename>
+      <min>0.865942</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>1</id>
+    <name>Stick</name>
+    <type>Stick</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.99569</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.7</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>SideStick-Softest.wav</filename>
-     <min>0</min>
-     <max>0.188406</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>37</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SideStick-Soft.wav</filename>
-     <min>0.188406</min>
-     <max>0.402174</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SideStick-Med.wav</filename>
-     <min>0.402174</min>
-     <max>0.597826</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SideStick-Hard.wav</filename>
-     <min>0.597826</min>
-     <max>0.782609</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SideStick-Hardest.wav</filename>
-     <min>0.782609</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>2</id>
-   <name>Snare</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1.02155</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.7</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>38</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Softest.wav</filename>
+      <min>0</min>
+      <max>0.188406</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Soft.wav</filename>
+      <min>0.188406</min>
+      <max>0.402174</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Med.wav</filename>
+      <min>0.402174</min>
+      <max>0.597826</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Hard.wav</filename>
+      <min>0.597826</min>
+      <max>0.782609</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Hardest.wav</filename>
+      <min>0.782609</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>2</id>
+    <name>Snare</name>
+    <type>Snare</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1.02155</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.7</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Snare-Softest.wav</filename>
-     <min>0</min>
-     <max>0.202899</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>38</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Snare-Soft.wav</filename>
-     <min>0.202899</min>
-     <max>0.376812</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Snare-Med.wav</filename>
-     <min>0.376812</min>
-     <max>0.568841</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Snare-Hard.wav</filename>
-     <min>0.568841</min>
-     <max>0.782609</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Snare-Hardest.wav</filename>
-     <min>0.782609</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>3</id>
-   <name>Hand Clap</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1.02155</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.7</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>39</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Softest.wav</filename>
+      <min>0</min>
+      <max>0.202899</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Soft.wav</filename>
+      <min>0.202899</min>
+      <max>0.376812</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Med.wav</filename>
+      <min>0.376812</min>
+      <max>0.568841</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Hard.wav</filename>
+      <min>0.568841</min>
+      <max>0.782609</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Hardest.wav</filename>
+      <min>0.782609</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>3</id>
+    <name>Hand Clap</name>
+    <type>Hand Clap</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1.02155</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.7</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>HandClap.wav</filename>
-     <min>0</min>
-     <max>1</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>39</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>4</id>
-   <name>Snare Rimshot</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.7</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>40</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HandClap.wav</filename>
+      <min>0</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>4</id>
+    <name>Snare Rimshot</name>
+    <type>Snare Rimshot</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.7</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>SnareRimshot-Softest.wav</filename>
-     <min>0</min>
-     <max>0.188406</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>40</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SnareRimshot-Soft.wav</filename>
-     <min>0.188406</min>
-     <max>0.380435</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SnareRimshot-Med.wav</filename>
-     <min>0.380435</min>
-     <max>0.594203</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SnareRimshot-Hard.wav</filename>
-     <min>0.594203</min>
-     <max>0.728261</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>SnareRimshot-Hardest.wav</filename>
-     <min>0.728261</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>5</id>
-   <name>Floor Tom</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1.04741</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.44</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>41</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Softest.wav</filename>
+      <min>0</min>
+      <max>0.188406</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Soft.wav</filename>
+      <min>0.188406</min>
+      <max>0.380435</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Med.wav</filename>
+      <min>0.380435</min>
+      <max>0.594203</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Hard.wav</filename>
+      <min>0.594203</min>
+      <max>0.728261</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Hardest.wav</filename>
+      <min>0.728261</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>5</id>
+    <name>Floor Tom</name>
+    <type>Tom Floor</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1.04741</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.44</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>TomFloor-Softest.wav</filename>
-     <min>0</min>
-     <max>0.199275</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>41</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>TomFloor-Soft.wav</filename>
-     <min>0.199275</min>
-     <max>0.394928</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>TomFloor-Med.wav</filename>
-     <min>0.394928</min>
-     <max>0.608696</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>TomFloor-Hard.wav</filename>
-     <min>0.608696</min>
-     <max>0.786232</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>TomFloor-Hardest.wav</filename>
-     <min>0.786232</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>6</id>
-   <name>Hat Closed</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.685345</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.48</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>42</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Softest.wav</filename>
+      <min>0</min>
+      <max>0.199275</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Soft.wav</filename>
+      <min>0.199275</min>
+      <max>0.394928</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Med.wav</filename>
+      <min>0.394928</min>
+      <max>0.608696</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Hard.wav</filename>
+      <min>0.608696</min>
+      <max>0.786232</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Hardest.wav</filename>
+      <min>0.786232</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>6</id>
+    <name>Hat Closed</name>
+    <type>Hi-hat Closed</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.685345</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.48</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>HatClosed-Softest.wav</filename>
-     <min>0</min>
-     <max>0.173913</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>42</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatClosed-Soft.wav</filename>
-     <min>0.173913</min>
-     <max>0.373188</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatClosed-Med.wav</filename>
-     <min>0.373188</min>
-     <max>0.576087</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatClosed-Hard.wav</filename>
-     <min>0.576087</min>
-     <max>0.786232</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatClosed-Hardest.wav</filename>
-     <min>0.786232</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>7</id>
-   <name>Tom 2</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.76</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>43</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Softest.wav</filename>
+      <min>0</min>
+      <max>0.173913</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Soft.wav</filename>
+      <min>0.173913</min>
+      <max>0.373188</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Med.wav</filename>
+      <min>0.373188</min>
+      <max>0.576087</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Hard.wav</filename>
+      <min>0.576087</min>
+      <max>0.786232</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Hardest.wav</filename>
+      <min>0.786232</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>7</id>
+    <name>Tom 2</name>
+    <type>Tom Low</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.76</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Tom2-Softest.wav</filename>
-     <min>0</min>
-     <max>0.177536</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>43</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom2-Soft.wav</filename>
-     <min>0.177536</min>
-     <max>0.373188</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom2-Med.wav</filename>
-     <min>0.373188</min>
-     <max>0.576087</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom2-Hard.wav</filename>
-     <min>0.576087</min>
-     <max>0.782609</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom2-Hardest.wav</filename>
-     <min>0.782609</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>8</id>
-   <name>Hat Pedal</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.685345</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.48</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>44</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Softest.wav</filename>
+      <min>0</min>
+      <max>0.177536</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Soft.wav</filename>
+      <min>0.177536</min>
+      <max>0.373188</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Med.wav</filename>
+      <min>0.373188</min>
+      <max>0.576087</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Hard.wav</filename>
+      <min>0.576087</min>
+      <max>0.782609</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Hardest.wav</filename>
+      <min>0.782609</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>8</id>
+    <name>Hat Pedal</name>
+    <type>Hi-hat Pedal</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.685345</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.48</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>HatPedal-Softest.wav</filename>
-     <min>0</min>
-     <max>0.210145</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>44</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatPedal-Soft.wav</filename>
-     <min>0.210145</min>
-     <max>0.384058</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatPedal-Med.wav</filename>
-     <min>0.384058</min>
-     <max>0.594203</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatPedal-Hard.wav</filename>
-     <min>0.594203</min>
-     <max>0.797101</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatPedal-Hardest.wav</filename>
-     <min>0.797101</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>9</id>
-   <name>Tom 1</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.8</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>45</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Softest.wav</filename>
+      <min>0</min>
+      <max>0.210145</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Soft.wav</filename>
+      <min>0.210145</min>
+      <max>0.384058</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Med.wav</filename>
+      <min>0.384058</min>
+      <max>0.594203</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Hard.wav</filename>
+      <min>0.594203</min>
+      <max>0.797101</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Hardest.wav</filename>
+      <min>0.797101</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>9</id>
+    <name>Tom 1</name>
+    <type>Tom Mid</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.8</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Tom1-Softest.wav</filename>
-     <min>0</min>
-     <max>0.202899</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>45</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom1-Soft.wav</filename>
-     <min>0.202899</min>
-     <max>0.394928</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom1-Med.wav</filename>
-     <min>0.394928</min>
-     <max>0.605072</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom1-Hard.wav</filename>
-     <min>0.605072</min>
-     <max>0.786232</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Tom1-Hardest.wav</filename>
-     <min>0.786232</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>10</id>
-   <name>Hat Open</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.698276</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.48</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>46</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Softest.wav</filename>
+      <min>0</min>
+      <max>0.202899</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Soft.wav</filename>
+      <min>0.202899</min>
+      <max>0.394928</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Med.wav</filename>
+      <min>0.394928</min>
+      <max>0.605072</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Hard.wav</filename>
+      <min>0.605072</min>
+      <max>0.786232</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Hardest.wav</filename>
+      <min>0.786232</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>10</id>
+    <name>Hat Open</name>
+    <type>Hi-hat Open</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.698276</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.48</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>HatOpen-Softest.wav</filename>
-     <min>0</min>
-     <max>0.202899</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>46</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatOpen-Soft.wav</filename>
-     <min>0.202899</min>
-     <max>0.398551</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatOpen-Med.wav</filename>
-     <min>0.398551</min>
-     <max>0.605072</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatOpen-Hard.wav</filename>
-     <min>0.605072</min>
-     <max>0.797101</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatOpen-Hardest.wav</filename>
-     <min>0.797101</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>11</id>
-   <name>Cowbell</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.568965</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.32</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>56</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Softest.wav</filename>
+      <min>0</min>
+      <max>0.202899</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Soft.wav</filename>
+      <min>0.202899</min>
+      <max>0.398551</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Med.wav</filename>
+      <min>0.398551</min>
+      <max>0.605072</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Hard.wav</filename>
+      <min>0.605072</min>
+      <max>0.797101</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Hardest.wav</filename>
+      <min>0.797101</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>11</id>
+    <name>Cowbell</name>
+    <type>Cowbell</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.568965</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.32</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Cowbell-Softest.wav</filename>
-     <min>0</min>
-     <max>0.184783</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>56</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Cowbell-Soft.wav</filename>
-     <min>0.184783</min>
-     <max>0.384058</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Cowbell-Med.wav</filename>
-     <min>0.384058</min>
-     <max>0.576087</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Cowbell-Hard.wav</filename>
-     <min>0.576087</min>
-     <max>0.782609</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Cowbell-Hardest.wav</filename>
-     <min>0.782609</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>12</id>
-   <name>Ride</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.633621</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.56</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>51</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Softest.wav</filename>
+      <min>0</min>
+      <max>0.184783</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Soft.wav</filename>
+      <min>0.184783</min>
+      <max>0.384058</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Med.wav</filename>
+      <min>0.384058</min>
+      <max>0.576087</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Hard.wav</filename>
+      <min>0.576087</min>
+      <max>0.782609</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Hardest.wav</filename>
+      <min>0.782609</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>12</id>
+    <name>Ride</name>
+    <type>Ride Bow</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.633621</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.56</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Ride-Softest.wav</filename>
-     <min>0</min>
-     <max>0.195652</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>51</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Ride-Soft.wav</filename>
-     <min>0.195652</min>
-     <max>0.376812</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Ride-Med.wav</filename>
-     <min>0.376812</min>
-     <max>0.572464</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Ride-Hard.wav</filename>
-     <min>0.572464</min>
-     <max>0.782609</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Ride-Hardest.wav</filename>
-     <min>0.782609</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>13</id>
-   <name>Crash</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.517241</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.74</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>49</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Softest.wav</filename>
+      <min>0</min>
+      <max>0.195652</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Soft.wav</filename>
+      <min>0.195652</min>
+      <max>0.376812</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Med.wav</filename>
+      <min>0.376812</min>
+      <max>0.572464</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Hard.wav</filename>
+      <min>0.572464</min>
+      <max>0.782609</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Hardest.wav</filename>
+      <min>0.782609</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>13</id>
+    <name>Crash</name>
+    <type>Crash</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.517241</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.74</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Crash-Softest.wav</filename>
-     <min>0</min>
-     <max>0.199275</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>49</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Crash-Soft.wav</filename>
-     <min>0.199275</min>
-     <max>0.384058</max>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Softest.wav</filename>
+      <min>0</min>
+      <max>0.199275</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Soft.wav</filename>
+      <min>0.199275</min>
+      <max>0.384058</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Med.wav</filename>
+      <min>0.384058</min>
+      <max>0.59058</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Hard.wav</filename>
+      <min>0.59058</min>
+      <max>0.789855</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Hardest.wav</filename>
+      <min>0.789855</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>14</id>
+    <name>Ride 2</name>
+    <type>Ride Bow 2</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>1</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.5</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
+    <gain>0.6</gain>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>59</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Crash-Med.wav</filename>
-     <min>0.384058</min>
-     <max>0.59058</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Crash-Hard.wav</filename>
-     <min>0.59058</min>
-     <max>0.789855</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Crash-Hardest.wav</filename>
-     <min>0.789855</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>14</id>
-   <name>Ride 2</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>1</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.5</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>0.6</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>59</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-5.wav</filename>
+      <min>0.8</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-4.wav</filename>
+      <min>0.6</min>
+      <max>0.8</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-3.wav</filename>
+      <min>0.4</min>
+      <max>0.6</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-2.wav</filename>
+      <min>0.2</min>
+      <max>0.4</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-1.wav</filename>
+      <min>0</min>
+      <max>0.2</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>15</id>
+    <name>Splash</name>
+    <type>Splash</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.543103</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.98</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>24Ride-5.wav</filename>
-     <min>0.8</min>
-     <max>1</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>57</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>24Ride-4.wav</filename>
-     <min>0.6</min>
-     <max>0.8</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>24Ride-3.wav</filename>
-     <min>0.4</min>
-     <max>0.6</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>24Ride-2.wav</filename>
-     <min>0.2</min>
-     <max>0.4</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>24Ride-1.wav</filename>
-     <min>0</min>
-     <max>0.2</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>15</id>
-   <name>Splash</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.543103</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.98</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>57</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Softest.wav</filename>
+      <min>0</min>
+      <max>0.195652</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Soft.wav</filename>
+      <min>0.195652</min>
+      <max>0.362319</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Med.wav</filename>
+      <min>0.362319</min>
+      <max>0.568841</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Hard.wav</filename>
+      <min>0.568841</min>
+      <max>0.75</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Hardest.wav</filename>
+      <min>0.75</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>16</id>
+    <name>Hat Semi-Open</name>
+    <type>Hi-hat Semi-Open</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.69</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>1</pan_L>
+    <pan_R>0.48</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>Splash-Softest.wav</filename>
-     <min>0</min>
-     <max>0.195652</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>82</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Splash-Soft.wav</filename>
-     <min>0.195652</min>
-     <max>0.362319</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Splash-Med.wav</filename>
-     <min>0.362319</min>
-     <max>0.568841</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Splash-Hard.wav</filename>
-     <min>0.568841</min>
-     <max>0.75</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Splash-Hardest.wav</filename>
-     <min>0.75</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>16</id>
-   <name>Hat Semi-Open</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.69</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>1</pan_L>
-   <pan_R>0.48</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>82</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Softest.wav</filename>
+      <min>0</min>
+      <max>0.188406</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Soft.wav</filename>
+      <min>0.188406</min>
+      <max>0.380435</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Med.wav</filename>
+      <min>0.380435</min>
+      <max>0.57971</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Hard.wav</filename>
+      <min>0.57971</min>
+      <max>0.782609</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Hardest.wav</filename>
+      <min>0.782609</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+   <instrument>
+    <id>17</id>
+    <name>Bell</name>
+    <type>Ride Bell</type>
+    <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
+    <drumkit>GMRockKit</drumkit>
+    <volume>0.534828</volume>
+    <isMuted>false</isMuted>
+    <isSoloed>false</isSoloed>
+    <pan_L>0.56</pan_L>
+    <pan_R>1</pan_R>
+    <pitchOffset>0</pitchOffset>
+    <randomPitchFactor>0</randomPitchFactor>
     <gain>1</gain>
-    <layer>
-     <filename>HatSemiOpen-Softest.wav</filename>
-     <min>0</min>
-     <max>0.188406</max>
+    <applyVelocity>true</applyVelocity>
+    <filterActive>false</filterActive>
+    <filterCutoff>1</filterCutoff>
+    <filterResonance>0</filterResonance>
+    <Attack>0</Attack>
+    <Decay>0</Decay>
+    <Sustain>1</Sustain>
+    <Release>1000</Release>
+    <muteGroup>-1</muteGroup>
+    <midiOutChannel>-1</midiOutChannel>
+    <midiOutNote>81</midiOutNote>
+    <isStopNote>false</isStopNote>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
+    <isHihat>-1</isHihat>
+    <lower_cc>0</lower_cc>
+    <higher_cc>127</higher_cc>
+    <FX1Level>0</FX1Level>
+    <FX2Level>0</FX2Level>
+    <FX3Level>0</FX3Level>
+    <FX4Level>0</FX4Level>
+    <instrumentComponent>
+     <name>Main</name>
      <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatSemiOpen-Soft.wav</filename>
-     <min>0.188406</min>
-     <max>0.380435</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatSemiOpen-Med.wav</filename>
-     <min>0.380435</min>
-     <max>0.57971</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatSemiOpen-Hard.wav</filename>
-     <min>0.57971</min>
-     <max>0.782609</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>HatSemiOpen-Hardest.wav</filename>
-     <min>0.782609</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
-  <instrument>
-   <id>17</id>
-   <name>Bell</name>
-   <drumkitPath>/usr/local/share/hydrogen/data/drumkits/GMRockKit</drumkitPath>
-   <drumkit>GMRockKit</drumkit>
-   <volume>0.534828</volume>
-   <isMuted>false</isMuted>
-   <isSoloed>false</isSoloed>
-   <pan_L>0.56</pan_L>
-   <pan_R>1</pan_R>
-   <pitchOffset>0</pitchOffset>
-   <randomPitchFactor>0</randomPitchFactor>
-   <gain>1</gain>
-   <applyVelocity>true</applyVelocity>
-   <filterActive>false</filterActive>
-   <filterCutoff>1</filterCutoff>
-   <filterResonance>0</filterResonance>
-   <Attack>0</Attack>
-   <Decay>0</Decay>
-   <Sustain>1</Sustain>
-   <Release>1000</Release>
-   <muteGroup>-1</muteGroup>
-   <midiOutChannel>-1</midiOutChannel>
-   <midiOutNote>81</midiOutNote>
-   <isStopNote>false</isStopNote>
-   <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
-   <isHihat>-1</isHihat>
-   <lower_cc>0</lower_cc>
-   <higher_cc>127</higher_cc>
-   <FX1Level>0</FX1Level>
-   <FX2Level>0</FX2Level>
-   <FX3Level>0</FX3Level>
-   <FX4Level>0</FX4Level>
-   <instrumentComponent>
-    <component_id>0</component_id>
-    <gain>1</gain>
-    <layer>
-     <filename>Bell-Softest.wav</filename>
-     <min>0</min>
-     <max>0.210145</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Bell-Soft.wav</filename>
-     <min>0.210145</min>
-     <max>0.405797</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Bell-Med.wav</filename>
-     <min>0.405797</min>
-     <max>0.605072</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Bell-Hard.wav</filename>
-     <min>0.605072</min>
-     <max>0.786232</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-    <layer>
-     <filename>Bell-Hardest.wav</filename>
-     <min>0.786232</min>
-     <max>1</max>
-     <gain>1</gain>
-     <pitch>0</pitch>
-     <ismodified>false</ismodified>
-     <smode>forward</smode>
-     <startframe>0</startframe>
-     <loopframe>0</loopframe>
-     <loops>0</loops>
-     <endframe>0</endframe>
-     <userubber>0</userubber>
-     <rubberdivider>1</rubberdivider>
-     <rubberCsettings>4</rubberCsettings>
-     <rubberPitch>1</rubberPitch>
-    </layer>
-   </instrumentComponent>
-  </instrument>
- </instrumentList>
+     <isMuted>false</isMuted>
+     <isSoloed>false</isSoloed>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Softest.wav</filename>
+      <min>0</min>
+      <max>0.210145</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Soft.wav</filename>
+      <min>0.210145</min>
+      <max>0.405797</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Med.wav</filename>
+      <min>0.405797</min>
+      <max>0.605072</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Hard.wav</filename>
+      <min>0.605072</min>
+      <max>0.786232</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+     <layer>
+      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Hardest.wav</filename>
+      <min>0.786232</min>
+      <max>1</max>
+      <gain>1</gain>
+      <pitch>0</pitch>
+      <isMuted>false</isMuted>
+      <isSoloed>false</isSoloed>
+      <ismodified>false</ismodified>
+      <smode>forward</smode>
+      <startframe>0</startframe>
+      <loopframe>0</loopframe>
+      <loops>0</loops>
+      <endframe>0</endframe>
+      <userubber>0</userubber>
+      <rubberdivider>1</rubberdivider>
+      <rubberCsettings>4</rubberCsettings>
+      <rubberPitch>1</rubberPitch>
+     </layer>
+    </instrumentComponent>
+   </instrument>
+  </instrumentList>
+ </drumkit_info>
+ <lastLoadedDrumkitPath></lastLoadedDrumkitPath>
  <patternList>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Crash</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>48</size>
    <denominator>4</denominator>
@@ -2196,14 +2435,19 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>13</instrument>
+     <type>Crash</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
    </noteList>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Ride</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>432</size>
    <denominator>4</denominator>
@@ -2217,6 +2461,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>14</instrument>
+     <type>Ride Bow 2</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2229,14 +2474,19 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>12</instrument>
+     <type>Ride Bow</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
    </noteList>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Toms 1</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
@@ -2250,6 +2500,7 @@
      <key>C2</key>
      <length>-1</length>
      <instrument>9</instrument>
+     <type>Tom Mid</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2262,6 +2513,7 @@
      <key>C1</key>
      <length>-1</length>
      <instrument>9</instrument>
+     <type>Tom Mid</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2274,6 +2526,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>9</instrument>
+     <type>Tom Mid</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2286,14 +2539,19 @@
      <key>C-1</key>
      <length>-1</length>
      <instrument>9</instrument>
+     <type>Tom Mid</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
    </noteList>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Toms 2</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
@@ -2307,6 +2565,7 @@
      <key>C2</key>
      <length>-1</length>
      <instrument>7</instrument>
+     <type>Tom Low</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2319,6 +2578,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2331,6 +2591,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2343,6 +2604,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2355,6 +2617,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2367,6 +2630,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2379,6 +2643,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2391,6 +2656,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2403,6 +2669,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2415,6 +2682,7 @@
      <key>C1</key>
      <length>-1</length>
      <instrument>7</instrument>
+     <type>Tom Low</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2427,6 +2695,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2439,6 +2708,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2451,6 +2721,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2463,6 +2734,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2475,6 +2747,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2487,6 +2760,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2499,6 +2773,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2511,6 +2786,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2523,6 +2799,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>7</instrument>
+     <type>Tom Low</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2535,6 +2812,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2547,6 +2825,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2559,6 +2838,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2571,6 +2851,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2583,6 +2864,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2595,6 +2877,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2607,6 +2890,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2619,6 +2903,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2631,6 +2916,7 @@
      <key>C-1</key>
      <length>-1</length>
      <instrument>7</instrument>
+     <type>Tom Low</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2643,6 +2929,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2655,6 +2942,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2667,6 +2955,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2679,6 +2968,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2691,6 +2981,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2703,6 +2994,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2715,6 +3007,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2727,14 +3020,19 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
    </noteList>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Kick &amp; Snare</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>96</size>
    <denominator>4</denominator>
@@ -2748,6 +3046,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>0</instrument>
+     <type>Kick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2760,6 +3059,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>3</instrument>
+     <type>Hand Clap</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2772,6 +3072,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>4</instrument>
+     <type>Snare Rimshot</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2784,6 +3085,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>17</instrument>
+     <type>Ride Bell</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2796,6 +3098,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>15</instrument>
+     <type>Splash</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2808,6 +3111,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>11</instrument>
+     <type>Cowbell</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2820,6 +3124,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>8</instrument>
+     <type>Hi-hat Pedal</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2832,6 +3137,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>2</instrument>
+     <type>Snare</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2844,14 +3150,19 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>1</instrument>
+     <type>Stick</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
    </noteList>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Hat</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
@@ -2865,6 +3176,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>10</instrument>
+     <type>Hi-hat Open</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2877,6 +3189,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>8</instrument>
+     <type>Hi-hat Pedal</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2889,6 +3202,7 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>6</instrument>
+     <type>Hi-hat Closed</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
@@ -2901,45 +3215,106 @@
      <key>C0</key>
      <length>-1</length>
      <instrument>16</instrument>
+     <type>Hi-hat Semi-Open</type>
      <note_off>false</note_off>
      <probability>1</probability>
     </note>
    </noteList>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
+   <name>Ride Copy</name>
+   <author></author>
+   <info></info>
+   <license>undefined license</license>
+   <category>not_categorized</category>
+   <size>432</size>
+   <denominator>4</denominator>
+   <noteList>
+    <note>
+     <position>0</position>
+     <leadlag>0</leadlag>
+     <velocity>0.8</velocity>
+     <pan>0</pan>
+     <pitch>0</pitch>
+     <key>C0</key>
+     <length>-1</length>
+     <instrument>14</instrument>
+     <type>Ride Bow 2</type>
+     <note_off>false</note_off>
+     <probability>1</probability>
+    </note>
+    <note>
+     <position>96</position>
+     <leadlag>0</leadlag>
+     <velocity>0.8</velocity>
+     <pan>0</pan>
+     <pitch>0</pitch>
+     <key>C0</key>
+     <length>-1</length>
+     <instrument>12</instrument>
+     <type>Ride Bow</type>
+     <note_off>false</note_off>
+     <probability>1</probability>
+    </note>
+   </noteList>
+  </pattern>
+  <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Pattern 7</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
    <noteList/>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Pattern 8</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
    <noteList/>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Pattern 9</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
    <noteList/>
   </pattern>
   <pattern>
+   <formatVersion>2</formatVersion>
+   <userVersion>0</userVersion>
    <name>Pattern 10</name>
+   <author></author>
    <info></info>
+   <license>undefined license</license>
    <category>not_categorized</category>
    <size>192</size>
    <denominator>4</denominator>
    <noteList/>
   </pattern>
  </patternList>
- <virtualPatternList/>
+ <virtualPatternList>
+  <pattern>
+   <name>Ride</name>
+   <virtual>Ride Copy</virtual>
+  </pattern>
+ </virtualPatternList>
  <patternSequence>
   <group>
    <patternID>Crash</patternID>

--- a/src/tests/data/song/AE_noteEnqueuing.h2song
+++ b/src/tests/data/song/AE_noteEnqueuing.h2song
@@ -79,7 +79,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Softest.wav</filename>
+      <filename>Kick-Softest.wav</filename>
       <min>0</min>
       <max>0.202899</max>
       <gain>1</gain>
@@ -98,7 +98,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Soft.wav</filename>
+      <filename>Kick-Soft.wav</filename>
       <min>0.202899</min>
       <max>0.369565</max>
       <gain>1</gain>
@@ -117,7 +117,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Med.wav</filename>
+      <filename>Kick-Med.wav</filename>
       <min>0.369565</min>
       <max>0.731884</max>
       <gain>1</gain>
@@ -136,7 +136,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Hard.wav</filename>
+      <filename>Kick-Hard.wav</filename>
       <min>0.731884</min>
       <max>0.865942</max>
       <gain>1</gain>
@@ -155,7 +155,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Kick-Hardest.wav</filename>
+      <filename>Kick-Hardest.wav</filename>
       <min>0.865942</min>
       <max>1</max>
       <gain>1</gain>
@@ -215,7 +215,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Softest.wav</filename>
+      <filename>SideStick-Softest.wav</filename>
       <min>0</min>
       <max>0.188406</max>
       <gain>1</gain>
@@ -234,7 +234,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Soft.wav</filename>
+      <filename>SideStick-Soft.wav</filename>
       <min>0.188406</min>
       <max>0.402174</max>
       <gain>1</gain>
@@ -253,7 +253,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Med.wav</filename>
+      <filename>SideStick-Med.wav</filename>
       <min>0.402174</min>
       <max>0.597826</max>
       <gain>1</gain>
@@ -272,7 +272,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Hard.wav</filename>
+      <filename>SideStick-Hard.wav</filename>
       <min>0.597826</min>
       <max>0.782609</max>
       <gain>1</gain>
@@ -291,7 +291,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SideStick-Hardest.wav</filename>
+      <filename>SideStick-Hardest.wav</filename>
       <min>0.782609</min>
       <max>1</max>
       <gain>1</gain>
@@ -351,7 +351,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Softest.wav</filename>
+      <filename>Snare-Softest.wav</filename>
       <min>0</min>
       <max>0.202899</max>
       <gain>1</gain>
@@ -370,7 +370,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Soft.wav</filename>
+      <filename>Snare-Soft.wav</filename>
       <min>0.202899</min>
       <max>0.376812</max>
       <gain>1</gain>
@@ -389,7 +389,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Med.wav</filename>
+      <filename>Snare-Med.wav</filename>
       <min>0.376812</min>
       <max>0.568841</max>
       <gain>1</gain>
@@ -408,7 +408,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Hard.wav</filename>
+      <filename>Snare-Hard.wav</filename>
       <min>0.568841</min>
       <max>0.782609</max>
       <gain>1</gain>
@@ -427,7 +427,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Snare-Hardest.wav</filename>
+      <filename>Snare-Hardest.wav</filename>
       <min>0.782609</min>
       <max>1</max>
       <gain>1</gain>
@@ -487,7 +487,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HandClap.wav</filename>
+      <filename>HandClap.wav</filename>
       <min>0</min>
       <max>1</max>
       <gain>1</gain>
@@ -547,7 +547,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Softest.wav</filename>
+      <filename>SnareRimshot-Softest.wav</filename>
       <min>0</min>
       <max>0.188406</max>
       <gain>1</gain>
@@ -566,7 +566,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Soft.wav</filename>
+      <filename>SnareRimshot-Soft.wav</filename>
       <min>0.188406</min>
       <max>0.380435</max>
       <gain>1</gain>
@@ -585,7 +585,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Med.wav</filename>
+      <filename>SnareRimshot-Med.wav</filename>
       <min>0.380435</min>
       <max>0.594203</max>
       <gain>1</gain>
@@ -604,7 +604,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Hard.wav</filename>
+      <filename>SnareRimshot-Hard.wav</filename>
       <min>0.594203</min>
       <max>0.728261</max>
       <gain>1</gain>
@@ -623,7 +623,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/SnareRimshot-Hardest.wav</filename>
+      <filename>SnareRimshot-Hardest.wav</filename>
       <min>0.728261</min>
       <max>1</max>
       <gain>1</gain>
@@ -683,7 +683,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Softest.wav</filename>
+      <filename>TomFloor-Softest.wav</filename>
       <min>0</min>
       <max>0.199275</max>
       <gain>1</gain>
@@ -702,7 +702,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Soft.wav</filename>
+      <filename>TomFloor-Soft.wav</filename>
       <min>0.199275</min>
       <max>0.394928</max>
       <gain>1</gain>
@@ -721,7 +721,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Med.wav</filename>
+      <filename>TomFloor-Med.wav</filename>
       <min>0.394928</min>
       <max>0.608696</max>
       <gain>1</gain>
@@ -740,7 +740,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Hard.wav</filename>
+      <filename>TomFloor-Hard.wav</filename>
       <min>0.608696</min>
       <max>0.786232</max>
       <gain>1</gain>
@@ -759,7 +759,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/TomFloor-Hardest.wav</filename>
+      <filename>TomFloor-Hardest.wav</filename>
       <min>0.786232</min>
       <max>1</max>
       <gain>1</gain>
@@ -819,7 +819,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Softest.wav</filename>
+      <filename>HatClosed-Softest.wav</filename>
       <min>0</min>
       <max>0.173913</max>
       <gain>1</gain>
@@ -838,7 +838,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Soft.wav</filename>
+      <filename>HatClosed-Soft.wav</filename>
       <min>0.173913</min>
       <max>0.373188</max>
       <gain>1</gain>
@@ -857,7 +857,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Med.wav</filename>
+      <filename>HatClosed-Med.wav</filename>
       <min>0.373188</min>
       <max>0.576087</max>
       <gain>1</gain>
@@ -876,7 +876,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Hard.wav</filename>
+      <filename>HatClosed-Hard.wav</filename>
       <min>0.576087</min>
       <max>0.786232</max>
       <gain>1</gain>
@@ -895,7 +895,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatClosed-Hardest.wav</filename>
+      <filename>HatClosed-Hardest.wav</filename>
       <min>0.786232</min>
       <max>1</max>
       <gain>1</gain>
@@ -955,7 +955,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Softest.wav</filename>
+      <filename>Tom2-Softest.wav</filename>
       <min>0</min>
       <max>0.177536</max>
       <gain>1</gain>
@@ -974,7 +974,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Soft.wav</filename>
+      <filename>Tom2-Soft.wav</filename>
       <min>0.177536</min>
       <max>0.373188</max>
       <gain>1</gain>
@@ -993,7 +993,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Med.wav</filename>
+      <filename>Tom2-Med.wav</filename>
       <min>0.373188</min>
       <max>0.576087</max>
       <gain>1</gain>
@@ -1012,7 +1012,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Hard.wav</filename>
+      <filename>Tom2-Hard.wav</filename>
       <min>0.576087</min>
       <max>0.782609</max>
       <gain>1</gain>
@@ -1031,7 +1031,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom2-Hardest.wav</filename>
+      <filename>Tom2-Hardest.wav</filename>
       <min>0.782609</min>
       <max>1</max>
       <gain>1</gain>
@@ -1091,7 +1091,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Softest.wav</filename>
+      <filename>HatPedal-Softest.wav</filename>
       <min>0</min>
       <max>0.210145</max>
       <gain>1</gain>
@@ -1110,7 +1110,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Soft.wav</filename>
+      <filename>HatPedal-Soft.wav</filename>
       <min>0.210145</min>
       <max>0.384058</max>
       <gain>1</gain>
@@ -1129,7 +1129,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Med.wav</filename>
+      <filename>HatPedal-Med.wav</filename>
       <min>0.384058</min>
       <max>0.594203</max>
       <gain>1</gain>
@@ -1148,7 +1148,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Hard.wav</filename>
+      <filename>HatPedal-Hard.wav</filename>
       <min>0.594203</min>
       <max>0.797101</max>
       <gain>1</gain>
@@ -1167,7 +1167,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatPedal-Hardest.wav</filename>
+      <filename>HatPedal-Hardest.wav</filename>
       <min>0.797101</min>
       <max>1</max>
       <gain>1</gain>
@@ -1227,7 +1227,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Softest.wav</filename>
+      <filename>Tom1-Softest.wav</filename>
       <min>0</min>
       <max>0.202899</max>
       <gain>1</gain>
@@ -1246,7 +1246,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Soft.wav</filename>
+      <filename>Tom1-Soft.wav</filename>
       <min>0.202899</min>
       <max>0.394928</max>
       <gain>1</gain>
@@ -1265,7 +1265,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Med.wav</filename>
+      <filename>Tom1-Med.wav</filename>
       <min>0.394928</min>
       <max>0.605072</max>
       <gain>1</gain>
@@ -1284,7 +1284,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Hard.wav</filename>
+      <filename>Tom1-Hard.wav</filename>
       <min>0.605072</min>
       <max>0.786232</max>
       <gain>1</gain>
@@ -1303,7 +1303,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Tom1-Hardest.wav</filename>
+      <filename>Tom1-Hardest.wav</filename>
       <min>0.786232</min>
       <max>1</max>
       <gain>1</gain>
@@ -1363,7 +1363,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Softest.wav</filename>
+      <filename>HatOpen-Softest.wav</filename>
       <min>0</min>
       <max>0.202899</max>
       <gain>1</gain>
@@ -1382,7 +1382,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Soft.wav</filename>
+      <filename>HatOpen-Soft.wav</filename>
       <min>0.202899</min>
       <max>0.398551</max>
       <gain>1</gain>
@@ -1401,7 +1401,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Med.wav</filename>
+      <filename>HatOpen-Med.wav</filename>
       <min>0.398551</min>
       <max>0.605072</max>
       <gain>1</gain>
@@ -1420,7 +1420,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Hard.wav</filename>
+      <filename>HatOpen-Hard.wav</filename>
       <min>0.605072</min>
       <max>0.797101</max>
       <gain>1</gain>
@@ -1439,7 +1439,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatOpen-Hardest.wav</filename>
+      <filename>HatOpen-Hardest.wav</filename>
       <min>0.797101</min>
       <max>1</max>
       <gain>1</gain>
@@ -1499,7 +1499,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Softest.wav</filename>
+      <filename>Cowbell-Softest.wav</filename>
       <min>0</min>
       <max>0.184783</max>
       <gain>1</gain>
@@ -1518,7 +1518,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Soft.wav</filename>
+      <filename>Cowbell-Soft.wav</filename>
       <min>0.184783</min>
       <max>0.384058</max>
       <gain>1</gain>
@@ -1537,7 +1537,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Med.wav</filename>
+      <filename>Cowbell-Med.wav</filename>
       <min>0.384058</min>
       <max>0.576087</max>
       <gain>1</gain>
@@ -1556,7 +1556,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Hard.wav</filename>
+      <filename>Cowbell-Hard.wav</filename>
       <min>0.576087</min>
       <max>0.782609</max>
       <gain>1</gain>
@@ -1575,7 +1575,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Cowbell-Hardest.wav</filename>
+      <filename>Cowbell-Hardest.wav</filename>
       <min>0.782609</min>
       <max>1</max>
       <gain>1</gain>
@@ -1635,7 +1635,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Softest.wav</filename>
+      <filename>Ride-Softest.wav</filename>
       <min>0</min>
       <max>0.195652</max>
       <gain>1</gain>
@@ -1654,7 +1654,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Soft.wav</filename>
+      <filename>Ride-Soft.wav</filename>
       <min>0.195652</min>
       <max>0.376812</max>
       <gain>1</gain>
@@ -1673,7 +1673,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Med.wav</filename>
+      <filename>Ride-Med.wav</filename>
       <min>0.376812</min>
       <max>0.572464</max>
       <gain>1</gain>
@@ -1692,7 +1692,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Hard.wav</filename>
+      <filename>Ride-Hard.wav</filename>
       <min>0.572464</min>
       <max>0.782609</max>
       <gain>1</gain>
@@ -1711,7 +1711,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Ride-Hardest.wav</filename>
+      <filename>Ride-Hardest.wav</filename>
       <min>0.782609</min>
       <max>1</max>
       <gain>1</gain>
@@ -1771,7 +1771,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Softest.wav</filename>
+      <filename>Crash-Softest.wav</filename>
       <min>0</min>
       <max>0.199275</max>
       <gain>1</gain>
@@ -1790,7 +1790,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Soft.wav</filename>
+      <filename>Crash-Soft.wav</filename>
       <min>0.199275</min>
       <max>0.384058</max>
       <gain>1</gain>
@@ -1809,7 +1809,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Med.wav</filename>
+      <filename>Crash-Med.wav</filename>
       <min>0.384058</min>
       <max>0.59058</max>
       <gain>1</gain>
@@ -1828,7 +1828,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Hard.wav</filename>
+      <filename>Crash-Hard.wav</filename>
       <min>0.59058</min>
       <max>0.789855</max>
       <gain>1</gain>
@@ -1847,7 +1847,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Crash-Hardest.wav</filename>
+      <filename>Crash-Hardest.wav</filename>
       <min>0.789855</min>
       <max>1</max>
       <gain>1</gain>
@@ -1907,7 +1907,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-5.wav</filename>
+      <filename>24Ride-5.wav</filename>
       <min>0.8</min>
       <max>1</max>
       <gain>1</gain>
@@ -1926,7 +1926,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-4.wav</filename>
+      <filename>24Ride-4.wav</filename>
       <min>0.6</min>
       <max>0.8</max>
       <gain>1</gain>
@@ -1945,7 +1945,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-3.wav</filename>
+      <filename>24Ride-3.wav</filename>
       <min>0.4</min>
       <max>0.6</max>
       <gain>1</gain>
@@ -1964,7 +1964,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-2.wav</filename>
+      <filename>24Ride-2.wav</filename>
       <min>0.2</min>
       <max>0.4</max>
       <gain>1</gain>
@@ -1983,7 +1983,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/24Ride-1.wav</filename>
+      <filename>24Ride-1.wav</filename>
       <min>0</min>
       <max>0.2</max>
       <gain>1</gain>
@@ -2043,7 +2043,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Softest.wav</filename>
+      <filename>Splash-Softest.wav</filename>
       <min>0</min>
       <max>0.195652</max>
       <gain>1</gain>
@@ -2062,7 +2062,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Soft.wav</filename>
+      <filename>Splash-Soft.wav</filename>
       <min>0.195652</min>
       <max>0.362319</max>
       <gain>1</gain>
@@ -2081,7 +2081,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Med.wav</filename>
+      <filename>Splash-Med.wav</filename>
       <min>0.362319</min>
       <max>0.568841</max>
       <gain>1</gain>
@@ -2100,7 +2100,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Hard.wav</filename>
+      <filename>Splash-Hard.wav</filename>
       <min>0.568841</min>
       <max>0.75</max>
       <gain>1</gain>
@@ -2119,7 +2119,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Splash-Hardest.wav</filename>
+      <filename>Splash-Hardest.wav</filename>
       <min>0.75</min>
       <max>1</max>
       <gain>1</gain>
@@ -2179,7 +2179,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Softest.wav</filename>
+      <filename>HatSemiOpen-Softest.wav</filename>
       <min>0</min>
       <max>0.188406</max>
       <gain>1</gain>
@@ -2198,7 +2198,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Soft.wav</filename>
+      <filename>HatSemiOpen-Soft.wav</filename>
       <min>0.188406</min>
       <max>0.380435</max>
       <gain>1</gain>
@@ -2217,7 +2217,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Med.wav</filename>
+      <filename>HatSemiOpen-Med.wav</filename>
       <min>0.380435</min>
       <max>0.57971</max>
       <gain>1</gain>
@@ -2236,7 +2236,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Hard.wav</filename>
+      <filename>HatSemiOpen-Hard.wav</filename>
       <min>0.57971</min>
       <max>0.782609</max>
       <gain>1</gain>
@@ -2255,7 +2255,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/HatSemiOpen-Hardest.wav</filename>
+      <filename>HatSemiOpen-Hardest.wav</filename>
       <min>0.782609</min>
       <max>1</max>
       <gain>1</gain>
@@ -2315,7 +2315,7 @@ p, li { white-space: pre-wrap; }
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Softest.wav</filename>
+      <filename>Bell-Softest.wav</filename>
       <min>0</min>
       <max>0.210145</max>
       <gain>1</gain>
@@ -2334,7 +2334,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Soft.wav</filename>
+      <filename>Bell-Soft.wav</filename>
       <min>0.210145</min>
       <max>0.405797</max>
       <gain>1</gain>
@@ -2353,7 +2353,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Med.wav</filename>
+      <filename>Bell-Med.wav</filename>
       <min>0.405797</min>
       <max>0.605072</max>
       <gain>1</gain>
@@ -2372,7 +2372,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Hard.wav</filename>
+      <filename>Bell-Hard.wav</filename>
       <min>0.605072</min>
       <max>0.786232</max>
       <gain>1</gain>
@@ -2391,7 +2391,7 @@ p, li { white-space: pre-wrap; }
       <rubberPitch>1</rubberPitch>
      </layer>
      <layer>
-      <filename>/usr/local/share/hydrogen/data/drumkits/GMRockKit/Bell-Hardest.wav</filename>
+      <filename>Bell-Hardest.wav</filename>
       <min>0.786232</min>
       <max>1</max>
       <gain>1</gain>

--- a/src/tests/data/song/AE_sampleConsistency.h2song
+++ b/src/tests/data/song/AE_sampleConsistency.h2song
@@ -69,7 +69,7 @@
     <component_id>0</component_id>
     <gain>1</gain>
     <layer>
-     <filename>/home/phil/git/hydrogen/src/tests/data/song/res/playbackTrack.flac</filename>
+     <filename>./res/playbackTrack.flac</filename>
      <min>0</min>
      <max>1</max>
      <gain>1</gain>


### PR DESCRIPTION
previously, when exporting into separate tracks Hydrogen did just check whether there is a note corresponding to a given instrument. However, it did checked _all_ patterns, regardless of whether they are actually played back in the song or not.

Now, we will only check those notes played back and avoid empty tracks being exported.