### PR TITLE
Rework InstrumentEditor

### DIFF
--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -877,19 +877,21 @@ void HydrogenApp::showDirector()
 }
 
 
-void HydrogenApp::showSampleEditor( const QString& name, int mSelectedComponemt,
-									int mSelectedLayer )
+void HydrogenApp::showSampleEditor( const QString& name, int nSelectedComponent,
+									int nSelectedLayer )
 {
 
-	if ( m_pSampleEditor ){
+	if ( m_pSampleEditor != nullptr ){
 		QApplication::setOverrideCursor(Qt::WaitCursor);
 		m_pSampleEditor->close();
 		delete m_pSampleEditor;
 		m_pSampleEditor = nullptr;
 		QApplication::restoreOverrideCursor();
 	}
+
 	QApplication::setOverrideCursor(Qt::WaitCursor);
-	m_pSampleEditor = new SampleEditor( nullptr, mSelectedComponemt, mSelectedLayer, name );
+	m_pSampleEditor = new SampleEditor(
+		nullptr, nSelectedComponent, nSelectedLayer, name );
 	m_pSampleEditor->show();
 	QApplication::restoreOverrideCursor();
 }

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -55,7 +55,6 @@ namespace H2Core
 class SongEditorPanel;
 class PlayerControl;
 class PatternEditorPanel;
-class InstrumentEditorPanel;
 class SongEditor;
 class Mixer;
 class AudioEngineInfoForm;
@@ -119,12 +118,12 @@ class HydrogenApp :  public QObject, public EventListener,  public H2Core::Objec
 		bool hideKeyboardCursor();
 		void setHideKeyboardCursor( bool bHidden );
 
+		AudioEngineInfoForm*		getAudioEngineInfoForm();
+		Director*			getDirector();
 		Mixer*				getMixer();
 		MainForm*			getMainForm();
 		SongEditorPanel*		getSongEditorPanel();
-		AudioEngineInfoForm*		getAudioEngineInfoForm();
 		PlaylistEditor*			getPlaylistEditor();
-		Director*			getDirector();
 		SampleEditor*			getSampleEditor();
 		PatternEditorPanel*		getPatternEditorPanel();
 		PlayerControl*			getPlayerControl();

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -27,79 +27,61 @@
 #include <QtWidgets>
 #include <memory>
 
-#include <core/Basics/Instrument.h>
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
 
-#include "../EventListener.h"
 #include "../Widgets/PixmapWidget.h"
 #include "../Widgets/WidgetWithScalableFont.h"
 
-class Fader;
-class LCDDisplay;
-class LCDSpinBox;
 class Button;
 class ClickableLabel;
-class Rotary;
-class LCDCombo;
-class WaveDisplay;
+class Fader;
+class InstrumentEditorPanel;
 class LayerPreview;
+class LCDCombo;
+class LCDDisplay;
+class LCDSpinBox;
+class Rotary;
+class WaveDisplay;
 class WidgetWithInput;
 
 ///
 /// Instrument Editor
 ///
 /** \ingroup docGUI*/
-class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 12, 14>,  public H2Core::Object<InstrumentEditor>, public EventListener
+class InstrumentEditor :  public QWidget,
+						  protected WidgetWithScalableFont<10, 12, 14>,
+						  public H2Core::Object<InstrumentEditor>
 {
 	H2_OBJECT(InstrumentEditor)
 	Q_OBJECT
 
 	public:
-		explicit InstrumentEditor( QWidget* parent );
+		explicit InstrumentEditor( QWidget* parent,
+								   InstrumentEditorPanel* pPanel );
 		~InstrumentEditor();
 
 		void updateEditor();
 
-		void selectLayer( int nLayer );
+		LayerPreview* getLayerPreview();
 
-		void selectComponent( int nComponent );
 		void renameComponent( int nComponentId, const QString& sNewName );
-		bool getIsActive() const;
-
-		// implements EventListener interface
-		virtual void selectedInstrumentChangedEvent() override;
-	virtual void drumkitLoadedEvent() override;
-	virtual void updateSongEvent( int ) override;
-	virtual void instrumentParametersChangedEvent( int ) override;
-		// ~ implements EventListener interface
 
 	public slots:
 	/** Used by #Shotlist */
 	void showLayers( bool bShow );
 		void showSampleEditor();
-		void onPreferencesChanged( const H2Core::Preferences::Changes& changes );
 		void addComponentAction();
 		void deleteComponentAction();
 		void renameComponentAction();
 		void switchComponentAction( int nId );
 
 	private slots:
-		void rotaryChanged(WidgetWithInput *ref);
 		void loadLayerBtnClicked();
-		void filterActiveBtnClicked();
 		void removeLayerButtonClicked();
 		void onDropDownCompoClicked();
 
-		void muteGroupChanged( double fValue );
-		void onIsStopNoteCheckBoxClicked( bool on );
-		void onIsApplyVelocityCheckBoxClicked( bool on);
 		void midiOutChannelChanged( double fValue );
-		void midiOutNoteChanged( double fValue );
-
-		void hihatGroupChanged( double fValue );
-		void hihatMinRangeChanged( double fValue );
-		void hihatMaxRangeChanged( double fValue );
 
 		void sampleSelectionChanged( int );
 
@@ -107,14 +89,9 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 
 
 	private:
-		std::shared_ptr<H2Core::Instrument> m_pInstrument;
-		int m_nSelectedLayer;
-		int m_nSelectedComponent;
+		InstrumentEditorPanel* m_pInstrumentEditorPanel;
 
-		/** Whether a valid instrument was provided an all contained widgets
-		 * should be enabled. */
-		bool m_bIsActive;
-		void activate( bool bActivate );
+		void updateActivation();
 
 		Button *m_pShowInstrumentBtn;
 		Button *m_pShowLayersBtn;
@@ -143,7 +120,6 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 		ClickableLabel* m_pPitchCoarseLbl;
 		ClickableLabel* m_pPitchFineLbl;
 		ClickableLabel* m_pPitchRandomLbl;
-		void updateInstrumentPitch();
 
 		// Low pass filter
 		Button *m_pFilterBypassBtn;
@@ -236,8 +212,8 @@ class InstrumentEditor :  public QWidget, protected WidgetWithScalableFont<10, 1
 		void setAutoVelocity();
 };
 
-inline bool InstrumentEditor::getIsActive() const {
-	return m_bIsActive;
+inline LayerPreview* InstrumentEditor::getLayerPreview() {
+	return m_pLayerPreview;
 }
 
 #endif

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -20,37 +20,28 @@
  *
  */
 
-#include <QLabel>
-#include <QPixmap>
+#include "InstrumentEditorPanel.h"
+
 #include <QGridLayout>
 
-#include <core/Hydrogen.h>
 #include <core/Basics/Drumkit.h>
+#include <core/Basics/Instrument.h>
+#include <core/Basics/InstrumentComponent.h>
+#include <core/Hydrogen.h>
 
-#include "InstrumentEditorPanel.h"
+#include "InstrumentEditor.h"
+#include "LayerPreview.h"
 #include "../HydrogenApp.h"
 
-
-InstrumentEditorPanel* InstrumentEditorPanel::m_pInstance = nullptr;
-
-InstrumentEditorPanel* InstrumentEditorPanel::get_instance()
-{
-	if ( m_pInstance == nullptr  ) {
-		m_pInstance = new InstrumentEditorPanel( nullptr );
-	}
-	return m_pInstance;
-}
-
-
-
 InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent )
+	: m_nSelectedComponent( 0 )
+	, m_nSelectedLayer( 0 )
 {
 	UNUSED( pParent );
 
-	
+	m_pInstrument = H2Core::Hydrogen::get_instance()->getSelectedInstrument();
 
-	m_pInstance = this;
-	m_pInstrumentEditor = new InstrumentEditor( nullptr );
+	m_pInstrumentEditor = new InstrumentEditor( nullptr, this );
 
 	// LAYOUT
 	QGridLayout *vbox = new QGridLayout();
@@ -60,27 +51,90 @@ InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent )
 	vbox->addWidget( m_pInstrumentEditor, 0, 0 );
 
 	this->setLayout( vbox );
-	m_nLayer = 0;
 
 	HydrogenApp::get_instance()->addEventListener(this);
+
+	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
+			 this, &InstrumentEditorPanel::onPreferencesChanged );
 }
 
