### PR TITLE
ExportSongDialog: export names (#2096)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Show the Crash Reporter and exit with return code `1` on unhandled
 			exceptions.
 		- Fix crashes in SampleEditor (#2092).
+		- Fix track names in multi track export. When using just the file extension,
+			the raw instrument names will be used (#2096).
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -137,7 +137,7 @@ std::vector<Filesystem::AudioFormat> Filesystem::m_supportedAudioFormats = {
 	AudioFormat::W64
 };
 
-QString Filesystem::AudioFormatToSuffix( const AudioFormat& format ) {
+QString Filesystem::AudioFormatToSuffix( const AudioFormat& format, bool bSilent ) {
 	switch( format ) {
 		case AudioFormat::Aif:
 		case AudioFormat::Aifc:
@@ -163,12 +163,15 @@ QString Filesystem::AudioFormatToSuffix( const AudioFormat& format ) {
 			return "wav";
 		case AudioFormat::Unknown:
 		default:
-			ERRORLOG( "Unknown audio format" );
+			if ( ! bSilent ) {
+				ERRORLOG( "Unknown audio format" );
+			}
 			return "";
 	}
 }
 
-Filesystem::AudioFormat Filesystem::AudioFormatFromSuffix( const QString& sPath ) {
+Filesystem::AudioFormat Filesystem::AudioFormatFromSuffix( const QString& sPath,
+														   bool bSilent ) {
 	const QString sPathLower = sPath.toLower();
 	if ( sPathLower.endsWith( "aiff" ) ) {
 		return AudioFormat::Aif;
@@ -200,7 +203,9 @@ Filesystem::AudioFormat Filesystem::AudioFormatFromSuffix( const QString& sPath 
 	else if ( sPathLower.endsWith( "wav" ) ) {
 		return AudioFormat::Wav;
 	} else {
-		ERRORLOG( QString( "Unknown suffix in [%1]" ).arg( sPath ) );
+		if ( ! bSilent ) {
+			ERRORLOG( QString( "Unknown suffix in [%1]" ).arg( sPath ) );
+		}
 		return AudioFormat::Unknown;
 	}
 }

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -106,10 +106,12 @@ namespace H2Core
 			};
 			/** Converts @a format to the default lower case suffix of the
 			 * format. */
-			static QString AudioFormatToSuffix( const AudioFormat& format );
+			static QString AudioFormatToSuffix( const AudioFormat& format,
+												bool bSilent = false  );
 			/** Determines the audio format of the provided filename or path
 			 * based on its suffix. */
-			static AudioFormat AudioFormatFromSuffix( const QString& sFile );
+			static AudioFormat AudioFormatFromSuffix( const QString& sFile,
+													  bool bSilent = false );
 
 
 		static const QString songs_ext;

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -612,22 +612,37 @@ void ExportSongDialog::exportTracks()
 			}
 		}
 
-		QStringList filenameList =  exportNameTxt->text().split( m_sExtension );
-
-		QString firstItem;
-		if( !filenameList.isEmpty() ){
-			firstItem = filenameList.first();
+		// Ensure we use the right extension.
+		const QString sSuffix = QString( ".%1" ).arg( m_sExtension );
+		const QString sTemplateName = exportNameTxt->text();
+		QString sBaseName = sTemplateName;
+		if ( sTemplateName.endsWith( sSuffix, Qt::CaseInsensitive ) ) {
+			sBaseName.chop( sSuffix.size() );
 		}
-		const QString sFilename = QString( "%1-%2.%3" ).arg( firstItem )
-			.arg( findUniqueExportFilenameForInstrument(
-					  pInstrumentList->get( m_nInstrument ) ) )
-			.arg( m_sExtension );
 
-		if ( QFile( sFilename ).exists() == true && m_bQfileDialog == false &&
+		const QString sInstrumentName = findUniqueExportFilenameForInstrument(
+			pInstrumentList->get( m_nInstrument ) );
+		QString sExportName;
+		if ( sBaseName.isEmpty() || sBaseName.endsWith( "/" ) ||
+			 sBaseName.endsWith( "\\" ) ) {
+			// Allow to use just the instrument names when leaving the song name
+			// blank.
+			sExportName = QString( "%1%2" ).arg( sBaseName )
+				.arg( sInstrumentName );
+		}
+		else {
+			sExportName = QString( "%1-%2" ).arg( sBaseName )
+				.arg( sInstrumentName );
+		}
+
+		const QString sFileName = QString( "%1%2" ).arg( sExportName )
+			.arg( sSuffix );
+
+		if ( QFile( sFileName ).exists() == true && m_bQfileDialog == false &&
 			 ! m_bOverwriteFiles ) {
 			const int nRes = QMessageBox::information(
 				this, "Hydrogen", tr( "The file %1 exists. \nOverwrite the existing file?")
-				.arg( sFilename ),
+				.arg( sFileName ),
 				QMessageBox::Yes | QMessageBox::No | QMessageBox::YesToAll );
 			if ( nRes == QMessageBox::No ) {
 				return;
@@ -648,7 +663,7 @@ void ExportSongDialog::exportTracks()
 		
 		pSong->getInstrumentList()->get(m_nInstrument)->set_currently_exported( true );
 		
-		m_pHydrogen->startExportSong( sFilename );
+		m_pHydrogen->startExportSong( sFileName );
 
 		if(! (m_nInstrument == pInstrumentList->size()) ){
 			m_nInstrument++;

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -102,6 +102,19 @@ ExportSongDialog::ExportSongDialog(QWidget* parent)
 
 	HydrogenApp::get_instance()->addEventListener( this );
 
+	browseBtn->setFixedFontSize( 13 );
+	browseBtn->setSize( QSize( 80, 26 ) );
+	browseBtn->setBorderRadius( 3 );
+	browseBtn->setType( Button::Type::Push );
+	okBtn->setFixedFontSize( 13 );
+	okBtn->setSize( QSize( 80, 26 ) );
+	okBtn->setBorderRadius( 3 );
+	okBtn->setType( Button::Type::Push );
+	closeBtn->setFixedFontSize( 13 );
+	closeBtn->setBorderRadius( 3 );
+	closeBtn->setSize( QSize( 80, 26 ) );
+	closeBtn->setType( Button::Type::Push );
+
 	m_pProgressBar->setValue( 0 );
 	
 	m_bQfileDialog = false;
@@ -705,8 +718,11 @@ void ExportSongDialog::formatComboIndexChanged( int nIndex )
 	const auto format = m_formatMap[ nIndex ];
 	if ( format == Filesystem::AudioFormat::Unknown ) {
 		ERRORLOG( QString( "Invalid index [%1]" ).arg( nIndex ) );
+		okBtn->setIsActive( false );
 		return;
 	}
+
+	okBtn->setIsActive( true );
 
 	switch( format ) {
 	case Filesystem::AudioFormat::Wav:
@@ -775,9 +791,10 @@ void ExportSongDialog::on_exportNameTxt_textChanged( const QString& )
 	if ( format == Filesystem::AudioFormat::Unknown ) {
 		ERRORLOG( QString( "Unknown file format in filename [%1]" )
 				  .arg( exportNameTxt->text() ) );
-		okBtn->setEnabled( false );
+		okBtn->setIsActive( false );
 		return;
 	}
+	okBtn->setIsActive( true );
 	const auto previousFormat = m_formatMap[ formatCombo->currentIndex() ];
 
 	if ( previousFormat != format ) {

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -786,11 +786,11 @@ void ExportSongDialog::on_exportNameTxt_textChanged( const QString& )
 	const auto splittedFilename = exportNameTxt->text().split(".");
 
 	const auto format = Filesystem::AudioFormatFromSuffix(
-		splittedFilename.last() );
+		splittedFilename.last(), true );
 
 	if ( format == Filesystem::AudioFormat::Unknown ) {
-		ERRORLOG( QString( "Unknown file format in filename [%1]" )
-				  .arg( exportNameTxt->text() ) );
+		WARNINGLOG( QString( "Unknown file format in filename [%1]" )
+					.arg( exportNameTxt->text() ) );
 		okBtn->setIsActive( false );
 		return;
 	}

--- a/src/gui/src/ExportSongDialog_UI.ui
+++ b/src/gui/src/ExportSongDialog_UI.ui
@@ -64,7 +64,7 @@
        <item row="0" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLineEdit" name="exportNameTxt">
+          <widget class="LCDDisplay" name="exportNameTxt">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -80,7 +80,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="browseBtn">
+          <widget class="Button" name="browseBtn">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -117,7 +117,7 @@
         </widget>
        </item>
        <item row="2" column="1">
-        <widget class="QComboBox" name="formatCombo">
+        <widget class="LCDCombo" name="formatCombo">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -140,7 +140,7 @@
         </widget>
        </item>
        <item row="3" column="1">
-        <widget class="QComboBox" name="sampleRateCombo">
+        <widget class="LCDCombo" name="sampleRateCombo">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -199,7 +199,7 @@
         </widget>
        </item>
        <item row="4" column="1">
-        <widget class="QComboBox" name="sampleDepthCombo">
+        <widget class="LCDCombo" name="sampleDepthCombo">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -248,7 +248,7 @@
         </widget>
        </item>
        <item row="5" column="1">
-        <widget class="QDoubleSpinBox" name="compressionLevelSpinBox">
+        <widget class="LCDSpinBox" name="compressionLevelSpinBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -289,7 +289,7 @@
         </widget>
        </item>
        <item row="8" column="1">
-        <widget class="QComboBox" name="resampleComboBox">
+        <widget class="LCDCombo" name="resampleComboBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -346,7 +346,7 @@
         </widget>
        </item>
        <item row="10" column="1">
-        <widget class="QComboBox" name="exportTypeCombo">
+        <widget class="LCDCombo" name="exportTypeCombo">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -412,7 +412,7 @@
        <item row="22" column="0" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
-          <widget class="QPushButton" name="okBtn">
+          <widget class="Button" name="okBtn">
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -450,7 +450,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QPushButton" name="closeBtn">
+          <widget class="Button" name="closeBtn">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
              <horstretch>0</horstretch>
@@ -501,6 +501,32 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LCDDisplay</class>
+   <extends>QLineEdit</extends>
+   <header location="global">../src/Widgets/LCDDisplay.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDCombo</class>
+   <extends>QComboBox</extends>
+   <header location="global">../src/Widgets/LCDCombo.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>LCDSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header location="global">../src/Widgets/LCDSpinBox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Button</class>
+   <extends>QPushButton</extends>
+   <header location="global">../src/Widgets/Button.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
a "." did leak into the filenames created when exporting the song to multi track. Also, we do now ensure to use the whole string provided in the export file line edit. Previously, when entering e.g. `/path/to/example.mp3.test.mp3` the resulting files were `/path/to/example-<INSTRUMENT_NAME>.mp3`.

In addition, it is now possible to export to the raw instrument names by just providing the suffix , like `/path/to/.flac`.

The export button is now visually disabled in case the suffix in the provided path is off.