### PR TITLE
Add dedicated mute and solo color

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -44,6 +44,7 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 			with a tail showing their effective length in the pattern editor (can be
 			disabled in Preferences > Appearance > Interface > Indicate effective note
 			length).
+		- Custom colors for 'mute' and 'solo'.
 	* Changed
 		- Drumkit handling was reworked. Each song will now hold a proper drumkit.
 			Tweaking its name, instruments etc. does not affect the kits in the Sound

--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -278,6 +278,10 @@
     <spinBoxTextColor>240,240,240</spinBoxTextColor>
     <playheadColor>0,0,0</playheadColor>
     <cursorColor>38,39,44</cursorColor>
+    <muteColor>191,51,51</muteColor>
+    <muteTextColor>255,255,255</muteTextColor>
+    <soloColor>168,136,38</soloColor>
+    <soloTextColor>255,255,255</soloTextColor>
    </widget>
   </colorTheme>
   <SongEditor_ColoringMethod>1</SongEditor_ColoringMethod>

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -334,7 +334,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Silenciar</translation>
     </message>
     <message>
@@ -1386,6 +1386,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Sol</translation>
     </message>
 </context>
 <context>
@@ -2874,14 +2879,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Silenciar</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Sol</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4043,6 +4040,14 @@ La ruta a l&apos;Script i el nom del Script no poden tenir espais en blanc.</tra
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5641,10 +5646,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Sol</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Ztlumit</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Sólo</translation>
     </message>
 </context>
 <context>
@@ -2872,14 +2877,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Ztlumit</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Sólo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4041,6 +4038,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5639,10 +5644,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Sólo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Mute</translation>
     </message>
     <message>
@@ -1388,6 +1388,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2908,14 +2913,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Stumm</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation>Effect %1 Pegel</translation>
     </message>
@@ -4074,6 +4071,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5695,10 +5700,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Schalte Instrument stumm</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Σίγηση</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Μόνο του</translation>
     </message>
 </context>
 <context>
@@ -2901,14 +2906,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Σίγηση</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Μόνο του</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4075,6 +4072,14 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5698,10 +5703,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Σίγηση οργάνου</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Μόνο του</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation></translation>
     </message>
     <message>
@@ -1384,6 +1384,11 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2861,14 +2866,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation></translation>
     </message>
@@ -4027,6 +4024,14 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
         <translation></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5623,10 +5628,6 @@ p, li { white-space: pre-wrap; }
     <name>SidebarRow</name>
     <message>
         <source>Mute instrument</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Solo</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1384,6 +1384,11 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2861,14 +2866,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4027,6 +4024,14 @@ The path to the script and the scriptname must without whitespaces.</source>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
         <translation></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5623,10 +5628,6 @@ p, li { white-space: pre-wrap; }
     <name>SidebarRow</name>
     <message>
         <source>Mute instrument</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Solo</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Silencio</translation>
     </message>
     <message>
@@ -1389,6 +1389,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2915,14 +2920,6 @@ Debería funcionar correctamente mientras utilices el GMRockKit, y no uses tresi
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Silencio</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation>FX %1 envío</translation>
     </message>
@@ -4087,6 +4084,14 @@ La ruta al script y al nombre del script no pueden contener espacios en blanco.<
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5708,10 +5713,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Silenciar instrumento</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Muet</translation>
     </message>
     <message>
@@ -1388,6 +1388,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2916,14 +2921,6 @@ L&apos;exportation LilyPond est une fonctionnalité expérimentale.
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Muet</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation>effet %1 envoi</translation>
     </message>
@@ -4088,6 +4085,14 @@ Le chemin vers le script et le nom du script doivent être sans espaces.</transl
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5709,10 +5714,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Rendre l&apos;instrument muet</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Silencio</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2900,14 +2905,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Silencio</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4070,6 +4067,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5678,10 +5683,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Silenciar instrumento</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Escludi</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2872,14 +2877,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Escludi</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4041,6 +4038,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5639,10 +5644,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Némít</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Szóló</translation>
     </message>
 </context>
 <context>
@@ -2866,14 +2871,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Némít</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Szóló</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4031,6 +4028,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5629,10 +5634,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Szóló</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Escludi</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2875,14 +2880,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Escludi</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4045,6 +4042,14 @@ Il percorso dello script o il suo nome non devono contenere spazi.</translation>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5643,10 +5648,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Isola strumento</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -334,7 +334,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>ミュート</translation>
     </message>
     <message>
@@ -1386,6 +1386,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>ソロ</translation>
     </message>
 </context>
 <context>
@@ -2898,14 +2903,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>ミュート</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>ソロ</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4068,6 +4065,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5676,10 +5681,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>ソロ</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Dempen</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2873,14 +2878,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Dempen</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4038,6 +4035,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5636,10 +5641,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Wyciszenie</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2869,14 +2874,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Wyciszenie</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4034,6 +4031,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5632,10 +5637,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Mudo</translation>
     </message>
     <message>
@@ -1388,6 +1388,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Solo</translation>
     </message>
 </context>
 <context>
@@ -2913,14 +2918,6 @@ Deveria funcionar corretamente dado que você usou o GMRockKit e que você não 
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Mudo</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation>FX %1 envio</translation>
     </message>
@@ -4085,6 +4082,14 @@ O caminho para o script e o nome do script não devem conter espaços em branco.
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5706,10 +5711,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Silenciar instrumento</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Solo</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Тихо</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Соло</translation>
     </message>
 </context>
 <context>
@@ -2898,14 +2903,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Тихо</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Соло</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4065,6 +4062,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5668,10 +5673,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Приглушить инструмент</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Соло</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Утишај</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Соло</translation>
     </message>
 </context>
 <context>
@@ -2894,14 +2899,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Утишај</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Соло</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4066,6 +4063,14 @@ The path to the script and the scriptname must be without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5687,10 +5692,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Утишај инструменат</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Соло</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Ljudlöst</translation>
     </message>
     <message>
@@ -1384,6 +1384,11 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2866,14 +2871,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Ljudlöst</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4031,6 +4028,14 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5628,10 +5633,6 @@ p, li { white-space: pre-wrap; }
     <name>SidebarRow</name>
     <message>
         <source>Mute instrument</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Solo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>Приглушити</translation>
     </message>
     <message>
@@ -1385,6 +1385,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>Соло</translation>
     </message>
 </context>
 <context>
@@ -2899,14 +2904,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>Приглушити</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Соло</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4071,6 +4068,14 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5692,10 +5697,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>Приглушити інструмент</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>Соло</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -333,7 +333,7 @@ Text displayed on the button indicating that the Beat Counter will only set temp
     </message>
     <message>
         <source>Mute</source>
-        <extracomment>Text displayed on the button for muting the master strip. Its size is designed for a four characters.</extracomment>
+        <extracomment>Text displayed on the button for muting the master strip as well as other places.</extracomment>
         <translation>静音</translation>
     </message>
     <message>
@@ -1386,6 +1386,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Components</source>
         <extracomment>Text displayed on the button to show the Layer view of the Instrument Rack. Its size is designed to hold ten characters but is quite flexible.</extracomment>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo</source>
+        <extracomment>Text displayed at various places referring to the solo buttons.</extracomment>
+        <translation>独奏</translation>
     </message>
 </context>
 <context>
@@ -2899,14 +2904,6 @@ LilyPond 导出是一项实验性功能。
 <context>
     <name>MixerLine</name>
     <message>
-        <source>Mute</source>
-        <translation>静音</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>独奏</translation>
-    </message>
-    <message>
         <source>FX %1 send</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4071,6 +4068,14 @@ The path to the script and the scriptname must without whitespaces.</source>
     <message>
         <source>Note Off and Mute Group</source>
         <extracomment>This color will be used for both noteOffs / stop notes as well as for * the tail of the effective note length introduced by stop notes and the * mute group feature.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Solo Text</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5692,10 +5697,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Mute instrument</source>
         <translation>静音乐器</translation>
-    </message>
-    <message>
-        <source>Solo</source>
-        <translation>独奏</translation>
     </message>
     <message>
         <source>Some samples for this instrument failed to load.</source>

--- a/data/themes/default.h2theme
+++ b/data/themes/default.h2theme
@@ -74,6 +74,10 @@
    <spinBoxTextColor>240,240,240</spinBoxTextColor>
    <playheadColor>0,0,0</playheadColor>
    <cursorColor>38,39,44</cursorColor>
+   <muteColor>191,51,51</muteColor>
+   <muteTextColor>255,255,255</muteTextColor>
+   <soloColor>168,136,38</soloColor>
+   <soloTextColor>255,255,255</soloTextColor>
   </widget>
  </colorTheme>
  <interfaceTheme>

--- a/src/core/Preferences/Theme.cpp
+++ b/src/core/Preferences/Theme.cpp
@@ -92,6 +92,10 @@ ColorTheme::ColorTheme()
 	, m_accentTextColor( QColor( 255, 255, 255 ) )
 	, m_playheadColor( QColor( 0, 0, 0 ) )
 	, m_cursorColor( QColor( 38, 39, 44 ) )
+	, m_muteColor( QColor( 247, 100, 100 ) )
+	, m_muteTextColor( QColor( 10, 10, 10 ) )
+	, m_soloColor( QColor( 67, 96, 131 ) )
+	, m_soloTextColor( QColor( 255, 255, 255 ) )
 {
 }
 
@@ -194,6 +198,10 @@ void ColorTheme::saveTo( XMLNode& parent ) const {
 	widgetNode.write_color( "spinBoxTextColor", m_spinBoxTextColor );
 	widgetNode.write_color( "playheadColor", m_playheadColor );
 	widgetNode.write_color( "cursorColor", m_cursorColor );
+	widgetNode.write_color( "muteColor", m_muteColor );
+	widgetNode.write_color( "muteTextColor", m_muteTextColor );
+	widgetNode.write_color( "soloColor", m_soloColor );
+	widgetNode.write_color( "soloTextColor", m_soloTextColor );
 }
 
 ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
@@ -490,7 +498,23 @@ ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
 			widgetNode.read_color(
 				"cursorColor",
 				colorTheme.m_cursorColor, false, false, bSilent );
-	}
+		colorTheme.m_muteColor =
+			widgetNode.read_color(
+				"muteColor",
+				colorTheme.m_muteColor, false, false, bSilent );
+		colorTheme.m_muteTextColor =
+			widgetNode.read_color(
+				"muteTextColor",
+				colorTheme.m_muteTextColor, false, false, bSilent );
+		colorTheme.m_soloColor =
+			widgetNode.read_color(
+				"soloColor",
+				colorTheme.m_soloColor, false, false, bSilent );
+		colorTheme.m_soloTextColor =
+			widgetNode.read_color(
+				"soloTextColor",
+				colorTheme.m_soloTextColor, false, false, bSilent );
+}
 	else {
 		WARNINGLOG( "<widget> node not found" );
 	}
