### PR TITLE
PatternEditor: tweak quantization, property drag, and hear notes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -105,6 +105,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				  as well as property drawing can now be undone/redone in a single action.
 				- PianoRoll does now have a proper sidebar including per-line action in
 				  right click popup menu.
+				- Right-click drag does now alter either note length or property.
 	* Fixed
 		- Components can now carry arbitrary names and name duplication is handled
 			properly.

--- a/ChangeLog
+++ b/ChangeLog
@@ -89,7 +89,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- PatternEditor:
 				- Handling is now centered on interaction with existing notes. Only
 				  adding of new notes is dependent on the current grid.
-				- Alt key modifier can be used to add/move/change off the current grid.
+				- The quantization button does now affect keyboard and mouse inputs too.
+				- Alt key modifier can be used to temporarily turn off quantization.
 				- Instruments of the current kit and instrument types of all notes in a
 				  pattern are now handled separately in the sidebar.
 				- Single notes can now be dragged or altered using right-click popup

--- a/ChangeLog
+++ b/ChangeLog
@@ -107,6 +107,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- PianoRoll does now have a proper sidebar including per-line action in
 				  right click popup menu.
 				- Right-click drag does now alter either note length or property.
+				- The hear notes button does now also affect sounds triggered by clicking
+				  the sidebar of the pattern editor.
 	* Fixed
 		- Components can now carry arbitrary names and name duplication is handled
 			properly.

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -3017,10 +3017,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3084,6 +3080,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -3015,10 +3015,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3082,6 +3078,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -3051,10 +3051,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Multi-Pattern Auswahl konnte nicht eingefügt werden</translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation>Noteneigenschaft durch Ziehen der Maus angepasst</translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3118,6 +3114,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -3044,10 +3044,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3111,6 +3107,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -3004,10 +3004,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation></translation>
     </message>
@@ -3072,6 +3068,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Set note type</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -3004,10 +3004,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3071,6 +3067,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -3058,10 +3058,6 @@ Debería funcionar correctamente mientras utilices el GMRockKit, y no uses tresi
         <translation>No se puede pegar selección multi-patrón</translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3125,6 +3121,10 @@ Debería funcionar correctamente mientras utilices el GMRockKit, y no uses tresi
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -3059,10 +3059,6 @@ L&apos;exportation LilyPond est une fonctionnalité expérimentale.
         <translation>Impossible de coller une sélection multi-motifs</translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3126,6 +3122,10 @@ L&apos;exportation LilyPond est une fonctionnalité expérimentale.
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -3043,10 +3043,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3110,6 +3106,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -3015,10 +3015,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3082,6 +3078,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -3009,10 +3009,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3076,6 +3072,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -3018,10 +3018,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3085,6 +3081,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -3041,10 +3041,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3108,6 +3104,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -3016,10 +3016,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3083,6 +3079,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -3012,10 +3012,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3079,6 +3075,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -3056,10 +3056,6 @@ Deveria funcionar corretamente dado que você usou o GMRockKit e que você não 
         <translation>Não é possível colar seleção de multi-padrão</translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3123,6 +3119,10 @@ Deveria funcionar corretamente dado que você usou o GMRockKit e que você não 
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -3041,10 +3041,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3108,6 +3104,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -3037,10 +3037,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3104,6 +3100,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -3009,10 +3009,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3076,6 +3072,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -3042,10 +3042,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3109,6 +3105,10 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -3042,10 +3042,6 @@ LilyPond 导出是一项实验性功能。
         <translation>无法粘贴多样式选择</translation>
     </message>
     <message>
-        <source>edit note properties by dragging</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>paste notes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3109,6 +3105,10 @@ LilyPond 导出是一项实验性功能。
     </message>
     <message>
         <source>Set note type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Drag edit note property:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -382,12 +382,7 @@ void DrumPatternEditor::paintEvent( QPaintEvent* ev )
 		const auto baseStyle = static_cast<NoteStyle>(
 			( ppPattern == pPattern ? NoteStyle::Foreground :
 			  NoteStyle::Background ) | NoteStyle::Hovered);