+InstrumentEditorPanel::~InstrumentEditorPanel() {
+}
 
+void InstrumentEditorPanel::updateEditors() {
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	const auto pSong = pHydrogen->getSong();
 
-InstrumentEditorPanel::~InstrumentEditorPanel()
+	m_pInstrument = pHydrogen->getSelectedInstrument();
+
+	// Check whether the current selection is still valid.
+	if ( pSong != nullptr && m_pInstrument != nullptr ) {
+		// As each instrument can have an arbitrary compoments, we have to
+		// ensure to select a valid one.
+		m_nSelectedComponent = std::clamp(
+			m_nSelectedComponent, 0,
+			static_cast<int>(m_pInstrument->getComponents()->size()) - 1 );
+
+		m_nSelectedLayer = std::clamp(
+			m_nSelectedLayer, 0, H2Core::InstrumentComponent::getMaxLayers() );
+	}
+	else {
+		m_nSelectedLayer = -1;
+		m_nSelectedComponent = 0;
+	}
+
+	m_pInstrumentEditor->updateEditor();
+}
+
+void InstrumentEditorPanel::drumkitLoadedEvent() {
+	updateEditors();
+}
+
+void InstrumentEditorPanel::instrumentParametersChangedEvent( int nInstrumentNumber )
 {
-	INFOLOG( "DESTROY" );
+	auto pSong = H2Core::Hydrogen::get_instance()->getSong();
+
+	// Check if either this particular line or all lines should be updated.
+	if ( pSong != nullptr && pSong->getDrumkit() != nullptr &&
+		 m_pInstrument != nullptr && nInstrumentNumber != -1 &&
+		 m_pInstrument !=
+		 pSong->getDrumkit()->getInstruments()->get( nInstrumentNumber ) ) {
+		// In case nInstrumentNumber does not belong to the currently
+		// selected instrument we don't have to do anything.
+	}
+	else {
+		updateEditors();
+	}
 }
 