@@ -633,8 +657,16 @@ QString ColorTheme::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2m_playheadColor: %3\n" ).arg( sPrefix )
 					 .arg( s ).arg( m_playheadColor.name() ) )
 			.append( QString( "%1%2m_cursorColor: %3\n" ).arg( sPrefix )
-					 .arg( s ).arg( m_cursorColor.name() ) );
-	}
+					 .arg( s ).arg( m_cursorColor.name() ) )
+			.append( QString( "%1%2m_muteColor: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_muteColor.name() ) )
+			.append( QString( "%1%2m_muteTextColor: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_muteTextColor.name() ) )
+			.append( QString( "%1%2m_soloColor: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_soloColor.name() ) )
+			.append( QString( "%1%2m_soloTextColor: %3\n" ).arg( sPrefix )
+					 .arg( s ).arg( m_soloTextColor.name() ) );
+}
 	else {
 		sOutput = QString( "[ColorTheme] " )
 			.append( QString( "m_songEditor_backgroundColor: %1" )
@@ -762,7 +794,15 @@ QString ColorTheme::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", m_playheadColor: %1" )
 					 .arg( m_playheadColor.name() ) )
 			.append( QString( ", m_cursorColor: %1" )
-					 .arg( m_cursorColor.name() ) );
+					 .arg( m_cursorColor.name() ) )
+			.append( QString( ", m_muteColor: %1" )
+					 .arg( m_muteColor.name() ) )
+			.append( QString( ", m_muteTextColor: %1" )
+					 .arg( m_muteTextColor.name() ) )
+			.append( QString( ", m_soloColor: %1" )
+					 .arg( m_soloColor.name() ) )
+			.append( QString( ", m_soloTextColor: %1" )
+					 .arg( m_soloTextColor.name() ) );
 	}
 
 	return sOutput;

--- a/src/core/Preferences/Theme.cpp
+++ b/src/core/Preferences/Theme.cpp
@@ -92,9 +92,9 @@ ColorTheme::ColorTheme()
 	, m_accentTextColor( QColor( 255, 255, 255 ) )
 	, m_playheadColor( QColor( 0, 0, 0 ) )
 	, m_cursorColor( QColor( 38, 39, 44 ) )
-	, m_muteColor( QColor( 247, 100, 100 ) )
-	, m_muteTextColor( QColor( 10, 10, 10 ) )
-	, m_soloColor( QColor( 67, 96, 131 ) )
+	, m_muteColor( QColor( 191, 51, 51 ) )
+	, m_muteTextColor( QColor( 255, 255, 255 ) )
+	, m_soloColor( QColor( 168, 136, 38 ) )
 	, m_soloTextColor( QColor( 255, 255, 255 ) )
 {
 }

--- a/src/core/Preferences/Theme.h
+++ b/src/core/Preferences/Theme.h
@@ -139,6 +139,11 @@ public:
 	QColor m_spinBoxTextColor;
 	QColor m_playheadColor;
 	QColor m_cursorColor;
+
+		QColor m_muteColor;
+		QColor m_muteTextColor;
+		QColor m_soloColor;
+		QColor m_soloTextColor;
 };
 
 	

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -33,9 +33,11 @@ CommonStrings::CommonStrings(){
 	/*: Text displayed on the button for muting an instrument strip in
 	  the mixer. Its size is designed for a single character.*/
 	m_sSmallMuteButton = tr( "M" );
-	/*: Text displayed on the button for muting the master strip. Its
-	  size is designed for a four characters.*/
+	/*: Text displayed on the button for muting the master strip as well as
+	  other places. */
 	m_sBigMuteButton = tr( "Mute" );
+	/*: Text displayed at various places referring to the solo buttons.  */
+	m_sBigSoloButton = tr( "Solo" );
 	/*: Text displayed on the button for bypassing an element. Its
 	  size is designed for a three characters.*/
 	m_sBypassButton = tr( "BYP" );

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -47,6 +47,7 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getSmallSoloButton() const { return m_sSmallSoloButton; }
 	const QString& getSmallMuteButton() const { return m_sSmallMuteButton; }
 	const QString& getBigMuteButton() const { return m_sBigMuteButton; }
+	const QString& getBigSoloButton() const { return m_sBigSoloButton; }
 	const QString& getBypassButton() const { return m_sBypassButton; }
 	const QString& getEditButton() const { return m_sEditButton; }
 	const QString& getClearButton() const { return m_sClearButton; }
@@ -331,6 +332,7 @@ private:
 	QString m_sSmallSoloButton;
 	QString m_sSmallMuteButton;
 	QString m_sBigMuteButton;
+	QString m_sBigSoloButton;
 	QString m_sBypassButton;
 	QString m_sEditButton;
 	QString m_sClearButton;

--- a/src/gui/src/InstrumentEditor/ComponentView.cpp
+++ b/src/gui/src/InstrumentEditor/ComponentView.cpp
@@ -79,7 +79,7 @@ ComponentView::ComponentView( QWidget* pParent,
 	m_pShowLayersBtn = new Button(
 		pHeaderWidget, QSize( ComponentView::nExpansionButtonWidth,
 							  ComponentView::nExpansionButtonWidth ),
-		Button::Type::Push, "minus.svg", "", false,
+		Button::Type::Push, "minus.svg", "",
 		QSize( ComponentView::nExpansionButtonWidth - 4,
 			   ComponentView::nExpansionButtonWidth - 4 ) );
 	connect( m_pShowLayersBtn, &Button::clicked, [&](){
@@ -108,7 +108,7 @@ ComponentView::ComponentView( QWidget* pParent,
 		pHeaderWidget,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
 		Button::Type::Toggle, "",
-		pCommonStrings->getSmallMuteButton(), true, QSize(), tr("Mute component"),
+		pCommonStrings->getSmallMuteButton(), QSize(), tr( "Mute component" ),
 		false, true );
 	m_pComponentMuteBtn->setChecked( pComponent->getIsMuted() );
 	m_pComponentMuteBtn->setObjectName( "ComponentMuteButton" );
@@ -123,7 +123,7 @@ ComponentView::ComponentView( QWidget* pParent,
 		pHeaderWidget,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
 		Button::Type::Toggle, "",
-		pCommonStrings->getSmallSoloButton(), false, QSize(), tr("Solo component"),
+		pCommonStrings->getSmallSoloButton(), QSize(), tr( "Solo component" ),
 		false, true );
 	m_pComponentSoloBtn->setChecked( pComponent->getIsSoloed() );
 	m_pComponentSoloBtn->setObjectName( "ComponentSoloButton" );
@@ -328,7 +328,7 @@ ComponentView::ComponentView( QWidget* pParent,
 		pLayerPropWidget,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
 		Button::Type::Toggle, "",
-		pCommonStrings->getSmallMuteButton(), true, QSize(), tr("Mute layer"),
+		pCommonStrings->getSmallMuteButton(), QSize(), tr( "Mute layer" ),
 		false, true );
 	m_pLayerMuteBtn->setChecked( pComponent->getIsMuted() );
 	m_pLayerMuteBtn->setObjectName( "LayerMuteButton" );
@@ -346,9 +346,8 @@ ComponentView::ComponentView( QWidget* pParent,
 	m_pLayerSoloBtn = new Button(
 		pLayerPropWidget,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
-		Button::Type::Toggle, "",
-		pCommonStrings->getSmallSoloButton(), false, QSize(), tr("Solo layer"),
-		false, true );
+		Button::Type::Toggle, "", pCommonStrings->getSmallSoloButton(),
+		QSize(), tr( "Solo layer" ), false, true );
 	m_pLayerSoloBtn->setChecked( pComponent->getIsSoloed() );
 	m_pLayerSoloBtn->setObjectName( "LayerSoloButton" );
 	connect( m_pLayerSoloBtn, &Button::clicked, [&](){
@@ -412,10 +411,30 @@ ComponentView::ComponentView( QWidget* pParent,
 						 SLOT( addComponent() ) );
 	m_pDeleteAction = m_pPopup->addAction(
 		pCommonStrings->getMenuActionDelete(), this, SLOT( deleteComponent() ));
+
+	updateColors();
 	updateStyleSheet();
 }
 
 ComponentView::~ComponentView() {
+}
+
+void ComponentView::updateColors() {
+	const auto theme = Preferences::get_instance()->getTheme();
+
+	m_pComponentMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pComponentMuteBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_muteTextColor );
+	m_pComponentSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+	m_pComponentSoloBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_soloTextColor );
+
+	m_pLayerMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pLayerMuteBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_muteTextColor );
+	m_pLayerSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+	m_pLayerSoloBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_soloTextColor );
 }
 
 void ComponentView::updateStyleSheet() {

--- a/src/gui/src/InstrumentEditor/ComponentView.h
+++ b/src/gui/src/InstrumentEditor/ComponentView.h
@@ -86,6 +86,7 @@ class ComponentView : public QWidget,
 								std::shared_ptr<H2Core::InstrumentComponent> );
 		~ComponentView();
 
+		void updateColors();
 		void updateStyleSheet();
 		void updateView();
 

--- a/src/gui/src/InstrumentEditor/ComponentsEditor.cpp
+++ b/src/gui/src/InstrumentEditor/ComponentsEditor.cpp
@@ -92,6 +92,12 @@ ComponentsEditor::ComponentsEditor( InstrumentEditorPanel* pPanel )
 ComponentsEditor::~ComponentsEditor() {
 }
 
+void ComponentsEditor::updateColors() {
+	for ( auto& ppComponentView : m_componentViews ) {
+		ppComponentView->updateColors();
+	}
+}
+
 void ComponentsEditor::updateComponents() {
 
 	// We add a stretchable spacer item of zero height at the bottom. When

--- a/src/gui/src/InstrumentEditor/ComponentsEditor.h
+++ b/src/gui/src/InstrumentEditor/ComponentsEditor.h
@@ -51,6 +51,7 @@ class ComponentsEditor :  public QWidget,
 		explicit ComponentsEditor( InstrumentEditorPanel* pPanel );
 		~ComponentsEditor();
 
+		void updateColors();
 		void updateComponents();
 		void updateEditor();
 		void updateStyleSheet();

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -360,9 +360,9 @@ void InstrumentEditor::updateColors() {
 	const auto theme = Preferences::get_instance()->getTheme();
 
 	m_pFilterBypassBtn->setCheckedBackgroundColor(
-		theme.m_color.m_buttonRedColor );
+		theme.m_color.m_muteColor );
 	m_pFilterBypassBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_buttonRedTextColor );
+		theme.m_color.m_muteTextColor );
 }
 
 void InstrumentEditor::updateEditor() {

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -161,7 +161,7 @@ InstrumentEditor::InstrumentEditor( InstrumentEditorPanel* pPanel )
 	// Filter
 	m_pFilterBypassBtn = new Button(
 		m_pInstrumentProp, QSize( 36, 15 ), Button::Type::Toggle, "",
-		pCommonStrings->getBypassButton(), true, QSize( 0, 0 ), "", false, true );
+		pCommonStrings->getBypassButton(), QSize( 0, 0 ), "", false, true );
 	connect( m_pFilterBypassBtn, &Button::clicked, [&]() {
 		m_pInstrumentEditorPanel->getInstrument()->setFilterActive(
 			! m_pFilterBypassBtn->isChecked() );
@@ -349,10 +349,20 @@ InstrumentEditor::InstrumentEditor( InstrumentEditorPanel* pPanel )
 											  pCommonStrings->getHihatMaxRangeLabel() );
 	m_pHihatMaxRangeLbl->move( 208, 327 );
 
+	updateColors();
 	updateEditor();
 }
 
 InstrumentEditor::~InstrumentEditor() {
+}
+
+void InstrumentEditor::updateColors() {
+	const auto theme = Preferences::get_instance()->getTheme();
+
+	m_pFilterBypassBtn->setCheckedBackgroundColor(
+		theme.m_color.m_buttonRedColor );
+	m_pFilterBypassBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_buttonRedTextColor );
 }
 
 void InstrumentEditor::updateEditor() {

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.h
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.h
@@ -57,6 +57,7 @@ class InstrumentEditor :  public QWidget,
 		explicit InstrumentEditor( InstrumentEditorPanel* pPanel );
 		~InstrumentEditor();
 
+		void updateColors();
 		void updateEditor();
 
 	private slots:

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -74,7 +74,7 @@ InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent ) :
 		( InstrumentRack::nWidth - InstrumentEditor::nMargin * 2 ) / 2 + 1;
 	m_pShowInstrumentBtn = new Button(
 		pButtonWidget, QSize( nInstrumentBtnWidth, 22 ), Button::Type::Toggle, "",
-		pCommonStrings->getGeneralButton(), false, QSize(),
+		pCommonStrings->getGeneralButton(), QSize(),
 		tr( "Show instrument properties" ) );
 	m_pShowInstrumentBtn->setChecked( true );
 	connect( m_pShowInstrumentBtn, &Button::clicked, [=]() {
@@ -88,8 +88,7 @@ InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent ) :
 		pButtonWidget, QSize(
 			InstrumentRack::nWidth - InstrumentEditor::nMargin * 2 -
 			nInstrumentBtnWidth + 1, 22 ), Button::Type::Toggle, "",
-		pCommonStrings->getComponentsButton(), false, QSize(),
-		tr( "Show components" ) );
+		pCommonStrings->getComponentsButton(), QSize(), tr( "Show components" ) );
 	m_pShowComponentsBtn->setChecked( false );
 	connect( m_pShowComponentsBtn, &Button::clicked, [=]() {
 		pStackedEditorLayout->setCurrentIndex( 1 );
@@ -158,9 +157,11 @@ void InstrumentEditorPanel::onPreferencesChanged( const H2Core::Preferences::Cha
 	auto pPref = H2Core::Preferences::get_instance();
 
 	if ( changes & H2Core::Preferences::Changes::Colors ) {
+		m_pInstrumentEditor->updateColors();
 		m_pInstrumentEditor->setStyleSheet(
 			QString( "QLabel { background: %1 }" )
 			.arg( pPref->getTheme().m_color.m_windowColor.name() ) );
+		m_pComponentsEditor->updateColors();
 		m_pComponentsEditor->updateStyleSheet();
 	}
 	if ( changes & ( H2Core::Preferences::Changes::Font |

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -95,9 +95,9 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 	const auto gradientDefault = createGradient(
 		pPref->getTheme().m_color.m_accentColor );
 	const auto gradientMute = createGradient(
-		pPref->getTheme().m_color.m_buttonRedColor );
+		pPref->getTheme().m_color.m_muteColor );
 	const auto gradientSolo = createGradient(
-		pPref->getTheme().m_color.m_widgetColor );
+		pPref->getTheme().m_color.m_soloColor );
 
 	QFont fontText( pPref->getTheme().m_font.m_sLevel2FontFamily,
 					getPointSize( pPref->getTheme().m_font.m_fontSize ) );

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -176,11 +176,11 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 				p.fillRect( 0, y, width(), LayerPreview::nLayerHeight,
 							pPref->getTheme().m_color.m_windowColor );
 				if ( pSample != nullptr ) {
-					if ( pLayer->getIsSoloed() ) {
-						segmentGradient = gradientSolo;
-					}
-					else if ( pLayer->getIsMuted() ) {
+					if ( pLayer->getIsMuted() ) {
 						segmentGradient = gradientMute;
+					}
+					else if ( pLayer->getIsSoloed() ) {
+						segmentGradient = gradientSolo;
 					}
 					else {
 						segmentGradient = gradientDefault;

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -67,13 +67,12 @@ void WaveDisplay::createBackground( QPainter* painter ) {
 	const QColor borderColor = Qt::black;
 	QColor textColor, backgroundColor, waveFormColor;
 	if ( m_pLayer != nullptr && m_pLayer->getIsMuted() ) {
-		textColor = pPref->getTheme().m_color.m_buttonRedTextColor;
-		backgroundColor = pPref->getTheme().m_color.m_buttonRedColor;
+		textColor = pPref->getTheme().m_color.m_muteTextColor;
+		backgroundColor = pPref->getTheme().m_color.m_muteColor;
 	}
 	else if ( m_pLayer != nullptr && m_pLayer->getIsSoloed() ){
-		// Placeholder color till a proper solo color was introduced.
-		textColor = pPref->getTheme().m_color.m_widgetTextColor;
-		backgroundColor = pPref->getTheme().m_color.m_widgetColor;
+		textColor = pPref->getTheme().m_color.m_soloTextColor;
+		backgroundColor = pPref->getTheme().m_color.m_soloColor;
 	}
 	else {
 		textColor = pPref->getTheme().m_color.m_accentTextColor;

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -58,19 +58,19 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 	pTabButtonsWidget->setLayout( pTabHBox );
 
 	const int nInstrumentBtnWidth = InstrumentRack::nWidth / 2;
-	m_pShowInstrumentEditorBtn =
-		new Button( pTabButtonsWidget, QSize( nInstrumentBtnWidth, 24 ),
-					Button::Type::Toggle, "", pCommonStrings->getInstrumentButton(),
-					false, QSize(), tr( "Show Instrument editor" ) );
+	m_pShowInstrumentEditorBtn = new Button(
+		pTabButtonsWidget, QSize( nInstrumentBtnWidth, 24 ), Button::Type::Toggle,
+		"", pCommonStrings->getInstrumentButton(), QSize(),
+		tr( "Show Instrument editor" ) );
 	connect( m_pShowInstrumentEditorBtn, &QPushButton::clicked,
 			 [=]() { showSoundLibrary( false ); });
 	pTabHBox->addWidget( m_pShowInstrumentEditorBtn );
 
-	m_pShowSoundLibraryBtn =
-		new Button( pTabButtonsWidget,
-					QSize( InstrumentRack::nWidth - nInstrumentBtnWidth, 24 ),
-					Button::Type::Toggle, "", pCommonStrings->getSoundLibraryButton(),
-					false, QSize(), tr( "Show sound library" ) );
+	m_pShowSoundLibraryBtn = new Button(
+		pTabButtonsWidget,
+		QSize( InstrumentRack::nWidth - nInstrumentBtnWidth, 24 ),
+		Button::Type::Toggle, "", pCommonStrings->getSoundLibraryButton(),
+		QSize(), tr( "Show sound library" ) );
 	connect( m_pShowSoundLibraryBtn, &QPushButton::clicked,
 			 [=]() { showSoundLibrary( true ); });
 	pTabHBox->addWidget( m_pShowSoundLibraryBtn );

--- a/src/gui/src/Mixer/LadspaFXLine.cpp
+++ b/src/gui/src/Mixer/LadspaFXLine.cpp
@@ -53,7 +53,7 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 	// active button
 	m_pBypassBtn = new Button(
 		this, QSize( 34, 14 ), Button::Type::Toggle, "",
-		pCommonStrings->getBypassButton(), true, QSize(), tr( "FX bypass") );
+		pCommonStrings->getBypassButton(), QSize(), tr( "FX bypass") );
 	m_pBypassBtn->setObjectName( "MixerFXBypassButton" );
 	m_pBypassBtn->move( 52, 25 );
 #ifdef H2CORE_HAVE_LADSPA
@@ -69,7 +69,7 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 	// edit button
 	m_pEditBtn = new Button(
 		this, QSize( 34, 14 ), Button::Type::Push, "",
-		pCommonStrings->getEditButton(), false, QSize(), tr( "Edit FX parameters") );
+		pCommonStrings->getEditButton(), QSize(), tr( "Edit FX parameters") );
 	m_pEditBtn->setObjectName( "MixerFXEditButton" );
 	m_pEditBtn->move( 86, 25 );
 	connect( m_pEditBtn, &Button::clicked, [&](){
@@ -114,10 +114,18 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 		ClickableLabel::Color::Dark );
 	m_pReturnLbl->move( 123, 30 );
 
+	updateColors();
 	updateLine();
 }
 
 LadspaFXLine::~LadspaFXLine() {
+}
+
+void LadspaFXLine::updateColors() {
+	const auto theme = Preferences::get_instance()->getTheme();
+
+	m_pBypassBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pBypassBtn->setCheckedBackgroundTextColor( theme.m_color.m_muteTextColor );
 }
 
 void LadspaFXLine::updateLine() {

--- a/src/gui/src/Mixer/LadspaFXLine.h
+++ b/src/gui/src/Mixer/LadspaFXLine.h
@@ -55,6 +55,7 @@ public:
 							   std::shared_ptr<H2Core::LadspaFX> pFX, int nFx );
 		~LadspaFXLine();
 
+		void updateColors();
 		void updateLine();
 
 		std::shared_ptr<H2Core::LadspaFX> getFX() const;

--- a/src/gui/src/Mixer/MasterLine.cpp
+++ b/src/gui/src/Mixer/MasterLine.cpp
@@ -118,8 +118,9 @@ MasterLine::MasterLine( QWidget* pParent )
 	});
 
 	// Mute btn
-	m_pMuteBtn = new Button( this, QSize( 42, 17 ), Button::Type::Toggle, "",
-							 pCommonStrings->getBigMuteButton(), true );
+	m_pMuteBtn = new Button(
+		this, QSize( 42, 17 ), Button::Type::Toggle, "",
+		pCommonStrings->getBigMuteButton() );
 	m_pMuteBtn->setObjectName( "MixerMasterMuteButton" );
 	m_pMuteBtn->move( 20, 31 );
 	pAction = std::make_shared<Action>("MUTE_TOGGLE");
@@ -148,9 +149,19 @@ MasterLine::MasterLine( QWidget* pParent )
 		this, QSize( 51, 9 ), pCommonStrings->getSwingLabel(),
 		ClickableLabel::Color::Dark );
 	m_pVelocityLbl->move( 62, 190 );
+
+	updateColors();
 }
 
 MasterLine::~MasterLine() {
+}
+
+void MasterLine::updateColors() {
+	const auto theme = Preferences::get_instance()->getTheme();
+
+	m_pMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pMuteBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_muteTextColor );
 }
 
 void MasterLine::updateLine() {

--- a/src/gui/src/Mixer/MasterLine.h
+++ b/src/gui/src/Mixer/MasterLine.h
@@ -49,6 +49,7 @@ public:
 	explicit MasterLine(QWidget* parent);
 	~MasterLine();
 
+		void updateColors();
 	void	updateLine();
 	void	updatePeaks();
 

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -120,7 +120,7 @@ Mixer::Mixer( QWidget* pParent )
 
 	m_pOpenMixerSettingsBtn = new Button(
 		m_pMasterLine, QSize( 17, 17 ), Button::Type::Push, "cog.svg", "",
-		false, QSize( 13, 13 ), tr( "Mixer Settings" ) );
+		QSize( 13, 13 ), tr( "Mixer Settings" ) );
 	m_pOpenMixerSettingsBtn->setObjectName( "MixerSettingsButton" );
 	m_pOpenMixerSettingsBtn->move( 96, 6 );
 	connect( m_pOpenMixerSettingsBtn, SIGNAL( clicked() ), this,
@@ -128,7 +128,7 @@ Mixer::Mixer( QWidget* pParent )
 
 	m_pShowFXPanelBtn = new Button(
 		m_pMasterLine, QSize( 49, 15 ), Button::Type::Toggle, "",
-		pCommonStrings->getFXButton(), false, QSize(), tr( "Show FX panel" ) );
+		pCommonStrings->getFXButton(), QSize(), tr( "Show FX panel" ) );
 	m_pShowFXPanelBtn->setObjectName( "MixerShowFXButton" );
 	m_pShowFXPanelBtn->move( 63, 243 );
 	m_pShowFXPanelBtn->setChecked( pPref->isFXTabVisible() );
@@ -141,7 +141,7 @@ Mixer::Mixer( QWidget* pParent )
 
 	m_pShowPeaksBtn = new Button(
 		m_pMasterLine, QSize( 49, 15 ), Button::Type::Toggle, "",
-		pCommonStrings->getPeakButton(), false, QSize(),
+		pCommonStrings->getPeakButton(), QSize(),
 		tr( "Show instrument peaks" ) );
 	m_pShowPeaksBtn->setObjectName( "MixerShowPeaksButton" );
 	m_pShowPeaksBtn->move( 63, 259 );
@@ -336,6 +336,16 @@ void Mixer::openMixerSettingsDialog() {
 
 void Mixer::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {
 	auto pPref = H2Core::Preferences::get_instance();
+
+	if ( changes & H2Core::Preferences::Changes::Colors ) {
+		for ( auto& ppMixerLine : m_mixerLines ) {
+			ppMixerLine->updateColors();
+		}
+		for ( auto& ppLadspaLine : m_ladspaFXLines ) {
+			ppLadspaLine->updateColors();
+		}
+		m_pMasterLine->updateColors();
+	}
 
 	if ( changes & H2Core::Preferences::Changes::Font ) {
 		setFont( QFont( pPref->getTheme().m_font.m_sApplicationFontFamily, 10 ) );

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -62,7 +62,7 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 
 	// Play sample button
 	m_pPlaySampleBtn = new Button(
-		this, QSize( 20, 15 ), Button::Type::Push, "play.svg", "", false,
+		this, QSize( 20, 15 ), Button::Type::Push, "play.svg", "",
 		QSize( 7, 7 ), tr( "[Left click]: Play sample\n[Right click]: Stop all samples" ) );
 	m_pPlaySampleBtn->move( 6, 1 );
 	m_pPlaySampleBtn->setObjectName( "PlaySampleButton" );
@@ -101,7 +101,8 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 	// Mute button
 	m_pMuteBtn = new Button(
 		this, QSize( 22, 15 ), Button::Type::Toggle, "",
-		pCommonStrings->getSmallMuteButton(), true, QSize(), tr( "Mute" ) );
+		pCommonStrings->getSmallMuteButton(), QSize(),
+		pCommonStrings->getBigMuteButton() );
 	m_pMuteBtn->move( 5, 16 );
 	m_pMuteBtn->setObjectName( "MixerMuteButton" );
 	connect( m_pMuteBtn, &Button::clicked, [&]() {
@@ -115,7 +116,8 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 	// Solo button
 	m_pSoloBtn = new Button(
 		this, QSize( 22, 15 ), Button::Type::Toggle, "",
-		pCommonStrings->getSmallSoloButton(), false, QSize(), tr( "Solo" ) );
+		pCommonStrings->getSmallSoloButton(), QSize(),
+		pCommonStrings->getBigSoloButton() );
 	m_pSoloBtn->move( 28, 16 );
 	m_pSoloBtn->setObjectName( "MixerSoloButton" );
 	connect( m_pSoloBtn, &Button::clicked, [&]() {
@@ -194,10 +196,22 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 	m_pPeakLCD->setPalette( lcdPalette );
 
 	updateActions();
+	updateColors();
 	updateLine();
 }
 
 MixerLine::~MixerLine() {
+}
+
+void MixerLine::updateColors() {
+	const auto theme = Preferences::get_instance()->getTheme();
+
+	m_pMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pMuteBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_muteTextColor );
+	m_pSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+	m_pSoloBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_soloTextColor );
 }
 
 void MixerLine::updateLine() {

--- a/src/gui/src/Mixer/MixerLine.h
+++ b/src/gui/src/Mixer/MixerLine.h
@@ -65,6 +65,7 @@ public:
 	MixerLine( QWidget* pParent, std::shared_ptr<H2Core::Instrument> pInstrument );
 	~MixerLine();
 
+		void updateColors();
 		void updateLine();
 		void updatePeaks();
 		void updateSelected();

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1707,7 +1707,7 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 	}
 	else if ( noteStyle & NoteStyle::NoPlayback ) {
 		// Notes that won't be played back maintain their special color.
-		highlightColor = colorTheme.m_buttonRedColor;
+		highlightColor = colorTheme.m_muteColor;
 
 		// The color of the mute button itself would be too flash and draw too
 		// much attention to the note which are probably the ones the user does

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -326,7 +326,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pRecLayout->addWidget( m_pHearNotesLbl );
 	
 	m_pHearNotesBtn = new Button(
-		m_pRec, QSize( 21, 18 ), Button::Type::Toggle, "speaker.svg", "", false,
+		m_pRec, QSize( 21, 18 ), Button::Type::Toggle, "speaker.svg", "",
 		QSize( 15, 13 ), tr( "Hear new notes" ), false, false );
 	connect( m_pHearNotesBtn, SIGNAL( clicked() ),
 			 this, SLOT( hearNotesBtnClick() ) );
@@ -347,8 +347,8 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	
 	m_pQuantizeEventsBtn = new Button(
 		m_pRec, QSize( 21, 18 ), Button::Type::Toggle, "quantization.svg", "",
-		false, QSize( 15, 14 ), tr( "Quantize keyboard/midi events to grid" ),
-		false, false );
+		QSize( 15, 14 ), tr( "Quantize keyboard/midi events to grid" ), false,
+		false );
 	m_pQuantizeEventsBtn->setChecked( pPref->getQuantizeEvents() );
 	m_pQuantizeEventsBtn->setObjectName( "QuantizeEventsBtn" );
 	connect( m_pQuantizeEventsBtn, SIGNAL( clicked() ),
@@ -366,7 +366,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pRecLayout->addWidget( m_pShowPianoLbl );
 
 	__show_drum_btn = new Button(
-		m_pRec, QSize( 25, 18 ), Button::Type::Push, "drum.svg", "", false,
+		m_pRec, QSize( 25, 18 ), Button::Type::Push, "drum.svg", "",
 		QSize( 17, 13 ), pCommonStrings->getShowPianoRollEditorTooltip() );
 	__show_drum_btn->setObjectName( "ShowDrumBtn" );
 	connect( __show_drum_btn, SIGNAL( clicked() ),
@@ -383,7 +383,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	// change in future versions of Qt the tooltip will be assigned to
 	// both of them.
 	__show_piano_btn = new Button(
-		m_pRec, QSize( 25, 18 ), Button::Type::Push, "piano.svg", "", false,
+		m_pRec, QSize( 25, 18 ), Button::Type::Push, "piano.svg", "",
 		QSize( 19, 15 ), pCommonStrings->getShowPianoRollEditorTooltip() );
 	__show_piano_btn->move( 178, 1 );
 	__show_piano_btn->setObjectName( "ShowPianoBtn" );
@@ -394,7 +394,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pRecLayout->addWidget( __show_piano_btn );
 
 	m_pPatchBayBtn = new Button(
-		m_pRec, QSize( 25, 18 ), Button::Type::Push, "patchBay.svg", "", false,
+		m_pRec, QSize( 25, 18 ), Button::Type::Push, "patchBay.svg", "",
 		QSize( 19, 15 ), tr( "Show PatchBay" ) );
 	m_pPatchBayBtn->move( 209, 1 );
 	m_pPatchBayBtn->hide();
@@ -406,7 +406,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	// zoom-in btn
 	m_pZoomInBtn = new Button(
-		nullptr, QSize( 19, 15 ), Button::Type::Push, "plus.svg", "", false,
+		nullptr, QSize( 19, 15 ), Button::Type::Push, "plus.svg", "",
 		QSize( 9, 9 ), tr( "Zoom in" ) );
 	m_pZoomInBtn->setFocusPolicy( Qt::ClickFocus );
 	connect( m_pZoomInBtn, SIGNAL( clicked() ), this, SLOT( zoomInBtnClicked() ) );
@@ -414,7 +414,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	// zoom-out btn
 	m_pZoomOutBtn = new Button(
-		nullptr, QSize( 19, 15 ), Button::Type::Push, "minus.svg", "", false,
+		nullptr, QSize( 19, 15 ), Button::Type::Push, "minus.svg", "",
 		QSize( 9, 9 ), tr( "Zoom out" ) );
 	m_pZoomOutBtn->setFocusPolicy( Qt::ClickFocus );
 	connect( m_pZoomOutBtn, SIGNAL( clicked() ), this, SLOT( zoomOutBtnClicked() ) );
@@ -1668,6 +1668,7 @@ void PatternEditorPanel::onPreferencesChanged( const H2Core::Preferences::Change
 	}
 
 	if ( changes & ( H2Core::Preferences::Changes::Colors ) ) {
+		m_pSidebar->updateColors();
 		updateStyleSheet();
 		updateEditors();
 	}

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -436,26 +436,26 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 			 } );
 
 	m_pSampleWarning = new Button(
-		this, QSize( 15, 13 ), Button::Type::Icon, "warning.svg", "", false,
-		QSize(), tr( "Some samples for this instrument failed to load." ), true );
+		this, QSize( 15, 13 ), Button::Type::Icon, "warning.svg", "", QSize(),
+		tr( "Some samples for this instrument failed to load." ), true );
 	m_pSampleWarning->hide();
 	pHBox->addWidget( m_pSampleWarning );
 	connect(m_pSampleWarning, SIGNAL( clicked() ),
 			this, SLOT( sampleWarningClicked() ));
 
 	m_pMuteBtn = new Button(
-		this, QSize( SidebarRow::m_nButtonWidth, height() ),
-		Button::Type::Toggle, "", pCommonStrings->getSmallMuteButton(), true,
-		QSize(), tr("Mute instrument"), false, true );
+		this, QSize( SidebarRow::m_nButtonWidth, height() ), Button::Type::Toggle,
+		"", pCommonStrings->getSmallMuteButton(), QSize(), tr("Mute instrument"),
+		false, true );
 	m_pMuteBtn->setChecked( false );
 	m_pMuteBtn->setObjectName( "SidebarRowMuteButton" );
 	pHBox->addWidget( m_pMuteBtn );
 	connect(m_pMuteBtn, SIGNAL( clicked() ), this, SLOT( muteClicked() ));
 
 	m_pSoloBtn = new Button(
-		this, QSize( SidebarRow::m_nButtonWidth, height() ),
-		Button::Type::Toggle, "", pCommonStrings->getSmallSoloButton(), false,
-		QSize(), tr("Solo"), false, true );
+		this, QSize( SidebarRow::m_nButtonWidth, height() ), Button::Type::Toggle,
+		"", pCommonStrings->getSmallSoloButton(), QSize(),
+		pCommonStrings->getBigSoloButton(), false, true );
 	m_pSoloBtn->setChecked( false );
 	m_pSoloBtn->setObjectName( "SidebarRowSoloButton" );
 	pHBox->addWidget( m_pSoloBtn );
