### PR TITLE
build.sh: dynamically determine number of build jobs (#2128)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- LASH support has been deprecated and will be removed in version 2.0 of
 			Hydrogen (#1649).
 		- Allow to select and copy version in About dialog (#2127).
+		- Number of parallel build jobs in `build.sh` is now set dynamically to number
+			of virtual processors (#2128).
 	* Fixed
 		- Fix compilation with LASH support enabled (#2076).
 		- Fix Hue slider in Preferences > Appearance > Color (#2081).

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,15 @@ CMAKE_OPTIONS="
     -DWANT_COREMIDI=1 \
     -DWANT_INTEGRATION_TESTS=1
 "
-MAKE_OPTS="-j 3"
+NUMBER_OF_BUILD_JOBS=3
+if which nproc &> /dev/null; then
+    # Get the number of virtual processors on Linux.
+    NUMBER_OF_BUILD_JOBS=$(nproc)
+elif which sysctl &> /dev/null; then
+    # Get the number of virtual processors on macOS and *BSD.
+    NUMBER_OF_BUILD_JOBS=$(sysctl hw.ncpu | sed 's/.*: //')
+fi
+MAKE_OPTS="-j ${NUMBER_OF_BUILD_JOBS}"
 H2FLAGS="-V0xf"
 BUILD_DIR=./build
 BUILD_DIR_APPIMAGE=./build-appimage


### PR DESCRIPTION
based on the number of available virtual processors on the build system.

This was designed to be used with Linux, macOS, and *BSD. Windows does not matter since we have a dedicated build script for this platform in `windows/Build-WinNative.ps1`.

Fixes #2128