-void InstrumentEditorPanel::selectLayer( int nLayer )
-{
-	m_pInstrumentEditor->selectLayer( nLayer );
-	m_nLayer = nLayer;
+void InstrumentEditorPanel::selectedInstrumentChangedEvent() {
+	updateEditors();
 }
 
-void InstrumentEditorPanel::updateWaveDisplay()
-{
-	selectLayer ( m_nLayer ); // trigger a redisplay of wave preview
+void InstrumentEditorPanel::updateSongEvent( int nValue ) {
+	// A new song got loaded
+	if ( nValue == 0 ) {
+		updateEditors();
+	}
 }
 
+void InstrumentEditorPanel::setSelectedComponent( int nComponent ) {
+	m_nSelectedComponent = nComponent;
+}
+void InstrumentEditorPanel::setSelectedLayer( int nLayer ) {
+	m_nSelectedLayer = nLayer;
+}
 
+void InstrumentEditorPanel::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {
+	auto pPref = H2Core::Preferences::get_instance();
+
+	if ( changes & H2Core::Preferences::Changes::Colors ) {
+		m_pInstrumentEditor->setStyleSheet(
+			QString( "QLabel { background: %1 }" )
+			.arg( pPref->getTheme().m_color.m_windowColor.name() ) );
+	}
+	if ( changes & ( H2Core::Preferences::Changes::Font |
+					 H2Core::Preferences::Changes::Colors ) ) {
+		m_pInstrumentEditor->getLayerPreview()->update();
+	}
+}

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.h
@@ -27,45 +27,72 @@
 #include <QtWidgets>
 
 #include <core/Object.h>
-#include "InstrumentEditor.h"
 #include "../EventListener.h"
+
+namespace H2Core {
+	class Instrument;
+}
+class InstrumentEditor;
 
 ///
 /// Container for the Instrument Editor (Singleton).
 ///
 /** \ingroup docGUI*/
-class InstrumentEditorPanel : public QWidget, private H2Core::Object<InstrumentEditorPanel>, public EventListener
+class InstrumentEditorPanel : public QWidget,
+							  private H2Core::Object<InstrumentEditorPanel>,
+							  public EventListener
 {
     H2_OBJECT(InstrumentEditorPanel)
 	Q_OBJECT
 	public:
-		static InstrumentEditorPanel* get_instance();
-		~InstrumentEditorPanel();
-	
+		explicit InstrumentEditorPanel( QWidget *pParent );
 		explicit InstrumentEditorPanel(const InstrumentEditorPanel&) = delete;
+		~InstrumentEditorPanel();
 		InstrumentEditorPanel& operator=( const InstrumentEditorPanel& rhs ) = delete;
 
 		InstrumentEditor* getInstrumentEditor() const;
 
-		void selectLayer( int nLayer );
-		
-		int getSelectedLayer() {
-			return m_nLayer;
-		}
+		void updateEditors();
 
-		void updateWaveDisplay();
+		// implements EventListener interface
+		virtual void drumkitLoadedEvent() override;
+		virtual void instrumentParametersChangedEvent( int ) override;
+		virtual void selectedInstrumentChangedEvent() override;
+		virtual void updateSongEvent( int ) override;
+		// ~ implements EventListener interface
+
+		std::shared_ptr<H2Core::Instrument> getInstrument() const;
+		int getSelectedComponent() const;
+		int getSelectedLayer() const;
+
+		void setSelectedComponent( int nComponent );
+		void setSelectedLayer( int nLayer );
+
+	public slots:
+		void onPreferencesChanged( const H2Core::Preferences::Changes& changes );
 
 	private:
-		static InstrumentEditorPanel*	m_pInstance;
 		InstrumentEditor*				m_pInstrumentEditor;
-		int								m_nLayer;
 
-		explicit InstrumentEditorPanel( QWidget *pParent );
-
+		std::shared_ptr<H2Core::Instrument> m_pInstrument;
+		int m_nSelectedLayer;
+		int m_nSelectedComponent;
 };
 
-inline 	InstrumentEditor* InstrumentEditorPanel::getInstrumentEditor() const {
+inline InstrumentEditor* InstrumentEditorPanel::getInstrumentEditor() const {
 	return m_pInstrumentEditor;
 }
+
+inline std::shared_ptr<H2Core::Instrument> InstrumentEditorPanel::getInstrument() const {
+	return m_pInstrument;
+
+}
+inline int InstrumentEditorPanel::getSelectedComponent() const {
+	return m_nSelectedComponent;
+}
+inline int InstrumentEditorPanel::getSelectedLayer() const {
+	return m_nSelectedLayer;
+}
+
 #endif
 

--- a/src/gui/src/InstrumentEditor/LayerPreview.h
+++ b/src/gui/src/InstrumentEditor/LayerPreview.h
@@ -29,43 +29,36 @@
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
 #include <core/Basics/Instrument.h>
-#include "../EventListener.h"
 #include "../Widgets/WidgetWithScalableFont.h"
 
 namespace H2Core
 {
-class InstrumentLayer;
+	class InstrumentLayer;
 }
 
+class InstrumentEditorPanel;
+
 /** \ingroup docGUI*/
-class LayerPreview :  public QWidget, protected WidgetWithScalableFont<5, 6, 7>,  public H2Core::Object<LayerPreview>, public EventListener
+class LayerPreview :  public QWidget, protected WidgetWithScalableFont<5, 6, 7>,
+					  public H2Core::Object<LayerPreview>
 {
     H2_OBJECT(LayerPreview)
 	Q_OBJECT
 
 	public:
-		explicit LayerPreview(QWidget* pParent);
-		~LayerPreview();
+		static constexpr int m_nLayerHeight = 10;
 
-		void updateAll();
+		explicit LayerPreview( QWidget* pParent, InstrumentEditorPanel* pPanel );
+		~LayerPreview();
 
 		void paintEvent(QPaintEvent *ev) override;
 		virtual void mousePressEvent(QMouseEvent *ev) override;
 		virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 		virtual void mouseMoveEvent ( QMouseEvent *ev ) override;
 
-		void set_selected_component( int SelectedComponent );
-	void setSelectedLayer( int nSelectedLayer );
-
-public slots:
-		void onPreferencesChanged( const H2Core::Preferences::Changes& changes );
-	
 	private:
-		static const int		m_nLayerHeight = 10;
+		InstrumentEditorPanel*  m_pInstrumentEditorPanel;
 		QPixmap					m_speakerPixmap;
-		std::shared_ptr<H2Core::Instrument>	m_pInstrument;
-		int						m_nSelectedLayer;
-		int						m_nSelectedComponent;
 		bool					m_bMouseGrab;
 		bool					m_bGrabLeft;
 
@@ -94,17 +87,8 @@ public slots:
 		 */
 		void showLayerEndVelocity( const std::shared_ptr<H2Core::InstrumentLayer> pLayer, const QMouseEvent* pEvent );
 
-		virtual void selectedInstrumentChangedEvent() override;
-	virtual void drumkitLoadedEvent() override;
-	virtual void updateSongEvent(int) override;
 		/** Used to detect changed in the font*/
 		int getPointSizeButton() const;
 };
-
-inline void LayerPreview::setSelectedLayer( int nLayer ) {
-	if ( nLayer != m_nSelectedLayer ) {
-		m_nSelectedLayer = nLayer;
-	}
-}
 
 #endif

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -76,7 +76,9 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 // ~ TAB buttons
 
 
-	InstrumentEditorPanel::get_instance()->setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );
+	m_pInstrumentEditorPanel = new InstrumentEditorPanel( nullptr );
+	m_pInstrumentEditorPanel->setSizePolicy(
+		QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );
 
 	m_pSoundLibraryPanel = new SoundLibraryPanel( nullptr, false );
 
@@ -86,12 +88,13 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 	pGrid->setMargin( 0 );
 
 	pGrid->addWidget( pTabButtonsPanel, 0, 0, 1, 3 );
-	pGrid->addWidget( InstrumentEditorPanel::get_instance(), 2, 1 );
+	pGrid->addWidget( m_pInstrumentEditorPanel, 2, 1 );
 	pGrid->addWidget( m_pSoundLibraryPanel, 2, 1 );
 
 	this->setLayout( pGrid );
 	
-	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &InstrumentRack::onPreferencesChanged );
+	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
+			 this, &InstrumentRack::onPreferencesChanged );
 
 	showSoundLibrary( false );
 }
