### PR TITLE
Improve shortcut handling in custom widgets (#2098)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Changed
 		- The shortcut for starting/pausing transport can now be used spin boxed
 			(like the BPM one) too (#2098)
+		- Combo boxes do not accept focus (and preventing shortcuts) anymore.
 	* Fixed
 		- Fix compilation with LASH support enabled (#2076).
 		- Fix Hue slider in Preferences > Appearance > Color (#2081).

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.5
+	* Changed
+		- The shortcut for starting/pausing transport can now be used spin boxed
+			(like the BPM one) too (#2098)
 	* Fixed
 		- Fix compilation with LASH support enabled (#2076).
 		- Fix Hue slider in Preferences > Appearance > Color (#2081).

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -36,7 +36,7 @@ LCDCombo::LCDCombo( QWidget *pParent, QSize size, bool bModifyOnChange )
 	, m_nMaxWidth( 0 )
 	, m_bIsActive( true )
 {
-	setFocusPolicy( Qt::ClickFocus );
+	setFocusPolicy( Qt::NoFocus );
 
 	if ( ! size.isNull() ) {
 		adjustSize();

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -136,9 +136,11 @@ void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 	double fOldValue = value();
 
-	// Pass Undo/Redo commands up to the parent
+	// Pass Undo/Redo commands up to the parent. In addition, pause and play
+	// button will be passed to the parent too.
 	if ( ev->matches( QKeySequence::StandardKey::Undo )
-		 || ev->matches( QKeySequence::StandardKey::Redo ) ) {
+		 || ev->matches( QKeySequence::StandardKey::Redo )
+		 || ev->key() == Qt::Key_Space ) {
 		ev->ignore();
 		return;
 	}
@@ -150,11 +152,14 @@ void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 
 		 if ( ev->key() == Qt::Key_Up ) {
 			 fNextValue = nextValueInPatternSizeDenominator( true, false );
-		 } else if ( ev->key() == Qt::Key_Down ) {
+		 }
+		 else if ( ev->key() == Qt::Key_Down ) {
 			 fNextValue = nextValueInPatternSizeDenominator( false, false );
-		 } else if ( ev->key() == Qt::Key_PageUp ) {
+		 }
+		 else if ( ev->key() == Qt::Key_PageUp ) {
 			 fNextValue = nextValueInPatternSizeDenominator( true, true );
-		 } else if ( ev->key() == Qt::Key_PageDown ) {
+		 }
+		 else if ( ev->key() == Qt::Key_PageDown ) {
 			 fNextValue = nextValueInPatternSizeDenominator( false, true );
 		 }
 
@@ -166,16 +171,16 @@ void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 		 setValue( fNextValue );
 	 
 		 QDoubleSpinBox::keyPressEvent( ev );
-		 
-	 } else if ( m_kind == Kind::PatternSizeNumerator ) {
+	}
+	else if ( m_kind == Kind::PatternSizeNumerator ) {
 		
 		QDoubleSpinBox::keyPressEvent( ev );
 		
 		if ( value() < 1 ) {
 			setValue( 1 );
 		}
-		
-	} else {
+	}
+	else {
 		 QDoubleSpinBox::keyPressEvent( ev );
 	}
 	


### PR DESCRIPTION
`LCDSpinBox` does now ignore the shortcut for starting/pausing playback.

In addition, focus policy in `LCDCombo` was changed to `Qt::NoFocus`. Previously, used `Qt::ClickFocus`. It seems this was done at the same time when also introducing this setting to `LCDSpinBox`. In the later, it is quite useful since it prevents the widget to be reachable via tab (this should be used for the editors exclusively) while still allowing it to be modified using keyboard event after clicking it.

But for `LCDCombo` there is no advantange. Clicking the widget will open a popup menu and regardless of the focus policy of the widget itself, the user can still navigate the popup using keyboard. Instead, it has the negative side effect that the widget swallows all keyboard event (including shortcuts) after usage and the user has to focus out by clicking somewhere else first in order to start/pause transport via keyboard again.

Implements #2098 