@@ -625,6 +625,8 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 	} );
 
 	m_pFunctionPopup->setObjectName( "PatternEditorFunctionPopup" );
+
+	updateColors();
 
 	setLayout( pHBox );
 
@@ -926,9 +928,16 @@ void SidebarRow::mousePressEvent(QMouseEvent *ev)
 	PixmapWidget::mousePressEvent(ev);
 }
 
-void SidebarRow::updateFont() {
-	const auto pPref = H2Core::Preferences::get_instance();
+void SidebarRow::updateColors() {
+	const auto theme = H2Core::Preferences::get_instance()->getTheme();
 
+	m_pMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pMuteBtn->setCheckedBackgroundTextColor( theme.m_color.m_muteTextColor );
+	m_pSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+	m_pSoloBtn->setCheckedBackgroundTextColor( theme.m_color.m_soloTextColor );
+}
+
+void SidebarRow::updateFont() {
 	m_pInstrumentNameLbl->updateFont();
 	m_pTypeLbl->updateFont();
 }
@@ -985,6 +994,12 @@ PatternEditorSidebar::~PatternEditorSidebar()
 {
 	//INFOLOG( "DESTROY" );
 	delete m_pDragScroller;
+}
+
+void PatternEditorSidebar::updateColors() {
+	for ( auto& rrow : m_rows ) {
+		rrow->updateColors();
+	}
 }
 
 void PatternEditorSidebar::updateEditor() {

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.h
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.h
@@ -125,6 +125,7 @@ class SidebarRow : public PixmapWidget
 		void setSelected( bool isSelected );
 		void setDimed( bool bDimed );
 
+		void updateColors();
 		void updateFont();
 		void updateStyleSheet();
 		void updateTypeLabelVisibility( bool bVisible );
@@ -189,6 +190,7 @@ class PatternEditorSidebar : public QWidget,
 
 		virtual void instrumentMuteSoloChangedEvent( int ) override;
 
+		void updateColors();
 		void updateEditor();
 		void updateFont();
 		void updateStyleSheet();

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -105,38 +105,42 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pTimeMilliSecondsLbl->move( 119, 30 );
 
 	// Rewind button
-	m_pRwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push,
-							"rewind.svg", "", false, QSize( 13, 13 ), tr("Rewind") );
+	m_pRwdBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "rewind.svg", "",
+		QSize( 13, 13 ), tr( "Rewind" ) );
 	m_pRwdBtn->setObjectName( "PlayerControlRewindButton" );
 	m_pRwdBtn->move( 166, 15 );
