### PR TITLE
Fix jack race condition and memory leaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 			the raw instrument names will be used (#2096).
 		- Fix import bug for drumkits created in version >= 2.0.
 		- Fix memory leakage for songs created in version >= 2.0.
+		- Fix memory leakage for notes with probability < 1.0.
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix crashes in SampleEditor (#2092).
 		- Fix track names in multi track export. When using just the file extension,
 			the raw instrument names will be used (#2096).
+		- Fix import bug for drumkits created in version >= 2.0.
+		- Fix memory leakage for songs created in version >= 2.0.
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2788,6 +2788,25 @@ const PatternList* AudioEngine::getNextPatterns() const {
 	return nullptr;
 }
 
+QString AudioEngine::StateToQString( const State& state ) {
+	switch( state ) {
+		case State::Uninitialized:
+			return "Uninitialized";
+		case State::Initialized:
+			return "Initialized";
+		case State::Prepared:
+			return "Prepared";
+		case State::Ready:
+			return "Ready";
+		case State::Playing:
+			return "Playing";
+		case State::Testing:
+			return "Testing";
+		default:
+			return "Unknown state";
+	}
+}
+
 QString AudioEngine::toQString( const QString& sPrefix, bool bShort ) const {
 	QString s = Base::sPrintIndention;
 

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2619,9 +2619,12 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 												 m_pQueuingPosition->getPatternTickPosition(),
 												 pPattern ) {
 					Note *pNote = it->second;
-					if ( pNote != nullptr ) {
+					if ( pNote != nullptr && pNote->get_instrument_id() != -1 &&
+						 pNote->get_instrument() != nullptr &&
+						 pNote->get_instrument()->get_id() != -1 ) {
+
 						pNote->set_just_recorded( false );
-						
+
 						Note *pCopiedNote = new Note( pNote );
 
 						// Lead or Lag.

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -1329,6 +1329,7 @@ void AudioEngine::processPlayNotes( unsigned long nframes )
 				if ( fNoteProbability < (float) rand() / (float) RAND_MAX ) {
 					m_songNoteQueue.pop();
 					pNote->get_instrument()->dequeue();
+					delete pNote;
 					continue;
 				}
 			}

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -129,6 +129,7 @@ public:
 		 */
 		Testing = 6
 	};
+		static QString StateToQString( const State& state );
 
 	/**
 	 * Maximum value the standard deviation of the Gaussian

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -626,25 +626,36 @@ void Drumkit::addInstrument( std::shared_ptr<Instrument> pInstrument ) {
 		}
 	}
 
-	// create a new valid ID for this instrument
-	int nNewId = __instruments->size();
-	for ( int ii = 0; ii < __instruments->size(); ++ii ) {
-		bool bIsPresent = false;
-		for ( const auto& ppInstrument : *__instruments ) {
-			if ( ppInstrument != nullptr &&
-				 ppInstrument->get_id() == ii ) {
-				bIsPresent = true;
+	// In case there already is an instrument featuring its ID, we have to
+	// create a new one.
+	bool bIdAlreadyPresent = false;
+	for ( const auto& ppInstrument : *__instruments ) {
+		if ( ppInstrument != nullptr &&
+			 ppInstrument->get_id() == pInstrument->get_id() ) {
+			bIdAlreadyPresent = true;
+			break;
+		}
+	}
+	if ( bIdAlreadyPresent && pInstrument->get_id() >= 0 ) {
+		int nNewId = __instruments->size();
+		for ( int ii = 0; ii < __instruments->size(); ++ii ) {
+			bool bIsPresent = false;
+			for ( const auto& ppInstrument : *__instruments ) {
+				if ( ppInstrument != nullptr &&
+					 ppInstrument->get_id() == ii ) {
+					bIsPresent = true;
+					break;
+				}
+			}
+
+			if ( ! bIsPresent ) {
+				nNewId = ii;
 				break;
 			}
 		}
 
-		if ( ! bIsPresent ) {
-			nNewId = ii;
-			break;
-		}
+		pInstrument->set_id( nNewId );
 	}
-
-	pInstrument->set_id( nNewId );
 
 	__instruments->add( pInstrument );
 }

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -1343,6 +1343,14 @@ void JackAudioDriver::JackTimebaseCallback(jack_transport_state_t state,
 
 	pAudioEngine->lock( RIGHT_HERE );
 
+	// Ensure the callback is not triggered during startup or teardown.
+	if ( pAudioEngine->getState() != AudioEngine::State::Ready ||
+		 pAudioEngine->getState() != AudioEngine::State::Playing ||
+		 pAudioEngine->getState() != AudioEngine::State::Testing ) {
+		pAudioEngine->unlock();
+		return;
+	}
+
 	const long long nInitialFrame = pJackPosition->frame;
 
 	const auto posFromFrame = [&]( long long nFrame,


### PR DESCRIPTION
When using JACK Timebase support, Hydrogen could segfault during shutdown due to a race condition.

In addition, I found some memory leaks.