### PR TITLE
Further Qt6 fixes

### DIFF
--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -816,40 +816,45 @@ QStringList Filesystem::usr_drumkit_list( )
 	return drumkit_list( usr_drumkits_dir() ) ;
 }
 
-QString Filesystem::prepare_sample_path( const QString& fname )
+QString Filesystem::prepare_sample_path( const QString& sFileName )
 {
-	int idx = get_basename_idx_under_drumkit( fname );
-	if ( idx >= 0 ) {
-		return fname.midRef( idx ).toString();
+	const int nIdx = get_basename_idx_under_drumkit( sFileName );
+	if ( nIdx >= 0 ) {
+		return sFileName.right( nIdx );
 	}
-	return fname;
+	return sFileName;
 }
 
-bool Filesystem::file_is_under_drumkit( const QString& fname )
+bool Filesystem::file_is_under_drumkit( const QString& sFileName )
 {
-	return get_basename_idx_under_drumkit( fname ) != -1;
+	return get_basename_idx_under_drumkit( sFileName ) != -1;
 }
 
-int Filesystem::get_basename_idx_under_drumkit( const QString& fname )
+int Filesystem::get_basename_idx_under_drumkit( const QString& sFileName )
 {
-	if( fname.startsWith( usr_drumkits_dir() ) )
-	{
-		int start = usr_drumkits_dir().size();
-		int index = fname.indexOf( "/", start );
-		QString dk_name = fname.midRef( start , index - start).toString();
-		if ( usr_drumkit_list().contains( dk_name ) ) {
-			return index + 1;
+	auto getIndex = [=]( const QString& sDrumkitDir ) {
+		const int nStart = usr_drumkits_dir().size();
+		const int nIndex = sFileName.indexOf( "/", nStart );
+#ifdef H2CORE_HAVE_QT6
+		const QString sDrumkitName = sFileName.sliced( nStart , nIndex - nStart );
+#else
+		const QString sDrumkitName = sFileName.midRef( nStart , nIndex - nStart );
+#endif
+		if ( drumkit_list( sDrumkitDir ).contains( sDrumkitName ) ) {
+			return nIndex + 1;
 		}
+		else {
+			return -1;
+		}
+	};
+
+	if ( sFileName.startsWith( usr_drumkits_dir() ) ) {
+		return getIndex( usr_drumkits_dir() );
 	}
 
-	if( fname.startsWith( sys_drumkits_dir() ) )
-	{
-		int start = sys_drumkits_dir().size();
-		int index = fname.indexOf( "/", start);
-		QString dk_name = fname.midRef( start, index - start).toString();
-		if ( sys_drumkit_list().contains( dk_name ) ) {
-			return index + 1;
-		}
+
+	if ( sFileName.startsWith( sys_drumkits_dir() ) ) {
+		return getIndex( sys_drumkits_dir() );
 	}
 
 	return -1;

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -838,7 +838,8 @@ int Filesystem::get_basename_idx_under_drumkit( const QString& sFileName )
 #ifdef H2CORE_HAVE_QT6
 		const QString sDrumkitName = sFileName.sliced( nStart , nIndex - nStart );
 #else
-		const QString sDrumkitName = sFileName.midRef( nStart , nIndex - nStart );
+		const QString sDrumkitName =
+			sFileName.midRef( nStart , nIndex - nStart ).toString();
 #endif
 		if ( drumkit_list( sDrumkitDir ).contains( sDrumkitName ) ) {
 			return nIndex + 1;

--- a/src/core/IO/MidiCommon.cpp
+++ b/src/core/IO/MidiCommon.cpp
@@ -34,72 +34,72 @@ void MidiMessage::clear() {
 
 void MidiMessage::setType( int nStatusByte ) {
 
-	if ( ( nStatusByte >= 128 ) && ( nStatusByte < 144 ) ) {
+	if ( nStatusByte >= 128 && nStatusByte < 144 ) {
 		m_nChannel = nStatusByte - 128;
 		m_type = MidiMessage::NOTE_OFF;
 	}
-	else if ( ( nStatusByte >= 144 ) && ( nStatusByte < 160 ) ) {
+	else if ( nStatusByte >= 144 && nStatusByte < 160 ) {
 		m_nChannel = nStatusByte - 144;
 		m_type = MidiMessage::NOTE_ON;
 	}
-	else if ( ( nStatusByte >= 160 ) && ( nStatusByte < 176 ) ) {
+	else if ( nStatusByte >= 160 && nStatusByte < 176 ) {
 		m_nChannel = nStatusByte - 160;
 		m_type = MidiMessage::POLYPHONIC_KEY_PRESSURE;
 	}
-	else if ( ( nStatusByte >= 176 ) && ( nStatusByte < 192 ) ) {
+	else if ( nStatusByte >= 176 && nStatusByte < 192 ) {
 		m_nChannel = nStatusByte - 176;
 		m_type = MidiMessage::CONTROL_CHANGE;
 	}
-	else if ( ( nStatusByte >= 192 ) && ( nStatusByte < 208 ) ) {
+	else if ( nStatusByte >= 192 && nStatusByte < 208 ) {
 		m_nChannel = nStatusByte - 192;
 		m_type = MidiMessage::PROGRAM_CHANGE;
 	}
-	else if ( ( nStatusByte >= 208 ) && ( nStatusByte < 224 ) ) {
+	else if ( nStatusByte >= 208 && nStatusByte < 224 ) {
 		m_nChannel = nStatusByte - 208;
 		m_type = MidiMessage::CHANNEL_PRESSURE;
 	}
-	else if ( ( nStatusByte >= 224 ) && ( nStatusByte < 240 ) ) {
+	else if ( nStatusByte >= 224 && nStatusByte < 240 ) {
 		m_nChannel = nStatusByte - 224;
 		m_type = MidiMessage::PITCH_WHEEL;
 	}
 	// System Common Messages
-	else if ( ( nStatusByte == 240 ) ) {
+	else if ( nStatusByte == 240 ) {
 		m_nChannel = nStatusByte - 224;
 		m_type = MidiMessage::SYSEX;
 	}
-	else if ( ( nStatusByte == 241 ) ) {
+	else if ( nStatusByte == 241 ) {
 		m_type = MidiMessage::QUARTER_FRAME;
 	}
-	else if ( ( nStatusByte == 242 ) ) {
+	else if ( nStatusByte == 242 ) {
 		m_type = MidiMessage::SONG_POS;
 	}
-	else if ( ( nStatusByte == 243 ) ) {
+	else if ( nStatusByte == 243 ) {
 		m_type = MidiMessage::SONG_SELECT;
 	}
 	// 244, 245 are undefined/reserved
-	else if ( ( nStatusByte == 246 ) ) {
+	else if ( nStatusByte == 246 ) {
 		m_type = MidiMessage::TUNE_REQUEST;
 	}
 	// 247 indicates the end of a SysEx (240) message
 	// System Realtime Messages
-	else if ( ( nStatusByte == 248 ) ) {
+	else if ( nStatusByte == 248 ) {
 		m_type = MidiMessage::TIMING_CLOCK;
 	}
 	// 249 is undefined/reserved
-	else if ( ( nStatusByte == 250 ) ) {
+	else if ( nStatusByte == 250 ) {
 		m_type = MidiMessage::START;
 	}
-	else if ( ( nStatusByte == 251 ) ) {
+	else if ( nStatusByte == 251 ) {
 		m_type = MidiMessage::CONTINUE;
 	}
-	else if ( ( nStatusByte == 252 ) ) {
+	else if ( nStatusByte == 252 ) {
 		m_type = MidiMessage::STOP;
 	}
 	// 253 is undefined/reserved
-	else if ( ( nStatusByte == 254 ) ) {
+	else if ( nStatusByte == 254 ) {
 		m_type = MidiMessage::ACTIVE_SENSING;
 	}
-	else if ( ( nStatusByte == 255 ) ) {
+	else if ( nStatusByte == 255 ) {
 		m_type = MidiMessage::RESET;
 	}
 }

--- a/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
+++ b/src/gui/src/AudioFileBrowser/SampleWaveDisplay.cpp
@@ -74,7 +74,7 @@ void SampleWaveDisplay::paintEvent(QPaintEvent *ev)
 	}
 
 	QFont font;
-	font.setWeight( 63 );
+	font.setWeight( QFont::Bold );
 	painter.setFont( font );
 	painter.setPen( QColor( 255 , 255, 255, 200 ) );
 	painter.drawText( 0, 0, width(), 20, Qt::AlignCenter, m_sSampleName );

--- a/src/gui/src/Compatibility/DropEvent.cpp
+++ b/src/gui/src/Compatibility/DropEvent.cpp
@@ -1,0 +1,47 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include <core/config.h>
+
+#include "DropEvent.h"
+
+DropEvent::DropEvent( QDropEvent* pEv ) :
+#ifdef H2CORE_HAVE_QT6
+	QDropEvent( pEv->position(), pEv->possibleActions(), pEv->mimeData(),
+				pEv->buttons(), pEv->modifiers() ) {
+#else
+	QDropEvent( pEv->pos(), pEv->possibleActions(), pEv->mimeData(),
+				pEv->mouseButtons(), pEv->keyboardModifiers() ) {
+#endif
+};
+
+DropEvent::~DropEvent() {
+}
+
+QPointF DropEvent::position() const {
+#ifdef H2CORE_HAVE_QT6
+	return QDropEvent::position();
+#else
+	return QDropEvent::pos();
+#endif
+}

--- a/src/gui/src/Compatibility/DropEvent.h
+++ b/src/gui/src/Compatibility/DropEvent.h
@@ -20,46 +20,25 @@
  *
  */
 
-#include "SoundLibraryTree.h"
+#ifndef DROPEVENT_H_
+#define DROPEVENT_H_
 
-#include "../Compatibility/MouseEvent.h"
+#include <QDropEvent>
 
-#include <QMimeData>
-
-SoundLibraryTree::SoundLibraryTree( QWidget *pParent )
- : QTreeWidget( pParent )
+/** Compatibility class to support QDropEvent more esily in Qt5 and Qt6.
+ *
+ * At some point, when we dropped Qt5 support, we can drop this class too and
+ * use the plain `QDropEvent` again. Therefore, it is important to _not_ add
+ * any members incompatible with the Qt6 interface of QDropEvent. */
+/** \ingroup docGUI docWidgets*/
+class DropEvent : public QDropEvent
 {
-	setHeaderLabels( QStringList( tr( "Sound library" ) ) );
-	setAlternatingRowColors( true );
-	setRootIsDecorated( false );
 
-	headerItem()->setHidden( true ); // hides the header
+public:
+	DropEvent( QDropEvent* );
+	~DropEvent();
 
-}
+	QPointF	position() const;
+};
 
-
-void SoundLibraryTree::mousePressEvent(QMouseEvent *event)
-{
-//	INFOLOG( "[mousePressEvent]" );
-	QTreeWidget::mousePressEvent( event );
-
-	auto pEv = static_cast<MouseEvent*>( event );
-
-	if ( event->button() == Qt::RightButton ) {
-		emit rightClicked( pEv->globalPosition().toPoint() );
-
-	}
-	else if (event->button() == Qt::LeftButton ) {
-		emit leftClicked( pEv->globalPosition().toPoint() );
-	}
-}
-
-
-
-void SoundLibraryTree::mouseMoveEvent(QMouseEvent *event)
-{
-	emit onMouseMove( event );
-}
-
-
-
+#endif // DROPEVENT_H_

--- a/src/gui/src/Compatibility/MouseEvent.cpp
+++ b/src/gui/src/Compatibility/MouseEvent.cpp
@@ -1,0 +1,55 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include <core/config.h>
+
+#include "MouseEvent.h"
+
+MouseEvent::MouseEvent( QMouseEvent* pEv ) :
+#ifdef H2CORE_HAVE_QT6
+	QMouseEvent( pEv->type(), pEv->position(), pEv->globalPosition(),
+				 pEv->button(), pEv->buttons(), pEv->modifiers() ) {
+#else
+	QMouseEvent( pEv->type(), pEv->pos(), pEv->globalPos(), pEv->button(),
+				 pEv->buttons(), pEv->modifiers() ) {
+#endif
+};
+
+MouseEvent::~MouseEvent() {
+}
+
+QPointF MouseEvent::globalPosition() const {
+#ifdef H2CORE_HAVE_QT6
+	return QMouseEvent::globalPosition();
+#else
+	return QMouseEvent::globalPos();
+#endif
+}
+
+QPointF MouseEvent::position() const {
+#ifdef H2CORE_HAVE_QT6
+	return QMouseEvent::position();
+#else
+	return QMouseEvent::pos();
+#endif
+}

--- a/src/gui/src/Compatibility/MouseEvent.h
+++ b/src/gui/src/Compatibility/MouseEvent.h
@@ -20,46 +20,26 @@
  *
  */
 
-#include "SoundLibraryTree.h"
+#ifndef MOUSEEVENT_H_
+#define MOUSEEVENT_H_
 
-#include "../Compatibility/MouseEvent.h"
+#include <QMouseEvent>
 
-#include <QMimeData>
-
-SoundLibraryTree::SoundLibraryTree( QWidget *pParent )
- : QTreeWidget( pParent )
+/** Compatibility class to support QMouseEvent more esily in Qt5 and Qt6.
+ *
+ * At some point, when we dropped Qt5 support, we can drop this class too and
+ * use the plain `QMouseEvent` again. Therefore, it is important to _not_ add
+ * any members incompatible with the Qt6 interface of QMouseEvent. */
+/** \ingroup docGUI docWidgets*/
+class MouseEvent : public QMouseEvent
 {
-	setHeaderLabels( QStringList( tr( "Sound library" ) ) );
-	setAlternatingRowColors( true );
-	setRootIsDecorated( false );
 
-	headerItem()->setHidden( true ); // hides the header
+public:
+	MouseEvent( QMouseEvent* );
+	~MouseEvent();
 
-}
+	QPointF	globalPosition() const;
+	QPointF	position() const;
+};
 
-
-void SoundLibraryTree::mousePressEvent(QMouseEvent *event)
-{
-//	INFOLOG( "[mousePressEvent]" );
-	QTreeWidget::mousePressEvent( event );
-
-	auto pEv = static_cast<MouseEvent*>( event );
-
-	if ( event->button() == Qt::RightButton ) {
-		emit rightClicked( pEv->globalPosition().toPoint() );
-
-	}
-	else if (event->button() == Qt::LeftButton ) {
-		emit leftClicked( pEv->globalPosition().toPoint() );
-	}
-}
-
-
-
-void SoundLibraryTree::mouseMoveEvent(QMouseEvent *event)
-{
-	emit onMouseMove( event );
-}
-
-
-
+#endif // MOUSEEVENT_H_

--- a/src/gui/src/Compatibility/README.md
+++ b/src/gui/src/Compatibility/README.md
@@ -1,0 +1,5 @@
+Auxiliary wrapper classes introduced to support broader ranges of Qt5 and Qt6
+and to work around having countless `#ifdef`s in our source code.
+
+Once Qt5 support will be dropped (not planned yet), these classes should be
+dropped as well.

--- a/src/gui/src/Compatibility/WheelEvent.cpp
+++ b/src/gui/src/Compatibility/WheelEvent.cpp
@@ -23,6 +23,8 @@
 
 #include <core/config.h>
 
+#include <QtGlobal>	// for QT_VERSION
+
 #include "WheelEvent.h"
 
 WheelEvent::WheelEvent( QWheelEvent* pEv ) :

--- a/src/gui/src/Compatibility/WheelEvent.cpp
+++ b/src/gui/src/Compatibility/WheelEvent.cpp
@@ -28,7 +28,11 @@
 #include "WheelEvent.h"
 
 WheelEvent::WheelEvent( QWheelEvent* pEv ) :
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
 	QWheelEvent( pEv->position(), pEv->globalPosition(),
+#else
+	QWheelEvent( pEv->pos(), pEv->globalPos(),
+#endif
 				 pEv->pixelDelta(), pEv->angleDelta(), pEv->buttons(),
 				 pEv->modifiers(), pEv->phase(), pEv->inverted() ) {
 };

--- a/src/gui/src/Compatibility/WheelEvent.cpp
+++ b/src/gui/src/Compatibility/WheelEvent.cpp
@@ -1,0 +1,51 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2008 by Alex >Comix< Cominu [comix@users.sourceforge.net]
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include <core/config.h>
+
+#include "WheelEvent.h"
+
+WheelEvent::WheelEvent( QWheelEvent* pEv ) :
+	QWheelEvent( pEv->position(), pEv->globalPosition(),
+				 pEv->pixelDelta(), pEv->angleDelta(), pEv->buttons(),
+				 pEv->modifiers(), pEv->phase(), pEv->inverted() ) {
+};
+
+WheelEvent::~WheelEvent() {
+}
+
+QPointF WheelEvent::globalPosition() const {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+	return QWheelEvent::globalPosition();
+#else
+	return QWheelEvent::globalPos();
+#endif
+}
+
+QPointF WheelEvent::position() const {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
+	return QWheelEvent::position();
+#else
+	return QWheelEvent::pos();
+#endif
+}

--- a/src/gui/src/Compatibility/WheelEvent.h
+++ b/src/gui/src/Compatibility/WheelEvent.h
@@ -20,46 +20,27 @@
  *
  */
 
-#include "SoundLibraryTree.h"
+#ifndef WHEELEVENT_H_
+#define WHEELEVENT_H_
 
-#include "../Compatibility/MouseEvent.h"
+#include <QWheelEvent>
 
-#include <QMimeData>
-
-SoundLibraryTree::SoundLibraryTree( QWidget *pParent )
- : QTreeWidget( pParent )
+/** Compatibility class to support QWheelEvent more esily in Qt5 and Qt6.
+ *
+ * At some point, when we dropped Qt5 support, we can drop this class too and
+ * use the plain `QWheelEvent` again. Therefore, it is important to _not_ add
+ * any members incompatible with the Qt6 interface of QWheelEvent. */
+/** \ingroup docGUI docWidgets*/
+class WheelEvent : public QWheelEvent
 {
-	setHeaderLabels( QStringList( tr( "Sound library" ) ) );
-	setAlternatingRowColors( true );
-	setRootIsDecorated( false );
 
-	headerItem()->setHidden( true ); // hides the header
+public:
+	WheelEvent( QWheelEvent* );
+	~WheelEvent();
 
-}
+	QPointF	globalPosition() const;
 
+	QPointF	position() const;
+};
 
-void SoundLibraryTree::mousePressEvent(QMouseEvent *event)
-{
-//	INFOLOG( "[mousePressEvent]" );
-	QTreeWidget::mousePressEvent( event );
-
-	auto pEv = static_cast<MouseEvent*>( event );
-
-	if ( event->button() == Qt::RightButton ) {
-		emit rightClicked( pEv->globalPosition().toPoint() );
-
-	}
-	else if (event->button() == Qt::LeftButton ) {
-		emit leftClicked( pEv->globalPosition().toPoint() );
-	}
-}
-
-
-
-void SoundLibraryTree::mouseMoveEvent(QMouseEvent *event)
-{
-	emit onMouseMove( event );
-}
-
-
-
+#endif // WHEELEVENT_H_

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -276,7 +276,7 @@ void HydrogenApp::setupSinglePanedInterface()
 	pSouthPanel->setObjectName( "SouthPanel" );
 	QHBoxLayout *pEditorHBox = new QHBoxLayout();
 	pEditorHBox->setSpacing( 5 );
-	pEditorHBox->setMargin( 0 );
+	pEditorHBox->setContentsMargins( 0, 0, 0, 0 );
 	pSouthPanel->setLayout( pEditorHBox );
 
 	// INSTRUMENT RACK
@@ -309,7 +309,7 @@ void HydrogenApp::setupSinglePanedInterface()
 	// LAYOUT!!
 	m_pMainVBox = new QVBoxLayout();
 	m_pMainVBox->setSpacing( 1 );
-	m_pMainVBox->setMargin( 0 );
+	m_pMainVBox->setContentsMargins( 0, 0, 0, 0 );
 	m_pMainVBox->addWidget( m_pPlayerControl );
 
 	m_pMainVBox->addSpacing( 3 );

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -55,7 +55,7 @@ InstrumentEditorPanel::InstrumentEditorPanel( QWidget *pParent )
 	// LAYOUT
 	QGridLayout *vbox = new QGridLayout();
 	vbox->setSpacing( 0 );
-	vbox->setMargin( 0 );
+	vbox->setContentsMargins( 0, 0, 0, 0 );
 
 	vbox->addWidget( m_pInstrumentEditor, 0, 0 );
 

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -36,6 +36,7 @@
 
 using namespace H2Core;
 
+#include "../Compatibility/MouseEvent.h"
 #include "../Skin.h"
 #include "../HydrogenApp.h"
 #include "InstrumentEditorPanel.h"
@@ -255,6 +256,8 @@ void LayerPreview::mouseReleaseEvent(QMouseEvent *ev)
 		return;
 	}
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	/*
 	 * We want the tooltip to still show if mouse pointer
 	 * is over an active layer's boundary
@@ -267,11 +270,13 @@ void LayerPreview::mouseReleaseEvent(QMouseEvent *ev)
 			int x1 = (int)( pLayer->get_start_velocity() * width() );
 			int x2 = (int)( pLayer->get_end_velocity() * width() );
 			
-			if ( ( ev->x() < x1  + 5 ) && ( ev->x() > x1 - 5 ) ){
+			if ( ( pEv->position().x() < x1  + 5 ) &&
+				 ( pEv->position().x() > x1 - 5 ) ){
 				setCursor( QCursor( Qt::SizeHorCursor ) );
 				showLayerStartVelocity(pLayer, ev);
 			}
-			else if ( ( ev->x() < x2 + 5 ) && ( ev->x() > x2 - 5 ) ) {
+			else if ( ( pEv->position().x() < x2 + 5 ) &&
+					  ( pEv->position().x() > x2 - 5 ) ) {
 				setCursor( QCursor( Qt::SizeHorCursor ) );
 				showLayerEndVelocity(pLayer, ev);
 			}
@@ -283,11 +288,13 @@ void LayerPreview::mousePressEvent(QMouseEvent *ev)
 {
 	const int nPosition = 0;
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	if ( m_pInstrument == nullptr ) {
 		return;
 	}
-	if ( ev->y() < 20 ) {
-		const float fVelocity = (float)ev->x() / (float)width();
+	if ( pEv->position().y() < 20 ) {
+		const float fVelocity = (float)pEv->position().x() / (float)width();
 
 		if ( m_pInstrument->hasSamples() ) {
 			Note * pNote = new Note( m_pInstrument, nPosition, fVelocity );
@@ -313,7 +320,7 @@ void LayerPreview::mousePressEvent(QMouseEvent *ev)
 		}
 	}
 	else {
-		m_nSelectedLayer = ( ev->y() - 20 ) / m_nLayerHeight;
+		m_nSelectedLayer = ( pEv->position().y() - 20 ) / m_nLayerHeight;
 
 		update();
 		InstrumentEditorPanel::get_instance()->selectLayer( m_nSelectedLayer );
@@ -330,13 +337,13 @@ void LayerPreview::mousePressEvent(QMouseEvent *ev)
 				int x1 = (int)( pLayer->get_start_velocity() * width() );
 				int x2 = (int)( pLayer->get_end_velocity() * width() );
 				
-				if ( ( ev->x() < x1  + 5 ) && ( ev->x() > x1 - 5 ) ){
+				if ( ( pEv->position().x() < x1  + 5 ) && ( pEv->position().x() > x1 - 5 ) ){
 					setCursor( QCursor( Qt::SizeHorCursor ) );
 					m_bGrabLeft = true;
 					m_bMouseGrab = true;
 					showLayerStartVelocity(pLayer, ev);
 				}
-				else if ( ( ev->x() < x2 + 5 ) && ( ev->x() > x2 - 5 ) ){
+				else if ( ( pEv->position().x() < x2 + 5 ) && ( pEv->position().x() > x2 - 5 ) ){
 					setCursor( QCursor( Qt::SizeHorCursor ) );
 					m_bGrabLeft = false;
 					m_bMouseGrab = true;
@@ -356,8 +363,10 @@ void LayerPreview::mouseMoveEvent( QMouseEvent *ev )
 		return;
 	}
 
-	int x = ev->pos().x();
-	int y = ev->pos().y();
+	auto pEv = static_cast<MouseEvent*>( ev );
+
+	int x = pEv->position().x();
+	int y = pEv->position().y();
 
 	float fVel = (float)x / (float)width();
 	if (fVel < 0 ) {
@@ -399,7 +408,7 @@ void LayerPreview::mouseMoveEvent( QMouseEvent *ev )
 		}
 	}
 	else {
-		m_nSelectedLayer = ( ev->y() - 20 ) / m_nLayerHeight;
+		m_nSelectedLayer = ( pEv->position().y() - 20 ) / m_nLayerHeight;
 		if ( m_nSelectedLayer < InstrumentComponent::getMaxLayers() ) {
 			auto pComponent = m_pInstrument->get_component(m_nSelectedComponent);
 			if( pComponent ){
@@ -444,22 +453,28 @@ int LayerPreview::getMidiVelocityFromRaw( const float raw )
 	return static_cast<int> (raw * 127);
 }
 
-void LayerPreview::showLayerStartVelocity( const std::shared_ptr<InstrumentLayer> pLayer, const QMouseEvent* pEvent )
+void LayerPreview::showLayerStartVelocity( const std::shared_ptr<InstrumentLayer> pLayer,
+										   QMouseEvent* pEvent )
 {
 	const float fVelo = pLayer->get_start_velocity();
 
-	QToolTip::showText( pEvent->globalPos(),
+	auto pEv = static_cast<MouseEvent*>( pEvent );
+
+	QToolTip::showText( pEv->globalPosition().toPoint(),
 			tr( "Dec. = %1\nMIDI = %2" )
 				.arg( QString::number( fVelo, 'f', 2) )
 				.arg( getMidiVelocityFromRaw( fVelo ) +1 ),
 			this);
 }
 
-void LayerPreview::showLayerEndVelocity( const std::shared_ptr<InstrumentLayer> pLayer, const QMouseEvent* pEvent )
+void LayerPreview::showLayerEndVelocity( const std::shared_ptr<InstrumentLayer> pLayer,
+										 QMouseEvent* pEvent )
 {
 	const float fVelo = pLayer->get_end_velocity();
 
-	QToolTip::showText( pEvent->globalPos(),
+	auto pEv = static_cast<MouseEvent*>( pEvent );
+
+	QToolTip::showText( pEv->globalPosition().toPoint(),
 			tr( "Dec. = %1\nMIDI = %2" )
 				.arg( QString::number( fVelo, 'f', 2) )
 				.arg( getMidiVelocityFromRaw( fVelo ) +1 ),

--- a/src/gui/src/InstrumentEditor/LayerPreview.h
+++ b/src/gui/src/InstrumentEditor/LayerPreview.h
@@ -84,7 +84,8 @@ public slots:
 		 * @param pLayer    The layer
 		 * @param pEvent    The event carrying mouse position
 		 */
-		void showLayerStartVelocity( const std::shared_ptr<H2Core::InstrumentLayer> pLayer, const QMouseEvent* pEvent );
+		void showLayerStartVelocity( const std::shared_ptr<H2Core::InstrumentLayer> pLayer,
+									 QMouseEvent* pEvent );
 
 		/**
 		 * display a layer's end velocity in a tooltip
@@ -92,7 +93,8 @@ public slots:
 		 * @param pLayer    The layer
 		 * @param pEvent    The event carrying mouse position
 		 */
-		void showLayerEndVelocity( const std::shared_ptr<H2Core::InstrumentLayer> pLayer, const QMouseEvent* pEvent );
+		void showLayerEndVelocity( const std::shared_ptr<H2Core::InstrumentLayer> pLayer,
+								   QMouseEvent* pEvent );
 
 		virtual void selectedInstrumentChangedEvent() override;
 	virtual void drumkitLoadedEvent() override;

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -88,7 +88,7 @@ void WaveDisplay::createBackground( QPainter* painter ) {
 	}
 	
 	QFont font( pPref->getApplicationFontFamily(), getPointSize( pPref->getFontSize() ) );
-	font.setWeight( 63 );
+	font.setWeight( QFont::Bold );
 	painter->setFont( font );
 	painter->setPen( QColor( 255 , 255, 255, 200 ) );
 	

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -61,7 +61,7 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 
 	QHBoxLayout *pTabHBox = new QHBoxLayout();
 	pTabHBox->setSpacing( 0 );
-	pTabHBox->setMargin( 0 );
+	pTabHBox->setContentsMargins( 0, 0, 0, 0 );
 	pTabHBox->addWidget( m_pShowInstrumentEditorBtn );
 	pTabHBox->addWidget( m_pShowSoundLibraryBtn );
 
@@ -77,7 +77,7 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 	// LAYOUT
 	QGridLayout *pGrid = new QGridLayout();
 	pGrid->setSpacing( 0 );
-	pGrid->setMargin( 0 );
+	pGrid->setContentsMargins( 0, 0, 0, 0 );
 
 	pGrid->addWidget( pTabButtonsPanel, 0, 0, 1, 3 );
 	pGrid->addWidget( InstrumentEditorPanel::get_instance(), 2, 1 );

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -54,7 +54,7 @@ LadspaFXProperties::LadspaFXProperties(QWidget* parent, uint nLadspaFX)
 
 	QHBoxLayout *hbox = new QHBoxLayout();
 	hbox->setSpacing( 0 );
-	hbox->setMargin( 0 );
+	hbox->setContentsMargins( 0, 0, 0, 0 );
 	setLayout( hbox );
 
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -728,11 +728,12 @@ bool MainForm::action_file_save_as()
 		// We will prompt for saving the changes applied to the
 		// drumkit usage and require the user to exit this transient
 		// state first.
-		if ( QMessageBox::information( this, "Hydrogen",
-									   tr( "\nThere have been recent changes to the drumkit settings.\n"
-										   "The session needs to be saved before exporting will can be continued.\n" ),
-		                               QMessageBox::Save | QMessageBox::Cancel,
-		                               QMessageBox::Save )
+		if ( QMessageBox::information(
+				 this, "Hydrogen",
+				 tr( "\nThere have been recent changes to the drumkit settings.\n"
+					 "The session needs to be saved before exporting will can be continued.\n" ),
+				 QMessageBox::Save | QMessageBox::Cancel,
+				 QMessageBox::Save )
 		     == QMessageBox::Cancel ) {
 			INFOLOG( "Exporting cancelled at relinking" );
 			return false;
@@ -2337,16 +2338,13 @@ bool MainForm::handleUnsavedChanges()
 	bool done = false;
 	bool rv = true;
 	while ( !done && Hydrogen::get_instance()->getSong()->getIsModified() ) {
-		switch(
-				 QMessageBox::information( this, "Hydrogen",
-										 tr("\nThe document contains unsaved changes.\n"
-												"Do you want to save the changes?\n"),
-										   pCommonStrings->getButtonSave(),
-										   pCommonStrings->getButtonDiscard(),
-										   pCommonStrings->getButtonCancel(),
-										   0,      // Enter == button 0
-										   2 ) ) { // Escape == button 2
-		case 0: // Save clicked or Alt+S pressed or Enter pressed.
+		switch (
+			QMessageBox::information(
+				this, "Hydrogen", tr("\nThe document contains unsaved changes.\n"
+									 "Do you want to save the changes?\n"),
+				QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel,
+				QMessageBox::Save ) ) {
+		case QMessageBox::Save: // Save clicked or Alt+S pressed or Enter pressed.
 			// If the save fails, the __is_modified flag will still be true
 			if ( ! Hydrogen::get_instance()->getSong()->getFilename().isEmpty() ) {
 				if ( ! action_file_save() ) {
@@ -2361,11 +2359,11 @@ bool MainForm::handleUnsavedChanges()
 			}
 			// save
 			break;
-		case 1: // Discard clicked or Alt+D pressed
+		case QMessageBox::Discard:
 			// don't save but exit
 			done = true;
 			break;
-		case 2: // Cancel clicked or Alt+C pressed or Escape pressed
+		case QMessageBox::Cancel:
 			// don't exit
 			return false;
 		}
@@ -2374,19 +2372,16 @@ bool MainForm::handleUnsavedChanges()
 	while ( !done && Playlist::get_instance()->getIsModified() ) {
 		switch(
 			QMessageBox::information(
-				this, 
-				"Hydrogen",
+				this, "Hydrogen",
 				tr("\nThe current playlist contains unsaved changes.\n"
 				   "Do you want to discard the changes?\n"),
-				pCommonStrings->getButtonDiscard(),
-				pCommonStrings->getButtonCancel(),
-				nullptr,      // Enter == button 0
-				2 ) ) { // Escape == button 1
-		case 0: // Discard clicked or Alt+D pressed
+				QMessageBox::Discard | QMessageBox::Cancel,
+				QMessageBox::Discard ) ) {
+		case QMessageBox::Discard:
 				// don't save but exit
 			done = true;
 			break;
-		case 1: // Cancel clicked or Alt+C pressed or Escape pressed
+		case QMessageBox::Cancel:
 				// don't exit
 			return false;
 		}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -310,41 +310,63 @@ void MainForm::createMenuBar()
 		sLabelOpenDemo = tr( "Open &Demo" );
 	}
 	
-	m_pFileMenu->addAction( sLabelNew, this, SLOT( action_file_new() ), QKeySequence( "Ctrl+N" ) );
+	auto pActionFileNew = m_pFileMenu->addAction(
+		sLabelNew, this, SLOT( action_file_new() ) );
+	pActionFileNew->setShortcut( QKeySequence( "Ctrl+N" ) );
 	
 	m_pFileMenu->addSeparator();				// -----
 	
-	m_pFileMenu->addAction( tr( "Song Properties" ), this, SLOT( action_file_songProperties() ), QKeySequence( "" ) );
+	m_pFileMenu->addAction( tr( "Song Properties" ), this, SLOT( action_file_songProperties() ) );
 	
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction( sLabelOpen, this, SLOT( action_file_open() ), QKeySequence( "Ctrl+O" ) );
-	if ( ! bUnderSessionManagement ) {
-		m_pFileMenu->addAction( sLabelOpenDemo, this, SLOT( action_file_openDemo() ), QKeySequence( "Ctrl+D" ) );
+	auto pActionFileOpen = m_pFileMenu->addAction(
+		sLabelOpen, this, SLOT( action_file_open() ) );
+	pActionFileOpen->setShortcut( QKeySequence( "Ctrl+O" ) );
+	  if ( ! bUnderSessionManagement ) {
+		auto pActionFileDemo = m_pFileMenu->addAction(
+			sLabelOpenDemo, this, SLOT( action_file_openDemo() ) );
+		pActionFileDemo->setShortcut( QKeySequence( "Ctrl+D" ) );
 	}
 	m_pRecentFilesMenu = m_pFileMenu->addMenu( sLabelOpenRecent );
 
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction( tr( "&Save" ), this, SLOT( action_file_save() ), QKeySequence( "Ctrl+S" ) );
-	m_pFileMenu->addAction( sLabelSaveAs, this, SLOT( action_file_save_as() ), QKeySequence( "Ctrl+Shift+S" ) );
+	auto pActionFileSave = m_pFileMenu->addAction(
+		tr( "&Save" ), this, SLOT( action_file_save() ) );
+	pActionFileSave->setShortcut( QKeySequence( "Ctrl+S" ) );
+	auto pActionFileSaveAs = m_pFileMenu->addAction(
+		sLabelSaveAs, this, SLOT( action_file_save_as() ) );
+	pActionFileSaveAs->setShortcut( QKeySequence( "Ctrl+Shift+S" ) );
 	
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction ( tr ( "Open &Pattern" ), this, SLOT ( action_file_openPattern() ), QKeySequence ( "Ctrl+Shift+P" ) );
-	m_pFileMenu->addAction( tr( "E&xport Pattern As..." ), this, SLOT( action_file_export_pattern_as() ), QKeySequence( "Ctrl+P" ) );
+	auto pActionOpenPattern = m_pFileMenu->addAction (
+		tr( "Open &Pattern" ), this, SLOT( action_file_openPattern() ) );
+	pActionOpenPattern->setShortcut( QKeySequence( "Ctrl+Shift+P" ) );
+	auto pActionExportPattern = m_pFileMenu->addAction(
+		tr( "E&xport Pattern As..." ), this, SLOT( action_file_export_pattern_as() ) );
+	pActionExportPattern->setShortcut( QKeySequence( "Ctrl+P" ) );
 
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction( tr( "Export &MIDI File" ), this, SLOT( action_file_export_midi() ), QKeySequence( "Ctrl+M" ) );
-	m_pFileMenu->addAction( tr( "&Export Song" ), this, SLOT( action_file_export() ), QKeySequence( "Ctrl+E" ) );
-	m_pFileMenu->addAction( tr( "Export &LilyPond File" ), this, SLOT( action_file_export_lilypond() ), QKeySequence( "Ctrl+L" ) );
+	auto pActionExportMidi = m_pFileMenu->addAction(
+		tr( "Export &MIDI File" ), this, SLOT( action_file_export_midi() ) );
+	pActionExportMidi->setShortcut( QKeySequence( "Ctrl+M" ) );
+	auto pActionExportSong = m_pFileMenu->addAction(
+		tr( "&Export Song" ), this, SLOT( action_file_export() ) );
+	pActionExportSong->setShortcut( QKeySequence( "Ctrl+E" ) );
+	auto pActionExportLilyPond = m_pFileMenu->addAction(
+		tr( "Export &LilyPond File" ), this, SLOT( action_file_export_lilypond() ) );
+	pActionExportLilyPond->setShortcut( QKeySequence( "Ctrl+L" ) );
 
 
 #ifndef Q_OS_MACX
 	m_pFileMenu->addSeparator();				// -----
 
-	m_pFileMenu->addAction( tr("&Quit"), this, SLOT( action_file_exit() ), QKeySequence( "Ctrl+Q" ) );
+	auto pActionQuit = m_pFileMenu->addAction(
+		tr("&Quit"), this, SLOT( action_file_exit() ) );
+	pActionQuit->setShortcut( QKeySequence( "Ctrl+Q" ) );
 #endif
 
 	updateRecentUsedSongList();
@@ -353,63 +375,75 @@ void MainForm::createMenuBar()
 
 	// Undo menu
 	m_pUndoMenu = pMenubar->addMenu( tr( "&Undo" ) );
-	m_pUndoMenu->addAction( tr( "&Undo" ), this, SLOT( action_undo() ), QKeySequence( "Ctrl+Z" ) );
-	m_pUndoMenu->addAction( tr( "&Redo" ), this, SLOT( action_redo() ), QKeySequence( "Shift+Ctrl+Z" ) );
-	m_pUndoMenu->addAction( tr( "Undo &History" ), this, SLOT( openUndoStack() ), QKeySequence( "" ) );
+	auto pActionUndo = m_pUndoMenu->addAction(
+		tr( "&Undo" ), this, SLOT( action_undo() ) );
+	pActionUndo->setShortcut( QKeySequence( "Ctrl+Z" ) );
+	auto pActionRedo = m_pUndoMenu->addAction(
+		tr( "&Redo" ), this, SLOT( action_redo() ) );
+	pActionRedo->setShortcut( QKeySequence( "Shift+Ctrl+Z" ) );
+	m_pUndoMenu->addAction( tr( "Undo &History" ), this, SLOT( openUndoStack() ) );
 
 	// DRUMKITS MENU
 	m_pDrumkitsMenu = pMenubar->addMenu( tr( "Drum&kits" ) );
-	m_pDrumkitsMenu->addAction( tr( "&New" ), this, SLOT( action_instruments_clearAll() ), QKeySequence( "" ) );
-	m_pDrumkitsMenu->addAction( tr( "&Open" ), this, SLOT( action_banks_open() ), QKeySequence( "" ) );
-	m_pDrumkitsMenu->addAction( tr( "&Properties" ), this, SLOT( action_banks_properties() ), QKeySequence( "" ) );
+	m_pDrumkitsMenu->addAction( tr( "&New" ), this, SLOT( action_instruments_clearAll() ) );
+	m_pDrumkitsMenu->addAction( tr( "&Open" ), this, SLOT( action_banks_open() ) );
+	m_pDrumkitsMenu->addAction( tr( "&Properties" ), this, SLOT( action_banks_properties() ) );
 
 	m_pDrumkitsMenu->addSeparator();				// -----
 
-	m_pDrumkitsMenu->addAction( tr( "&Save" ), this, SLOT( action_instruments_saveLibrary() ), QKeySequence( "" ) );
-	m_pDrumkitsMenu->addAction( tr( "Save &As" ), this, SLOT( action_instruments_saveAsLibrary() ), QKeySequence( "" ) );
+	m_pDrumkitsMenu->addAction( tr( "&Save" ), this, SLOT( action_instruments_saveLibrary() ) );
+	m_pDrumkitsMenu->addAction( tr( "Save &As" ), this, SLOT( action_instruments_saveAsLibrary() ) );
 
 	m_pDrumkitsMenu->addSeparator();				// -----
 
-	m_pDrumkitsMenu->addAction( tr( "&Export" ), this, SLOT( action_instruments_exportLibrary() ), QKeySequence( "" ) );
-	m_pDrumkitsMenu->addAction( tr( "&Import" ), this, SLOT( action_instruments_importLibrary() ), QKeySequence( "" ) );
-	m_pDrumkitsMenu->addAction( tr( "On&line Import" ), this, SLOT( action_instruments_onlineImportLibrary() ), QKeySequence( "" ) );
+	m_pDrumkitsMenu->addAction( tr( "&Export" ), this, SLOT( action_instruments_exportLibrary() ) );
+	m_pDrumkitsMenu->addAction( tr( "&Import" ), this, SLOT( action_instruments_importLibrary() ) );
+	m_pDrumkitsMenu->addAction( tr( "On&line Import" ), this, SLOT( action_instruments_onlineImportLibrary() ) );
 
 	// INSTRUMENTS MENU
 	m_pInstrumentsMenu = pMenubar->addMenu( tr( "In&struments" ) );
-	m_pInstrumentsMenu->addAction( tr( "Add &Instrument" ), this, SLOT( action_instruments_addInstrument() ), QKeySequence( "" ) );
-	m_pInstrumentsMenu->addAction( tr( "Clea&r All" ), this, SLOT( action_instruments_clearAll() ), QKeySequence( "" ) );
+	m_pInstrumentsMenu->addAction( tr( "Add &Instrument" ), this, SLOT( action_instruments_addInstrument() ) );
+	m_pInstrumentsMenu->addAction( tr( "Clea&r All" ), this, SLOT( action_instruments_clearAll() ) );
 
 	m_pInstrumentsMenu->addSeparator();				// -----
 
-	m_pInstrumentsMenu->addAction( tr( "Add &Component" ), this, SLOT( action_instruments_addComponent() ), QKeySequence( "" ) );
+	m_pInstrumentsMenu->addAction( tr( "Add &Component" ), this, SLOT( action_instruments_addComponent() ) );
 
 	// VIEW MENU
 	m_pViewMenu = pMenubar->addMenu( tr( "&View" ) );
 
-	m_pViewPlaylistEditorAction = m_pViewMenu->addAction( tr("Play&list Editor"), this, SLOT( action_window_showPlaylistDialog() ), QKeySequence( "" ) );
+	m_pViewPlaylistEditorAction = m_pViewMenu->addAction( tr("Play&list Editor"), this, SLOT( action_window_showPlaylistDialog() ) );
 	m_pViewPlaylistEditorAction->setCheckable( true );
-	m_pViewDirectorAction = m_pViewMenu->addAction( tr("&Director"), this, SLOT( action_window_show_DirectorWidget() ), QKeySequence( "Alt+D" ) );
+	m_pViewDirectorAction = m_pViewMenu->addAction(
+		tr("&Director"), this, SLOT( action_window_show_DirectorWidget() ) );
+	m_pViewDirectorAction->setShortcut( QKeySequence( "Alt+D" ) );
 	m_pViewDirectorAction->setCheckable( true );
 
 	m_pFileMenu->addSeparator();
-	m_pViewMixerAction = m_pViewMenu->addAction( tr("&Mixer"), this, SLOT( action_window_showMixer() ), QKeySequence( "Alt+M" ) );
+	m_pViewMixerAction = m_pViewMenu->addAction(
+		tr("&Mixer"), this, SLOT( action_window_showMixer() ) );
+	m_pViewMixerAction->setShortcut( QKeySequence( "Alt+M" ) );
 	m_pViewMixerAction->setCheckable( true );
 	update_mixer_checkbox();						// if checkbox need to be checked.
 
-	m_pViewMixerInstrumentRackAction = m_pViewMenu->addAction( tr("&Instrument Rack"), this, SLOT( action_window_showInstrumentRack() ), QKeySequence( "Alt+I" ) );
+	m_pViewMixerInstrumentRackAction = m_pViewMenu->addAction(
+		tr("&Instrument Rack"), this, SLOT( action_window_showInstrumentRack() ) );
+	m_pViewMixerInstrumentRackAction->setShortcut( QKeySequence( "Alt+I" ) );
 	m_pViewMixerInstrumentRackAction->setCheckable( true );
 	update_instrument_checkbox( Preferences::get_instance()->getInstrumentRackProperties().visible );
 
-	m_pViewAutomationPathAction = m_pViewMenu->addAction( tr("&Automation Path"), this, SLOT( action_window_showAutomationArea() ), QKeySequence( "Alt+A" ) );
+	m_pViewAutomationPathAction = m_pViewMenu->addAction(
+		tr("&Automation Path"), this, SLOT( action_window_showAutomationArea() ) );
+	m_pViewAutomationPathAction->setShortcut( QKeySequence( "Alt+A" ) );
 	m_pViewAutomationPathAction->setCheckable( true );
 	update_automation_checkbox();
 
 	m_pViewMenu->addSeparator();				// -----
 
-	m_pViewTimelineAction = m_pViewMenu->addAction( tr("&Timeline"), this, SLOT( action_window_showTimeline() ), QKeySequence( "" ) );
+	m_pViewTimelineAction = m_pViewMenu->addAction( tr("&Timeline"), this, SLOT( action_window_showTimeline() ) );
 	m_pViewTimelineAction->setCheckable( true );
 	
-	m_pViewPlaybackTrackAction = m_pViewMenu->addAction( tr("&Playback Track"), this, SLOT( action_window_showPlaybackTrack() ), QKeySequence( "" ) );
+	m_pViewPlaybackTrackAction = m_pViewMenu->addAction( tr("&Playback Track"), this, SLOT( action_window_showPlaybackTrack() ) );
 	m_pViewPlaybackTrackAction->setCheckable( true );
 
 	m_pViewPlaybackTrackActionGroup = new QActionGroup( this );
@@ -419,17 +453,23 @@ void MainForm::createMenuBar()
 
 	m_pViewMenu->addSeparator();				// -----
 
-	m_pViewMenu->addAction( tr("&Full screen"), this, SLOT( action_window_toggleFullscreen() ), QKeySequence( "Alt+F" ) );
+	auto pActionFullScreen = m_pViewMenu->addAction(
+		tr("&Full screen"), this, SLOT( action_window_toggleFullscreen() ) );
+	pActionFullScreen->setShortcut( QKeySequence( "Alt+F" ) );
 
 
 	// Options menu
 	m_pOptionsMenu = pMenubar->addMenu( tr( "&Options" ));
 
 	m_pInputModeMenu = m_pOptionsMenu->addMenu( tr( "Input &Mode" ) );
-	m_pInstrumentAction = m_pInputModeMenu->addAction( tr( "&Instrument" ), this, SLOT( action_inputMode_instrument() ), QKeySequence( "Ctrl+Alt+I" ) );
+	m_pInstrumentAction = m_pInputModeMenu->addAction(
+		tr( "&Instrument" ), this, SLOT( action_inputMode_instrument() ) );
+	m_pInstrumentAction->setShortcut( QKeySequence( "Ctrl+Alt+I" ) );
 	m_pInstrumentAction->setCheckable( true );
 
-	m_pDrumkitAction = m_pInputModeMenu->addAction( tr( "&Drumkit" ), this, SLOT( action_inputMode_drumkit() ), QKeySequence( "Ctrl+Alt+D" ) );
+	m_pDrumkitAction = m_pInputModeMenu->addAction(
+		tr( "&Drumkit" ), this, SLOT( action_inputMode_drumkit() ) );
+	m_pDrumkitAction->setShortcut( QKeySequence( "Ctrl+Alt+D" ) );
 	m_pDrumkitAction->setCheckable( true );
 
 	if( Preferences::get_instance()->__playselectedinstrument )
@@ -441,7 +481,9 @@ void MainForm::createMenuBar()
 		m_pDrumkitAction->setChecked (true );
 	}
 
-	m_pOptionsMenu->addAction( tr("&Preferences"), this, SLOT( showPreferencesDialog() ), QKeySequence( "Alt+P" ) );
+	auto pActionPreferences = m_pOptionsMenu->addAction(
+		tr("&Preferences"), this, SLOT( showPreferencesDialog() ) );
+	pActionPreferences->setShortcut( QKeySequence( "Alt+P" ) );
 
 	// ~ Tools menu
 
@@ -454,11 +496,11 @@ void MainForm::createMenuBar()
 		m_pDebugMenu->addAction( tr( "Show &Filesystem Info" ), this, SLOT( action_debug_showFilesystemInfo() ) );
 		
 		m_pLogLevelMenu = m_pDebugMenu->addMenu( tr( "&Log Level" ) );		
-		m_pLogLevelMenu->addAction( tr( "&None" ), this, SLOT( action_debug_logLevel_none() ), QKeySequence( "" ) );
-		m_pLogLevelMenu->addAction( tr( "&Error" ), this, SLOT( action_debug_logLevel_info() ), QKeySequence( "" ) );
-		m_pLogLevelMenu->addAction( tr( "&Warning" ), this, SLOT( action_debug_logLevel_warn() ), QKeySequence( "" ) );
-		m_pLogLevelMenu->addAction( tr( "&Info" ), this, SLOT( action_debug_logLevel_info() ), QKeySequence( "" ) );
-		m_pLogLevelMenu->addAction( tr( "&Debug" ), this, SLOT( action_debug_logLevel_debug() ), QKeySequence( "" ) );
+		m_pLogLevelMenu->addAction( tr( "&None" ), this, SLOT( action_debug_logLevel_none() ) );
+		m_pLogLevelMenu->addAction( tr( "&Error" ), this, SLOT( action_debug_logLevel_info() ) );
+		m_pLogLevelMenu->addAction( tr( "&Warning" ), this, SLOT( action_debug_logLevel_warn() ) );
+		m_pLogLevelMenu->addAction( tr( "&Info" ), this, SLOT( action_debug_logLevel_info() ) );
+		m_pLogLevelMenu->addAction( tr( "&Debug" ), this, SLOT( action_debug_logLevel_debug() ) );
 		
 		m_pDebugMenu->addAction( tr( "&Open Log File" ), this, SLOT( action_debug_openLogfile()) );
 		
@@ -470,9 +512,12 @@ void MainForm::createMenuBar()
 
 	// INFO menu
 	m_pInfoMenu = pMenubar->addMenu( tr( "I&nfo" ) );
-	m_pInfoMenu->addAction( tr("User &Manual"), this, SLOT( showUserManual() ), QKeySequence( "Ctrl+?" ) );
+	auto pActionUserManual = m_pInfoMenu->addAction(
+		tr("User &Manual"), this, SLOT( showUserManual() ) );
+	pActionUserManual->setShortcut( QKeySequence( "Ctrl+?" ) );
 	m_pInfoMenu->addSeparator();
-	m_pInfoMenu->addAction( tr("&About"), this, SLOT( action_help_about() ), QKeySequence( tr("", "Info|About") ) );
+	auto pActionAbout = m_pInfoMenu->addAction( tr("&About"), this, SLOT( action_help_about() ) );
+	pActionAbout->setShortcut( QKeySequence( tr("", "Info|About") ) );
 	m_pInfoMenu->addAction( tr("&Report Bug"), this, SLOT( action_report_bug() ));
 	m_pInfoMenu->addAction( tr("&Donate"), this, SLOT( action_donate() ));
 	// ~ INFO menu

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -968,7 +968,7 @@ void MainForm::action_file_export_pattern_as( int nPatternRow )
 		return;
 	}
 
-	QFileInfo fileInfo = fd.selectedFiles().first();
+	QFileInfo fileInfo( fd.selectedFiles().first() );
 	Preferences::get_instance()->setLastExportPatternAsDirectory( fileInfo.path() );
 	QString filePath = fileInfo.absoluteFilePath();
 

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -61,7 +61,7 @@ Mixer::Mixer( QWidget* pParent )
 // fader Panel
 	m_pFaderHBox = new QHBoxLayout();
 	m_pFaderHBox->setSpacing( 0 );
-	m_pFaderHBox->setMargin( 0 );
+	m_pFaderHBox->setContentsMargins( 0, 0, 0, 0 );
 
 	m_pFaderPanel = new QWidget( nullptr );
 	m_pFaderPanel->resize( MixerLine::nWidth * MAX_INSTRUMENTS, nFixedHeight );
@@ -150,7 +150,7 @@ Mixer::Mixer( QWidget* pParent )
 	// LAYOUT!
 	QHBoxLayout *pLayout = new QHBoxLayout();
 	pLayout->setSpacing( 0 );
-	pLayout->setMargin( 0 );
+	pLayout->setContentsMargins( 0, 0, 0, 0 );
 
 	pLayout->addWidget( m_pFaderScrollArea );
 	pLayout->addWidget( m_pFXFrame );
@@ -171,7 +171,7 @@ Mixer::Mixer( QWidget* pParent )
 
 	auto pMainLayout = new QHBoxLayout();
 	pMainLayout->setSpacing( 0 );
-	pMainLayout->setMargin( 0 );
+	pMainLayout->setContentsMargins( 0, 0, 0, 0 );
 	pMainLayout->addWidget( pMainScrollArea );
 	setLayout( pMainLayout );
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -42,6 +42,7 @@
 #include <core/Helpers/Xml.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
+#include "../Compatibility/MouseEvent.h"
 #include "UndoActions.h"
 #include "../HydrogenApp.h"
 #include "../Mixer/Mixer.h"
@@ -186,16 +187,20 @@ void DrumPatternEditor::mouseClickEvent( QMouseEvent *ev )
 	if ( pSong == nullptr ) {
 		return;
 	}
+
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	int nInstruments = pSong->getInstrumentList()->size();
-	int row = (int)( ev->y()  / (float)m_nGridHeight);
+	int row = (int)( pEv->position().y()  / (float)m_nGridHeight);
 	if (row >= nInstruments) {
 		return;
 	}
-	int nColumn = getColumn( ev->x(), /* bUseFineGrained=*/ true );
+	int nColumn = getColumn( pEv->position().x(), /* bUseFineGrained=*/ true );
 	int nRealColumn = 0;
 
-	if( ev->x() > PatternEditor::nMargin ) {
-		nRealColumn = ( ev->x() - PatternEditor::nMargin) / static_cast<float>(m_fGridWidth);
+	if( pEv->position().x() > PatternEditor::nMargin ) {
+		nRealColumn = ( pEv->position().x() - PatternEditor::nMargin) /
+			static_cast<float>(m_fGridWidth);
 	}
 
 	if ( nColumn >= (int)m_pPattern->get_length() ) {
@@ -217,7 +222,7 @@ void DrumPatternEditor::mouseClickEvent( QMouseEvent *ev )
 
 	} else if ( ev->button() == Qt::RightButton ) {
 
-		m_pPopupMenu->popup( ev->globalPos() );
+		m_pPopupMenu->popup( pEv->globalPosition().toPoint() );
 	}
 
 	m_pPatternEditorPanel->setCursorPosition( nColumn );
@@ -233,7 +238,9 @@ void DrumPatternEditor::mouseClickEvent( QMouseEvent *ev )
 
 void DrumPatternEditor::mousePressEvent( QMouseEvent* ev ) {
 
-	if ( ev->x() > m_nActiveWidth ) {
+	auto pEv = static_cast<MouseEvent*>( ev );
+
+	if ( pEv->position().x() > m_nActiveWidth ) {
 		return;
 	}
 	
@@ -243,7 +250,8 @@ void DrumPatternEditor::mousePressEvent( QMouseEvent* ev ) {
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	int nInstruments = pSong->getInstrumentList()->size();
-	int nRow = static_cast<int>( ev->y() / static_cast<float>(m_nGridHeight) );
+	int nRow = static_cast<int>( pEv->position().y() /
+								 static_cast<float>(m_nGridHeight) );
 	if ( nRow >= nInstruments || nRow < 0 ) {
 		return;
 	}
@@ -265,7 +273,7 @@ void DrumPatternEditor::mousePressEvent( QMouseEvent* ev ) {
 
 	// Update cursor position
 	if ( ! HydrogenApp::get_instance()->hideKeyboardCursor() ) {
-		int nColumn = getColumn( ev->x(), /* bUseFineGrained=*/ true );
+		int nColumn = getColumn( pEv->position().x(), /* bUseFineGrained=*/ true );
 		if ( ( m_pPattern != nullptr &&
 			   nColumn >= (int)m_pPattern->get_length() ) ||
 			 nColumn >= MAX_INSTRUMENTS ) {
@@ -287,13 +295,15 @@ void DrumPatternEditor::mouseDragStartEvent( QMouseEvent *ev )
 	if ( m_pPattern == nullptr ) {
 		return;
 	}
+
+	auto pEv = static_cast<MouseEvent*>( ev );
 	
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 
 	// Set the selected instrument _before_ it will be stored in
 	// PatternEditor::mouseDragStartEvent.
-	int nRow = std::floor(static_cast<float>(ev->y()) /
+	int nRow = std::floor(static_cast<float>(pEv->position().y()) /
 						  static_cast<float>(m_nGridHeight));
 	pHydrogen->setSelectedInstrumentNumber( nRow );
 	auto pSelectedInstrument = pHydrogen->getSelectedInstrument();
@@ -308,16 +318,16 @@ void DrumPatternEditor::mouseDragStartEvent( QMouseEvent *ev )
 	// properties.
 	PatternEditor::mouseDragStartEvent( ev );
 	
-	int nColumn = getColumn( ev->x() );
+	int nColumn = getColumn( pEv->position().x() );
 	
 	if ( ev->button() == Qt::RightButton ) {
 		// Right button drag: adjust note length
 		int nRealColumn = 0;
 
-		if( ev->x() > PatternEditor::nMargin ) {
+		if( pEv->position().x() > PatternEditor::nMargin ) {
 			nRealColumn =
 				static_cast<int>(std::floor(
-					static_cast<float>((ev->x() - PatternEditor::nMargin)) /
+					static_cast<float>((pEv->position().x() - PatternEditor::nMargin)) /
 					m_fGridWidth));
 		}
 
@@ -336,8 +346,9 @@ void DrumPatternEditor::mouseDragStartEvent( QMouseEvent *ev )
 ///
 void DrumPatternEditor::mouseDragUpdateEvent( QMouseEvent *ev )
 {
+	auto pEv = static_cast<MouseEvent*>( ev );
 	int nRow = MAX_INSTRUMENTS - 1 -
-		static_cast<int>(std::floor(static_cast<float>(ev->y())  /
+		static_cast<int>(std::floor(static_cast<float>(pEv->position().y())  /
 									static_cast<float>(m_nGridHeight)));
 	if ( nRow >= MAX_INSTRUMENTS ) {
 		return;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1037,7 +1037,7 @@ void NotePropertiesRuler::scrolled( int nValue ) {
 	update();
 }
 
-void NotePropertiesRuler::enterEvent( QEvent *ev ) {
+void NotePropertiesRuler::enterEvent( QEnterEvent *ev ) {
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -1037,7 +1037,11 @@ void NotePropertiesRuler::scrolled( int nValue ) {
 	update();
 }
 
+#ifdef H2CORE_HAVE_QT6
 void NotePropertiesRuler::enterEvent( QEnterEvent *ev ) {
+#else
+void NotePropertiesRuler::enterEvent( QEvent *ev ) {
+#endif
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -127,7 +127,7 @@ class NotePropertiesRuler : public PatternEditor, protected WidgetWithScalableFo
 		void keyPressEvent( QKeyEvent *ev ) override;
 		void addUndoAction();
 		void prepareUndoAction( int x );
-		void enterEvent( QEvent *ev ) override;
+		void enterEvent( QEnterEvent *ev ) override;
 		void leaveEvent( QEvent *ev ) override;
 
 		virtual void mouseMoveEvent( QMouseEvent *ev ) override;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -127,7 +127,11 @@ class NotePropertiesRuler : public PatternEditor, protected WidgetWithScalableFo
 		void keyPressEvent( QKeyEvent *ev ) override;
 		void addUndoAction();
 		void prepareUndoAction( int x );
-		void enterEvent( QEnterEvent *ev ) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 		void leaveEvent( QEvent *ev ) override;
 
 		virtual void mouseMoveEvent( QMouseEvent *ev ) override;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -878,7 +878,11 @@ void PatternEditor::scrolled( int nValue ) {
 	update();
 }
 
+#ifdef H2CORE_HAVE_QT6
 void PatternEditor::enterEvent( QEnterEvent *ev ) {
+#else
+void PatternEditor::enterEvent( QEvent *ev ) {
+#endif
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -878,7 +878,7 @@ void PatternEditor::scrolled( int nValue ) {
 	update();
 }
 
-void PatternEditor::enterEvent( QEvent *ev ) {
+void PatternEditor::enterEvent( QEnterEvent *ev ) {
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -300,7 +300,7 @@ protected:
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;
-	virtual void enterEvent( QEvent *ev ) override;
+	virtual void enterEvent( QEnterEvent *ev ) override;
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void focusInEvent( QFocusEvent *ev ) override;
 	virtual void focusOutEvent( QFocusEvent *ev ) override;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -300,7 +300,11 @@ protected:
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;
-	virtual void enterEvent( QEnterEvent *ev ) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void focusInEvent( QFocusEvent *ev ) override;
 	virtual void focusOutEvent( QFocusEvent *ev ) override;

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -197,7 +197,7 @@ QLabel {\
  }" ).arg( textColor.name() ) );
 }
 
-void InstrumentLine::enterEvent( QEvent* ev ) {
+void InstrumentLine::enterEvent( QEnterEvent* ev ) {
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.cpp
@@ -197,7 +197,11 @@ QLabel {\
  }" ).arg( textColor.name() ) );
 }
 
-void InstrumentLine::enterEvent( QEnterEvent* ev ) {
+#ifdef H2CORE_HAVE_QT6
+void InstrumentLine::enterEvent( QEnterEvent *ev ) {
+#else
+void InstrumentLine::enterEvent( QEvent *ev ) {
+#endif
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -109,7 +109,7 @@ public slots:
 
 		virtual void mousePressEvent(QMouseEvent *ev) override;
 	virtual void mouseDoubleClickEvent( QMouseEvent* ev ) override;
-	virtual void enterEvent( QEvent *ev );
+	virtual void enterEvent( QEnterEvent *ev );
 	virtual void leaveEvent( QEvent *ev );
 	virtual void paintEvent( QPaintEvent* ev ) override;
 		H2Core::Pattern* getCurrentPattern();

--- a/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
+++ b/src/gui/src/PatternEditor/PatternEditorInstrumentList.h
@@ -109,7 +109,11 @@ public slots:
 
 		virtual void mousePressEvent(QMouseEvent *ev) override;
 	virtual void mouseDoubleClickEvent( QMouseEvent* ev ) override;
-	virtual void enterEvent( QEnterEvent *ev );
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent *ev );
 	virtual void paintEvent( QPaintEvent* ev ) override;
 		H2Core::Pattern* getCurrentPattern();

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -94,12 +94,12 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	QHBoxLayout *m_pEditorTop1_hbox = new QHBoxLayout( m_pEditorTop1 );
 	m_pEditorTop1_hbox->setSpacing( 0 );
-	m_pEditorTop1_hbox->setMargin( 0 );
+	m_pEditorTop1_hbox->setContentsMargins( 0, 0, 0, 0 );
 	m_pEditorTop1_hbox->setAlignment( Qt::AlignLeft );
 
 	QHBoxLayout *m_pEditorTop1_hbox_2 = new QHBoxLayout( m_pEditorTop2 );
 	m_pEditorTop1_hbox_2->setSpacing( 2 );
-	m_pEditorTop1_hbox_2->setMargin( 0 );
+	m_pEditorTop1_hbox_2->setContentsMargins( 0, 0, 0, 0 );
 	m_pEditorTop1_hbox_2->setAlignment( Qt::AlignLeft );
 
 
@@ -504,7 +504,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	
 	QHBoxLayout *pPatternEditorHScrollBarLayout = new QHBoxLayout();
 	pPatternEditorHScrollBarLayout->setSpacing( 0 );
-	pPatternEditorHScrollBarLayout->setMargin( 0 );
+	pPatternEditorHScrollBarLayout->setContentsMargins( 0, 0, 0, 0 );
 	pPatternEditorHScrollBarLayout->addWidget( m_pPatternEditorHScrollBar );
 	pPatternEditorHScrollBarLayout->addWidget( zoom_in_btn );
 	pPatternEditorHScrollBarLayout->addWidget( zoom_out_btn );
@@ -535,7 +535,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	QVBoxLayout *pPropertiesVBox = new QVBoxLayout( pPropertiesPanel );
 	pPropertiesVBox->setSpacing( 0 );
-	pPropertiesVBox->setMargin( 0 );
+	pPropertiesVBox->setContentsMargins( 0, 0, 0, 0 );
 
 
 	m_pPropertiesCombo =
@@ -562,7 +562,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 
 	QGridLayout *pGrid = new QGridLayout();
 	pGrid->setSpacing( 0 );
-	pGrid->setMargin( 0 );
+	pGrid->setContentsMargins( 0, 0, 0, 0 );
 
 	pGrid->addWidget( m_pEditorTop1, 0, 0 );
 	pGrid->addWidget( m_pEditorTop2, 0, 1, 1, 2 );
@@ -619,7 +619,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	// LAYOUT
 	QVBoxLayout *pVBox = new QVBoxLayout();
 	pVBox->setSpacing( 0 );
-	pVBox->setMargin( 0 );
+	pVBox->setContentsMargins( 0, 0, 0, 0 );
 	this->setLayout( pVBox );
 
 	pVBox->addWidget( pMainPanel );

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -36,6 +36,7 @@ using namespace H2Core;
 #include "PatternEditorRuler.h"
 #include "PatternEditorPanel.h"
 #include "NotePropertiesRuler.h"
+#include "../Compatibility/MouseEvent.h"
 #include "../HydrogenApp.h"
 #include "../Skin.h"
 
@@ -194,8 +195,10 @@ void PatternEditorRuler::hideEvent ( QHideEvent *ev )
 
 void PatternEditorRuler::mousePressEvent( QMouseEvent* ev ) {
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	if ( ev->button() == Qt::LeftButton &&
-		 ev->x() < m_nWidthActive ) {
+		 pEv->position().x() < m_nWidthActive ) {
 		auto pHydrogen = Hydrogen::get_instance();
 		auto pCoreActionController = pHydrogen->getCoreActionController();
 		auto pHydrogenApp = HydrogenApp::get_instance();
@@ -240,7 +243,8 @@ void PatternEditorRuler::mousePressEvent( QMouseEvent* ev ) {
 
 void PatternEditorRuler::mouseMoveEvent( QMouseEvent* ev ) {
 
-	if ( ev->x() < m_nWidthActive ) {
+	auto pEv = static_cast<MouseEvent*>( ev );
+	if ( pEv->position().x() < m_nWidthActive ) {
 	
 		auto pHydrogenApp = HydrogenApp::get_instance();
 		DrumPatternEditor* pDrumPatternEditor;
@@ -274,7 +278,8 @@ void PatternEditorRuler::mouseMoveEvent( QMouseEvent* ev ) {
 
 		int nHoveredColumn =
 			static_cast<int>(std::floor( static_cast<float>(
-				std::max( ev->x() - PatternEditor::nMargin +
+				std::max( static_cast<int>(pEv->position().x()) -
+						  PatternEditor::nMargin +
 						  static_cast<int>(std::round(1 / fColumnWidth / 2) ), 0 )) *
 										 fColumnWidth ));
 		

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -37,6 +37,7 @@
 #include <core/Helpers/Xml.h>
 using namespace H2Core;
 
+#include "../Compatibility/MouseEvent.h"
 #include "../HydrogenApp.h"
 #include "../Skin.h"
 
@@ -460,15 +461,17 @@ void PianoRollEditor::mouseClickEvent( QMouseEvent *ev ) {
 		return;
 	}
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	auto pHydrogenApp = HydrogenApp::get_instance();
 	std::shared_ptr<Song> pSong = Hydrogen::get_instance()->getSong();
 
-	int nPressedLine = ((int) ev->y()) / ((int) m_nGridHeight);
+	int nPressedLine = ((int) pEv->position().y()) / ((int) m_nGridHeight);
 	if ( nPressedLine >= (int) m_nOctaves * 12 ) {
 		return;
 	}
 
-	int nColumn = getColumn( ev->x(), /* bUseFineGrained=*/ true );
+	int nColumn = getColumn( pEv->position().x(), /* bUseFineGrained=*/ true );
 
 	if ( nColumn >= (int)m_pPattern->get_length() ) {
 		update( 0, 0, width(), height() );
@@ -492,8 +495,8 @@ void PianoRollEditor::mouseClickEvent( QMouseEvent *ev ) {
 	if (ev->button() == Qt::LeftButton ) {
 
 		unsigned nRealColumn = 0;
-		if( ev->x() > PatternEditor::nMargin ) {
-			nRealColumn = (ev->x() - PatternEditor::nMargin) / static_cast<float>(m_fGridWidth);
+		if( pEv->position().x() > PatternEditor::nMargin ) {
+			nRealColumn = (pEv->position().x() - PatternEditor::nMargin) / static_cast<float>(m_fGridWidth);
 		}
 
 		if ( ev->modifiers() & Qt::ShiftModifier ) {
@@ -523,14 +526,16 @@ void PianoRollEditor::mouseClickEvent( QMouseEvent *ev ) {
 
 	} else if ( ev->button() == Qt::RightButton ) {
 		// Show context menu
-		m_pPopupMenu->popup( ev->globalPos() );
+		m_pPopupMenu->popup( pEv->globalPosition().toPoint() );
 
 	}
 
 }
 
 void PianoRollEditor::mousePressEvent( QMouseEvent* ev ) {
-	if ( ev->x() > m_nActiveWidth ) {
+	auto pEv = static_cast<MouseEvent*>( ev );
+
+	if ( pEv->position().x() > m_nActiveWidth ) {
 		return;
 	}
 
@@ -552,13 +557,13 @@ void PianoRollEditor::mousePressEvent( QMouseEvent* ev ) {
 
 	// Update cursor position
 	if ( ! pHydrogenApp->hideKeyboardCursor() ) {
-		int nPressedLine = ((int) ev->y()) / ((int) m_nGridHeight);
+		int nPressedLine = ((int) pEv->position().y()) / ((int) m_nGridHeight);
 		if ( nPressedLine >= (int) m_nOctaves * 12 ) {
 			return;
 		}
 		m_nCursorPitch = lineToPitch( nPressedLine );	
 
-		int nColumn = getColumn( ev->x(), /* bUseFineGrained=*/ true );
+		int nColumn = getColumn( pEv->position().x(), /* bUseFineGrained=*/ true );
 		if ( ( m_pPattern != nullptr &&
 			   nColumn >= (int)m_pPattern->get_length() ) ||
 			 nColumn >= MAX_INSTRUMENTS ) {
@@ -578,20 +583,22 @@ void PianoRollEditor::mouseDragStartEvent( QMouseEvent *ev )
 		return;
 	}
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	// Handles cursor repositioning and hiding and stores general
 	// properties.
 	PatternEditor::mouseDragStartEvent( ev );
 	
 	m_pDraggedNote = nullptr;
 	Hydrogen *pHydrogen = Hydrogen::get_instance();
-	int nColumn = getColumn( ev->x() );
+	int nColumn = getColumn( pEv->position().x() );
 	auto pSelectedInstrument = pHydrogen->getSelectedInstrument();
 	if ( pSelectedInstrument == nullptr ) {
 		DEBUGLOG( "No instrument selected" );
 		return;
 	}
 
-	int nRow = std::floor(static_cast<float>(ev->y()) /
+	int nRow = std::floor(static_cast<float>(pEv->position().y()) /
 						  static_cast<float>(m_nGridHeight));
 
 	Note::Octave pressedOctave = Note::pitchToOctave( lineToPitch( nRow ) );
@@ -601,10 +608,10 @@ void PianoRollEditor::mouseDragStartEvent( QMouseEvent *ev )
 	if (ev->button() == Qt::RightButton ) {
 
 		int nRealColumn = 0;
-		if( ev->x() > PatternEditor::nMargin ) {
+		if( pEv->position().x() > PatternEditor::nMargin ) {
 			nRealColumn =
 				static_cast<int>(std::floor(
-					static_cast<float>((ev->x() - PatternEditor::nMargin)) /
+					static_cast<float>((pEv->position().x() - PatternEditor::nMargin)) /
 					m_fGridWidth));
 		}
 
@@ -622,7 +629,9 @@ void PianoRollEditor::mouseDragStartEvent( QMouseEvent *ev )
 
 void PianoRollEditor::mouseDragUpdateEvent( QMouseEvent *ev )
 {
-	int nRow = std::floor(static_cast<float>(ev->y()) /
+	auto pEv = static_cast<MouseEvent*>( ev );
+
+	int nRow = std::floor(static_cast<float>(pEv->position().y()) /
 						  static_cast<float>(m_nGridHeight));
 	if ( nRow >= (int) m_nOctaves * 12 ) {
 		return;

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -76,7 +76,7 @@ PlayerControl::PlayerControl(QWidget *parent)
 
 	QHBoxLayout *hbox = new QHBoxLayout();
 	hbox->setSpacing( 0 );
-	hbox->setMargin( 0 );
+	hbox->setContentsMargins( 0, 0, 0, 0 );
 	setLayout( hbox );
 
 // CONTROLS

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -196,7 +196,7 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 
 	QVBoxLayout *pSideBarLayout = new QVBoxLayout(sideBarWidget);
 	pSideBarLayout->setSpacing(0);
-	pSideBarLayout->setMargin(0);
+	pSideBarLayout->setContentsMargins( 0, 0, 0, 0 );
 
 	// zoom-in btn
 	Button *pUpBtn = new Button( nullptr, QSize( 16, 16 ), Button::Type::Push, "up.svg", "", false, QSize( 9, 9 ), tr( "sort" ) );

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -85,16 +85,30 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 	// Playlist menu
 	m_pPlaylistMenu = m_pMenubar->addMenu( tr( "&Playlist" ) );
 
-	m_pPlaylistMenu->addAction( tr( "Add song to Play&list" ), this, SLOT( addSong() ), QKeySequence( "Ctrl+A" ) );
-	m_pPlaylistMenu->addAction( tr( "Add &current song to Playlist" ), this, SLOT( addCurrentSong() ), QKeySequence( "Ctrl+Alt+A" ) );
+	auto pActionAddSong = m_pPlaylistMenu->addAction(
+		tr( "Add song to Play&list" ), this, SLOT( addSong() ) );
+	pActionAddSong->setShortcut( QKeySequence( "Ctrl+A" ) );
+	auto pActionAddCurrent = m_pPlaylistMenu->addAction(
+		tr( "Add &current song to Playlist" ), this, SLOT( addCurrentSong() ) );
+	pActionAddCurrent->setShortcut( QKeySequence( "Ctrl+Alt+A" ) );
 	m_pPlaylistMenu->addSeparator();				// -----
-	m_pPlaylistMenu->addAction( tr( "&Remove selected song from Playlist" ), this, SLOT( removeFromList() ), QKeySequence::Delete );
-	m_pPlaylistMenu->addAction( tr( "&New Playlist" ), this, SLOT( clearPlaylist() ), QKeySequence( "Ctrl+N" ) );
+	auto pActionRemoveSong = m_pPlaylistMenu->addAction(
+		tr( "&Remove selected song from Playlist" ), this, SLOT( removeFromList() ) );
+	pActionRemoveSong->setShortcut( QKeySequence::Delete );
+	auto pActionNew = m_pPlaylistMenu->addAction(
+		tr( "&New Playlist" ), this, SLOT( clearPlaylist() ) );
+	pActionNew->setShortcut( QKeySequence( "Ctrl+N" ) );
 	m_pPlaylistMenu->addSeparator();
-	m_pPlaylistMenu->addAction( tr( "&Open Playlist" ), this, SLOT( loadList() ), QKeySequence( "Ctrl+O" ) );
+	auto pActionOpen = m_pPlaylistMenu->addAction(
+		tr( "&Open Playlist" ), this, SLOT( loadList() ) );
+	pActionOpen->setShortcut( QKeySequence( "Ctrl+O" ) );
 	m_pPlaylistMenu->addSeparator();
-	m_pPlaylistMenu->addAction( tr( "&Save Playlist" ), this, SLOT( saveList() ), QKeySequence( "Ctrl+S" ) );
-	m_pPlaylistMenu->addAction( tr( "Save Playlist &as" ), this, SLOT( saveListAs() ), QKeySequence( "Ctrl+Shift+S" ) );
+	auto pActionSave = m_pPlaylistMenu->addAction(
+		tr( "&Save Playlist" ), this, SLOT( saveList() ) );
+	pActionSave->setShortcut( QKeySequence( "Ctrl+S" ) );
+	auto pActionSaveAs = m_pPlaylistMenu->addAction(
+		tr( "Save Playlist &as" ), this, SLOT( saveListAs() ) );
+	pActionSaveAs->setShortcut( QKeySequence( "Ctrl+Shift+S" ) );
 	m_pPlaylistMenu->setFont( font );
 
 #ifdef WIN32
@@ -103,12 +117,12 @@ PlaylistDialog::PlaylistDialog ( QWidget* pParent )
 	// Script menu
 	m_pScriptMenu = m_pMenubar->addMenu( tr( "&Scripts" ) );
 
-	m_pScriptMenu->addAction( tr( "&Add Script to selected song" ), this, SLOT( loadScript() ), QKeySequence( "" ) );
-	m_pScriptMenu->addAction( tr( "&Edit selected Script" ), this, SLOT( editScript() ), QKeySequence( "" ) );
+	m_pScriptMenu->addAction( tr( "&Add Script to selected song" ), this, SLOT( loadScript() ) );
+	m_pScriptMenu->addAction( tr( "&Edit selected Script" ), this, SLOT( editScript() ) );
 	m_pScriptMenu->addSeparator();
-	m_pScriptMenu->addAction( tr( "&Remove selected Script" ), this, SLOT( removeScript() ), QKeySequence( "" ) );
+	m_pScriptMenu->addAction( tr( "&Remove selected Script" ), this, SLOT( removeScript() ) );
 	m_pScriptMenu->addSeparator();
-	m_pScriptMenu->addAction( tr( "&Create a new Script" ), this, SLOT( newScript() ), QKeySequence( "" ) );
+	m_pScriptMenu->addAction( tr( "&Create a new Script" ), this, SLOT( newScript() ) );
 	m_pScriptMenu->setFont( font );
 #endif
 

--- a/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistDialog.cpp
@@ -360,18 +360,17 @@ void PlaylistDialog::clearPlaylist()
 
 	if( IsModified ) {
 		auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-		switch(QMessageBox::information( this, "Hydrogen",
-										 tr("\nThe current playlist contains unsaved changes.\n"
-												"Do you want to discard the changes?\n"),
-										 pCommonStrings->getButtonDiscard(),
-										 pCommonStrings->getButtonCancel(),
-										 nullptr,      // Enter == button 0
-										 2 ) ) { // Escape == button 1
-		case 0: // Discard clicked or Alt+D pressed
+		switch(QMessageBox::information(
+				   this, "Hydrogen",
+				   tr("\nThe current playlist contains unsaved changes.\n"
+					  "Do you want to discard the changes?\n"),
+				   QMessageBox::Discard | QMessageBox::Cancel,
+				   QMessageBox::Cancel ) ) {
+		case QMessageBox::Discard:
 			// don't save but exit
 			DiscardChanges = true;
 			break;
-		case 1: // Cancel clicked or Alt+C pressed or Escape pressed
+		case QMessageBox::Cancel:
 			// don't exit
 			DiscardChanges = false;
 			break;

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -813,12 +813,11 @@ void PreferencesDialog::on_okBtn_clicked()
 	updateDriverPreferences();
 
 	if ( m_bNeedDriverRestart ) {
-		int res = QMessageBox::information( this, "Hydrogen",
-											tr( "Driver restart required.\n Restart driver?"),
-											pCommonStrings->getButtonOk(),
-											pCommonStrings->getButtonCancel(),
-											nullptr, 1 );
-		if ( res != 0 ) {
+		if ( QMessageBox::information(
+				 this, "Hydrogen",
+				 tr( "Driver restart required.\n Restart driver?"),
+				 QMessageBox::Ok | QMessageBox::Cancel,
+				 QMessageBox::Cancel ) == QMessageBox::Cancel ) {
 			// Don't save the Preferences and don't close the PreferencesDialog
 			return;
 		}
@@ -827,14 +826,12 @@ void PreferencesDialog::on_okBtn_clicked()
 	// Check whether the current audio driver is valid
 	if ( pHydrogen->getAudioOutput() == nullptr ||
 		 dynamic_cast<NullDriver*>(pHydrogen->getAudioOutput()) != nullptr ) {
-		int nRes = QMessageBox::warning( this, "Hydrogen",
-										 QString( "%1\n" )
-										 .arg( pCommonStrings->getAudioDriverNotPresent() )
-										 .append( tr( "Are you sure you want to proceed?" ) ),
-										 pCommonStrings->getButtonOk(),
-										 pCommonStrings->getButtonCancel(),
-										 nullptr, 1 );
-		if ( nRes != 0 ) {
+		if ( QMessageBox::warning(
+				 this, "Hydrogen", QString( "%1\n" )
+				 .arg( pCommonStrings->getAudioDriverNotPresent() )
+				 .append( tr( "Are you sure you want to proceed?" ) ),
+				 QMessageBox::Ok | QMessageBox::Cancel,
+				 QMessageBox::Cancel ) == QMessageBox::Cancel ) {
 			return;
 		}
 	}

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -2222,7 +2222,7 @@ void PreferencesDialog::importTheme() {
 		return;
 	}
 
-	QFileInfo fileInfo = fd.selectedFiles().first();
+	QFileInfo fileInfo( fd.selectedFiles().first() );
 	QString sSelectedPath = fileInfo.absoluteFilePath();
 	H2Core::Preferences::get_instance()->setLastImportThemeDirectory( fd.directory().absolutePath() );
 
@@ -2277,7 +2277,7 @@ void PreferencesDialog::exportTheme() {
 		return;
 	}
 
-	QFileInfo fileInfo = fd.selectedFiles().first();
+	QFileInfo fileInfo( fd.selectedFiles().first() );
 	QString sSelectedPath = fileInfo.absoluteFilePath();
 
 	if ( sSelectedPath.isEmpty() ||

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
@@ -141,7 +141,7 @@ void MainSampleWaveDisplay::paintEvent(QPaintEvent *ev)
 	QColor startColor = QColor( 32, 173, 0, 200 );
 	QColor endColor = QColor( 217, 68, 0, 200 );
 	QColor loopColor =  QColor( 93, 170, 254, 200 );
-	font.setWeight( 63 );
+	font.setWeight( QFont::Bold );
 	painter.setFont( font );
 //start frame pointer
 	set_paint_color(painter, startColor, m_SelectedSlider == START, m_SelectedSlider);

--- a/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/MainSampleWaveDisplay.cpp
@@ -20,14 +20,16 @@
  *
  */
 
+#include "MainSampleWaveDisplay.h"
+
 #include <core/Basics/Sample.h>
 #include <core/Basics/Song.h>
 #include <core/Basics/Instrument.h>
+#include "../Compatibility/MouseEvent.h"
 #include "HydrogenApp.h"
 #include "SampleEditor.h"
 using namespace H2Core;
 
-#include "MainSampleWaveDisplay.h"
 #include "../Skin.h"
 
 MainSampleWaveDisplay::MainSampleWaveDisplay(QWidget* pParent)
@@ -245,8 +247,12 @@ void MainSampleWaveDisplay::mousePressEvent(QMouseEvent *ev)
 void MainSampleWaveDisplay::testPosition( QMouseEvent *ev )
 {
 	assert(ev);
+
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 //startframepointer
-	int x = std::min(width() - 25, std::max(25, ev->x()));
+	int x = std::min(width() - 25,
+					 std::max(25, static_cast<int>(pEv->position().x())));
 
 	if  ( m_SelectedSlider == START ) {
 		m_nStartFramePosition = x;
@@ -296,13 +302,15 @@ void MainSampleWaveDisplay::chooseSlider(QMouseEvent * ev)
 {
 	assert(ev);
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	QPoint start = QPoint(m_nStartFramePosition, height());
 	QPoint end = QPoint(m_nEndFramePosition, height() / 2);
 	QPoint loop = QPoint(m_nLoopFramePosition, 0);
 
-	int ds = (ev->pos() - start).manhattanLength();
-	int de = (ev->pos() - end).manhattanLength();
-	int dl = (ev->pos() - loop).manhattanLength();
+	int ds = (pEv->position() - start).manhattanLength();
+	int de = (pEv->position() - end).manhattanLength();
+	int dl = (pEv->position() - loop).manhattanLength();
 	m_SelectedSlider = NONE;
 
 	if (ds <= de && ds <= dl) {

--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -158,15 +158,14 @@ void SampleEditor::closeEvent(QCloseEvent *event)
 {
 	if ( !m_bSampleEditorClean ) {
 		auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-		int err = QMessageBox::information( this, "Hydrogen",
-											pCommonStrings->getUnsavedChanges(),
-											pCommonStrings->getButtonOk(),
-											pCommonStrings->getButtonCancel(),
-											nullptr, 1 );
-		if ( err == 0 ) {
+		if ( QMessageBox::information(
+				 this, "Hydrogen", pCommonStrings->getUnsavedChanges(),
+				 QMessageBox::Ok | QMessageBox::Cancel,
+				 QMessageBox::Cancel ) == QMessageBox::Ok ) {
 			setClean();
 			accept();
-		} else {
+		}
+		else {
 			event->ignore();
 			return;
 		}
@@ -367,20 +366,18 @@ void SampleEditor::on_ClosePushButton_clicked()
 {
 	if ( !m_bSampleEditorClean ){
 		auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-		int err = QMessageBox::information( this, "Hydrogen",
-											pCommonStrings->getUnsavedChanges(),
-											pCommonStrings->getButtonOk(),
-											pCommonStrings->getButtonCancel(),
-											nullptr, 1 );
-		if ( err == 0 ){
+		if ( QMessageBox::information(
+				 this, "Hydrogen", pCommonStrings->getUnsavedChanges(),
+				 QMessageBox::Ok | QMessageBox::Cancel,
+				 QMessageBox::Cancel ) == QMessageBox::Ok ) {
 			setClean();
 			accept();
-		}else
-		{
+		}
+		else {
 			return;
 		}
-	}else
-	{
+	}
+	else {
 		accept();
 	}
 }
@@ -403,18 +400,11 @@ void SampleEditor::on_PrevChangesPushButton_clicked()
 bool SampleEditor::getCloseQuestion()
 {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	
-	bool close = false;
-	int err = QMessageBox::information( this, "Hydrogen", 
-										pCommonStrings->getUnsavedChanges(),
-										pCommonStrings->getButtonOk(),
-										pCommonStrings->getButtonCancel(),
-										nullptr, 1 );
-	if ( err == 0 ) {
-		close = true;
-	}
 
-	return close;
+	return QMessageBox::information(
+		this, "Hydrogen", pCommonStrings->getUnsavedChanges(),
+		QMessageBox::Ok | QMessageBox::Cancel,
+		QMessageBox::Cancel ) == QMessageBox::Ok;
 }
 
 

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include "TargetWaveDisplay.h"
+
 #include <core/Basics/Sample.h>
 #include <core/Basics/Song.h>
 #include <core/Basics/Instrument.h>
@@ -27,6 +29,7 @@
 
 #include <memory>
 
+#include "../Compatibility/MouseEvent.h"
 #include "HydrogenApp.h"
 #include "SampleEditor.h"
 
@@ -37,7 +40,6 @@ using namespace H2Core;
 
 #include <vector>
 #include <algorithm>
-#include "TargetWaveDisplay.h"
 #include "../Skin.h"
 
 static TargetWaveDisplay::EnvelopeEditMode getEnvelopeEditMode();
@@ -255,11 +257,13 @@ void TargetWaveDisplay::updateDisplay( std::shared_ptr<H2Core::InstrumentLayer> 
 
 void TargetWaveDisplay::updateMouseSelection(QMouseEvent *ev)
 {
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	m_EditMode = getEnvelopeEditMode();
 	const Sample::VelocityEnvelope & envelope = (m_EditMode == TargetWaveDisplay::VELOCITY) ? m_VelocityEnvelope : m_PanEnvelope;
 
-	m_nX = std::min(UI_WIDTH, std::max(0, ev->x()));
-	m_nY = std::min(UI_HEIGHT, std::max(0, ev->y()));
+	m_nX = std::min(UI_WIDTH, std::max(0, static_cast<int>(pEv->position().x())));
+	m_nY = std::min(UI_HEIGHT, std::max(0, static_cast<int>(pEv->position().y())));
 
 	if ( !(ev->buttons() & Qt::LeftButton) || m_nSelectedEnvelopePoint == -1) {
 		QPoint mousePoint(m_nX, m_nY);

--- a/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
+++ b/src/gui/src/SampleEditor/TargetWaveDisplay.cpp
@@ -139,9 +139,9 @@ void TargetWaveDisplay::paintEvent(QPaintEvent *ev)
 		painter.drawLine( x, RCenter, x, -m_pPeakData_Right[x +1] +RCenter  );
 	}
 
-	QFont Font;
-	Font.setWeight( 63 );
-	painter.setFont( Font );
+	QFont font;
+	font.setWeight( QFont::Bold );
+	painter.setFont( font );
 
 	painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 	painter.setPen( QPen( QColor( 255, 255, 255 ), 1, Qt::SolidLine ) );

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -2050,10 +2050,11 @@ void SongEditorPatternList::patternPopup_save()
 	QString sPath = Files::savePatternNew( pPattern->get_name(), pPattern,
 										   pSong, pHydrogen->getLastLoadedDrumkitName() );
 	if ( sPath.isEmpty() ) {
-		if ( QMessageBox::information( this, "Hydrogen", tr( "The pattern-file exists. \nOverwrite the existing pattern?"),
-									   pCommonStrings->getButtonOk(),
-									   pCommonStrings->getButtonCancel(),
-									   nullptr, 1 ) != 0 ) {
+		if ( QMessageBox::information(
+				 this, "Hydrogen",
+				 tr( "The pattern-file exists. \nOverwrite the existing pattern?"),
+				 QMessageBox::Ok | QMessageBox::Cancel,
+				 QMessageBox::Cancel ) != QMessageBox::Ok ) {
 			setRowSelection( RowSelection::None );
 			return;
 		}

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1100,7 +1100,11 @@ void SongEditor::scrolled( int nValue ) {
 	update();
 }
 
+#ifdef H2CORE_HAVE_QT6
 void SongEditor::enterEvent( QEnterEvent *ev ) {
+#else
+void SongEditor::enterEvent( QEvent *ev ) {
+#endif
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1100,7 +1100,7 @@ void SongEditor::scrolled( int nValue ) {
 	update();
 }
 
-void SongEditor::enterEvent( QEvent *ev ) {
+void SongEditor::enterEvent( QEnterEvent *ev ) {
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -201,7 +201,11 @@ class SongEditor : public QWidget
 		virtual void paintEvent(QPaintEvent *ev) override;
 		virtual void focusInEvent( QFocusEvent *ev ) override;
 	virtual void focusOutEvent( QFocusEvent *ev ) override;
+#ifdef H2CORE_HAVE_QT6
 		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 		virtual void leaveEvent( QEvent *ev ) override;
 		//! @}
 

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -201,7 +201,7 @@ class SongEditor : public QWidget
 		virtual void paintEvent(QPaintEvent *ev) override;
 		virtual void focusInEvent( QFocusEvent *ev ) override;
 	virtual void focusOutEvent( QFocusEvent *ev ) override;
-		virtual void enterEvent( QEvent *ev ) override;
+		virtual void enterEvent( QEnterEvent *ev ) override;
 		virtual void leaveEvent( QEvent *ev ) override;
 		//! @}
 
@@ -440,7 +440,6 @@ class SongEditorPositionRuler :  public QWidget, protected WidgetWithScalableFon
 		virtual void mouseReleaseEvent(QMouseEvent *ev) override;
 		virtual void paintEvent( QPaintEvent *ev ) override;
 
-	// virtual void enterEvent( QEvent* ev ) override;
 	virtual void leaveEvent( QEvent* ev ) override;
 	virtual bool event( QEvent* ev ) override;
 

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -685,15 +685,14 @@ void SongEditorPanel::downBtnClicked()
 void SongEditorPanel::clearSequence()
 {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	int res = QMessageBox::information( this, "Hydrogen",
-										tr( "Warning, this will erase your pattern sequence.\nAre you sure?"),
-										pCommonStrings->getButtonOk(),
-										pCommonStrings->getButtonCancel(),
-										nullptr, 1 );
-	if ( res == 1 ) {
+	if ( QMessageBox::information(
+			 this, "Hydrogen",
+			 tr( "Warning, this will erase your pattern sequence.\nAre you sure?"),
+			 QMessageBox::Ok | QMessageBox::Cancel,
+			 QMessageBox::Cancel ) == QMessageBox::Cancel ) {
 		return;
 	}
-	
+
 	QString filename = Filesystem::tmp_file_path( "SEQ.xml" );
 	SE_deletePatternSequenceAction *pAction = new SE_deletePatternSequenceAction( filename );
 	HydrogenApp *pH2App = HydrogenApp::get_instance();

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -272,7 +272,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	
 	QHBoxLayout *pHZoomLayout = new QHBoxLayout();
 	pHZoomLayout->setSpacing( 0 );
-	pHZoomLayout->setMargin( 0 );
+	pHZoomLayout->setContentsMargins( 0, 0, 0, 0 );
 	pHZoomLayout->addWidget( m_pViewPlaybackBtn );
 	pHZoomLayout->addWidget( m_pViewTimelineBtn );
 	pHZoomLayout->addWidget( m_pHScrollBar );
@@ -384,7 +384,7 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	// ok...let's build the layout
 	QGridLayout *pGridLayout = new QGridLayout();
 	pGridLayout->setSpacing( 0 );
-	pGridLayout->setMargin( 0 );
+	pGridLayout->setContentsMargins( 0, 0, 0, 0 );
 
 	pGridLayout->addWidget( pBackPanel, 0, 0 );
 	pGridLayout->addWidget( m_pWidgetStack, 0, 1 );

--- a/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanelBpmWidget.cpp
@@ -100,12 +100,12 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 	// In case the input text can not be parsed by Qt `fNewBpm' is 0
 	// and also covered by the warning below.
 	if ( fNewBpm > MAX_BPM || fNewBpm < MIN_BPM ){
-		QMessageBox::warning( this, "Hydrogen",
-							  QString( tr( "Please enter a number within the range of " )
-									   .append( QString( "[%1,%2]" )
-												.arg( MIN_BPM )
-												.arg( MAX_BPM ) ) ),
-							  pCommonStrings->getButtonCancel() );
+		QMessageBox::warning(
+			this, "Hydrogen",
+			QString( tr( "Please enter a number within the range of " )
+					 .append( QString( "[%1,%2]" ).arg( MIN_BPM )
+							  .arg( MAX_BPM ) ) ),
+			QMessageBox::Cancel, QMessageBox::Cancel );
 		return;
 	}
 
@@ -113,9 +113,10 @@ void SongEditorPanelBpmWidget::on_okBtn_clicked()
 	int nNewColumn = columnSpinBox->text().toInt() - 1;
 	if ( ! ( m_bTempoMarkerPresent && nNewColumn == m_nColumn ) &&
 		 pTimeline->hasColumnTempoMarker( nNewColumn ) ) {
-		QMessageBox::warning( this, "Hydrogen",
-							  QString( tr( "There is already a tempo marker present at this Column. Please use left-click to edit it instead." ) ),
-							  pCommonStrings->getButtonCancel() );
+		QMessageBox::warning(
+			this, "Hydrogen",
+			QString( tr( "There is already a tempo marker present at this Column. Please use left-click to edit it instead." ) ),
+			QMessageBox::Cancel, QMessageBox::Cancel );
 		return;
 	}
 	

--- a/src/gui/src/SoundLibrary/FileBrowser.cpp
+++ b/src/gui/src/SoundLibrary/FileBrowser.cpp
@@ -46,7 +46,7 @@ FileBrowser::FileBrowser( QWidget* pParent )
 	QWidget *pDirectoryPanel = new QWidget( nullptr );
 	QHBoxLayout *hbox = new QHBoxLayout();
 	hbox->setSpacing( 0 );
-	hbox->setMargin( 0 );
+	hbox->setContentsMargins( 0, 0, 0, 0 );
 	hbox->addWidget( m_pDirectoryLabel );
 	hbox->addWidget( m_pUpBtn );
 	pDirectoryPanel->setLayout( hbox );
@@ -71,7 +71,7 @@ FileBrowser::FileBrowser( QWidget* pParent )
 	// LAYOUT
 	QVBoxLayout *vbox = new QVBoxLayout();
 	vbox->setSpacing( 0 );
-	vbox->setMargin( 0 );
+	vbox->setContentsMargins( 0, 0, 0, 0 );
 
 	vbox->addWidget( pDirectoryPanel );
 	vbox->addWidget( m_pDirList );

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -20,10 +20,6 @@
  *
  */
 
-#ifndef H2CORE_HAVE_QT6
-  #include <QTextCodec>
-#endif
-
 #include "SoundLibraryExportDialog.h"
 #include "../HydrogenApp.h"
 #include "../CommonStrings.h"
@@ -32,6 +28,10 @@
 #include <core/Helpers/Filesystem.h>
 #include <core/Preferences/Preferences.h>
 #include <core/Basics/DrumkitComponent.h>
+
+#ifndef H2CORE_HAVE_QT6
+  #include <QTextCodec>
+#endif
 
 using namespace H2Core;
 

--- a/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryExportDialog.cpp
@@ -115,10 +115,6 @@ void SoundLibraryExportDialog::on_exportBtn_clicked()
 						.arg( sTargetName ) );
 
 		msgBox.setStandardButtons( QMessageBox::Ok | QMessageBox::Cancel );
-		msgBox.setButtonText(QMessageBox::Ok,
-							 pCommonStrings->getButtonOk() );
-		msgBox.setButtonText(QMessageBox::Cancel,
-							 pCommonStrings->getButtonCancel());
 		msgBox.setDefaultButton(QMessageBox::Ok);
 
 		if ( msgBox.exec() == QMessageBox::Cancel ) {

--- a/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryOpenDialog.cpp
@@ -37,7 +37,7 @@ SoundLibraryOpenDialog::SoundLibraryOpenDialog( QWidget* pParent )
 
 	QVBoxLayout *pVBox = new QVBoxLayout();
 	pVBox->setSpacing( 6 );
-	pVBox->setMargin( 9 );
+	pVBox->setContentsMargins( 9, 9, 9, 9 );
 
 
 	// Sound Library Panel

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -597,11 +597,6 @@ void SoundLibraryPanel::on_drumkitLoadAction()
 
 			msgBox.setStandardButtons( QMessageBox::Save | QMessageBox::Discard |
 									   QMessageBox::Cancel );
-			msgBox.setButtonText(QMessageBox::Save, tr("Keep"));
-			msgBox.setButtonText(QMessageBox::Discard,
-								 pCommonStrings->getButtonDiscard() );
-			msgBox.setButtonText(QMessageBox::Cancel,
-								 pCommonStrings->getButtonCancel());
 			msgBox.setDefaultButton(QMessageBox::Cancel);
 			
 			switch ( msgBox.exec() )
@@ -753,12 +748,11 @@ void SoundLibraryPanel::on_drumkitDeleteAction()
 		return;
 	}
 
-	int res = QMessageBox::warning( this, "Hydrogen",
-									tr( "Warning, the \"%1\" drumkit will be deleted from disk.\nAre you sure?").arg(sDrumkitName),
-									pCommonStrings->getButtonOk(),
-									pCommonStrings->getButtonCancel(),
-									nullptr, 1 );
-	if ( res == 1 ) {
+	if ( QMessageBox::warning(
+			 this, "Hydrogen",
+			 tr( "Warning, the \"%1\" drumkit will be deleted from disk.\nAre you sure?").arg(sDrumkitName),
+			 QMessageBox::Ok | QMessageBox::Cancel,
+			 QMessageBox::Cancel ) == QMessageBox::Cancel ) {
 		return;
 	}
 
@@ -834,12 +828,11 @@ void SoundLibraryPanel::on_patternDeleteAction()
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	QString patternPath = __sound_library_tree->currentItem()->text( 1 );
 
-	int res = QMessageBox::information( this, "Hydrogen",
-										tr( "Warning, the selected pattern will be deleted from disk.\nAre you sure?"),
-										pCommonStrings->getButtonOk(),
-										pCommonStrings->getButtonCancel(),
-										nullptr, 1 );
-	if ( res == 1 ) {
+	if ( QMessageBox::information(
+			 this, "Hydrogen",
+			 tr( "Warning, the selected pattern will be deleted from disk.\nAre you sure?"),
+			 QMessageBox::Ok | QMessageBox::Cancel,
+			 QMessageBox::Cancel ) == QMessageBox::Cancel ) {
 		return;
 	}
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -116,7 +116,7 @@ SoundLibraryPanel::SoundLibraryPanel( QWidget *pParent, bool bInItsOwnDialog )
 	// LAYOUT
 	QVBoxLayout *pVBox = new QVBoxLayout();
 	pVBox->setSpacing( 0 );
-	pVBox->setMargin( 0 );
+	pVBox->setContentsMargins( 0, 0, 0, 0 );
 
 	pVBox->addWidget( __sound_library_tree );
 	

--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -21,6 +21,8 @@
  */
 
 #include "AutomationPathView.h"
+
+#include "../Compatibility/MouseEvent.h"
 #include "../SongEditor/SongEditor.h"
 #include "../SongEditor/SongEditorPanel.h"
 #include "../HydrogenApp.h"
@@ -134,9 +136,11 @@ QPoint AutomationPathView::translatePoint(const std::pair<float,float> &p) const
  */
 bool AutomationPathView::checkBounds(QMouseEvent *event) const
 {
-	return event->x() > SongEditor::nMargin
-		&& event->y() > m_nMarginHeight
-		&& event->y() < height()-m_nMarginHeight;
+	auto pEv = static_cast<MouseEvent*>( event );
+
+	return pEv->position().x() > SongEditor::nMargin
+		&& pEv->position().y() > m_nMarginHeight
+		&& pEv->position().y() < height()-m_nMarginHeight;
 }
 
 
@@ -147,8 +151,11 @@ std::pair<const float, float> AutomationPathView::locate(QMouseEvent *event) con
 {
 	int contentHeight = height() - 2* m_nMarginHeight;
 
-	float x = (event->x() - SongEditor::nMargin) / (float)m_nGridWidth;
-	float y = ((contentHeight-event->y()+m_nMarginHeight)/(float)contentHeight)
+	auto pEv = static_cast<MouseEvent*>( event );
+
+	float x = (pEv->position().x() - SongEditor::nMargin) / (float)m_nGridWidth;
+	float y = ((contentHeight - pEv->position().y() + m_nMarginHeight)/
+			   (float)contentHeight)
 		* (_path->get_max() - _path->get_min()) + _path->get_min();
 
 	return std::pair<const float,float>(x,y);

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -102,7 +102,11 @@ void ClickableLabel::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void ClickableLabel::enterEvent( QEnterEvent* ev ) {
+#ifdef H2CORE_HAVE_QT6
+void ClickableLabel::enterEvent( QEnterEvent *ev ) {
+#else
+void ClickableLabel::enterEvent( QEvent *ev ) {
+#endif
 	QLabel::enterEvent( ev );
 	if ( m_bIsEditable ) {
 		m_bEntered = true;

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -102,7 +102,7 @@ void ClickableLabel::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void ClickableLabel::enterEvent( QEvent* ev ) {
+void ClickableLabel::enterEvent( QEnterEvent* ev ) {
 	QLabel::enterEvent( ev );
 	if ( m_bIsEditable ) {
 		m_bEntered = true;

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -67,7 +67,7 @@ private:
 	void updateFont( QString sFontFamily, H2Core::FontTheme::FontSize fontSize );
 
 	virtual void mousePressEvent( QMouseEvent * e ) override;
-	virtual void enterEvent( QEvent * e ) override;
+	virtual void enterEvent( QEnterEvent * e ) override;
 	virtual void leaveEvent( QEvent * e ) override;
 	virtual void paintEvent( QPaintEvent * e ) override;
 	QSize m_size;

--- a/src/gui/src/Widgets/ClickableLabel.h
+++ b/src/gui/src/Widgets/ClickableLabel.h
@@ -67,7 +67,11 @@ private:
 	void updateFont( QString sFontFamily, H2Core::FontTheme::FontSize fontSize );
 
 	virtual void mousePressEvent( QMouseEvent * e ) override;
-	virtual void enterEvent( QEnterEvent * e ) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent * e ) override;
 	virtual void paintEvent( QPaintEvent * e ) override;
 	QSize m_size;

--- a/src/gui/src/Widgets/ColorSelectionButton.cpp
+++ b/src/gui/src/Widgets/ColorSelectionButton.cpp
@@ -56,7 +56,7 @@ void ColorSelectionButton::mousePressEvent(QMouseEvent*ev) {
 	}
 }
 
-void ColorSelectionButton::enterEvent(QEvent *ev) {
+void ColorSelectionButton::enterEvent(QEnterEvent *ev) {
 	UNUSED( ev );
 	m_bMouseOver = true;
 	update();

--- a/src/gui/src/Widgets/ColorSelectionButton.cpp
+++ b/src/gui/src/Widgets/ColorSelectionButton.cpp
@@ -56,7 +56,11 @@ void ColorSelectionButton::mousePressEvent(QMouseEvent*ev) {
 	}
 }
 
-void ColorSelectionButton::enterEvent(QEnterEvent *ev) {
+#ifdef H2CORE_HAVE_QT6
+void ColorSelectionButton::enterEvent( QEnterEvent *ev ) {
+#else
+void ColorSelectionButton::enterEvent( QEvent *ev ) {
+#endif
 	UNUSED( ev );
 	m_bMouseOver = true;
 	update();

--- a/src/gui/src/Widgets/ColorSelectionButton.h
+++ b/src/gui/src/Widgets/ColorSelectionButton.h
@@ -56,7 +56,7 @@ private:
 	bool m_bMouseOver;
 
 	virtual void mousePressEvent(QMouseEvent *ev) override;
-	virtual void enterEvent(QEvent *ev) override;
+	virtual void enterEvent(QEnterEvent *ev) override;
 	virtual void leaveEvent(QEvent *ev) override;
 	virtual void paintEvent( QPaintEvent* ev) override;
 

--- a/src/gui/src/Widgets/ColorSelectionButton.h
+++ b/src/gui/src/Widgets/ColorSelectionButton.h
@@ -56,7 +56,11 @@ private:
 	bool m_bMouseOver;
 
 	virtual void mousePressEvent(QMouseEvent *ev) override;
-	virtual void enterEvent(QEnterEvent *ev) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent(QEvent *ev) override;
 	virtual void paintEvent( QPaintEvent* ev) override;
 

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -20,11 +20,12 @@
  *
  */
 
+#include "Fader.h"
 
+#include "../Compatibility/MouseEvent.h"
 #include "../Skin.h"
 #include "../HydrogenApp.h"
 #include "../MainForm.h"
-#include "Fader.h"
 #include "MidiSenseWidget.h"
 
 #include <QtGui>
@@ -124,11 +125,14 @@ void Fader::mouseMoveEvent( QMouseEvent *ev )
 		return;
 	}
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	float fValue;
 	if ( m_type == Type::Vertical ) {
-		fValue = static_cast<float>( ev->x() ) / static_cast<float>( width() );
+		fValue = static_cast<float>( pEv->position().x() ) / static_cast<float>( width() );
 	} else {
-		fValue = static_cast<float>( height() - ev->y() ) / static_cast<float>( height() );
+		fValue = static_cast<float>( height() - pEv->position().y() ) /
+			static_cast<float>( height() );
 	}
 	if ( fValue > 1. ) { // for QToolTip text validity
 		fValue = 1.;
@@ -139,7 +143,8 @@ void Fader::mouseMoveEvent( QMouseEvent *ev )
 	fValue = fValue * ( m_fMax - m_fMin ) + m_fMin;
 
 	setValue( fValue, true );
-	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
+	QToolTip::showText( pEv->globalPosition().toPoint(),
+						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
 
@@ -148,6 +153,8 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 	if ( ! m_bIsActive ) {
 		return;
 	}
+
+	auto pEv = static_cast<MouseEvent*>( ev );
 	
 	if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
@@ -162,11 +169,12 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 		setCursor( QCursor( Qt::SizeVerCursor ) );
 
 		m_fMousePressValue = m_fValue;
-		m_fMousePressY = ev->y();
+		m_fMousePressY = pEv->position().y();
 		mouseMoveEvent( ev );
 	}
 	
-	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
+	QToolTip::showText( pEv->globalPosition().toPoint(),
+						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
 void Fader::paintEvent( QPaintEvent *ev)

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -161,7 +161,7 @@ void LCDCombo::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void LCDCombo::enterEvent( QEvent* ev ) {
+void LCDCombo::enterEvent( QEnterEvent* ev ) {
 	QComboBox::enterEvent( ev );
 	m_bEntered = true;
 }

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -161,7 +161,11 @@ void LCDCombo::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void LCDCombo::enterEvent( QEnterEvent* ev ) {
+#ifdef H2CORE_HAVE_QT6
+void LCDCombo::enterEvent( QEnterEvent *ev ) {
+#else
+void LCDCombo::enterEvent( QEvent *ev ) {
+#endif
 	QComboBox::enterEvent( ev );
 	m_bEntered = true;
 }

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -71,7 +71,11 @@ private:
 	int m_nMaxWidth;
 		
 	virtual void paintEvent( QPaintEvent *ev ) override;
-	virtual void enterEvent( QEnterEvent *ev ) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent *ev ) override;
 };
 inline void LCDCombo::setModifyOnChange( bool bModifyOnChange ) {

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -71,7 +71,7 @@ private:
 	int m_nMaxWidth;
 		
 	virtual void paintEvent( QPaintEvent *ev ) override;
-	virtual void enterEvent( QEvent *ev ) override;
+	virtual void enterEvent( QEnterEvent *ev ) override;
 	virtual void leaveEvent( QEvent *ev ) override;
 };
 inline void LCDCombo::setModifyOnChange( bool bModifyOnChange ) {

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -369,7 +369,11 @@ void LCDSpinBox::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void LCDSpinBox::enterEvent( QEnterEvent* ev ) {
+#ifdef H2CORE_HAVE_QT6
+void LCDSpinBox::enterEvent( QEnterEvent *ev ) {
+#else
+void LCDSpinBox::enterEvent( QEvent *ev ) {
+#endif
 	QDoubleSpinBox::enterEvent( ev );
 	m_bEntered = true;
 }

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -369,7 +369,7 @@ void LCDSpinBox::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void LCDSpinBox::enterEvent( QEvent* ev ) {
+void LCDSpinBox::enterEvent( QEnterEvent* ev ) {
 	QDoubleSpinBox::enterEvent( ev );
 	m_bEntered = true;
 }

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -118,7 +118,7 @@ private:
 	virtual QString textFromValue( double fValue ) const override;
 	virtual double valueFromText( const QString& sText ) const override;	
 	virtual void paintEvent( QPaintEvent *ev ) override;
-	virtual void enterEvent( QEvent *ev ) override;
+	virtual void enterEvent( QEnterEvent *ev ) override;
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void wheelEvent( QWheelEvent *ev ) override;
 	virtual void keyPressEvent( QKeyEvent *ev ) override;

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -118,7 +118,11 @@ private:
 	virtual QString textFromValue( double fValue ) const override;
 	virtual double valueFromText( const QString& sText ) const override;	
 	virtual void paintEvent( QPaintEvent *ev ) override;
-	virtual void enterEvent( QEnterEvent *ev ) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void wheelEvent( QWheelEvent *ev ) override;
 	virtual void keyPressEvent( QKeyEvent *ev ) override;

--- a/src/gui/src/Widgets/StatusMessageDisplay.cpp
+++ b/src/gui/src/Widgets/StatusMessageDisplay.cpp
@@ -113,7 +113,7 @@ void StatusMessageDisplay::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void StatusMessageDisplay::enterEvent( QEvent* ev ) {
+void StatusMessageDisplay::enterEvent( QEnterEvent* ev ) {
 	LCDDisplay::enterEvent( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/Widgets/StatusMessageDisplay.cpp
+++ b/src/gui/src/Widgets/StatusMessageDisplay.cpp
@@ -22,6 +22,8 @@
  */
 
 #include "StatusMessageDisplay.h"
+
+#include "../Compatibility/MouseEvent.h"
 #include "../HydrogenApp.h"
 
 #include <core/Preferences/Preferences.h>
@@ -136,7 +138,9 @@ void StatusMessageDisplay::mousePressEvent( QMouseEvent* ev ) {
 		messageMenu->addAction( sMessage );
 	}
 
-	messageMenu->popup( ev->globalPos() );
+	auto pEv = static_cast<MouseEvent*>( ev );
+
+	messageMenu->popup( pEv->globalPosition().toPoint() );
 }
 
 void StatusMessageDisplay::showMessage( const QString& sMessage, const QString& sCaller ) {

--- a/src/gui/src/Widgets/StatusMessageDisplay.cpp
+++ b/src/gui/src/Widgets/StatusMessageDisplay.cpp
@@ -113,7 +113,11 @@ void StatusMessageDisplay::paintEvent( QPaintEvent *ev ) {
 	}
 }
 
-void StatusMessageDisplay::enterEvent( QEnterEvent* ev ) {
+#ifdef H2CORE_HAVE_QT6
+void StatusMessageDisplay::enterEvent( QEnterEvent *ev ) {
+#else
+void StatusMessageDisplay::enterEvent( QEvent *ev ) {
+#endif
 	LCDDisplay::enterEvent( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/Widgets/StatusMessageDisplay.h
+++ b/src/gui/src/Widgets/StatusMessageDisplay.h
@@ -83,7 +83,11 @@ private:
 	bool m_bEntered;
 		
 	virtual void paintEvent( QPaintEvent *ev ) override;
-	virtual void enterEvent( QEnterEvent *ev ) override;
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void mousePressEvent( QMouseEvent* ev ) override;
 };

--- a/src/gui/src/Widgets/StatusMessageDisplay.h
+++ b/src/gui/src/Widgets/StatusMessageDisplay.h
@@ -83,7 +83,7 @@ private:
 	bool m_bEntered;
 		
 	virtual void paintEvent( QPaintEvent *ev ) override;
-	virtual void enterEvent( QEvent *ev ) override;
+	virtual void enterEvent( QEnterEvent *ev ) override;
 	virtual void leaveEvent( QEvent *ev ) override;
 	virtual void mousePressEvent( QMouseEvent* ev ) override;
 };

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -20,6 +20,9 @@
  *
  */
 #include "WidgetWithInput.h"
+
+#include "../Compatibility/MouseEvent.h"
+#include "../Compatibility/WheelEvent.h"
 #include "../CommonStrings.h"
 #include "../HydrogenApp.h"
 #include "MidiSenseWidget.h"
@@ -156,6 +159,8 @@ void WidgetWithInput::mousePressEvent(QMouseEvent *ev)
 	if ( ! m_bIsActive ) {
 		return;
 	}
+
+	auto pEv = static_cast<MouseEvent*>( ev );
 	
 	if ( ev->button() == Qt::LeftButton && ev->modifiers() == Qt::ControlModifier ) {
 		resetValueToDefault();
@@ -171,10 +176,11 @@ void WidgetWithInput::mousePressEvent(QMouseEvent *ev)
 		setCursor( QCursor( Qt::SizeVerCursor ) );
 
 		m_fMousePressValue = m_fValue;
-		m_fMousePressY = ev->y();
+		m_fMousePressY = pEv->position().y();
 	}
 	
-	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
+	QToolTip::showText( pEv->globalPosition().toPoint(),
+						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
 void WidgetWithInput::mouseReleaseEvent( QMouseEvent *ev )
@@ -198,6 +204,8 @@ void WidgetWithInput::wheelEvent ( QWheelEvent *ev )
 		return;
 	}
 
+	auto pEv = static_cast<WheelEvent*>( ev );
+
 	float fStepFactor;
 	float fDelta = 1.0;
 
@@ -217,12 +225,7 @@ void WidgetWithInput::wheelEvent ( QWheelEvent *ev )
 
 	setValue( getValue() + ( fDelta * fStepFactor ), true );
 	
-	QToolTip::showText(
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 14, 0 )
-					    ev->globalPosition().toPoint(),
-#else
-					    ev->globalPos(),
-#endif
+	QToolTip::showText( pEv->globalPosition().toPoint(),
 						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
@@ -237,6 +240,8 @@ void WidgetWithInput::mouseMoveEvent( QMouseEvent *ev )
 
 	float fStepFactor;
 
+	auto pEv = static_cast<MouseEvent*>( ev );
+
 	if ( ev->modifiers() == Qt::ControlModifier ) {
 		fStepFactor = m_nScrollSpeedFast;
 	} else {
@@ -245,12 +250,13 @@ void WidgetWithInput::mouseMoveEvent( QMouseEvent *ev )
 
 	float fRange = m_fMax - m_fMin;
 
-	float fDeltaY = ev->y() - m_fMousePressY;
+	float fDeltaY = pEv->position().y() - m_fMousePressY;
 	float fNewValue = ( m_fMousePressValue - fStepFactor * ( fDeltaY / 100.0 * fRange ) );
 
 	setValue( fNewValue, true );
 
-	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
+	QToolTip::showText( pEv->globalPosition().toPoint(),
+						QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
 #ifdef H2CORE_HAVE_QT6

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -253,7 +253,7 @@ void WidgetWithInput::mouseMoveEvent( QMouseEvent *ev )
 	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
-void WidgetWithInput::enterEvent( QEvent *ev ) {
+void WidgetWithInput::enterEvent( QEnterEvent *ev ) {
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -253,7 +253,11 @@ void WidgetWithInput::mouseMoveEvent( QMouseEvent *ev )
 	QToolTip::showText( ev->globalPos(), QString( "%1" ).arg( m_fValue, 0, 'f', 2 ) , this );
 }
 
+#ifdef H2CORE_HAVE_QT6
 void WidgetWithInput::enterEvent( QEnterEvent *ev ) {
+#else
+void WidgetWithInput::enterEvent( QEvent *ev ) {
+#endif
 	UNUSED( ev );
 	m_bEntered = true;
 	update();

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -99,7 +99,7 @@ protected:
 	virtual void mouseReleaseEvent( QMouseEvent *ev );
 	virtual void mouseMoveEvent(QMouseEvent *ev);
 	virtual void wheelEvent( QWheelEvent *ev );
-	virtual void enterEvent( QEvent *ev );
+	virtual void enterEvent( QEnterEvent *ev );
 	virtual void leaveEvent( QEvent *ev );
 	virtual void keyPressEvent( QKeyEvent *ev );
 

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -99,7 +99,11 @@ protected:
 	virtual void mouseReleaseEvent( QMouseEvent *ev );
 	virtual void mouseMoveEvent(QMouseEvent *ev);
 	virtual void wheelEvent( QWheelEvent *ev );
-	virtual void enterEvent( QEnterEvent *ev );
+#ifdef H2CORE_HAVE_QT6
+		virtual void enterEvent( QEnterEvent *ev ) override;
+#else
+		virtual void enterEvent( QEvent *ev ) override;
+#endif
 	virtual void leaveEvent( QEvent *ev );
 	virtual void keyPressEvent( QKeyEvent *ev );
 

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -20,6 +20,11 @@
  *
  */
 
+#include <core/config.h>
+#include <core/Version.h>
+#include <core/Preferences/Theme.h>
+#include <getopt.h>
+
 #include <QtGui>
 #include <QtWidgets>
 #include <QLibraryInfo>
@@ -29,11 +34,6 @@
 #ifndef H2CORE_HAVE_QT6
   #include <QTextCodec>
 #endif
-
-#include <core/config.h>
-#include <core/Version.h>
-#include <core/Preferences/Theme.h>
-#include <getopt.h>
 
 #include "ShotList.h"
 #include "SplashScreen.h"

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -213,9 +213,11 @@ int main(int argc, char *argv[])
 #endif
 	Reporter::spawn( argc, argv );
 	try {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
+#ifndef H2CORE_HAVE_QT6
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
 		QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 		QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+  #endif
 #endif
 		// Create bootstrap QApplication to get H2 Core set up with correct Filesystem paths before starting GUI application.
 		QCoreApplication *pBootStrApp = new QCoreApplication( argc, argv );

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -337,7 +337,11 @@ int main(int argc, char *argv[])
 			}
 			languages << locale.uiLanguages();
 			if ( H2Core::Translations::loadTranslation( languages, qttor, QString( "qt" ),
+#ifdef H2CORE_HAVE_QT6
+														QLibraryInfo::path(QLibraryInfo::TranslationsPath) ) ) {
+#else
 														QLibraryInfo::location(QLibraryInfo::TranslationsPath) ) ) {
+#endif
 				pQApp->installTranslator( &qttor );
 			} else {
 				___INFOLOG( QString("Warning: No Qt translation for locale %1 found.").arg(locale.name()));

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -250,10 +250,12 @@ int main(int argc, char *argv[])
 		// See below for H2Core::Hydrogen.
 
 		___INFOLOG( QString("Using QT version ") + QString( qVersion() ) );
-#ifndef H2CORE_HAVE_QT6
-		___INFOLOG( QString( "System encoding: [%1]" )
-					.arg( QString( QTextCodec::codecForLocale()->name() ) ) );
+#ifdef H2CORE_HAVE_QT6
+		const QString sEncoding = QLocale::system().name();
+#else
+		const QString sEncoding = QTextCodec::codecForLocale()->name();
 #endif
+		___INFOLOG( QString( "System encoding: [%1]" ).arg( sEncoding ) );
 		___INFOLOG( "Using data path: " + H2Core::Filesystem::sys_data_path() );
 
 		H2Core::Preferences *pPref = H2Core::Preferences::get_instance();


### PR DESCRIPTION
Various fixes and tweaks to allow building our source code using both Qt5 and Qt6 without `gcc` compiler warnings (when using the options defined in our `build.sh` script).

Most notably, `QMouseEvent`, `QDropEvent`, and `QWheelEvent` have been wrapped in classes called `MouseEvent`, `DropEvent`, and `WheelEvent`. They provide a consistent API for all Qt versions we support and allow us to write source code without countless `#ifdef`s or compiler warnings. The idea is to drop these classes when dropping the Qt5 support at some point in the future.

Implements #2144.