-	connect(m_pRwdBtn, SIGNAL( clicked() ), this, SLOT( rewindBtnClicked() ));
+	connect( m_pRwdBtn, SIGNAL( clicked() ), this, SLOT( rewindBtnClicked() ));
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("<<_PREVIOUS_BAR");
 	m_pRwdBtn->setAction( pAction );
 
 	// Record button
-	m_pRecBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Toggle,
-							"record.svg", "", false, QSize( 11, 11 ), tr("Record"), true );
+	m_pRecBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Toggle, "record.svg", "",
+		QSize( 11, 11 ), tr( "Record" ), true );
 	m_pRecBtn->setObjectName( "PlayerControlRecordButton" );
 	m_pRecBtn->move( 193, 15 );
 	m_pRecBtn->setChecked(false);
 	m_pRecBtn->setHidden(false);
-	connect(m_pRecBtn, SIGNAL( clicked() ), this, SLOT( recBtnClicked() ));
+	connect( m_pRecBtn, SIGNAL( clicked() ), this, SLOT( recBtnClicked() ));
 	pAction = std::make_shared<Action>("RECORD_READY");
 	m_pRecBtn->setAction( pAction );
 
 	// Play button
-	m_pPlayBtn = new Button( pControlsPanel, QSize( 30, 21 ), Button::Type::Toggle,
-							 "play_pause.svg", "", false, QSize( 30, 21 ), tr("Play/ Pause") );
+	m_pPlayBtn = new Button(
+		pControlsPanel, QSize( 30, 21 ), Button::Type::Toggle, "play_pause.svg",
+		"", QSize( 30, 21 ), tr( "Play/ Pause" ) );
 	m_pPlayBtn->setObjectName( "PlayerControlPlayButton" );
 	m_pPlayBtn->move( 220, 15 );
 	m_pPlayBtn->setChecked(false);
-	connect(m_pPlayBtn, SIGNAL( clicked() ), this, SLOT( playBtnClicked() ));
+	connect( m_pPlayBtn, SIGNAL( clicked() ), this, SLOT( playBtnClicked() ));
 	pAction = std::make_shared<Action>("PLAY/PAUSE_TOGGLE");
 	m_pPlayBtn->setAction( pAction );
 
 	// Stop button
-	m_pStopBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push,
-							 "stop.svg", "", false, QSize( 11, 11 ), tr("Stop") );
+	m_pStopBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "stop.svg", "",
+		QSize( 11, 11 ), tr( "Stop" ) );
 	m_pStopBtn->setObjectName( "PlayerControlStopButton" );
 	m_pStopBtn->move( 252, 15 );
 	connect(m_pStopBtn, SIGNAL( clicked() ), this, SLOT( stopBtnClicked() ));
@@ -144,8 +148,9 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pStopBtn->setAction( pAction );
 
 	// Fast forward button
-	m_pFfwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push,
-							 "fast_forward.svg", "", false, QSize( 13, 13 ), tr("Fast Forward") );
+	m_pFfwdBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "fast_forward.svg",
+		"", QSize( 13, 13 ), tr( "Fast Forward" ) );
 	m_pFfwdBtn->setObjectName( "PlayerControlForwardButton" );
 	m_pFfwdBtn->move( 279, 15 );
 	connect(m_pFfwdBtn, SIGNAL( clicked() ), this, SLOT( fastForwardBtnClicked() ));
@@ -153,10 +158,9 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pFfwdBtn->setAction( pAction );
 
 	// Loop song button button
