### PR TITLE
AudioEngine: guard per-track ports with output mutex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,8 @@ XXXX-XX-XX the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 		- Fix memory leakage for notes with probability < 1.0.
 		- Fix incoming MIDI NOTE OFF handling.
 		- AppImage build dir is now removed on `build.sh r` (#2129).
+		- Fix potential crash with JACK audio driver on startup, teardown, or
+			song/drumkit loading.
 
 2024-12-07 the hydrogen team <hydrogen-devel@lists.sourceforge.net>
 	* Release 1.2.4

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -535,6 +535,23 @@ bool AudioEngine::isEndOfSongReached( std::shared_ptr<TransportPosition> pPos ) 
 	return false;
 }
 
+void AudioEngine::makeTrackPorts( std::shared_ptr<Song> pSong ) {
+
+	auto pJackAudioDriver = dynamic_cast<JackAudioDriver*>( m_pAudioDriver );
+	if ( pJackAudioDriver != nullptr ) {
+		// We have to guard this call using the special output buffer mutex to
+		// avoid `JackAudioDriver::makeTrackPorts` being called in parallel to
+		// `JackAudioDriver::clearPerTrackAudioBuffers` (called without an
+		// AudioEngine lock).
+		m_MutexOutputPointer.lock();
+
+		pJackAudioDriver->makeTrackOutputs( pSong );
+
+		m_MutexOutputPointer.unlock();
+	}
+
+}
+
 void AudioEngine::updateTransportPosition( double fTick, long long nFrame, std::shared_ptr<TransportPosition> pPos ) {
 
 	const auto pHydrogen = Hydrogen::get_instance();

--- a/src/core/AudioEngine/AudioEngine.h
+++ b/src/core/AudioEngine/AudioEngine.h
@@ -441,6 +441,8 @@ public:
 
 	bool			isEndOfSongReached( std::shared_ptr<TransportPosition> pPos ) const;
 
+		void makeTrackPorts( std::shared_ptr<Song> pSong );
+
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of
 	 * every new line

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -961,20 +961,18 @@ void Hydrogen::renameJackPorts( std::shared_ptr<Song> pSong )
 		return;
 	}
 	
-	if( Preferences::get_instance()->m_bJackTrackOuts == true ){
-		if ( hasJackAudioDriver() && pSong != nullptr ) {
+	if ( Preferences::get_instance()->m_bJackTrackOuts == true &&
+		hasJackAudioDriver() && pSong != nullptr ) {
 
-			// When restarting the audio driver after loading a new song under
-			// Non session management all ports have to be registered _prior_
-			// to the activation of the client.
-			if ( isUnderSessionManagement() &&
-				 getGUIState() != Hydrogen::GUIState::ready ) {
-				return;
-			}
-			auto pAudioEngine = m_pAudioEngine;
-
-			static_cast< JackAudioDriver* >( m_pAudioEngine->getAudioDriver() )->makeTrackOutputs( pSong );
+		// When restarting the audio driver after loading a new song under
+		// Non session management all ports have to be registered _prior_
+		// to the activation of the client.
+		if ( isUnderSessionManagement() &&
+			 getGUIState() != Hydrogen::GUIState::ready ) {
+			return;
 		}
+
+		m_pAudioEngine->makeTrackPorts( pSong );
 	}
 #endif
 }


### PR DESCRIPTION
A long time ago (4e5518743c090fa7f086595d79a95c4ebfcd2c90) the clearing of the provided audio buffers in `audioEngine_process` was moved outside of the audio engine lock in order to be more real-time friendly. Instead, access of output buffers at this that point is guarded by the dedicated `m_MutexOutputPoint` mutex.

However, only the main audio output buffers were properly guarded (during starting/stopping of the drivers). The per-track JACK ones were not and could cause segfaults when both `JackAudioDriver::makeTrackOutputs` and `JackAudioDriver::clearPerTrackAudioBuffers` are called in parallel. (This did could be reproduced using our unit tests).