### PR TITLE
Trigger multiple instruments using a single MIDI NOTE ON event (#1765)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -121,6 +121,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 				- does now add tempo changes and tags in case the Timeline is used (#933).
 				- does now add time signature events based on the length of the longest
 				  pattern within a column (#1680).
+		- MIDI import is now able to trigger multiple instruments using a single
+			NOTE ON event (#1765).
 
 	* Removed
 		- Preferences options `restoreLastSong` and `restoreLastPlaylist` were

--- a/ChangeLog
+++ b/ChangeLog
@@ -146,6 +146,10 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix crashes in SampleEditor (#2092).
 		- Fix track names in multi track export. When using just the file extension,
 			the raw instrument names will be used (#2096).
+		- Fix import bug for drumkits created in version >= 2.0.
+		- Fix memory leakage for songs created in version >= 2.0.
+		- Fix memory leakage for notes with probability < 1.0.
+		- Fix incoming MIDI NOTE OFF handling.
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -236,14 +236,18 @@ std::shared_ptr<Instrument>  InstrumentList::find( const QString& name ) const
 	return nullptr;
 }
 
-std::shared_ptr<Instrument>  InstrumentList::findMidiNote( const int note ) const
+std::vector< std::shared_ptr<Instrument> > InstrumentList::findByMidiNote(
+	const int nNote ) const
 {
-	for( int i=0; i<m_pInstruments.size(); i++ ) {
-		if ( m_pInstruments[i]->getMidiOutNote()==note ) {
-			return m_pInstruments[i];
+	std::vector< std::shared_ptr<Instrument> > instrumentsFound;
+
+	for ( const auto& ppInstrument : m_pInstruments ) {
+		if ( ppInstrument != nullptr && ppInstrument->getMidiOutNote() == nNote ) {
+			instrumentsFound.push_back( ppInstrument );
 		}
 	}
-	return nullptr;
+
+	return std::move( instrumentsFound );
 }
 
 std::shared_ptr<Instrument> InstrumentList::del( std::shared_ptr<Instrument> instrument )

--- a/src/core/Basics/InstrumentList.h
+++ b/src/core/Basics/InstrumentList.h
@@ -137,11 +137,11 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 		 */
 		std::shared_ptr<Instrument> find( const QString& name ) const;
 		/**
-		 * find an instrument which play the given midi note
-		 * \param note the Midi note of the instrument to find
+		 * find all instruments which play the given midi note
+		 * \param nNote the Midi note of the instruments to find
 		 * \return 0 if not found
 		 */
-		std::shared_ptr<Instrument> findMidiNote( const int note ) const;
+		std::vector< std::shared_ptr<Instrument> > findByMidiNote( const int nNote ) const;
 		/**
 		 * move an instrument from a position to another
 		 * \param idx_a the start index

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -2430,7 +2430,7 @@ bool CoreActionController::handleNote( int nNote, float fVelocity, bool bNoteOff
 	INFOLOG( QString( "[%1] mapped note [%2] to instrument [%3]" )
 			 .arg( sMode ).arg( nNote ).arg( nInstrument ) );
 
-	return pHydrogen->addRealtimeNote( nInstrument, fVelocity, false, nNote );
+	return pHydrogen->addRealtimeNote( nInstrument, fVelocity, bNoteOff, nNote );
 }
 
 void CoreActionController::insertRecentFile( const QString& sFilename ){

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -2362,32 +2362,31 @@ bool CoreActionController::handleNote( int nNote, float fVelocity, bool bNoteOff
 		return false;
 	}
 
-	int nInstrument = nNote - MidiMessage::instrumentOffset;
+	// Find the instrument(s) corresponding to the provided note.
 	auto pInstrumentList = pSong->getDrumkit()->getInstruments();
-	std::shared_ptr<Instrument> pInstrument = nullptr;
+	std::vector< std::shared_ptr<Instrument> > instrumentsMatching;
 	QString sMode;
-
 	if ( pPref->m_bPlaySelectedInstrument ){
-		nInstrument = pHydrogen->getSelectedInstrumentNumber();
-		pInstrument = pInstrumentList->get( pHydrogen->getSelectedInstrumentNumber());
+		auto pInstrument =
+			pInstrumentList->get( pHydrogen->getSelectedInstrumentNumber());
 		if ( pInstrument == nullptr ) {
 			WARNINGLOG( "No instrument selected!" );
 			return false;
 		}
+		instrumentsMatching.push_back( pInstrument );
 		sMode = "Play Selected Instrument";
 	}
 	else if ( pPref->m_bMidiFixedMapping ){
-		pInstrument = pInstrumentList->findMidiNote( nNote );
-		if ( pInstrument == nullptr ) {
+		instrumentsMatching = pInstrumentList->findByMidiNote( nNote );
+		if ( instrumentsMatching.size() == 0 ) {
 			WARNINGLOG( QString( "Unable to map note [%1] to instrument" )
 						.arg( nNote ) );
 			return false;
 		}
-		nInstrument = pInstrumentList->index( pInstrument );
 		sMode = "Map to Output MIDI note";
 	}
 	else {
-		nInstrument = nNote - MidiMessage::instrumentOffset;
+		const int nInstrument = nNote - MidiMessage::instrumentOffset;
 		if( nInstrument < 0 || nInstrument >= pInstrumentList->size()) {
 			WARNINGLOG( QString( "Instrument number [%1] - derived from note [%2] - out of bound note [%3,%4]" )
 						.arg( nInstrument ).arg( nNote )
@@ -2395,42 +2394,58 @@ bool CoreActionController::handleNote( int nNote, float fVelocity, bool bNoteOff
 			return false;
 		}
 
-		pInstrument = pInstrumentList->get( nInstrument );
+		auto pInstrument = pInstrumentList->get( nInstrument );
 		if ( pInstrument == nullptr ) {
 			WARNINGLOG( QString( "Unable to retrieve instrument [%1]" )
 						.arg( nInstrument ) );
 			return false;
 		}
+		instrumentsMatching.push_back( pInstrument );
 		sMode = "Map to instrument list position";
 	}
 
+	// Some finishing touches and note playback.
+	bool bSuccess = true;
+	QStringList instrumentStrings;
+	for ( const auto& ppInstrument : instrumentsMatching ) {
 
-	// Only look to change instrument if the current note is actually of hihat
-	// and hihat openness is outside the instrument selected
-	const int nHihatOpenness = pHydrogen->getHihatOpenness();
-	if ( pInstrument != nullptr &&
-		 pInstrument->getHihatGrp() >= 0 &&
-		 ( nHihatOpenness < pInstrument->getLowerCc() ||
-		   nHihatOpenness > pInstrument->getHigherCc() ) ) {
+		// Only look to change instrument if the current note is actually of hihat
+		// and hihat openness is outside the instrument selected
+		const int nHihatOpenness = pHydrogen->getHihatOpenness();
+		int nCurrentInstrument = pInstrumentList->index( ppInstrument );
+		if ( ppInstrument != nullptr && ppInstrument->getHihatGrp() >= 0 &&
+			 ( nHihatOpenness < ppInstrument->getLowerCc() ||
+			   nHihatOpenness > ppInstrument->getHigherCc() ) ) {
 
-		for ( int i = 0; i <= pInstrumentList->size(); i++ ) {
-			auto ppInstr = pInstrumentList->get( i );
-			if ( ppInstr != nullptr &&
-				pInstrument->getHihatGrp() == ppInstr->getHihatGrp() &&
-				nHihatOpenness >= ppInstr->getLowerCc() &&
-				nHihatOpenness <= ppInstr->getHigherCc() ) {
+			for ( int ii = 0; ii <= pInstrumentList->size(); ii++ ) {
+				auto ppOtherInstrument = pInstrumentList->get( ii );
+				if ( ppOtherInstrument != nullptr &&
+					 ppInstrument->getHihatGrp() ==
+					   ppOtherInstrument->getHihatGrp() &&
+					 nHihatOpenness >= ppOtherInstrument->getLowerCc() &&
+					 nHihatOpenness <= ppOtherInstrument->getHigherCc() ) {
 
-				nInstrument = i;
-				sMode = "Hihat Pressure Group";
-				break;
+					nCurrentInstrument = ii;
+					sMode = "Hihat Pressure Group";
+					break;
+				}
 			}
+		}
+
+		if ( pHydrogen->addRealtimeNote(
+				 nCurrentInstrument, fVelocity, bNoteOff, nNote ) ) {
+			instrumentStrings << QString( "%1 (%2)" )
+				.arg( ppInstrument->getName() ).arg( nCurrentInstrument );
+		}
+		else {
+			bSuccess = false;
 		}
 	}
 
-	INFOLOG( QString( "[%1] mapped note [%2] to instrument [%3]" )
-			 .arg( sMode ).arg( nNote ).arg( nInstrument ) );
+	INFOLOG( QString( "[%1] mapped note [%2] to instrument(s) [%3]" )
+			 .arg( sMode ).arg( nNote ).arg( instrumentStrings.join( ", " ) ) );
 
-	return pHydrogen->addRealtimeNote( nInstrument, fVelocity, bNoteOff, nNote );
+	return bSuccess;
 }
 
 void CoreActionController::insertRecentFile( const QString& sFilename ){

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -141,22 +141,23 @@ void MidiInput::handleMidiMessage( const MidiMessage& msg )
 		case MidiMessage::TIMING_CLOCK:
 		case MidiMessage::ACTIVE_SENSING:
 		case MidiMessage::RESET:
-			ERRORLOG( QString( "MIDI message of type [%1] is not supported by Hydrogen" )
+			INFOLOG( QString( "MIDI message of type [%1] is not supported by Hydrogen" )
 					  .arg( MidiMessage::TypeToQString( msg.m_type ) ) );
-			break;
+			return;
 
 		case MidiMessage::UNKNOWN:
-			ERRORLOG( "Unknown midi message" );
-			break;
+			WARNINGLOG( "Unknown midi message" );
+			return;
 
 		default:
-			ERRORLOG( QString( "unhandled midi message type: %1 (%2)" )
+			INFOLOG( QString( "unhandled midi message type: %1 (%2)" )
 					  .arg( static_cast<int>( msg.m_type ) )
 					  .arg( MidiMessage::TypeToQString( msg.m_type ) ) );
+			return;
 		}
 
 		// Two spaces after "msg." in a row to align message parameters
-		INFOLOG( QString( "DONE handling msg: [%1]" ).arg( msg.toQString() ) );
+		DEBUGLOG( QString( "DONE handling msg: [%1]" ).arg( msg.toQString() ) );
 }
 
 void MidiInput::handleControlChangeMessage( const MidiMessage& msg )

--- a/src/core/IO/MidiInput.cpp
+++ b/src/core/IO/MidiInput.cpp
@@ -201,22 +201,20 @@ void MidiInput::handleProgramChangeMessage( const MidiMessage& msg )
 	pHydrogen->setLastMidiEventParameter( 0 );
 }
 
-void MidiInput::handleNoteOnMessage( const MidiMessage& msg )
-{
-//	INFOLOG( "handleNoteOnMessage" );
+void MidiInput::handleNoteOnMessage( const MidiMessage& msg ) {
 
 	const int nNote = msg.m_nData1;
-	float fVelocity = msg.m_nData2 / 127.0;
+	const float fVelocity = msg.m_nData2 / 127.0;
 
 	if ( fVelocity == 0 ) {
 		handleNoteOffMessage( msg, false );
 		return;
 	}
 
-	MidiActionManager * pMidiActionManager = MidiActionManager::get_instance();
-	const auto pMidiMap = Preferences::get_instance()->getMidiMap();
-	Hydrogen *pHydrogen = Hydrogen::get_instance();
 	const auto pPref = Preferences::get_instance();
+	auto pMidiActionManager = MidiActionManager::get_instance();
+	const auto pMidiMap = pPref->getMidiMap();
+	auto pHydrogen = Hydrogen::get_instance();
 
 	pHydrogen->setLastMidiEvent( MidiMessage::Event::Note );
 	pHydrogen->setLastMidiEventParameter( msg.m_nData1 );


### PR DESCRIPTION
when using drumkit-based mapping of incoming MIDI NOTE events and activating "Use output note as input note" in the `Preferences` every `Instrument` holding the corresponding MIDI output note is now triggered. Previously, only the first one encountered was used for playback.

Fixes #1765
Fixes #599