-	m_pSongLoopBtn = new Button( pControlsPanel, QSize( 25, 19 ),
-								 Button::Type::Toggle, "loop.svg", "", false,
-								 QSize( 17, 13 ), tr("Loop song"),
-								 false, true );
+	m_pSongLoopBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Toggle, "loop.svg", "",
+		QSize( 17, 13 ), tr( "Loop song" ), false, true );
 	m_pSongLoopBtn->setObjectName( "PlayerControlLoopButton" );
 	m_pSongLoopBtn->move( 308, 15);
 	connect( m_pSongLoopBtn, &QPushButton::clicked,
@@ -175,11 +179,10 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pPatternModeLED = new LED( pControlsPanel, QSize( 11, 9 ) );
 	m_pPatternModeLED->move( 179, 4 );
 	m_pPatternModeLED->setActivated( true );
-	m_pPatternModeBtn = new Button( pControlsPanel, QSize( 59, 11 ),
-									Button::Type::Toggle, "",
-									pCommonStrings->getPatternModeButton(),
-									false, QSize(), tr("Pattern Mode"),
-									false, true );
+	m_pPatternModeBtn = new Button(
+		pControlsPanel, QSize( 59, 11 ), Button::Type::Toggle, "",
+		pCommonStrings->getPatternModeButton(), QSize(), tr( "Pattern Mode" ),
+		false, true );
 	m_pPatternModeBtn->setObjectName( "PlayerControlPatternModeButton" );
 	m_pPatternModeBtn->move( 190, 3 );
 	m_pPatternModeBtn->setChecked(true);
@@ -189,11 +192,10 @@ PlayerControl::PlayerControl(QWidget *parent)
 	// Song mode button
 	m_pSongModeLED = new LED( pControlsPanel, QSize( 11, 9 ) );
 	m_pSongModeLED->move( 252, 4 );
-	m_pSongModeBtn = new Button( pControlsPanel, QSize( 59, 11 ),
-								 Button::Type::Toggle, "",
-								 pCommonStrings->getSongModeButton(),
-								 false, QSize(), tr("Song Mode"),
-								 false, true );
+	m_pSongModeBtn = new Button(
+		pControlsPanel, QSize( 59, 11 ), Button::Type::Toggle, "",
+		pCommonStrings->getSongModeButton(), QSize(), tr( "Song Mode" ),
+		false, true );
 	m_pSongModeBtn->setObjectName( "PlayerControlSongModeButton" );
 	m_pSongModeBtn->move( 263, 3 );
 	connect( m_pSongModeBtn, &QPushButton::clicked,
@@ -209,11 +211,10 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_sBCOnOffBtnToolTip = tr("Toggle the BeatCounter Panel");
 	m_sBCOnOffBtnTimelineToolTip = tr( "Please deactivate the Timeline first in order to use the BeatCounter" );
 	m_sBCOnOffBtnJackTimebaseToolTip = tr( "In the presence of an external JACK Timebase controller the BeatCounter can not be used" );
-	m_pBCOnOffBtn = new Button( pControlsBBTBConoffPanel, QSize( 13, 42 ),
-								Button::Type::Toggle, "",
-								pCommonStrings->getBeatCounterButton(), false,
-								QSize(), m_sBCOnOffBtnToolTip,
-								false, true );
+	m_pBCOnOffBtn = new Button(
+		pControlsBBTBConoffPanel, QSize( 13, 42 ), Button::Type::Toggle, "",
+		pCommonStrings->getBeatCounterButton(), QSize(), m_sBCOnOffBtnToolTip,
+		false, true );
 	m_pBCOnOffBtn->move(0, 0);
 	connect( m_pBCOnOffBtn, SIGNAL( clicked() ),
 			 this, SLOT( activateBeatCounter() ) );
@@ -253,35 +254,35 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	m_pBeatCounterBeatLengthUpBtn = new Button(
 		m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push, "plus.svg", "",
-		false, QSize( 8, 8 ), "", false, true );
+		QSize( 8, 8 ), "", false, true );
 	m_pBeatCounterBeatLengthUpBtn->move( 2, 3 );
 	connect( m_pBeatCounterBeatLengthUpBtn, SIGNAL( clicked() ),
 			 this, SLOT( beatCounterBeatLengthUpBtnClicked() ) );
 
 	m_pBeatCounterBeatLengthDownBtn = new Button(
 		m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push, "minus.svg", "",
-		false, QSize( 8, 8 ), "", false, true );
+		QSize( 8, 8 ), "", false, true );
 	m_pBeatCounterBeatLengthDownBtn->move( 2, 14 );
 	connect( m_pBeatCounterBeatLengthDownBtn, SIGNAL( clicked() ),
 			 this, SLOT( beatCounterBeatLengthDownBtnClicked() ) );
 
 	m_pBeatCounterTotalBeatsUpBtn = new Button(
 		m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push, "plus.svg", "",
-		false, QSize( 8, 8 ), "", false, true );
+		QSize( 8, 8 ), "", false, true );
 	m_pBeatCounterTotalBeatsUpBtn->move( 64, 3 );
 	connect( m_pBeatCounterTotalBeatsUpBtn, SIGNAL( clicked() ),
 			 this, SLOT( beatCounterTotalBeatsUpBtnClicked() ) );
 
 	m_pBeatCounterTotalBeatsDownBtn = new Button(
 		m_pControlsBCPanel, QSize( 19, 12 ), Button::Type::Push, "minus.svg", "",
-		false, QSize( 8, 8 ), "", false, true );
+		QSize( 8, 8 ), "", false, true );
 	m_pBeatCounterTotalBeatsDownBtn->move( 64, 14 );
 	connect( m_pBeatCounterTotalBeatsDownBtn, SIGNAL( clicked() ),
 			 this, SLOT( beatCounterTotalBeatsDownBtnClicked() ) );
 
 	m_pBeatCounterSetPlayBtn = new Button(
 		m_pControlsBCPanel, QSize( 19, 15 ), Button::Type::Push, "",
-		pCommonStrings->getBeatCounterSetPlayButtonOff(), false, QSize(),
+		pCommonStrings->getBeatCounterSetPlayButtonOff(), QSize(),
 		tr("Set BPM / Set BPM and play"), false, true );
 	m_pBeatCounterSetPlayBtn->setObjectName( "BeatCounterSetPlayButton" );
 	m_pBeatCounterSetPlayBtn->move( 64, 25 );
@@ -315,12 +316,11 @@ PlayerControl::PlayerControl(QWidget *parent)
 	connect( m_pBpmSpinBox, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( bpmChanged( double ) ) );
 
-	m_pRubberBPMChange = new Button( pBPMPanel, QSize( 13, 42 ),
-									 Button::Type::Toggle, "",
-									 pCommonStrings->getRubberbandButton(),
-									 false, QSize(),
-									 tr("Recalculate Rubberband modified samples if bpm will change"),
-									 false, true );
+	m_pRubberBPMChange = new Button(
+		pBPMPanel, QSize( 13, 42 ), Button::Type::Toggle, "",
+		pCommonStrings->getRubberbandButton(), QSize(),
+		tr( "Recalculate Rubberband modified samples if bpm will change" ),
+		false, true );
 	m_pRubberBPMChange->setObjectName( "PlayerControlRubberbandButton" );
 	m_pRubberBPMChange->move( 131, 0 );
 	m_pRubberBPMChange->setChecked( pPref->getRubberBandBatchMode());
@@ -335,11 +335,9 @@ PlayerControl::PlayerControl(QWidget *parent)
 	m_pMetronomeLED = new MetronomeLED( pBPMPanel, QSize( 22, 7 ) );
 	m_pMetronomeLED->move( 7, 32 );
 
-	m_pMetronomeBtn = new Button( pBPMPanel, QSize( 24, 28 ),
-								  Button::Type::Toggle, "metronome.svg", "",
-								  false, QSize( 20, 20 ),
-								  tr("Switch metronome on/off"),
-								  false, true );
+	m_pMetronomeBtn = new Button(
+		pBPMPanel, QSize( 24, 28 ), Button::Type::Toggle, "metronome.svg", "",
+		QSize( 20, 20 ), tr( "Switch metronome on/off" ), false, true );
 	m_pMetronomeBtn->setObjectName( "MetronomeButton" );
 	m_pMetronomeBtn->setChecked( pPref->m_bUseMetronome );
 	m_pMetronomeBtn->move( 6, 2 );
@@ -362,12 +360,10 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	/*: Using the JACK the audio/midi input and output ports of any
 	  number of application can be connected.*/
-	m_pJackTransportBtn = new Button( pJackPanel, QSize( 53, 16 ),
-									  Button::Type::Toggle, "",
-									  pCommonStrings->getJackTransportButton(),
-									  false, QSize(),
-									  tr("JACK transport on/off"),
-									  false, true );
+	m_pJackTransportBtn = new Button(
+		pJackPanel, QSize( 53, 16 ), Button::Type::Toggle, "",
+		pCommonStrings->getJackTransportButton(), QSize(),
+		tr( "JACK transport on/off" ), false, true );
 	m_pJackTransportBtn->setObjectName( "PlayerControlJackTransportButton" );
 	updateJackTransport();
 	connect(m_pJackTransportBtn, SIGNAL( clicked() ), this, SLOT( jackTransportBtnClicked() ));
@@ -375,7 +371,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	m_pJackTimebaseBtn = new Button(
 		pJackPanel, QSize( 64, 16 ), Button::Type::Toggle, "",
-		pCommonStrings->getJackTimebaseButton(), false, QSize(),
+		pCommonStrings->getJackTimebaseButton(), QSize(),
 		pCommonStrings->getJackTimebaseTooltip(), false, true );
 	m_pJackTimebaseBtn->setObjectName( "PlayerControlJackTimebaseButton" );
 	updateJackTimebase();
@@ -410,9 +406,9 @@ PlayerControl::PlayerControl(QWidget *parent)
 	pLcdBackGround->setObjectName( "LcdBackground" );
 	hbox->addWidget( pLcdBackGround );
 