-		for ( const auto& ppNote : nnotes ) {
-			const auto style = static_cast<NoteStyle>(
-				m_selection.isSelected( ppNote ) ?
-				NoteStyle::Selected | baseStyle : baseStyle );
-			drawNote( painter, ppNote, style );
-		}
+		sortAndDrawNotes( painter, nnotes, baseStyle );
 	}
 
 	// Draw moved notes

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -339,7 +339,9 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 			m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
 		}
 
-		m_update = Update::Pattern;
+		if ( m_update != Update::Background ) {
+			m_update = Update::Pattern;
+		}
 		update();
 	}
 }
@@ -450,7 +452,9 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 
 	if ( bValueChanged ) {
 		triggerStatusMessage( notesStatusMessage, m_property );
-		m_update = Update::Pattern;
+		if ( m_update != Update::Background ) {
+			m_update = Update::Pattern;
+		}
 		update();
 	}
 }
@@ -459,7 +463,9 @@ void NotePropertiesRuler::selectionMoveEndEvent( QInputEvent *ev ) {
 	//! The "move" has already been reflected in the notes. Now just complete Undo event.
 	addUndoAction( "" );
 
-	m_update = Update::Pattern;
+	if ( m_update != Update::Background ) {
+		m_update = Update::Pattern;
+	}
 	update();
 }
 
@@ -501,7 +507,9 @@ void NotePropertiesRuler::propertyDrawStart( QMouseEvent *ev )
 	setCursor( Qt::CrossCursor );
 	prepareUndoAction( ev );
 
-	m_update = Update::Pattern;
+	if ( m_update != Update::Background ) {
+		m_update = Update::Pattern;
+	}
 	update();
 }
 
@@ -669,7 +677,9 @@ void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
 
 	if ( bValueChanged ) {
 		Hydrogen::get_instance()->setIsModified( true );
-		m_update = Update::Pattern;
+		if ( m_update != Update::Background ) {
+			m_update = Update::Pattern;
+		}
 		update();
 		if ( m_property == PatternEditor::Property::Velocity ) {
 			// A note's velocity determines its color in the other pattern
@@ -685,7 +695,9 @@ void NotePropertiesRuler::propertyDrawEnd()
 	addUndoAction( "NotePropertiesRuler::propertyDraw" );
 	unsetCursor();
 
-	m_update = Update::Pattern;
+	if ( m_update != Update::Background ) {
+		m_update = Update::Pattern;
+	}
 	update();
 }
 

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -458,6 +458,11 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 			m_update = Update::Pattern;
 		}
 		update();