@@ -118,13 +121,13 @@ void InstrumentRack::showSoundLibrary( bool bShow ) {
 	if ( bShow ) {
 		m_pSoundLibraryPanel->show();
 		m_pShowSoundLibraryBtn->setChecked( true );
-		InstrumentEditorPanel::get_instance()->hide();
+		m_pInstrumentEditorPanel->hide();
 		m_pShowInstrumentEditorBtn->setChecked( false );
 	}
 	else {
 		m_pSoundLibraryPanel->hide();
 		m_pShowSoundLibraryBtn->setChecked( false );
-		InstrumentEditorPanel::get_instance()->show();
+		m_pInstrumentEditorPanel->show();
 		m_pShowInstrumentEditorBtn->setChecked( true );
 	}
 }

--- a/src/gui/src/InstrumentRack.h
+++ b/src/gui/src/InstrumentRack.h
@@ -32,22 +32,27 @@
 #include "Widgets/WidgetWithScalableFont.h"
 
 class Button;
+class InstrumentEditorPanel;
 class SoundLibraryPanel;
 
 /** \ingroup docGUI*/
-class InstrumentRack : public QWidget, protected WidgetWithScalableFont<5, 6, 7>, private H2Core::Object<InstrumentRack>
+class InstrumentRack : public QWidget,
+					   protected WidgetWithScalableFont<5, 6, 7>,
+					   private H2Core::Object<InstrumentRack>
 {
     H2_OBJECT(InstrumentRack)
 	Q_OBJECT
-	public:
-		explicit InstrumentRack( QWidget *pParent );
-		~InstrumentRack();
 
-		SoundLibraryPanel* getSoundLibraryPanel() {	return m_pSoundLibraryPanel;	}
-
+public:
 		/** 450 - InstrumentEditor layer view +
 		 * 24 - tab button */
 		static constexpr int m_nMinimumHeight = 450;
+
+		explicit InstrumentRack( QWidget *pParent );
+		~InstrumentRack();
+
+		InstrumentEditorPanel* getInstrumentEditorPanel() const;
+		SoundLibraryPanel* getSoundLibraryPanel() const;
 
 public slots:
 	/** Used by the #Shotlist*/
@@ -61,8 +66,17 @@ public slots:
 		/// button for showing the Instrument Editor
 		Button *m_pShowInstrumentEditorBtn;
 
-		SoundLibraryPanel* m_pSoundLibraryPanel;
+		InstrumentEditorPanel* m_pInstrumentEditorPanel;
 
+		SoundLibraryPanel* m_pSoundLibraryPanel;
 };
