### PR TITLE
Parser: add options to en/disable ANSI colors in log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.5] - XXXX-XX-XX
 
+### Added
+
+- CLI options `--log-colors` and `--no-log-colors` to enable and disable ANSI
+  colors in log messages.
+
 ### Changed
 
 - The shortcut for starting/pausing transport can now be used spin boxed (like

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -166,10 +166,12 @@ Logger::Logger( const QString& sLogFilePath, bool bUseStdout,
 
 	if ( ! m_bLogColors ) {
 		m_colorList << "" << "" << "" << "" << "" << "" << "";
+		m_sColorOff = "";
 	}
 	else {
 		m_colorList << "" << "\033[31m" << "\033[36m" << "\033[32m" << "\033[35m"
 					<< "\033[35;1m" << "\033[35;1m";
+		m_sColorOff = "\033[0m";
 	}
 
 	// Sanity checks.
@@ -242,11 +244,14 @@ void Logger::log( unsigned level, const QString& sClassName, const char* func_na
 			.arg( QDateTime::currentDateTime().toString( "hh:mm:ss.zzz" ) );
 	}
 
-	const QString sCol = sColor.isEmpty() ? m_colorList[ i ] : sColor;
+	QString sCol = "";
+	if ( m_bLogColors ) {
+		sCol = sColor.isEmpty() ? m_colorList[ i ] : sColor;
+	}
 
-	const QString tmp = QString( "%1%2%3[%4::%5] %6\033[0m\n" )
+	const QString tmp = QString( "%1%2%3[%4::%5] %6%7\n" )
 		.arg( sCol ).arg( sTimestampPrefix ).arg( m_prefixList[i] )
-		.arg( sClassName ).arg( func_name ).arg( sMsg );
+		.arg( sClassName ).arg( func_name ).arg( sMsg ).arg( m_sColorOff );
 
 	pthread_mutex_lock( &__mutex );
 	__msg_queue.push_back( tmp );

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -120,7 +120,8 @@ void* loggerThread_func( void* param ) {
 }
 
 Logger* Logger::bootstrap( unsigned msk, const QString& sLogFilePath,
-						   bool bUseStdout, bool bLogTimestamps ) {
+						   bool bUseStdout, bool bLogTimestamps,
+						   bool bLogColors ) {
 	Logger::set_bit_mask( msk );
 
 	// When starting Hydrogen after a fresh install with no user-level .hydrogen
@@ -139,30 +140,37 @@ Logger* Logger::bootstrap( unsigned msk, const QString& sLogFilePath,
 		Filesystem::mkdir( dir.absolutePath() );
 	}
 
-	return Logger::create_instance( sLogFilePath, bUseStdout, bLogTimestamps );
+	return Logger::create_instance( sLogFilePath, bUseStdout, bLogTimestamps,
+									bLogColors );
 }
 
 Logger* Logger::create_instance( const QString& sLogFilePath, bool bUseStdout,
-								 bool bLogTimestamps ) {
-	if ( __instance == nullptr ) __instance = new Logger( sLogFilePath, bUseStdout,
-														  bLogTimestamps );
+								 bool bLogTimestamps, bool bLogColors ) {
+	if ( __instance == nullptr ) {
+		__instance = new Logger(
+		sLogFilePath, bUseStdout, bLogTimestamps, bLogColors );
+	}
 	return __instance;
 }
 
-Logger::Logger( const QString& sLogFilePath, bool bUseStdout, bool bLogTimestamps ) :
-	__running( true ),
-	m_sLogFilePath( sLogFilePath ),
-	m_bUseStdout( bUseStdout ),
-	m_bLogTimestamps( bLogTimestamps ) {
+Logger::Logger( const QString& sLogFilePath, bool bUseStdout,
+				bool bLogTimestamps, bool bLogColors )
+	: __running( true )
+	, m_sLogFilePath( sLogFilePath )
+	, m_bUseStdout( bUseStdout )
+	, m_bLogTimestamps( bLogTimestamps )
+	, m_bLogColors( bLogColors ) {
 	__instance = this;
 
 	m_prefixList << "" << "(E) " << "(W) " << "(I) " << "(D) " << "(C)" << "(L) ";
-#ifdef WIN32
-	m_colorList << "" << "" << "" << "" << "" << "" << "";
-#else
-	m_colorList << "" << "\033[31m" << "\033[36m" << "\033[32m" << "\033[35m"
-				<< "\033[35;1m" << "\033[35;1m";
-#endif
+
+	if ( ! m_bLogColors ) {
+		m_colorList << "" << "" << "" << "" << "" << "" << "";
+	}
+	else {
+		m_colorList << "" << "\033[31m" << "\033[36m" << "\033[32m" << "\033[35m"
+					<< "\033[35;1m" << "\033[35;1m";
+	}
 
 	// Sanity checks.
 	QFileInfo fiLogFile( m_sLogFilePath );

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -147,6 +147,8 @@ class Logger {
 		static QString *getCrashContext() { return Logger::pCrashContext; }
 		/** @} */
 
+		bool getLogColors() const;
+
 		/** Helper class to preserve and restore recursive crash context strings using an RAAI pattern */
 		class CrashContext {
 			QString *pSavedContext;
@@ -175,6 +177,7 @@ class Logger {
 
 		QStringList m_prefixList;
 		QStringList m_colorList;
+		QString m_sColorOff;
 
 	bool m_bUseStdout;
 		bool m_bLogTimestamps;
@@ -196,6 +199,10 @@ class Logger {
 		static int hextoi( const char* str, long len );
 #endif // HAVE_SSCANF
 };
+
+inline bool Logger::getLogColors() const {
+	return m_bLogColors;
+}
 
 };
 

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -63,7 +63,8 @@ class Logger {
 	static Logger* bootstrap( unsigned msk,
 							  const QString& sLogFilePath = QString(),
 							  bool bUseStdout = true,
-							  bool bLogTimestamps = false );
+							  bool bLogTimestamps = false,
+							  bool bLogColors = true );
 		/**
 		 * If #__instance equals 0, a new H2Core::Logger
 		 * singleton will be created and stored in it.
@@ -72,7 +73,8 @@ class Logger {
 		 */
 	static Logger* create_instance( const QString& sLogFilePath = QString(),
 									bool bUseStdout = true,
-									bool bLogTimestamps = false );
+									bool bLogTimestamps = false,
+									bool bLogColors = true );
 
 		/**
 		 * Returns a pointer to the current H2Core::Logger
@@ -176,12 +178,13 @@ class Logger {
 
 	bool m_bUseStdout;
 		bool m_bLogTimestamps;
+		bool m_bLogColors;
 
 		thread_local static QString *pCrashContext;
 
 		/** constructor */
 	Logger( const QString& sLogFilePath = QString(), bool bUseStdout = true,
-			bool bLogTimestamps = false );
+			bool bLogTimestamps = false, bool bLogColors = true );
 
 #ifndef HAVE_SSCANF
 		/**

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -467,12 +467,39 @@ void NsmClient::replaceDrumkitPath( std::shared_ptr<H2Core::Song> pSong, const Q
 }
 
 void NsmClient::printError( const QString& msg ) {
-	std::cerr << "[\033[30mHydrogen\033[0m]\033[31m "
-			  << "Error: " << msg.toLocal8Bit().data() << "\033[0m" << std::endl;
+	const bool bLogColor = __logger->getLogColors();
+
+	if ( bLogColor ) {
+		std::cerr << "[\033[30mHydrogen\033[0m]\033[31m ";
+	} else {
+		std::cerr << "[Hydrogen] ";
+	}
+
+	std::cerr << "Error: " << msg.toLocal8Bit().data();
+
+	if ( bLogColor ) {
+		std::cerr << "\033[0m";
+	}
+
+	std::cerr << std::endl;
 }
+
 void NsmClient::printMessage( const QString& msg ) {
-	std::cerr << "[\033[30mHydrogen\033[0m]\033[32m "
-			  << msg.toLocal8Bit().data() << "\033[0m" << std::endl;
+	const bool bLogColor = __logger->getLogColors();
+
+	if ( bLogColor ) {
+		std::cerr << "[\033[30mHydrogen\033[0m]\033[32m ";
+	} else {
+		std::cerr << "[Hydrogen] ";
+	}
+
+	std::cerr << msg.toLocal8Bit().data();
+
+	if ( bLogColor ) {
+		std::cerr << "\033[0m";
+	}
+
+	std::cerr << std::endl;
 }
 
 int NsmClient::SaveCallback( char** outMsg, void* userData ) {

--- a/src/core/Object.h
+++ b/src/core/Object.h
@@ -154,6 +154,7 @@ class Base {
 		}
 		static bool __count;               ///< should we count class instances
 		static Logger * __logger;
+		static bool bLogColors;
 		static void registerClass(const char *name, const atomic_obj_cpt_t *counters);
 	static timeval __last_clock;
 	

--- a/src/gui/src/Parser.cpp
+++ b/src/gui/src/Parser.cpp
@@ -83,6 +83,11 @@ bool Parser::parse( int argc, char* argv[] ) {
 	QCommandLineOption logTimestampsOption(
 		QStringList() << "T" <<
 		"log-timestamps", "Add timestamps to all log messages" );
+	QCommandLineOption logColorsOption(
+		QStringList() << "log-colors", "Use ANSI colors in log messages" );
+	QCommandLineOption noLogColorsOption(
+		QStringList() << "no-log-colors",
+		"Suppress ANSI colors in log messages" );
 
 	QCommandLineOption systemDataPathOption(
 		QStringList() << "P" <<
@@ -119,6 +124,8 @@ bool Parser::parse( int argc, char* argv[] ) {
 	parser.addOption( verboseOption );
 	parser.addOption( logFileOption );
 	parser.addOption( logTimestampsOption );
+	parser.addOption( logColorsOption );
+	parser.addOption( noLogColorsOption );
 
 	parser.addOption( systemDataPathOption );
 	parser.addOption( configFileOption );
@@ -156,6 +163,20 @@ bool Parser::parse( int argc, char* argv[] ) {
 	}
 	m_sLogFile = parser.value( logFileOption );
 	m_bLogTimestamps = parser.isSet( logTimestampsOption );
+
+#ifdef WIN32
+	m_bLogColors = false;
+#else
+	m_bLogColors = true;
+#endif
+
+	// If both options are present, having colors wins.
+	if ( parser.isSet( logColorsOption ) ) {
+		m_bLogColors = true;
+	}
+	else if ( parser.isSet( noLogColorsOption ) ) {
+		m_bLogColors = false;
+	}
 
 	m_sSysDataPath = parser.value( systemDataPathOption );
 	m_sConfigFilePath = parser.value( configFileOption );

--- a/src/gui/src/Parser.h
+++ b/src/gui/src/Parser.h
@@ -69,6 +69,7 @@ class Parser {
 			return m_sLogFile; }
 		bool getLogTimestamps() const {
 			return m_bLogTimestamps; }
+		bool getLogColors() const {return m_bLogColors; }
 
 		const QString& getSysDataPath() const {
 			return m_sSysDataPath; }
@@ -98,6 +99,7 @@ class Parser {
 		unsigned m_logLevel;
 		QString  m_sLogFile;
 		bool     m_bLogTimestamps;
+		bool     m_bLogColors;
 
 		QString  m_sSysDataPath;
 		QString  m_sConfigFilePath;

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
 		// Man your battle stations... this is not a drill.
 		auto pLogger = H2Core::Logger::bootstrap(
 			parser.getLogLevel(), parser.getLogFile(), true,
-			parser.getLogTimestamps() );
+			parser.getLogTimestamps(), parser.getLogColors() );
 		H2Core::Base::bootstrap(
 			pLogger, pLogger->should_log( H2Core::Logger::Debug ) );
 


### PR DESCRIPTION
Previously ANSI colors in log messages had been disabled on Windows and enabled on all other platforms.

But in some edge cases this behavior was not that satisfying - e.g. writing log messages to a file on Windows and using an ANSI-capable editor (me) or doing the same using an editor being not ANSI-capable on other platforms (see #2136).

The default behavior did not change. But using this patch the user is able to overwrite in both cases.

Fixes #2136