### PR TITLE
JACK per-track fixes and sample preview ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [2.0.0] - XXXX-XX-XX
 
 ### Added
+
 - PortMidi driver does open a input/output port which can be discovered and
   connected to by other applications when port was set to "None" in the
   Preferences (not supported on Windows).
@@ -49,7 +50,7 @@ All notable changes to this project will be documented in this file.
   Preferences > Appearance > Interface > Indicate effective note length).
 - Custom colors for 'mute' and 'solo'.
 - When activating per-track JACK outputs, Hydrogen does now provided additional
-  ports for both metronome and playback track (#1150).
+  ports for metronome, playback track, and sample preview (#1150).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ All notable changes to this project will be documented in this file.
   - The "Layers" tab was replaced by a "Components" one containing collapsible
     versions of the previous view for all components.
   - Both components and layers can now be muted and soloed.
+  - Adding, deleting, and replacing of layers can be undone.
 - JACK per-track output ports are now mapped on drumkit switch or manipulation
   on instrument with same type. Ports of instruments without type aren't mapped
   at all (same as for notes) (#1071).

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -1401,6 +1401,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -1396,6 +1396,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Desar cançó</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Uložit skladbu</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -1398,6 +1398,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Song speichern</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -1403,6 +1403,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Αποθήκευση του τραγουδιού</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -1399,6 +1399,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Guardar canción</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -1404,6 +1404,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -1398,6 +1398,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Sauvegarder le morceau</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -1403,6 +1403,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Gardar a canción</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Spremi pjesmu</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Szám mentése</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Salva canzone</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -1401,6 +1401,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -1396,6 +1396,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>ソングの保存</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Opname opslaan</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Zapisz utwór</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -1398,6 +1398,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Salvar canção</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -1403,6 +1403,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Сохранить композицию</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Сачувај песму</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Spara sång</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -1395,6 +1395,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>Записати композицію</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -1400,6 +1400,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1401,6 +1401,21 @@ Please set your system&apos;s locale to UTF-8!</source>
         <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Add layer</source>
+        <extracomment>Representing adding an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete layer</source>
+        <extracomment>Representing deleting an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit layer</source>
+        <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1396,6 +1396,11 @@ Please set your system&apos;s locale to UTF-8!</source>
         <source>Save song</source>
         <translation>保存乐曲</translation>
     </message>
+    <message>
+        <source>Editing type of instrument</source>
+        <extracomment>Representing a altering of an instrument type in the undo history and * context menu.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ComponentView</name>

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -1390,13 +1390,20 @@ std::shared_ptr<Instrument> Drumkit::mapInstrument( const QString& sType,
 		// were loaded. Instead of loading the corresponding drumkit.xml file
 		// as is, the IDs of the instruments were overwritten in such a way it
 		// matched the order of the previous kit.
-		if ( pOldDrumkit != nullptr &&
-			 pOldDrumkit->getInstruments()->find( nInstrumentId ) != nullptr ) {
-			pInstrument = m_pInstruments->get(
-				pOldDrumkit->getInstruments()->index(
-					pOldDrumkit->getInstruments()->find( nInstrumentId ) ) );
+		if ( pOldDrumkit != nullptr ) {
+			auto pOldInstruments = pOldDrumkit->getInstruments();
+			const auto pOldInstrument =
+				pOldDrumkit->getInstruments()->find( nInstrumentId );
+			if ( pOldInstrument != nullptr ) {
+				const int nOldIndex = pOldInstruments->index( pOldInstrument );
+
+				if ( nOldIndex != -1 ) {
+					pInstrument = m_pInstruments->get( nOldIndex );
+				}
+			}
 		}
-		else {
+
+		if ( pInstrument == nullptr ) {
 			pInstrument = m_pInstruments->find( nInstrumentId );
 		}
 

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -1981,6 +1981,29 @@ bool CoreActionController::moveInstrument( int nSourceIndex, int nTargetIndex ) 
 	return true;
 }
 
+bool CoreActionController::setInstrumentType( int nInstrumentId,
+											  const DrumkitMap::Type& sType ) {
+	auto pHydrogen = Hydrogen::get_instance();
+	ASSERT_HYDROGEN
+
+	auto pSong = pHydrogen->getSong();
+	if ( pSong == nullptr || pSong->getDrumkit() == nullptr ) {
+		return false;
+	}
+
+	auto pInstrument = pSong->getDrumkit()->getInstruments()->
+		find( nInstrumentId );
+	if ( pInstrument == nullptr ) {
+		ERRORLOG( QString( "Uable to find instrument [%1] for type [%2]" )
+				  .arg( nInstrumentId ).arg( sType ) );
+		return false;
+	}
+
+	pInstrument->setType( sType );
+
+	return true;
+}
+
 bool CoreActionController::locateToColumn( int nPatternGroup ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	ASSERT_HYDROGEN

--- a/src/core/CoreActionController.h
+++ b/src/core/CoreActionController.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <memory>
 
+#include <core/Basics/DrumkitMap.h>
 #include <core/Object.h>
 
 namespace H2Core
@@ -360,6 +361,15 @@ class CoreActionController : public H2Core::Object<CoreActionController> {
 		 * within the instrument list and _not_ the ID of the instrument (which
 		 * stays the same during the move action). */
 		static bool moveInstrument( int nSourceIndex, int nTargetIndex );
+
+		/** Changing the type of an instrument - specified using its ID - of the
+		 * current drumkit.
+		 *
+		 * This one should be used over setDrumkit() since it is able to
+		 * properly handling setting the initial type or removing a type string
+		 * while honoring JACK per-track output ports. */
+		static bool setInstrumentType( int nInstrumentId,
+									   const DrumkitMap::Type& sType );
 
 		/** Relocates transport to the beginning of a particular
 		 * column/Pattern group.

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -378,6 +378,9 @@ void JackAudioDriver::makeTrackPorts( std::shared_ptr<Song> pSong,
 		return;
 	}
 
+	// Clean up all ports not required anymore.
+	cleanupPerTrackPorts();
+
 	auto createPorts = [=]( std::shared_ptr<Instrument> pInstrument,
 						   const QString& sPortName, bool* pError ) {
 		InstrumentPorts ports;

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -589,8 +589,6 @@ void JackAudioDriver::makeTrackPorts( std::shared_ptr<Song> pSong,
 		}
 	}
 
-	}
-
 	for ( const auto& ppInstrument : *pSong->getDrumkit()->getInstruments() ) {
 		if ( ppInstrument == nullptr ||
 			 m_portMap.find( ppInstrument ) != m_portMap.end() ) {

--- a/src/core/IO/JackAudioDriver.h
+++ b/src/core/IO/JackAudioDriver.h
@@ -497,6 +497,13 @@ private:
 		 * song. They will stay till teardown. */
 		PortMap m_portMapStatic;
 
+		/** Since #Sampler::m_pPreviewInstrument is changed with each new sample
+		 * to preview, this one serves as a dummy instrument mapping all
+		 * instruments not found in #m_portMap but with
+		 * #Instrument::m_bIsPreviewInstrument set to the per-track output ports
+		 * of the sample preview. */
+		std::shared_ptr<Instrument> m_pDummyPreviewInstrument;
+
 	/**
 	 * Current transport state returned by
 	 * _jack_transport_query()_ (jack/transport.h).  

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -615,6 +615,15 @@ CommonStrings::CommonStrings(){
 	/*: Representing renaming a component of the currently selected instrument
 	 * in the undo history */
 	m_sActionRenameComponent = tr( "Rename component" );
+	/*: Representing adding an instrument layer in the undo history. Both the
+	 *  name of the layer and the corresponding instrument will be appended. */
+	m_sActionAddInstrumentLayer = tr( "Add layer" );
+	/*: Representing deleting an instrument layer in the undo history. Both the
+	 *  name of the layer and the corresponding instrument will be appended. */
+	m_sActionDeleteInstrumentLayer = tr( "Delete layer" );
+	/*: Representing editing an instrument layer in the undo history. Both the
+	 *  name of the layer and the corresponding instrument will be appended. */
+	m_sActionEditInstrumentLayer = tr( "Edit layer" );
 
 	/*: Representing deleting all notes of a specific row in the pattern editor
 	 * in the undo history (the number of the row will be append) as well as in

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -586,6 +586,9 @@ CommonStrings::CommonStrings(){
 	/*: Representing a renaming of an instrument in the undo history and context
 	 * menu. */
 	m_sActionMoveInstrument = tr( "Move instrument" );
+	/*: Representing a altering of an instrument type in the undo history and
+	 * context menu. */
+	m_sActionSetInstrumentType = tr( "Editing type of instrument" );
 	/*: Representing a drumkit loading in the undo history */
 	m_sActionSwitchDrumkit = tr( "Switch drumkit" );
 	/*: Representing the creation of a new drumkit in the undo history */

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -247,6 +247,8 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 		const QString& getActionDropInstrument() const { return m_sActionDropInstrument; }
 		const QString& getActionRenameInstrument() const { return m_sActionRenameInstrument; }
 		const QString& getActionMoveInstrument() const { return m_sActionMoveInstrument; }
+		const QString& getActionSetInstrumentType() const {
+			return m_sActionSetInstrumentType; }
 		const QString& getActionSwitchDrumkit() const { return m_sActionSwitchDrumkit; }
 		const QString& getActionNewDrumkit() const { return m_sActionNewDrumkit; }
 		const QString& getActionLoadDrumkit() const {
@@ -528,6 +530,7 @@ private:
 		QString m_sActionDropInstrument;
 		QString m_sActionRenameInstrument;
 		QString m_sActionMoveInstrument;
+		QString m_sActionSetInstrumentType;
 		QString m_sActionSwitchDrumkit;
 		QString m_sActionNewDrumkit;
 		QString m_sActionLoadDrumkit;

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -261,6 +261,12 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 		const QString& getActionAddComponent() const { return m_sActionAddComponent; }
 		const QString& getActionDeleteComponent() const { return m_sActionDeleteComponent; }
 		const QString& getActionRenameComponent() const { return m_sActionRenameComponent; }
+		const QString& getActionAddInstrumentLayer() const {
+			return m_sActionAddInstrumentLayer; }
+		const QString& getActionDeleteInstrumentLayer() const {
+			return m_sActionDeleteInstrumentLayer; }
+		const QString& getActionEditInstrumentLayer() const {
+			return m_sActionEditInstrumentLayer; }
 
 		const QString& getActionClearAllNotesInRow() const {
 			return m_sActionClearAllNotesInRow; }
@@ -540,6 +546,9 @@ private:
 		QString m_sActionAddComponent;
 		QString m_sActionDeleteComponent;
 		QString m_sActionRenameComponent;
+		QString m_sActionAddInstrumentLayer;
+		QString m_sActionDeleteInstrumentLayer;
+		QString m_sActionEditInstrumentLayer;
 
 		QString m_sActionClearAllNotesInRow;
 		QString m_sActionClearAllNotes;

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -1040,6 +1040,38 @@ class SE_renameComponentAction : public QUndoCommand {
 };
 
 /** \ingroup docGUI*/
+class SE_setInstrumentTypeAction : public QUndoCommand
+{
+public:
+	SE_setInstrumentTypeAction( int nInstrumentId,
+								const H2Core::DrumkitMap::Type& sNewType,
+								const H2Core::DrumkitMap::Type& sOldType,
+								const QString& sInstrumentName )
+		: m_nInstrumentId( nInstrumentId )
+		, m_sNewType( sNewType )
+		, m_sOldType( sOldType ) {
+		const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+		setText( QString( "%1 [%2]: [%3] -> [%4]" )
+				 .arg( pCommonStrings->getActionSetInstrumentType() )
+				 .arg( sInstrumentName ).arg( sOldType ).arg( sNewType ) );
+	}
+	~SE_setInstrumentTypeAction(){}
+
+	virtual void undo() {
+		H2Core::CoreActionController::setInstrumentType(
+			m_nInstrumentId, m_sOldType );
+	}
+	virtual void redo() {
+		H2Core::CoreActionController::setInstrumentType(
+			m_nInstrumentId, m_sNewType );
+	}
+	private:
+		int m_nInstrumentId;
+		H2Core::DrumkitMap::Type m_sNewType;
+		H2Core::DrumkitMap::Type m_sOldType;
+};
+
+/** \ingroup docGUI*/
 class SE_automationPathAddPointAction : public QUndoCommand
 {
 public:

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -1001,16 +1001,19 @@ class SE_replaceInstrumentAction : public QUndoCommand {
 						 .arg( sOldName ).arg( sName ) );
 				break;
 			case Type::AddLayer:
-				setText( QString( "%1 [%2]" )
+				setText( QString( "%1 [%2]: [%3]" )
 						 .arg( pCommonStrings->getActionAddInstrumentLayer() )
+						 .arg( pNew != nullptr ? pNew->getName() : "nullptr" )
 						 .arg( sName ) );
 			case Type::DeleteLayer:
-				setText( QString( "%1 [%2]" )
+				setText( QString( "%1 [%2]: [%3]" )
 						 .arg( pCommonStrings->getActionDeleteInstrumentLayer() )
+						 .arg( pNew != nullptr ? pNew->getName() : "nullptr" )
 						 .arg( sName ) );
 			case Type::EditLayer:
-				setText( QString( "%1 [%2]" )
+				setText( QString( "%1 [%2]: [%3]" )
 						 .arg( pCommonStrings->getActionEditInstrumentLayer() )
+						 .arg( pNew != nullptr ? pNew->getName() : "nullptr" )
 						 .arg( sName ) );
 				break;
 			default:

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -960,7 +960,14 @@ class SE_replaceInstrumentAction : public QUndoCommand {
 			/** This could definitely be done more efficiently. But compared to
 			 * altering other instrument parameters, its name will most probably
 			 * only change very rarely. */
-			RenameInstrument = 3
+			RenameInstrument = 3,
+			/** At least one layer of one component was added. */
+			AddLayer,
+			/** At least one layer of one component was deleted. */
+			DeleteLayer,
+			/** At least one layer of one component was editing via the
+			 * SampleEditor. */
+			EditLayer
 		};
 
 		SE_replaceInstrumentAction( std::shared_ptr<H2Core::Instrument> pNew,
@@ -992,6 +999,19 @@ class SE_replaceInstrumentAction : public QUndoCommand {
 				setText( QString( "%1 [%2] -> [%3]" )
 						 .arg( pCommonStrings->getActionRenameInstrument() )
 						 .arg( sOldName ).arg( sName ) );
+				break;
+			case Type::AddLayer:
+				setText( QString( "%1 [%2]" )
+						 .arg( pCommonStrings->getActionAddInstrumentLayer() )
+						 .arg( sName ) );
+			case Type::DeleteLayer:
+				setText( QString( "%1 [%2]" )
+						 .arg( pCommonStrings->getActionDeleteInstrumentLayer() )
+						 .arg( sName ) );
+			case Type::EditLayer:
+				setText( QString( "%1 [%2]" )
+						 .arg( pCommonStrings->getActionEditInstrumentLayer() )
+						 .arg( sName ) );
 				break;
 			default:
 				___ERRORLOG( QString( "Unknown type [%1]" )


### PR DESCRIPTION
There were still some bugs in the JACK per-track output port mapping while working with typed and untyped instruments and using undo/redo.

In addition, I also created a static per-track output pair for our sample preview (playing the original sample in the `SampleEditor`) or previewing a sample in `AudioFileBrowser`. Quite an edge case, but all these sounds were not covered by any per-track port yet.

As a side effect, adding, replacing, and deleting layers in the `ComponentView` can now be undone and redone.