+
+inline InstrumentEditorPanel* InstrumentRack::getInstrumentEditorPanel() const {
+	return m_pInstrumentEditorPanel;
+
+}
+inline SoundLibraryPanel* InstrumentRack::getSoundLibraryPanel() const {
+	return m_pSoundLibraryPanel;
+}
 
 #endif

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -186,7 +186,8 @@ MainForm::MainForm( QApplication * pQApplication, const QString& sSongFilename,
 	h2app->getPatternEditorPanel()->installEventFilter (this);
 	h2app->getSongEditorPanel()->installEventFilter (this);
 	h2app->getPlayerControl()->installEventFilter(this);
-	InstrumentEditorPanel::get_instance()->installEventFilter(this);
+	h2app->getInstrumentRack()->getInstrumentEditorPanel()
+		->installEventFilter(this);
 	h2app->getAudioEngineInfoForm()->installEventFilter(this);
 	h2app->getDirector()->installEventFilter(this);
 	installEventFilter( this );
@@ -3099,7 +3100,7 @@ bool MainForm::handleKeyEvent( QObject* pQObject, QKeyEvent* pKeyEvent ) {
 				action_drumkit_new();
 				break;
 			case Shortcuts::Action::AddComponent:
-				InstrumentEditorPanel::get_instance()->
+				pHydrogenApp->getInstrumentRack()->getInstrumentEditorPanel()->
 					getInstrumentEditor()->addComponentAction();
 				break;
 

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -25,6 +25,7 @@
 #include "../CommonStrings.h"
 #include "../InstrumentEditor/InstrumentEditor.h"
 #include "../InstrumentEditor/InstrumentEditorPanel.h"
+#include "../InstrumentRack.h"
 
 #include "MainSampleWaveDisplay.h"
 #include "DetailWaveDisplay.h"
@@ -399,7 +400,8 @@ void SampleEditor::on_PrevChangesPushButton_clicked()
 	setClean();
 	Hydrogen::get_instance()->setIsModified( true );
 	QApplication::restoreOverrideCursor();
-	InstrumentEditorPanel::get_instance()->updateWaveDisplay();
+	HydrogenApp::get_instance()->getInstrumentRack()->getInstrumentEditorPanel()->
+		updateEditors();
 }
 
 
@@ -617,7 +619,8 @@ void SampleEditor::on_PlayPushButton_clicked()
 		return;
 	}
 