-	m_pShowMixerBtn = new Button( pLcdBackGround, QSize( 88, 23 ), Button::Type::Toggle,
-								  "", pCommonStrings->getMixerButton(), false, QSize(),
-								  tr( "Show mixer" ) );
+	m_pShowMixerBtn = new Button(
+		pLcdBackGround, QSize( 88, 23 ), Button::Type::Toggle, "",
+		pCommonStrings->getMixerButton(), QSize(), tr( "Show mixer" ) );
 	m_pShowMixerBtn->setChecked( pPref->getMixerProperties().visible );
 	m_pShowMixerBtn->move( 0, 0 );
 	connect( m_pShowMixerBtn, &Button::clicked, [&]() {
@@ -420,7 +416,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	m_pShowInstrumentRackBtn = new Button(
 		pLcdBackGround, QSize( 168, 23 ), Button::Type::Toggle, "",
-		pCommonStrings->getInstrumentRackButton(), false, QSize(),
+		pCommonStrings->getInstrumentRackButton(), QSize(),
 		tr( "Show Instrument Rack" ) );
 	m_pShowInstrumentRackBtn->setChecked(
 		pPref->getInstrumentRackProperties().visible );
@@ -949,6 +945,7 @@ void PlayerControl::updateJackTransport() {
 
 void PlayerControl::updateJackTimebase()
 {
+	const auto theme = Preferences::get_instance()->getTheme();
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	if ( ! pHydrogen->hasJackAudioDriver() ) {
@@ -959,7 +956,10 @@ void PlayerControl::updateJackTimebase()
 
 	if ( ! Preferences::get_instance()->m_bJackTimebaseEnabled ) {
 		m_pJackTimebaseBtn->setChecked( false );
-		m_pJackTimebaseBtn->setUseRedBackground( false );
+		m_pJackTimebaseBtn->setCheckedBackgroundColor(
+			theme.m_color.m_accentColor );
+		m_pJackTimebaseBtn->setCheckedBackgroundTextColor(
+			theme.m_color.m_accentTextColor );
 		m_pJackTimebaseBtn->setIsActive( false );
 		m_pJackTimebaseBtn->setBaseToolTip(
 			pCommonStrings->getJackTimebaseDisabledTooltip() );
@@ -968,7 +968,10 @@ void PlayerControl::updateJackTimebase()
 	else {
 		m_pJackTimebaseBtn->setIsActive( true );
 		m_pJackTimebaseBtn->setChecked( false );
-		m_pJackTimebaseBtn->setUseRedBackground( false );
+		m_pJackTimebaseBtn->setCheckedBackgroundColor(
+			theme.m_color.m_accentColor );
+		m_pJackTimebaseBtn->setCheckedBackgroundTextColor(
+			theme.m_color.m_accentTextColor );
 		m_pJackTimebaseBtn->setToolTip(
 			pCommonStrings->getJackTimebaseTooltip() );
 	}
@@ -981,7 +984,10 @@ void PlayerControl::updateJackTimebase()
 
 		case JackAudioDriver::Timebase::Listener:
 			m_pJackTimebaseBtn->setChecked( true );
-			m_pJackTimebaseBtn->setUseRedBackground( true );
+		m_pJackTimebaseBtn->setCheckedBackgroundColor(
+			theme.m_color.m_buttonRedColor );
+		m_pJackTimebaseBtn->setCheckedBackgroundTextColor(
+			theme.m_color.m_buttonRedTextColor );
 			m_pJackTimebaseBtn->setToolTip(
 				pCommonStrings->getJackTimebaseListenerTooltip() );
 			break;

--- a/src/gui/src/PlaylistEditor/PlaylistEditor.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistEditor.cpp
@@ -112,14 +112,18 @@ PlaylistEditor::PlaylistEditor( QWidget* pParent )
 	pControlsPanel->setPixmap( "/playerControlPanel/playlist_background_Control.png" );
 
 	// Rewind button
-	m_pRwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "rewind.svg", "", false, QSize( 13, 13 ), tr("Rewind") );
+	m_pRwdBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "rewind.svg", "",
+		QSize( 13, 13 ), tr( "Rewind" ) );
 	m_pRwdBtn->move( 4, 4 );
 	connect(m_pRwdBtn, SIGNAL( clicked() ), this, SLOT( rewindBtnClicked() ));
 	std::shared_ptr<Action> pAction = std::make_shared<Action>("PLAYLIST_PREV_SONG");
 	m_pRwdBtn->setAction( pAction );
 
 	// Play button
-	m_pPlayBtn = new Button( pControlsPanel, QSize( 30, 21 ), Button::Type::Toggle, "play.svg", "", false, QSize( 13, 13 ), tr("Play/ Pause/ Load selected song") );
+	m_pPlayBtn = new Button(
+		pControlsPanel, QSize( 30, 21 ), Button::Type::Toggle, "play.svg", "",
+		QSize( 13, 13 ), tr( "Play/ Pause/ Load selected song" ) );
 	m_pPlayBtn->move( 31, 4 );
 	m_pPlayBtn->setChecked(false);
 	connect(m_pPlayBtn, SIGNAL( clicked() ), this, SLOT( nodePlayBTN() ));
@@ -127,14 +131,18 @@ PlaylistEditor::PlaylistEditor( QWidget* pParent )
 	m_pPlayBtn->setAction( pAction );
 
 	// Stop button
-	m_pStopBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "stop.svg", "", false, QSize( 11, 11 ), tr("Stop") );
+	m_pStopBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "stop.svg", "",
+		QSize( 11, 11 ), tr( "Stop" ) );
 	m_pStopBtn->move( 63, 4 );
 	connect(m_pStopBtn, SIGNAL( clicked() ), this, SLOT( nodeStopBTN() ));
 	pAction = std::make_shared<Action>("STOP");
 	m_pStopBtn->setAction( pAction );
 
 	// Fast forward button
-	m_pFfwdBtn = new Button( pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "fast_forward.svg", "", false, QSize( 13, 13 ), tr("Fast Forward") );
+	m_pFfwdBtn = new Button(
+		pControlsPanel, QSize( 25, 19 ), Button::Type::Push, "fast_forward.svg",
+		"", QSize( 13, 13 ), tr( "Fast Forward" ) );
 	m_pFfwdBtn->move( 90, 4 );
 	connect(m_pFfwdBtn, SIGNAL( clicked() ), this, SLOT( ffWDBtnClicked() ));
 	pAction = std::make_shared<Action>("PLAYLIST_NEXT_SONG");
@@ -145,12 +153,16 @@ PlaylistEditor::PlaylistEditor( QWidget* pParent )
 	pSideBarLayout->setMargin(0);
 
 	// zoom-in btn
-	Button *pUpBtn = new Button( nullptr, QSize( 16, 16 ), Button::Type::Push, "up.svg", "", false, QSize( 9, 9 ), tr( "sort" ) );
+	Button *pUpBtn = new Button(
+		nullptr, QSize( 16, 16 ), Button::Type::Push, "up.svg", "", QSize( 9, 9 ),
+		tr( "sort" ) );
 	connect(pUpBtn, SIGNAL( clicked() ), this, SLOT(o_upBClicked()) );
 	pSideBarLayout->addWidget(pUpBtn);
 
 	// zoom-in btn
-	Button *pDownBtn = new Button( nullptr, QSize( 16, 16 ), Button::Type::Push, "down.svg", "", false, QSize( 9, 9 ), tr( "sort" ) );
+	Button *pDownBtn = new Button(
+		nullptr, QSize( 16, 16 ), Button::Type::Push, "down.svg", "",
+		QSize( 9, 9 ), tr( "sort" ) );
 	connect(pDownBtn, SIGNAL( clicked() ), this, SLOT(o_downBClicked()));
 	pSideBarLayout->addWidget(pDownBtn);
 

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -601,6 +601,12 @@ PreferencesDialog::PreferencesDialog(QWidget* parent)
 	new IndexedTreeItem( 0x207, pWidgetItem, tr( "Spin Box Text" ) );
 	new IndexedTreeItem( 0x208, pWidgetItem, tr( "Playhead" ) );
 	new IndexedTreeItem( 0x209, pWidgetItem, tr( "Cursor" ) );
+	new IndexedTreeItem( 0x20a, pWidgetItem,
+						 pCommonStrings->getBigMuteButton() );
+	new IndexedTreeItem( 0x20b, pWidgetItem, tr( "Mute Text" ) );
+	new IndexedTreeItem( 0x20c, pWidgetItem,
+						 pCommonStrings->getBigSoloButton() );
+	new IndexedTreeItem( 0x20d, pWidgetItem, tr( "Solo Text" ) );
 	
 	pTopLevelItem = new IndexedTreeItem( 0x000, colorTree, tr( "Song Editor" ) );
 	new IndexedTreeItem( 0x300, pTopLevelItem, tr( "Background" ) );
@@ -1901,6 +1907,10 @@ std::unique_ptr<QColor> PreferencesDialog::getColorById( int nId, const H2Core::
 	case 0x207: return std::make_unique<QColor>(colorTheme.m_spinBoxTextColor);
 	case 0x208: return std::make_unique<QColor>(colorTheme.m_playheadColor);
 	case 0x209: return std::make_unique<QColor>(colorTheme.m_cursorColor);
+	case 0x20a: return std::make_unique<QColor>(colorTheme.m_muteColor);
+	case 0x20b: return std::make_unique<QColor>(colorTheme.m_muteTextColor);
+	case 0x20c: return std::make_unique<QColor>(colorTheme.m_soloColor);
+	case 0x20d: return std::make_unique<QColor>(colorTheme.m_soloTextColor);
 	case 0x300: return std::make_unique<QColor>(colorTheme.m_songEditor_backgroundColor);
 	case 0x301: return std::make_unique<QColor>(colorTheme.m_songEditor_alternateRowColor);
 	case 0x302: return std::make_unique<QColor>(colorTheme.m_songEditor_virtualRowColor);
@@ -2000,6 +2010,14 @@ void PreferencesDialog::setColorById( int nId, const QColor& color,
 	case 0x208:  colorTheme.m_playheadColor = color;
 		break;
 	case 0x209:  colorTheme.m_cursorColor = color;
+		break;
+	case 0x20a:  colorTheme.m_muteColor = color;
+		break;
+	case 0x20b:  colorTheme.m_muteTextColor = color;
+		break;
+	case 0x20c:  colorTheme.m_soloColor = color;
+		break;
+	case 0x20d:  colorTheme.m_soloTextColor = color;
 		break;
 	case 0x300:  colorTheme.m_songEditor_backgroundColor = color;
 		break;

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -73,9 +73,10 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	// time line toggle button
 	m_bLastIsTimelineActivated = pSong->getIsTimelineActivated();
-	m_pTimelineBtn = new Button( pBackPanel, QSize( 98, 17 ), Button::Type::Toggle, "",
-								 pCommonStrings->getTimelineBigButton(), false, QSize(),
-								 pCommonStrings->getTimelineEnabled() );
+	m_pTimelineBtn = new Button(
+		pBackPanel, QSize( 98, 17 ), Button::Type::Toggle, "",
+		pCommonStrings->getTimelineBigButton(), QSize(),
+		pCommonStrings->getTimelineEnabled() );
 	m_pTimelineBtn->move( 94, 4 );
 	m_pTimelineBtn->setObjectName( "TimelineBtn" );
 	m_pTimelineBtn->setChecked( m_bLastIsTimelineActivated );
@@ -92,37 +93,46 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	}
 
 	// clear sequence button
-	m_pClearPatternSeqBtn = new Button( pBackPanel,	QSize( 61, 21 ), Button::Type::Push, "", pCommonStrings->getClearButton(), false, QSize(), tr("Clear pattern sequence") );
+	m_pClearPatternSeqBtn = new Button(
+		pBackPanel,	QSize( 61, 21 ), Button::Type::Push, "",
+		pCommonStrings->getClearButton(), QSize(), tr( "Clear pattern sequence" ) );
 	m_pClearPatternSeqBtn->move( 2, 25 );
-	connect( m_pClearPatternSeqBtn, SIGNAL( clicked() ), this, SLOT( clearSequence() ) );
+	connect( m_pClearPatternSeqBtn, SIGNAL( clicked() ),
+			 this, SLOT( clearSequence() ) );
 
 	// new pattern button
-	Button *newPatBtn = new Button( pBackPanel,	QSize( 25, 21 ), Button::Type::Push, "plus.svg", "", false, QSize( 15, 15 ), tr("Create new pattern") );
+	Button *newPatBtn = new Button(
+		pBackPanel,	QSize( 25, 21 ), Button::Type::Push, "plus.svg", "",
+		QSize( 15, 15 ), tr( "Create new pattern" ) );
 	newPatBtn->move( 64, 25 );
 	connect( newPatBtn, SIGNAL( clicked() ), this, SLOT( newPatBtnClicked() ) );
 
 	// down button
-	m_pDownBtn = new Button( pBackPanel, QSize( 25, 10 ), Button::Type::Push,
-							 "down.svg", "", false, QSize( 7, 7 ),
-							 tr("Move the selected pattern down"), false, true, 2 );
+	m_pDownBtn = new Button(
+		pBackPanel, QSize( 25, 10 ), Button::Type::Push, "down.svg", "",
+		QSize( 7, 7 ), tr( "Move the selected pattern down" ), false, true, 2 );
 	m_pDownBtn->move( 90, 36 );
 	connect( m_pDownBtn, SIGNAL( clicked() ), this, SLOT( downBtnClicked() ) );
 
 	// up button
-	m_pUpBtn = new Button( pBackPanel, QSize( 25, 10 ), Button::Type::Push,
-						   "up.svg", "", false, QSize( 7, 7 ),
-						   tr("Move the selected pattern up"), false, true, 2 );
+	m_pUpBtn = new Button(
+		pBackPanel, QSize( 25, 10 ), Button::Type::Push, "up.svg", "",
+		QSize( 7, 7 ), tr( "Move the selected pattern up" ), false, true, 2 );
 	m_pUpBtn->move( 90, 25 );
 	connect( m_pUpBtn, SIGNAL( clicked() ), this, SLOT( upBtnClicked() ) );
 
 	// Two buttons sharing the same position and either of them is
 	// shown unpressed.
-	m_pSelectionModeBtn = new Button( pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "select.svg", "", false, QSize( 17, 16 ), tr( "Select mode" ) );
+	m_pSelectionModeBtn = new Button(
+		pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "select.svg", "",
+		QSize( 17, 16 ), tr( "Select mode" ) );
 	m_pSelectionModeBtn->move( 116, 25 );
 	connect( m_pSelectionModeBtn, &QPushButton::clicked,
 			 [=](){ activateSelectMode( true ); } );
 
-	m_pDrawModeBtn = new Button( pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "draw.svg", "", false, QSize( 17, 16 ), tr( "Draw mode") );
+	m_pDrawModeBtn = new Button(
+		pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "draw.svg", "",
+		QSize( 17, 16 ), tr( "Draw mode" ) );
 	m_pDrawModeBtn->move( 116, 25 );
 	connect( m_pDrawModeBtn, &QPushButton::clicked,
 			 [=](){ activateSelectMode( false ); } );
@@ -135,21 +145,16 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	// Two buttons sharing the same position and either of them is
 	// shown unpressed
-	m_pPatternEditorLockedBtn = new Button( pBackPanel, QSize( 25, 21 ),
-											Button::Type::Toggle, "lock_closed.svg",
-											"", false, QSize( 21, 17 ),
-											pCommonStrings->getPatternEditorLocked(),
-											false, true );
+	m_pPatternEditorLockedBtn = new Button(
+		pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "lock_closed.svg", "",
+		QSize( 21, 17 ), pCommonStrings->getPatternEditorLocked(), false, true );
 	m_pPatternEditorLockedBtn->move( 142, 25 );
 	connect( m_pPatternEditorLockedBtn, &QPushButton::clicked,
 			 [=](){Hydrogen::get_instance()->setIsPatternEditorLocked( false ); } );
 
-	m_pPatternEditorUnlockedBtn = new Button( pBackPanel, QSize( 25, 21 ),
-											  Button::Type::Push,
-											  "lock_open.svg", "", false,
-											  QSize( 21, 17 ),
-											  pCommonStrings->getPatternEditorLocked(),
-											  false, true );
+	m_pPatternEditorUnlockedBtn = new Button(
+		pBackPanel, QSize( 25, 21 ), Button::Type::Push, "lock_open.svg", "",
+		QSize( 21, 17 ), pCommonStrings->getPatternEditorLocked(), false, true );
 	m_pPatternEditorUnlockedBtn->move( 142, 25 );
 	connect( m_pPatternEditorUnlockedBtn, &QPushButton::clicked,
 			 [=](){Hydrogen::get_instance()->setIsPatternEditorLocked( true ); } );
@@ -170,22 +175,17 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	// Two buttons sharing the same position and either of them is
 	// shown unpressed.
-	m_pPlaySelectedSingleBtn = new Button( pBackPanel, QSize( 25, 21 ),
-										 Button::Type::Push, "single_layer.svg",
-										 "", false, QSize( 17, 13 ),
-										 tr( "selected pattern mode"),
-										 false, true );
+	m_pPlaySelectedSingleBtn = new Button(
+		pBackPanel, QSize( 25, 21 ), Button::Type::Push, "single_layer.svg", "",
+		QSize( 17, 13 ), tr( "selected pattern mode" ), false, true );
 	m_pPlaySelectedSingleBtn->move( 168, 25 );
 	connect( m_pPlaySelectedSingleBtn, &QPushButton::clicked, [=]() {
 		activateStackedMode( true );
 	});
 
-	m_pPlaySelectedMultipleBtn = new Button( pBackPanel, QSize( 25, 21 ),
-										   Button::Type::Push,
-										   "multiple_layers.svg", "", false,
-										   QSize( 21, 17 ),
-										   tr( "stacked pattern mode"),
-										   false, true );
+	m_pPlaySelectedMultipleBtn = new Button(
+		pBackPanel, QSize( 25, 21 ), Button::Type::Push, "multiple_layers.svg", "",
+		QSize( 21, 17 ), tr( "stacked pattern mode" ), false, true );
 	m_pPlaySelectedMultipleBtn->move( 168, 25 );
 	m_pPlaySelectedMultipleBtn->hide();
 	connect( m_pPlaySelectedMultipleBtn, &QPushButton::clicked, [=]() {
@@ -210,23 +210,33 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	connect( m_pHScrollBar, SIGNAL(valueChanged(int)), this, SLOT( hScrollTo(int) ) );
 
 	// zoom-in btn
-	Button* pZoomInBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Push, "plus.svg", "", false, QSize( 9, 9 ) );
+	Button* pZoomInBtn = new Button(
+		nullptr, QSize( 19, 15 ), Button::Type::Push, "plus.svg", "",
+		QSize( 9, 9 ) );
 	connect( pZoomInBtn, SIGNAL( clicked() ), this, SLOT( zoomOutBtnClicked() ) );
 
 
 
 	// zoom-out btn
-	Button* pZoomOutBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Push, "minus.svg", "", false, QSize( 9, 9 ) );
+	Button* pZoomOutBtn = new Button(
+		nullptr, QSize( 19, 15 ), Button::Type::Push, "minus.svg", "",
+		QSize( 9, 9 ) );
 	connect( pZoomOutBtn, SIGNAL( clicked() ), this, SLOT( zoomInBtnClicked() ) );
 
 	// view playback track toggle button
-	m_pViewPlaybackBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Toggle, "", pCommonStrings->getPlaybackTrackButton(), false, QSize(), tr( "View playback track" ) );
+	m_pViewPlaybackBtn = new Button(
+		nullptr, QSize( 19, 15 ), Button::Type::Toggle, "",
+		pCommonStrings->getPlaybackTrackButton(), QSize(),
+		tr( "View playback track" ) );
 	m_pViewPlaybackBtn->setObjectName( "ViewPlaybackBtn" );
-	connect( m_pViewPlaybackBtn, SIGNAL( clicked() ), this, SLOT( viewPlaybackTrackBtnClicked() ) );
+	connect( m_pViewPlaybackBtn, SIGNAL( clicked() ),
+			 this, SLOT( viewPlaybackTrackBtnClicked() ) );
 	m_pViewPlaybackBtn->setChecked( pPref->getShowPlaybackTrack() );
 	
 	// Playback Fader
-	m_pPlaybackTrackFader = new Fader( pBackPanel, Fader::Type::Vertical, tr( "Playback track volume" ), false, false, 0.0, 1.5 );
+	m_pPlaybackTrackFader = new Fader(
+		pBackPanel, Fader::Type::Vertical, tr( "Playback track volume" ), false,
+		false, 0.0, 1.5 );
 	m_pPlaybackTrackFader->setObjectName( "SongEditorPlaybackTrackFader" );
 	m_pPlaybackTrackFader->move( 6, 1 );
 	m_pPlaybackTrackFader->setValue( pSong->getPlaybackTrackVolume() );
@@ -234,11 +244,10 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	connect( m_pPlaybackTrackFader, SIGNAL( valueChanged( WidgetWithInput* ) ), this, SLOT( faderChanged( WidgetWithInput* ) ) );
 
 	// mute playback track toggle button
-	m_pMutePlaybackBtn = new Button( pBackPanel, QSize( 34, 17 ),
-									 Button::Type::Toggle, "",
-									 pCommonStrings->getBigMuteButton(),
-									 true, QSize(), tr( "Mute playback track" ),
-									 false, true );
+	m_pMutePlaybackBtn = new Button(
+		pBackPanel, QSize( 34, 17 ), Button::Type::Toggle, "",
+		pCommonStrings->getBigMuteButton(), QSize(), tr( "Mute playback track" ),
+		false, true );
 	m_pMutePlaybackBtn->setObjectName( "SongEditorPlaybackTrackMuteButton" );
 	m_pMutePlaybackBtn->move( 158, 4 );
 	m_pMutePlaybackBtn->hide();
@@ -255,7 +264,9 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	}
 	
 	// edit playback track toggle button
-	m_pEditPlaybackBtn = new Button( pBackPanel, QSize( 34, 17 ), Button::Type::Push, "", pCommonStrings->getEditButton(), false, QSize(), tr( "Choose playback track") );
+	m_pEditPlaybackBtn = new Button(
+		pBackPanel, QSize( 34, 17 ), Button::Type::Push, "",
+		pCommonStrings->getEditButton(), QSize(), tr( "Choose playback track") );
 	m_pEditPlaybackBtn->setObjectName( "SongEditorPlaybackTrackEditButton" );
 	m_pEditPlaybackBtn->move( 123, 4 );
 	m_pEditPlaybackBtn->hide();
@@ -263,7 +274,9 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	m_pEditPlaybackBtn->setChecked( false );
 
 	// timeline view toggle button
-	m_pViewTimelineBtn = new Button( nullptr, QSize( 19, 15 ), Button::Type::Toggle, "", pCommonStrings->getTimelineButton(), false, QSize(), tr( "View timeline" ) );
+	m_pViewTimelineBtn = new Button(
+		nullptr, QSize( 19, 15 ), Button::Type::Toggle, "",
+		pCommonStrings->getTimelineButton(), QSize(), tr( "View timeline" ) );
 	m_pViewTimelineBtn->setObjectName( "TimeLineToggleBtn" );
 	connect( m_pViewTimelineBtn, SIGNAL( clicked() ), this, SLOT( viewTimelineBtnClicked() ) );
 	m_pViewTimelineBtn->setChecked( ! pPref->getShowPlaybackTrack() );
@@ -407,23 +420,30 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 
 	show();
 
+	updateColors();
 	updateEditors();
 
 	HydrogenApp::get_instance()->addEventListener( this );
 
 	m_pHighlightLockedTimer = new QTimer( this );
 	m_pHighlightLockedTimer->setSingleShot( true );
-	connect(m_pHighlightLockedTimer, &QTimer::timeout,
-			[=](){ m_pPatternEditorLockedBtn->setUseRedBackground( false ); } );
+	connect( m_pHighlightLockedTimer, &QTimer::timeout,
+			[=](){ const auto theme = Preferences::get_instance()->getTheme();
+				 m_pPatternEditorLockedBtn->setCheckedBackgroundColor(
+					theme.m_color.m_accentColor );
+				 m_pPatternEditorLockedBtn->setCheckedBackgroundTextColor(
+					theme.m_color.m_accentTextColor );
+			});
 
-	m_pTimer = new QTimer(this);
+	m_pTimer = new QTimer( this );
 	
-	connect(m_pTimer, SIGNAL(timeout()), this, SLOT( updatePlayHeadPosition() ) );
-	connect(m_pTimer, SIGNAL(timeout()), this, SLOT( updatePlaybackFaderPeaks() ) );
+	connect( m_pTimer, SIGNAL(timeout()), this, SLOT( updatePlayHeadPosition() ) );
+	connect( m_pTimer, SIGNAL(timeout()),
+			 this, SLOT( updatePlaybackFaderPeaks() ) );
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
 			 this, &SongEditorPanel::onPreferencesChanged );
 	