+
+		if ( m_property == Property::Velocity ) {
+			// Update note color.
+			m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
+		}
 	}
 }
 

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -358,6 +358,8 @@ void NotePropertiesRuler::mouseClickEvent( QMouseEvent *ev ) {
 		propertyDrawUpdate( ev );
 		propertyDrawEnd();
 
+		updateModifiers( ev );
+
 		// Focus cursor on clicked note
 		const auto notes = getElementsAtPoint( ev->pos(), getCursorMargin( ev ) );
 		if ( notes.size() > 0 ) {
@@ -525,6 +527,8 @@ void NotePropertiesRuler::prepareUndoAction( QMouseEvent* pEvent )
 
 	m_oldNotes.clear();
 
+	updateModifiers( pEvent );
+
 	const auto notesUnderPoint = getElementsAtPoint(
 		pEvent->pos(), getCursorMargin( pEvent ), pPattern );
 	for ( const auto& ppNote : notesUnderPoint ) {
@@ -549,6 +553,8 @@ void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
 	if ( pPattern == nullptr ) {
 		return;
 	}
+
+	updateModifiers( ev );
 
 	// Issuing redo/undo actions bases on draw changes are issued in batches. In
 	// case the cursor is moved slowly, we might have updates without any new

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -137,6 +137,24 @@ class NotePropertiesRuler : public PatternEditor,
 		void drawPattern() override;
 		void drawNote( QPainter& painter, std::shared_ptr<H2Core::Note> pNote,
 					   NoteStyle noteStyle, int nOffsetX = 0 );
+		/** Since properties of notes within the same row would end up being
+		 * painted on top of eachother, we go through the notes column by column
+		 * and add small horizontal offsets to each additional note to hint
+		 * their existence.
+		 *
+		 * In addition, we first aggregate all notes residing at the same
+		 * position (column) in the same row and sort them according to their
+		 * pitch. This way they order is not seemingly random (else notes would
+		 * be order according to the insertion time into the pattern. An
+		 * unintuitive measure from user perspective with all our redo/undo
+		 * facilities.)
+		 *
+		 * Also, we ensure selected notes will be rendered more prominently than
+		 * not selected ones. */
+		void sortAndDrawNotes( QPainter& p,
+							   std::vector< std::shared_ptr<H2Core::Note> > notes,
+							   NoteStyle baseStyle,
+							   bool bUpdateOffsets );
 
 		void paintEvent(QPaintEvent *ev) override;
 		void wheelEvent(QWheelEvent *ev) override;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1745,6 +1745,32 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 	pMovingPen->setWidth( 2 );
 }
 
+void PatternEditor::sortAndDrawNotes( QPainter& p,
+									  std::vector< std::shared_ptr<Note> > notes,
+									  NoteStyle baseStyle ) {
+	std::sort( notes.begin(), notes.end(), Note::compare );
+
+	// Prioritze selected notes over not selected ones.
+	std::vector< std::shared_ptr<Note> > selectedNotes, notSelectedNotes;
+	for ( const auto& ppNote : notes ) {
+		if ( m_selection.isSelected( ppNote ) ) {
+			selectedNotes.push_back( ppNote );
+		}
+		else {
+			notSelectedNotes.push_back( ppNote );
+		}
+	}
+
+	for ( const auto& ppNote : notSelectedNotes ) {
+		drawNote( p, ppNote, baseStyle );
+	}
+	auto selectedStyle =
+		static_cast<NoteStyle>(NoteStyle::Selected | baseStyle);
+	for ( const auto& ppNote : selectedNotes ) {
+		drawNote( p, ppNote, selectedStyle );
+	}
+}
+
 ///
 /// Ensure selection only refers to valid notes, and does not contain any stale references to deleted notes.
 ///
@@ -2347,36 +2373,6 @@ void PatternEditor::drawPattern()
 
 	const auto selectedRow = m_pPatternEditorPanel->getRowDB(
 		m_pPatternEditorPanel->getSelectedRowDB() );
-
-	// If there are multiple notes at the same position and column, the one with
-	// lowest pitch (bottom-most one in PianoRollEditor) will be rendered up
-	// front. If a subset of notes at this point is selected, the note with
-	// lowest pitch within the selection is used.
-	auto sortAndDrawNotes = [&]( QPainter& p,
-						  std::vector< std::shared_ptr<Note> > notes,
-						  NoteStyle baseStyle ) {
-		std::sort( notes.begin(), notes.end(), Note::compare );
-
-		// Prioritze selected notes over not selected ones.
-		std::vector< std::shared_ptr<Note> > selectedNotes, notSelectedNotes;
-		for ( const auto& ppNote : notes ) {
-			if ( m_selection.isSelected( ppNote ) ) {
-				selectedNotes.push_back( ppNote );
-			}
-			else {
-				notSelectedNotes.push_back( ppNote );
-			}
-		}
-
-		for ( const auto& ppNote : notSelectedNotes ) {
-			drawNote( p, ppNote, baseStyle );
-		}
-		auto selectedStyle =
-			static_cast<NoteStyle>(NoteStyle::Selected | baseStyle);
-		for ( const auto& ppNote : selectedNotes ) {
-			drawNote( p, ppNote, selectedStyle );
-		}
-	};
 
 	// We count notes in each position so we can display markers for rows which
 	// have more than one note in the same position (a chord or genuine

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1198,7 +1198,11 @@ void PatternEditor::mouseMoveEvent( QMouseEvent *ev )
 
 void PatternEditor::mouseReleaseEvent( QMouseEvent *ev )
 {
-	updateModifiers( ev );
+	// Don't call updateModifiers( ev ) in here because we want to apply the
+	// state of the modifiers used during the last update/rendering. Else the
+	// user might position a note carefully and it jumps to different place
+	// because she released the Alt modifier slightly earlier than the mouse
+	// button.
 
 	bool bUpdate = false;
 
@@ -1415,8 +1419,6 @@ void PatternEditor::undoDeselectAndOverwriteNotes( const std::vector< std::share
 
 QPoint PatternEditor::movingGridOffset( ) const {
 	QPoint rawOffset = m_selection.movingOffset();
-
-	const auto modifiers = m_selection.getModifiers();
 
 	// Quantization in y direction is mandatory. A note can not be placed
 	// between lines.
@@ -1906,7 +1908,11 @@ void PatternEditor::selectionMoveEndEvent( QInputEvent *ev )
 		return;
 	}
 
-	updateModifiers( ev );
+	// Don't call updateModifiers( ev ) in here because we want to apply the
+	// state of the modifiers used during the last update/rendering. Else the
+	// user might position a note carefully and it jumps to different place
+	// because she released the Alt modifier slightly earlier than the mouse
+	// button.
 
 	QPoint offset = movingGridOffset();
 	if ( offset.x() == 0 && offset.y() == 0 ) {
@@ -2274,7 +2280,11 @@ void PatternEditor::handleKeyboardCursor( bool bVisible ) {
 }
 
 void PatternEditor::keyReleaseEvent( QKeyEvent *ev ) {
-	updateModifiers( ev );
+	// Don't call updateModifiers( ev ) in here because we want to apply the
+	// state of the modifiers used during the last update/rendering. Else the
+	// user might position a note carefully and it jumps to different place
+	// because she released the Alt modifier slightly earlier than the mouse
+	// button.
 }
 
 void PatternEditor::enterEvent( QEvent *ev ) {

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -327,7 +327,6 @@ protected:
 	float m_fGridWidth;
 	unsigned m_nGridHeight;
 
-	bool m_bFineGrained;
 	bool m_bCopyNotMove;
 
 		enum class DragType {

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -194,6 +194,7 @@ public:
 	/** Caches the AudioEngine::m_nPatternTickPosition in the member
 		variable #m_nTick and triggers an update(). */
 	void updatePosition( float fTick );
+		void updateQuantization( QInputEvent* pEvent );
 
 		/** Additional action to perform on the first redo() call of
 		 * #SE_addOrRemoveNotes. */
@@ -420,6 +421,8 @@ protected:
 	 * state of the editor.
 	 */
 	bool updateWidth();
+
+		bool m_bQuantized;
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -194,7 +194,6 @@ public:
 	/** Caches the AudioEngine::m_nPatternTickPosition in the member
 		variable #m_nTick and triggers an update(). */
 	void updatePosition( float fTick );
-		void updateQuantization( QInputEvent* pEvent );
 
 		/** Additional action to perform on the first redo() call of
 		 * #SE_addOrRemoveNotes. */
@@ -421,8 +420,6 @@ protected:
 	 * state of the editor.
 	 */
 	bool updateWidth();
-
-		bool m_bQuantized;
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -383,6 +383,13 @@ protected:
 					 QBrush* pHighlightBrush, QPen* pMovingPen,
 					 QBrush* pMovingBrush, NoteStyle noteStyle ) const;
 
+		/** If there are multiple notes at the same position and column, the one
+		 * with lowest pitch (bottom-most one in PianoRollEditor) will be
+		 * rendered up front. If a subset of notes at this point is selected,
+		 * the note with lowest pitch within the selection is used. */
+		void sortAndDrawNotes( QPainter& p,
+							   std::vector< std::shared_ptr<H2Core::Note> > notes,
+							   NoteStyle baseStyle );
 	/**
 	 * Draw a note
 	 *

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -330,6 +330,17 @@ protected:
 	bool m_bFineGrained;
 	bool m_bCopyNotMove;
 
+		enum class DragType {
+			None,
+			Length,
+			Property
+		};
+		static QString DragTypeToQString( DragType dragType );
+		/** Specifies whether the user interaction is altering the length
+		 * (horizontal) or the currently selected property (vertical) of a
+		 * note. */
+		DragType m_dragType;
+
 		/** Keeps track of all notes being drag-edited using the right mouse
 		 * button. It maps the new, updated version of a note to an copy of
 		 * itself still bearing the original values.*/
@@ -340,6 +351,7 @@ protected:
 		/** Latest vertical position of a drag event. Adjusted in every drag
 		 * update. */
 		int m_nDragY;
+		QPoint m_dragStart;
 		/** When drag editing note properties using right-click drag in
 		 * #DrumPatternEditor and #PianoRollEditor, we display a status message
 		 * indicating the value change. But when dragging a selection of notes
@@ -347,7 +359,6 @@ protected:
 		 * display. We show all values changes of notes at the initial mouse
 		 * cursor position. */
 		std::vector< std::shared_ptr<H2Core::Note> > m_notesHoveredOnDragStart;
-		bool m_bPropertyDragActive;
 
 	PatternEditorPanel* m_pPatternEditorPanel;
 	QMenu *m_pPopupMenu;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -2019,6 +2019,15 @@ void PatternEditorPanel::updateQuantization( QInputEvent* pEvent ) {
 	if ( bQuantized != m_bQuantized ) {
 		m_bQuantized = bQuantized;
 
+		if ( pEvent != nullptr ) {
+			QKeyEvent* pKeyEvent = dynamic_cast<QKeyEvent*>( pEvent );
+			if ( pKeyEvent != nullptr ) {
+				// Re-quantize keyboard cursor (moved notes will be re-quantized
+				// automatically via movingGridOffset).
+				moveCursorLeft( pKeyEvent, 0 );
+			}
+		}
+
 		getVisibleEditor()->updateEditor();
 		getVisiblePropertiesRuler()->updateEditor();
 	}

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -117,6 +117,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	m_nResolution = pPref->getPatternEditorGridResolution();
 	m_bIsUsingTriplets = pPref->isPatternEditorUsingTriplets();
+	m_bQuantized = pPref->getQuantizeEvents();
 
 	QFont boldFont( pPref->getTheme().m_font.m_sApplicationFontFamily,
 					getPointSize( pPref->getTheme().m_font.m_fontSize ) );
@@ -898,6 +899,8 @@ void PatternEditorPanel::quantizeEventsBtnClick()
 	Preferences::get_instance()->setQuantizeEvents(
 		m_pQuantizeEventsBtn->isChecked() );
 
+	updateQuantization( nullptr );
+
 	if ( m_pQuantizeEventsBtn->isChecked() ) {
 		( HydrogenApp::get_instance() )->showStatusBarMessage( tr( "Quantize incoming keyboard/midi events = On" ) );
 	} else {
@@ -1602,10 +1605,10 @@ void PatternEditorPanel::setCursorColumn( int nCursorColumn,
 	}
 }
 
+// Ensure updateModifiers() was called on the provided event first.
 void PatternEditorPanel::moveCursorLeft( QKeyEvent* pEvent, int n ) {
 	int nNewColumn;
-	// By pressing the Alt button the user can bypass quantization.
-	if ( pEvent->modifiers() & Qt::AltModifier ) {
+	if ( ! m_bQuantized ) {
 		nNewColumn = m_nCursorColumn - 1;
 	}
 	else {
@@ -1621,6 +1624,7 @@ void PatternEditorPanel::moveCursorLeft( QKeyEvent* pEvent, int n ) {
 	setCursorColumn( std::max( nNewColumn, 0 ) );
 }
 
+// Ensure updateModifiers() was called on the provided event first.
 void PatternEditorPanel::moveCursorRight( QKeyEvent* pEvent, int n ) {
 	if ( m_pPattern == nullptr ) {
 		return;
@@ -1628,7 +1632,7 @@ void PatternEditorPanel::moveCursorRight( QKeyEvent* pEvent, int n ) {
 
 	int nNewColumn, nIncrement;
 	// By pressing the Alt button the user can bypass quantization.
-	if ( pEvent->modifiers() & Qt::AltModifier ) {
+	if ( ! m_bQuantized ) {
 		nNewColumn = m_nCursorColumn + 1;
 		nIncrement = 1;
 	}
@@ -1653,7 +1657,6 @@ void PatternEditorPanel::moveCursorRight( QKeyEvent* pEvent, int n ) {
 			}
 		}
 	}
-
 
 	setCursorColumn( nNewColumn );
 }
@@ -1992,6 +1995,21 @@ void PatternEditorPanel::updateDB() {
 		m_bTypeLabelsMustBeVisible = true;
 	} else {
 		m_bTypeLabelsMustBeVisible = false;
+	}
+}
+
+void PatternEditorPanel::updateQuantization( QInputEvent* pEvent ) {
+	bool bQuantized = Preferences::get_instance()->getQuantizeEvents();
+
+	if ( pEvent != nullptr && pEvent->modifiers() & Qt::AltModifier ) {
+		bQuantized = false;
+	}
+
+	if ( bQuantized != m_bQuantized ) {
+		m_bQuantized = bQuantized;
+
+		getVisibleEditor()->updateEditor();
+		getVisiblePropertiesRuler()->updateEditor();
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -2001,8 +2001,19 @@ void PatternEditorPanel::updateDB() {
 void PatternEditorPanel::updateQuantization( QInputEvent* pEvent ) {
 	bool bQuantized = Preferences::get_instance()->getQuantizeEvents();
 
-	if ( pEvent != nullptr && pEvent->modifiers() & Qt::AltModifier ) {
-		bQuantized = false;
+	if ( pEvent != nullptr ) {
+		if ( QKeyEvent* pKeyEvent = dynamic_cast<QKeyEvent*>( pEvent ) ) {
+			// Keyboard events for press and release of modifier keys don't have
+			// those keys in the modifiers set, so explicitly update these.
+			if ( ( pEvent->type() == QEvent::KeyPress &&
+				   pKeyEvent->key() == Qt::Key_Alt ) ||
+				 pEvent->modifiers() & Qt::AltModifier ) {
+				bQuantized = false;
+			}
+		}
+		else if ( pEvent->modifiers() & Qt::AltModifier ) {
+			bQuantized = false;
+		}
 	}
 
 	if ( bQuantized != m_bQuantized ) {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1914,6 +1914,7 @@ void PatternEditorPanel::updateDB() {
 	int nnRow = 0;
 
 	std::set<int> kitIds;
+	bool bInstrumentWithoutType = false;
 	// First we add all instruments of the current drumkit in the order author
 	// of the kit intended.
 	for ( const auto& ppInstrument : *pInstrumentList ) {
@@ -1921,6 +1922,10 @@ void PatternEditorPanel::updateDB() {
 			const bool bNoPlayback = ppInstrument->isMuted() ||
 				( pInstrumentList->isAnyInstrumentSoloed() &&
 				  ! ppInstrument->isSoloed() );
+
+			if ( ppInstrument->getType().isEmpty() ) {
+				bInstrumentWithoutType = true;
+			}
 
 			m_db.push_back(
 				DrumPatternRow( ppInstrument->getId(), ppInstrument->getType(),
@@ -1991,9 +1996,11 @@ void PatternEditorPanel::updateDB() {
 		setSelectedRowDB( m_db.size() - 1 );
 	}
 
-	if ( additionalIds.size() > 0 || additionalTypes.size() > 0 ) {
+	if ( additionalIds.size() > 0 || additionalTypes.size() > 0 ||
+		 bInstrumentWithoutType ) {
 		m_bTypeLabelsMustBeVisible = true;
-	} else {
+	}
+	else {
 		m_bTypeLabelsMustBeVisible = false;
 	}
 }

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1649,7 +1649,7 @@ void PatternEditorPanel::moveCursorRight( QKeyEvent* pEvent, int n ) {
 
 		// If a jump would be positioned beyond the end of the pattern, we move
 		// to the last possible position instead.
-		if ( n > 1 && nNewColumn >= m_pPattern->getLength() ) {
+		if ( nNewColumn >= m_pPattern->getLength() ) {
 			nNewColumn = std::floor( m_pPattern->getLength() /
 									 m_nCursorIncrement ) * m_nCursorIncrement;
 			if ( m_pPattern->getLength() % m_nCursorIncrement == 0 ) {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -306,10 +306,12 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 		void pasteNotesToRowOfAllPatterns( int nRow, int nPitch = PITCH_INVALID );
 
 		int getResolution() const;
+		bool isQuantized() const;
 		bool isUsingTriplets() const;
 
 		/** Update #m_db based on #H2Core::Song::m_pDrumkit and #m_pPattern. */
 		void updateDB();
+		void updateQuantization( QInputEvent* pEvent );
 
 		/** If set by the user, type labels in the sidebar will only be shown in
 		 * case there is a note not associated with the current drumkit in
@@ -474,6 +476,7 @@ class PatternEditorPanel :  public QWidget, protected WidgetWithScalableFont<8, 
 
 		int m_nResolution;
 		bool m_bIsUsingTriplets;
+		bool m_bQuantized;
 
 		bool m_bPatternSelectedViaTab;
 
@@ -510,6 +513,9 @@ inline int PatternEditorPanel::getSelectedRowDB() const {
 }
 inline int PatternEditorPanel::getResolution() const {
 	return m_nResolution;
+}
+inline bool PatternEditorPanel::isQuantized() const {
+	return m_bQuantized;
 }
 inline bool PatternEditorPanel::isUsingTriplets() const {
 	return m_bIsUsingTriplets;

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -398,7 +398,8 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 				auto pInstr = pSong->getDrumkit()->getInstruments()->
 					find( m_row.nInstrumentID );
 				if ( m_pMuteBtn != nullptr &&
-					 pInstr != nullptr && pInstr->hasSamples() ) {
+					 pInstr != nullptr && pInstr->hasSamples() &&
+					 pPref->getHearNewNotes() ) {
 
 					const int nWidth = m_pMuteBtn->x() - 5; // clickable field width
 					const float fVelocity = std::min(

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -278,10 +278,6 @@ private:
 
 	QRect m_lasso;				//!< Dimensions of a current selection lasso
 	QPoint m_movingOffset;		//!< Offset that a selection has been moved by
-		/** Keyboard modifiers used throughout the selection event/handling.
-		 * Note that they can be changed by the user at any time of the
-		 * interaction.*/
-		Qt::KeyboardModifiers m_modifiers;
 	QRect m_keyboardCursorStart; //!< Keyboard cursor position at the start of a keyboard gesture
 	//! @}
 
@@ -302,7 +298,6 @@ public:
 		m_mouseState = Up;
 		m_pClickEvent = nullptr;
 		m_selectionState = Idle;
-		m_modifiers = Qt::NoModifier;
 		m_pSelectionGroup = std::make_shared< SelectionGroup >();
 		m_pSelectionGroup->m_selectionWidgets.insert( w );
 		m_pDragScroller = nullptr;
@@ -388,12 +383,6 @@ public:
 		}
 	}
 
-		/** @returns the keyboard modifiers associated with the selection
-		 * event. */
-		Qt::KeyboardModifiers getModifiers() const {
-			return m_modifiers;
-		}
-
 	//! @name Selection iteration
 	//!
 	//! Shorthand iteration is provided so that ranged for loops can be used for convenience:
@@ -448,8 +437,6 @@ public:
 
 	void mousePressEvent( QMouseEvent *ev ) {
 
-		m_modifiers = ev->modifiers();
-
 		// macOS ctrl+left-click is reported as a
 		// right-click. However, only the 'press' event is reported,
 		// there are no move or release events. This is enough for
@@ -491,8 +478,6 @@ public:
 
 	void mouseMoveEvent( QMouseEvent *ev ) {
 
-		m_modifiers = ev->modifiers();
-
 		if ( m_mouseState == Down ) {
 			if ( (ev->pos() - m_pClickEvent->pos() ).manhattanLength() > QApplication::startDragDistance()
 				 || (ev->timestamp() - m_pClickEvent->timestamp()) > QApplication::startDragTime() ) {
@@ -506,8 +491,6 @@ public:
 	}
 
 	void mouseReleaseEvent( QMouseEvent *ev ) {
-
-		m_modifiers = ev->modifiers();
 
 		if ( m_selectionState == SelectionState::KeyboardLasso ||
 			 m_selectionState == SelectionState::KeyboardMoving ) {
@@ -664,7 +647,6 @@ public:
 		else if ( m_selectionState == MouseMoving ) {
 			m_movingOffset = ev->pos() - m_pClickEvent->pos();
 			m_pWidget->selectionMoveUpdateEvent( ev );
-
 		}
 		else {
 			// Pass drag update to widget
@@ -721,11 +703,6 @@ public:
 				 pCleanedEvent->matches( QKeySequence::SelectNextChar ) ||
 				 pCleanedEvent->matches( QKeySequence::MoveToPreviousChar ) ||
 				 pCleanedEvent->matches( QKeySequence::SelectPreviousChar ) ) ) {
-			// We only propagate Alt modifiers on left-right movement. This way
-			// the resulting position should always correspond the final
-			// position of the keyboard cursor. Regardless, whether the user did
-			// not press Alt on the final Enter hit or switched rows.
-			m_modifiers = ev->modifiers();
 		}
 
 		if ( ev->matches( QKeySequence::SelectNextChar )


### PR DESCRIPTION
Apart from minor fixes of glitches introduced in the recent `PatternEditor` overhaul, three things have been changed:

- The **quantization** button does now not only affect note recording but note placement by mouse or keyboard too. Quantization can also be turned off temporarily using the <kbd>Alt</kbd> modifier (already implemented, not part of this PR).
 
  When disabled all additional tick positions now available apart from those already accessible due to the chosen resolution are drawn with dotted lines. This makes them less pronounced and hopefully highlight what is going on.

  ![2025-03-06-074034_3840x1220_scrot](https://github.com/user-attachments/assets/e59a50fe-de44-404f-a8f0-b430b8180e9e)
- Instead of changing both the current note property and the length of the note, a **right-click drag** in `DrumPatternEditor` or `PianoRollEditor` will now just affect one of these. Which one is determined by the initial direction of the drag.
- The **hear notes** button in the `PatternEditorPanel` does now affect notes triggered via the sidebar as well. When unchecked, the whole pattern editor will be muted. Otherwise, both note insertion and clicking the sidebar will make sounds.