-	const int selectedLayer = InstrumentEditorPanel::get_instance()->getSelectedLayer();
+	const int selectedLayer = HydrogenApp::get_instance()->getInstrumentRack()->
+		getInstrumentEditorPanel()->getSelectedLayer();
 
 	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
 	if ( pSong == nullptr ) {
@@ -689,8 +692,8 @@ void SampleEditor::on_PlayOrigPushButton_clicked()
 		return;
 	}
 
-	const int nSelectedlayer =
-		InstrumentEditorPanel::get_instance()->getSelectedLayer();
+	const int nSelectedlayer = HydrogenApp::get_instance()->getInstrumentRack()->
+		getInstrumentEditorPanel()->getSelectedLayer();
 	auto pInstr = pSong->getDrumkit()->getInstruments()->get(
 		pHydrogen->getSelectedInstrumentNumber() );
 	if ( pInstr == nullptr ) {

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -43,6 +43,7 @@
 
 #include "CommonStrings.h"
 #include "HydrogenApp.h"
+#include "InstrumentEditor/InstrumentEditor.h"
 #include "InstrumentEditor/InstrumentEditorPanel.h"
 #include "InstrumentRack.h"
 #include "MainForm.h"
@@ -1018,12 +1019,14 @@ class SE_renameComponentAction : public QUndoCommand {
 					 .arg( sOldName ).arg( sNewName ) );
 		}
 		virtual void undo() {
-			InstrumentEditorPanel::get_instance()->getInstrumentEditor()
-				->renameComponent( m_nComponentId, m_sOldName );
+			HydrogenApp::get_instance()->getInstrumentRack()->
+				getInstrumentEditorPanel()->getInstrumentEditor()->
+				renameComponent( m_nComponentId, m_sOldName );
 		}
 		virtual void redo() {
-			InstrumentEditorPanel::get_instance()->getInstrumentEditor()
-				->renameComponent( m_nComponentId, m_sNewName );
+			HydrogenApp::get_instance()->getInstrumentRack()->
+				getInstrumentEditorPanel()->getInstrumentEditor()->
+				renameComponent( m_nComponentId, m_sNewName );
 		}
 	private:
 		QString m_sNewName;

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -433,5 +433,6 @@ void LCDSpinBox::onPreferencesChanged( const H2Core::Preferences::Changes& chang
 void LCDSpinBox::valueChanged( double fNewValue ) {
 	if ( m_type == Type::Int ) {
 		emit valueChanged( static_cast<int>(fNewValue) );
+		emit valueAdjusted();
 	}
 }

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -93,11 +93,15 @@ public slots:
 				      H2Core::Event::Trigger::Default );
 
 private slots:
-	void valueChanged( double fNewValue );
+		void valueChanged( double fNewValue );
 
 signals:
 	void slashKeyPressed();
 	void valueChanged( int );
+		/** A non-overloaded version of valueChanged() in order to use this
+		 * signal with the version of connect() (Qt signal handling) which
+		 * allows inline lambda functions. */
+		void valueAdjusted();
 	
 private:
 	double nextValueInPatternSizeDenominator( bool bUp, bool bAccelerated );


### PR DESCRIPTION
there was a minor bug on my short list introduced by the faulty event handling in the `InstrumentEditor`/`LayerPreview`. So, after reworking event handling in most parts, this one is next.

- The `InstrumentEditor` singleton was killed and the instance is now a member of `InstrumentRack`.
- The state of the instrument editor - selected instrument, component, and layer - do now reside in `InstrumentEditorPanel` exclusively.
- All event handling is now done in `InstrumentEditorPanel` and side effects are delegated to child classes.
- `onPreferencesChanged` is now handled centrally in `InstrumentEditorPanel`
- Side effects are now handled by updateX functions instead of the event handlers themselves