-	m_pTimer->start(100);
+	m_pTimer->start( 100 );
 }
 
 
@@ -480,7 +500,11 @@ void SongEditorPanel::updatePlayHeadPosition()
 }
 
 void SongEditorPanel::highlightPatternEditorLocked() {
-	m_pPatternEditorLockedBtn->setUseRedBackground( true );
+	const auto theme = Preferences::get_instance()->getTheme();
+	m_pPatternEditorLockedBtn->setCheckedBackgroundColor(
+		theme.m_color.m_buttonRedColor );
+	m_pPatternEditorLockedBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_buttonRedTextColor );
 	m_pHighlightLockedTimer->start( 250 );
 }
 
@@ -1098,6 +1122,10 @@ void SongEditorPanel::activateSelectMode( bool bActivate ) {
 void SongEditorPanel::onPreferencesChanged( const H2Core::Preferences::Changes& changes )
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	if ( changes & H2Core::Preferences::Changes::Colors ) {
+		updateColors();
+	}
+
 	if ( changes & ( H2Core::Preferences::Changes::GeneralTab |
 					 H2Core::Preferences::Changes::Colors |
 					 H2Core::Preferences::Changes::Font |
@@ -1182,6 +1210,14 @@ void SongEditorPanel::updateActionMode() {
 		m_pDrawModeBtn->hide();
 		m_pSelectionModeBtn->show();
 	}
+}
+
+void SongEditorPanel::updateColors() {
+	const auto theme = Preferences::get_instance()->getTheme();
+
+	m_pMutePlaybackBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pMutePlaybackBtn->setCheckedBackgroundTextColor(
+		theme.m_color.m_muteTextColor );
 }
 
 void SongEditorPanel::updateJacktimebaseState() {

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -146,6 +146,7 @@ class SongEditorPanel : public QWidget,
 		void setTimelineEnabled( bool bEnabled );
 
 		void updateActionMode();
+		void updateColors();
 		void updateJacktimebaseState();
 		void updatePatternEditorLocked();
 		void updatePatternMode();

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -35,8 +35,7 @@
 #include <core/Hydrogen.h>
 
 Button::Button( QWidget *pParent, const QSize& size, const Type& type,
-				const QString& sIcon, const QString& sText,
-				bool bUseRedBackground, const QSize& iconSize,
+				const QString& sIcon, const QString& sText, const QSize& iconSize,
 				const QString& sBaseTooltip, bool bColorful,
 				bool bModifyOnChange, int nBorderRadius )
 	: QPushButton( pParent )
@@ -48,11 +47,14 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 	, m_bLastCheckedState( false )
 	, m_sIcon( sIcon )
 	, m_bIsActive( true )
-	, m_bUseRedBackground( bUseRedBackground )
 	, m_nFixedFontSize( -1 )
 	, m_bModifyOnChange( bModifyOnChange )
 	, m_nBorderRadius( nBorderRadius )
 {
+	auto pPref = H2Core::Preferences::get_instance();
+	m_checkedBackgroundColor = pPref->getTheme().m_color.m_accentColor;
+	m_checkedBackgroundTextColor = pPref->getTheme().m_color.m_accentTextColor;
+
 	setFocusPolicy( Qt::NoFocus );
 	setSize( size );
 
@@ -75,7 +77,8 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 	updateStyleSheet();
 	updateTooltip();
 	
-	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &Button::onPreferencesChanged );
+	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
+			 this, &Button::onPreferencesChanged );
 
 	connect( this, SIGNAL(clicked()), this, SLOT(onClick()));
 }
@@ -110,11 +113,22 @@ void Button::updateIcon() {
 	}
 }
 
