### PR TITLE
SoundLibrary: fix integrity of drumkits

### DIFF
--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1262,7 +1262,7 @@ bool CoreActionController::setDrumkit( const QString& sDrumkit ) {
 		return false;
 	}
 
-	return setDrumkit( pDrumkit );
+	return setDrumkit( std::make_shared<Drumkit>(pDrumkit) );
 }
 
 bool CoreActionController::setDrumkit( std::shared_ptr<Drumkit> pNewDrumkit ) {

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1689,7 +1689,7 @@ void MainForm::loadDrumkit( const QString& sFileName, bool bLoad ) {
 
 				// Pass copy to allow kit in the SoundLibraryDatabase to stay in
 				// a pristine shape.
-				if ( ! switchDrumkit( std::shared_ptr<Drumkit>( pDrumkit ) ) ) {
+				if ( ! switchDrumkit( std::make_shared<Drumkit>( pDrumkit ) ) ) {
 					ERRORLOG( QString( "Unable to switch to freshly imported kit [%1]" )
 							  .arg( sFileName ) );
 				}

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -598,7 +598,7 @@ void SoundLibraryPanel::on_drumkitLoadAction()
 
 	// Pass a copy of the kit since we do not want to alter the settings of the
 	// original one.
-	MainForm::switchDrumkit( std::shared_ptr<Drumkit>( pDrumkit ) );
+	MainForm::switchDrumkit( std::make_shared<Drumkit>( pDrumkit ) );
 }
 
 void SoundLibraryPanel::switchDrumkit( std::shared_ptr<H2Core::Drumkit> pNewDrumkit,

--- a/src/tests/SoundLibraryTest.cpp
+++ b/src/tests/SoundLibraryTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include "SoundLibraryTest.h"
+
+#include <core/Basics/Drumkit.h>
+#include <core/Basics/Instrument.h>
+#include <core/Basics/InstrumentList.h>
+#include <core/Hydrogen.h>
+#include <core/SoundLibrary/SoundLibraryDatabase.h>
+
+void SoundLibraryTest::testKitRetrievalCopy() {
+	___INFOLOG( "" );
+
+	auto pDB = H2Core::Hydrogen::get_instance()->getSoundLibraryDatabase();
+
+	const float fNewGainValue = 1.23456;
+
+	auto pKit = pDB->getDrumkit( "GMRockKit" );
+	CPPUNIT_ASSERT( pKit != nullptr );
+
+	auto pKitCopy = std::make_shared<H2Core::Drumkit>( pKit );
+
+	pKitCopy->getInstruments()->get( 0 )->setGain( fNewGainValue );
+
+	auto pKitAgain = pDB->getDrumkit( "GMRockKit" );
+	CPPUNIT_ASSERT( pKitAgain != nullptr );
+	CPPUNIT_ASSERT( pKitAgain->getInstruments()->get( 0 )->getGain() !=
+					fNewGainValue );
+
+	___INFOLOG( "passed" );
+}
+
+void SoundLibraryTest::testKitRetrievalDirect() {
+	___INFOLOG( "" );
+
+	auto pDB = H2Core::Hydrogen::get_instance()->getSoundLibraryDatabase();
+
+	const float fNewGainValue = 1.23456;
+
+	auto pKit = pDB->getDrumkit( "GMRockKit" );
+	CPPUNIT_ASSERT( pKit != nullptr );
+
+	const float fOldValue = pKit->getInstruments()->get( 0 )->getGain();
+	pKit->getInstruments()->get( 0 )->setGain( fNewGainValue );
+
+	auto pKitAgain = pDB->getDrumkit( "GMRockKit" );
+	CPPUNIT_ASSERT( pKitAgain != nullptr );
+	CPPUNIT_ASSERT( pKitAgain->getInstruments()->get( 0 )->getGain() ==
+					fNewGainValue );
+
+	pKit->getInstruments()->get( 0 )->setGain( fOldValue );
+
+	___INFOLOG( "passed" );
+}

--- a/src/tests/SoundLibraryTest.h
+++ b/src/tests/SoundLibraryTest.h
@@ -1,0 +1,37 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include <core/config.h>
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <core/License.h>
+
+class SoundLibraryTest : public CppUnit::TestFixture {
+	CPPUNIT_TEST_SUITE( SoundLibraryTest );
+	CPPUNIT_TEST( testKitRetrievalCopy );
+	CPPUNIT_TEST( testKitRetrievalDirect );
+	CPPUNIT_TEST_SUITE_END();
+	
+public:
+	void testKitRetrievalCopy();
+	void testKitRetrievalDirect();
+};

--- a/src/tests/registeredTests.h
+++ b/src/tests/registeredTests.h
@@ -45,6 +45,7 @@
 #include "PatternTest.h"
 #include "SampleTest.cpp"
 #include "SongExportTest.h"
+#include "SoundLibraryTest.h"
 #include "TimeTest.h"
 #include "Translations.cpp"
 #include "TransportTest.h"
@@ -78,6 +79,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( OscServerTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( PatternTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( SampleTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( SongExportTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( SoundLibraryTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( TimeTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( TransportTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( UITranslationTest );


### PR DESCRIPTION
Ensure Drumkits from DB are always copied. Else all modifications would (at least for the current session) leak into the DB.