### PR TITLE
CoreActionController: fix NOTE OFF handling

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix import bug for drumkits created in version >= 2.0.
 		- Fix memory leakage for songs created in version >= 2.0.
 		- Fix memory leakage for notes with probability < 1.0.
+		- Fix incoming MIDI NOTE OFF handling.
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1824,7 +1824,7 @@ bool CoreActionController::handleNote( int nNote, float fVelocity, bool bNoteOff
 	INFOLOG( QString( "[%1] mapped note [%2] to instrument [%3]" )
 			 .arg( sMode ).arg( nNote ).arg( nInstrument ) );
 
-	return pHydrogen->addRealtimeNote( nInstrument, fVelocity, false, nNote );
+	return pHydrogen->addRealtimeNote( nInstrument, fVelocity, bNoteOff, nNote );
 }
 
 void CoreActionController::updatePreferences() {


### PR DESCRIPTION
`MidiInput` does provide an argument to `CoreActionController::handleNote` whether the encountered notes in due to a NOTE ON or NOTE OFF MIDI event. But this argument was not passed to the next function and was lost resulting in Hydrogen not handling NOTE OFF events