-void Button::setUseRedBackground( bool bUseRedBackground ) {
-	m_bUseRedBackground	= bUseRedBackground;
+void Button::setCheckedBackgroundColor( const QColor& color ) {
+	if ( color != m_checkedBackgroundColor ) {
+		m_checkedBackgroundColor = color;
 
-	updateStyleSheet();
-	update();
+		updateStyleSheet();
+		update();
+	}
+}
+
+void Button::setCheckedBackgroundTextColor( const QColor& color ) {
+	if ( color != m_checkedBackgroundTextColor ) {
+		m_checkedBackgroundTextColor = color;
+
+		updateStyleSheet();
+		update();
+	}
 }
 
 void Button::updateStyleSheet() {
@@ -127,72 +141,71 @@ void Button::updateStyleSheet() {
 
 	const auto theme = H2Core::Preferences::get_instance()->getTheme();
 	
-	int nFactorGradient = 126;
-	int nFactorGradientShadow = 225;
-	int nHover = 12;
-	float fStop1 = 0.2;
-	float fStop2 = 0.85;
-	float x1 = 0;
-	float x2 = 1;
-	float y1 = 0;
-	float y2 = 1;
+	const int nFactorGradient = 126;
+	const int nFactorGradientShadow = 225;
+	const int nHover = 12;
+	const float fStop1 = 0.2;
+	const float fStop2 = 0.85;
+	const float x1 = 0;
+	const float x2 = 1;
+	const float y1 = 0;
+	const float y2 = 1;
 
-	QColor baseColorBackground = theme.m_color.m_widgetColor;
-	QColor backgroundLight = baseColorBackground.lighter( nFactorGradient );
-	QColor backgroundDark = baseColorBackground.darker( nFactorGradient );
-	QColor backgroundLightHover = baseColorBackground.lighter( nFactorGradient + nHover );
-	QColor backgroundDarkHover = baseColorBackground.darker( nFactorGradient + nHover );
-	QColor backgroundShadowLight = baseColorBackground.lighter( nFactorGradientShadow );
-	QColor backgroundShadowDark = baseColorBackground.darker( nFactorGradientShadow );
-	QColor backgroundShadowLightHover = baseColorBackground.lighter( nFactorGradientShadow + nHover );
-	QColor backgroundShadowDarkHover = baseColorBackground.darker( nFactorGradientShadow + nHover );
-	QColor border = Qt::black;
+	const QColor baseColorBackground = theme.m_color.m_widgetColor;
+	const QColor backgroundLight = baseColorBackground.lighter( nFactorGradient );
+	const QColor backgroundDark = baseColorBackground.darker( nFactorGradient );
+	const QColor backgroundLightHover = baseColorBackground.lighter( nFactorGradient + nHover );
+	const QColor backgroundDarkHover = baseColorBackground.darker( nFactorGradient + nHover );
+	const QColor backgroundShadowLight = baseColorBackground.lighter( nFactorGradientShadow );
+	const QColor backgroundShadowDark = baseColorBackground.darker( nFactorGradientShadow );
+	const QColor backgroundShadowLightHover = baseColorBackground.lighter( nFactorGradientShadow + nHover );
+	const QColor backgroundShadowDarkHover = baseColorBackground.darker( nFactorGradientShadow + nHover );
+	const QColor border = Qt::black;
 
-	QColor baseColorBackgroundChecked, textChecked;
-	if ( ! m_bUseRedBackground ) {
-		baseColorBackgroundChecked = theme.m_color.m_accentColor;
-		textChecked = theme.m_color.m_accentTextColor;
-	} else {
-		baseColorBackgroundChecked = theme.m_color.m_buttonRedColor;
-		textChecked = theme.m_color.m_buttonRedTextColor;
-	}
+	const QColor backgroundCheckedLight =
+		m_checkedBackgroundColor.lighter( nFactorGradient );
+	const QColor backgroundCheckedDark =
+		m_checkedBackgroundColor.darker( nFactorGradient );
+	const QColor backgroundCheckedLightHover =
+		m_checkedBackgroundColor.lighter( nFactorGradient + nHover );
+	const QColor backgroundCheckedDarkHover =
+		m_checkedBackgroundColor.darker( nFactorGradient + nHover );
+	const QColor backgroundShadowCheckedLight =
+		m_checkedBackgroundColor.lighter( nFactorGradientShadow );
+	const QColor backgroundShadowCheckedDark =
+		m_checkedBackgroundColor.darker( nFactorGradientShadow );
+	const QColor backgroundShadowCheckedLightHover =
+		m_checkedBackgroundColor.lighter( nFactorGradientShadow + nHover );
+	const QColor backgroundShadowCheckedDarkHover =
+		m_checkedBackgroundColor.darker( nFactorGradientShadow + nHover );
+
+	const QColor textColor = theme.m_color.m_widgetTextColor;
 	
-	QColor backgroundCheckedLight = baseColorBackgroundChecked.lighter( nFactorGradient );
-	QColor backgroundCheckedDark = baseColorBackgroundChecked.darker( nFactorGradient );
-	QColor backgroundCheckedLightHover = baseColorBackgroundChecked.lighter( nFactorGradient + nHover );
-	QColor backgroundCheckedDarkHover = baseColorBackgroundChecked.darker( nFactorGradient + nHover );
-	QColor backgroundShadowCheckedLight = baseColorBackgroundChecked.lighter( nFactorGradientShadow );
-	QColor backgroundShadowCheckedDark = baseColorBackgroundChecked.darker( nFactorGradientShadow );
-	QColor backgroundShadowCheckedLightHover = baseColorBackgroundChecked.lighter( nFactorGradientShadow + nHover );
-	QColor backgroundShadowCheckedDarkHover = baseColorBackgroundChecked.darker( nFactorGradientShadow + nHover );
-
-	QColor textColor = theme.m_color.m_widgetTextColor;
-	
-	QColor backgroundInactiveLight =
+	const QColor backgroundInactiveLight =
 		Skin::makeWidgetColorInactive( backgroundLight );
-	QColor backgroundInactiveLightHover = backgroundInactiveLight;
-	QColor backgroundInactiveCheckedLight =
+	const QColor backgroundInactiveLightHover = backgroundInactiveLight;
+	const QColor backgroundInactiveCheckedLight =
 		Skin::makeWidgetColorInactive( backgroundCheckedLight );
-	QColor backgroundInactiveCheckedLightHover = backgroundInactiveCheckedLight;
-	QColor backgroundInactiveDark =
+	const QColor backgroundInactiveCheckedLightHover = backgroundInactiveCheckedLight;
+	const QColor backgroundInactiveDark =
 		Skin::makeWidgetColorInactive( backgroundDark );
-	QColor backgroundInactiveDarkHover = backgroundInactiveDark;
-	QColor backgroundInactiveCheckedDark =
+	const QColor backgroundInactiveDarkHover = backgroundInactiveDark;
+	const QColor backgroundInactiveCheckedDark =
 		Skin::makeWidgetColorInactive( backgroundCheckedDark );
-	QColor backgroundInactiveCheckedDarkHover = backgroundInactiveCheckedDark;
-	QColor backgroundShadowInactiveLight =
+	const QColor backgroundInactiveCheckedDarkHover = backgroundInactiveCheckedDark;
+	const QColor backgroundShadowInactiveLight =
 		Skin::makeWidgetColorInactive( backgroundShadowLight );
-	QColor backgroundShadowInactiveLightHover = backgroundShadowInactiveLight;
-	QColor backgroundShadowInactiveCheckedLight =
+	const QColor backgroundShadowInactiveLightHover = backgroundShadowInactiveLight;
+	const QColor backgroundShadowInactiveCheckedLight =
 		Skin::makeWidgetColorInactive( backgroundShadowCheckedLight );
-	QColor backgroundShadowInactiveCheckedLightHover = backgroundShadowInactiveCheckedLight;
-	QColor backgroundShadowInactiveDark =
+	const QColor backgroundShadowInactiveCheckedLightHover = backgroundShadowInactiveCheckedLight;
+	const QColor backgroundShadowInactiveDark =
 		Skin::makeWidgetColorInactive( backgroundShadowDark );
-	QColor backgroundShadowInactiveDarkHover = backgroundShadowInactiveDark;
-	QColor backgroundShadowInactiveCheckedDark =
+	const QColor backgroundShadowInactiveDarkHover = backgroundShadowInactiveDark;
+	const QColor backgroundShadowInactiveCheckedDark =
 		Skin::makeWidgetColorInactive( backgroundShadowCheckedDark );
-	QColor backgroundShadowInactiveCheckedDarkHover = backgroundShadowInactiveCheckedDark;
-	QColor textInactiveColor = Skin::makeTextColorInactive( textColor );
+	const QColor backgroundShadowInactiveCheckedDarkHover = backgroundShadowInactiveCheckedDark;
+	const QColor textInactiveColor = Skin::makeTextColorInactive( textColor );
 
 	setStyleSheet( QString( "\
 QPushButton:enabled { \
@@ -258,7 +271,7 @@ QPushButton:disabled:checked:hover { \
 				   .arg( backgroundDark.name() )
 				   .arg( backgroundLightHover.name() )
 				   .arg( backgroundDarkHover.name() )
-				   .arg( textChecked.name() )
+				   .arg( m_checkedBackgroundTextColor.name() )
 				   .arg( backgroundCheckedLight.name() )
 				   .arg( backgroundCheckedDark.name() )
 				   .arg( backgroundCheckedLightHover.name() )
@@ -269,7 +282,7 @@ QPushButton:disabled:checked:hover { \
 				   .arg( backgroundInactiveDark.name() )
 				   .arg( backgroundInactiveLightHover.name() )
 				   .arg( backgroundInactiveDarkHover.name() )
-				   .arg( textChecked.name() )
+				   .arg( m_checkedBackgroundTextColor.name() )
 				   .arg( backgroundInactiveCheckedLight.name() )
 				   .arg( backgroundInactiveCheckedDark.name() )
 				   .arg( backgroundInactiveCheckedLightHover.name() )

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -86,7 +86,6 @@ public:
 	 * \param type
 	 * \param sIcon
 	 * \param sText
-	 * \param bUseRedBackground
 	 * \param iconSize
 	 * \param sBaseTooltip
 	 * \param bColorful If set to false, the icon @a sIcon is expected
@@ -105,7 +104,6 @@ public:
 		   const Type& type = Type::Toggle,
 		   const QString& sIcon = "",
 		   const QString& sText = "",
-		   bool bUseRedBackground = false,
 		   const QSize& iconSize = QSize( 0, 0 ),
 		   const QString& sBaseTooltip = "",
 		   bool bColorful = false,
@@ -131,8 +129,8 @@ public:
 	void setFixedFontSize( int nPixelSize );
 	int getFixedFontSize() const;
 
-	void setUseRedBackground( bool bUseRedBackground );
-	bool getUseRedBackground() const;
+	void setCheckedBackgroundColor( const QColor& color );
+	void setCheckedBackgroundTextColor( const QColor& color );
 
 	void setBorderRadius( int nBorderRadius );
 	int getBorderRadius() const;
@@ -154,7 +152,6 @@ private:
 	void updateTooltip() override;
 	void updateIcon();
 
-	bool m_bUseRedBackground;
 	Type m_type;
 	QSize m_size;
 	QSize m_iconSize;
@@ -173,6 +170,9 @@ private:
 		soon as the value of the widget does change.*/
 	bool m_bModifyOnChange;
 
+		QColor m_checkedBackgroundColor;
+		QColor m_checkedBackgroundTextColor;
+
 	virtual void mousePressEvent(QMouseEvent *ev) override;
 	virtual void paintEvent( QPaintEvent* ev) override;
 
@@ -186,9 +186,6 @@ inline void Button::setFixedFontSize( int nPixelSize ) {
 }
 inline int Button::getFixedFontSize() const {
 	return m_nFixedFontSize;
-}
-inline bool Button::getUseRedBackground() const {
-	return m_bUseRedBackground;
 }
 inline const Button::Type& Button::getType() const {
 	return m_type;

--- a/src/tests/data/preferences/current.conf
+++ b/src/tests/data/preferences/current.conf
@@ -296,6 +296,10 @@
     <spinBoxTextColor>240,240,240</spinBoxTextColor>
     <playheadColor>0,0,0</playheadColor>
     <cursorColor>38,39,44</cursorColor>
+    <muteColor>191,51,51</muteColor>
+    <muteTextColor>255,255,255</muteTextColor>
+    <soloColor>168,136,38</soloColor>
+    <soloTextColor>255,255,255</soloTextColor>
    </widget>
   </colorTheme>
   <SongEditor_ColoringMethod>1</SongEditor_ColoringMethod>


### PR DESCRIPTION
![2025-04-06-104442_3840x1220_scrot](https://github.com/user-attachments/assets/fa2f240f-0e46-4ebd-8973-f1c47f990c49)

Historically the checked solo button was highlighted using `ColorTheme::m_accentColor` (bluish color with white text. Can be seen in various buttons in the player control panel). Not an ideal solution, but ok. But lately we want to color elements, like soloed layers in `LayerPreview`, to emphasize that they are soloed. This can not be done using the accent color, since that one is already used all over the place. It would not be evident what is going on.

Instead, a dedicated solo color is introduced and exposed in the color theme within the `PreferencesDialog`. And while at it, I also introduced a dedicated mute color.

`ColorTheme::m_buttonRedColor` is kept since there are a couple of use cases where the red color is used to indicate errors or emphasize other states instead of a muted state. E.g. the Jack Timebase button in the player control above or a the first beat in the `Director` (not shown in the screenshot).

