### PR TITLE
Add `--user-data` CLI option and fix unit test issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tests/jackTearDown/h2cli.log
 tests/jackTimebase/jackTimebase
 tests/jackTimebase/hydrogen.log
 tests/jackTimebase/test*.log
+test.log
 
 # Ignore cache folder of clangd used in LSP editor support.
 .cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 - CLI options `--log-colors` and `--no-log-colors` to enable and disable ANSI
   colors in log messages.
+- CLI option `--user-data` for both `hydrogen` and `h2cli` to provide an
+  alternative user-level data folder.
+- CMake option `-DWANT_QT6` to build Hydrogen using Qt6 instead of Qt5.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable changes to this project will be documented in this file.
   colors in log messages.
 - CLI option `--user-data` for both `hydrogen` and `h2cli` to provide an
   alternative user-level data folder.
-- CMake option `-DWANT_QT6` to build Hydrogen using Qt6 instead of Qt5.
 
 ### Changed
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -180,9 +180,12 @@ int main(int argc, char *argv[])
 		QCommandLineOption systemDataPathOption(
 			QStringList() << "P" << "data",
 			"Use an alternate system data path", "Path" );
+		QCommandLineOption userDataPathOption(
+			QStringList() << "user-data", "Use an alternate user data path",
+			"Path" );
 		QCommandLineOption configFileOption(
 			QStringList() << "config", "Use an alternate config file", "Path" );
-	QCommandLineOption kitOption(
+		QCommandLineOption kitOption(
 			QStringList() << "k" << "kit",
 			"Load a drumkit at startup", "DrumkitName" );
 		QCommandLineOption verboseOption(
@@ -205,6 +208,7 @@ int main(int argc, char *argv[])
 		parser.addOption( playlistFileNameOption );
 		parser.addOption( outputFileOption );
 		parser.addOption( systemDataPathOption );
+		parser.addOption( userDataPathOption );
 		parser.addOption( configFileOption );
 		parser.addOption( rateOption );
 		parser.addOption( bitsOption );
@@ -232,6 +236,7 @@ int main(int argc, char *argv[])
 		QString sSongFilename = parser.value( songFileOption );
 		const QString sPlaylistFilename = parser.value( playlistFileNameOption );
 		const QString sSysDataPath = parser.value( systemDataPathOption );
+		const QString sUsrDataPath = parser.value( userDataPathOption );
 		const QString sConfigFilePath = parser.value( configFileOption );
 		const QString sOutFilename = parser.value( outputFileOption );
 		const QString sSelectedDriver = parser.value( audioDriverOption );
@@ -302,7 +307,7 @@ int main(int argc, char *argv[])
 											sLogFile, true, bLogTimestamps );
 		Base::bootstrap( pLogger, pLogger->should_log( Logger::Debug ) );
 		H2Core::Filesystem::bootstrap(
-			pLogger, sSysDataPath, sConfigFilePath, sLogFile );
+			pLogger, sSysDataPath, sUsrDataPath, sConfigFilePath, sLogFile );
 		MidiMap::create_instance();
 		Preferences::create_instance();
 		Preferences* preferences = Preferences::get_instance();

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -211,6 +211,7 @@ Filesystem::AudioFormat Filesystem::AudioFormatFromSuffix( const QString& sPath,
 }
 
 bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
+							const QString& sUsrDataPath,
 							const QString& sUserConfigPath,
 							const QString& sLogFile )
 {
@@ -249,6 +250,12 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
 		INFOLOG( QString( "Using custom system data folder [%1]" )
 				 .arg( sSysDataPath ) );
 		__sys_data_path = sSysDataPath;
+	}
+
+	if ( ! sUsrDataPath.isEmpty() ) {
+		INFOLOG( QString( "Using custom user data folder [%1]" )
+				 .arg( sUsrDataPath ) );
+		__usr_data_path = sUsrDataPath;
 	}
 
 	if ( ! sUserConfigPath.isEmpty() ) {

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -250,12 +250,20 @@ bool Filesystem::bootstrap( Logger* logger, const QString& sSysDataPath,
 		INFOLOG( QString( "Using custom system data folder [%1]" )
 				 .arg( sSysDataPath ) );
 		__sys_data_path = sSysDataPath;
+		// Sanity check
+		if ( ! __sys_data_path.endsWith( QDir::separator() ) ) {
+			__sys_data_path.append( QDir::separator() );
+		}
 	}
 
 	if ( ! sUsrDataPath.isEmpty() ) {
 		INFOLOG( QString( "Using custom user data folder [%1]" )
 				 .arg( sUsrDataPath ) );
 		__usr_data_path = sUsrDataPath;
+		// Sanity check
+		if ( ! __usr_data_path.endsWith( QDir::separator() ) ) {
+			__usr_data_path.append( QDir::separator() );
+		}
 	}
 
 	if ( ! sUserConfigPath.isEmpty() ) {

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -129,15 +129,18 @@ namespace H2Core
 		/**
 		 * check user and system filesystem usability
 		 *
-		 * If either @a sSysDataPath, @a sLogFile, or @a sUserConfigFile are not
-		 * provided or empty, the corresponding default values will be used
+		 * If any argument is not provided or empty, the corresponding default
+		 * values will be used.
 		 *
 		 * \param logger is a pointer to the logger instance which will be used
 		 * \param sSysDataPath path to an alternate system data folder
+		 * \param sUsrDataPath path to an alternate user data folder
 		 * \param sUserConfigFile path to an alternate hydrogen.conf config file
 		 * \param sLogFile path to alternate log file
 		 */
-		static bool bootstrap( Logger* logger, const QString& sSysDataPath = "",
+		static bool bootstrap( Logger* logger,
+							   const QString& sSysDataPath = "",
+							   const QString& sUsrDataPath = "",
 							   const QString& sUserConfigFile = "",
 							   const QString& sLogFile = "" );
 

--- a/src/gui/src/Parser.cpp
+++ b/src/gui/src/Parser.cpp
@@ -92,6 +92,8 @@ bool Parser::parse( int argc, char* argv[] ) {
 	QCommandLineOption systemDataPathOption(
 		QStringList() << "P" <<
 		"data", "Use an alternate system data path", "Path" );
+	QCommandLineOption userDataPathOption(
+		QStringList() << "user-data", "Use an alternate user data path", "Path" );
 	QCommandLineOption configFileOption(
 		QStringList() << "config", "Use an alternate config file", "Path" );
 	QCommandLineOption uiLayoutOption(
@@ -128,6 +130,7 @@ bool Parser::parse( int argc, char* argv[] ) {
 	parser.addOption( noLogColorsOption );
 
 	parser.addOption( systemDataPathOption );
+	parser.addOption( userDataPathOption );
 	parser.addOption( configFileOption );
 	parser.addOption( uiLayoutOption );
 #ifdef H2CORE_HAVE_OSC
@@ -179,6 +182,7 @@ bool Parser::parse( int argc, char* argv[] ) {
 	}
 
 	m_sSysDataPath = parser.value( systemDataPathOption );
+	m_sUsrDataPath = parser.value( userDataPathOption );
 	m_sConfigFilePath = parser.value( configFileOption );
 	m_sUiLayout = parser.value( uiLayoutOption );
 	m_nOscPort = -1;

--- a/src/gui/src/Parser.h
+++ b/src/gui/src/Parser.h
@@ -73,6 +73,8 @@ class Parser {
 
 		const QString& getSysDataPath() const {
 			return m_sSysDataPath; }
+		const QString& getUsrDataPath() const {
+			return m_sUsrDataPath; }
 		const QString& getConfigFilePath() const {
 			return m_sConfigFilePath; }
 		const QString& getUiLayout() const {
@@ -102,6 +104,7 @@ class Parser {
 		bool     m_bLogColors;
 
 		QString  m_sSysDataPath;
+		QString  m_sUsrDataPath;
 		QString  m_sConfigFilePath;
 		QString  m_sUiLayout;
 		int      m_nOscPort;

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -240,8 +240,8 @@ int main(int argc, char *argv[])
 			pLogger, pLogger->should_log( H2Core::Logger::Debug ) );
 
 		H2Core::Filesystem::bootstrap(
-			pLogger, parser.getSysDataPath(), parser.getConfigFilePath(),
-			parser.getLogFile() );
+			pLogger, parser.getSysDataPath(), parser.getUsrDataPath(),
+			parser.getConfigFilePath(), parser.getLogFile() );
 		MidiMap::create_instance();
 		H2Core::Preferences::create_instance();
 		// See below for H2Core::Hydrogen.

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -60,7 +60,8 @@ void setupEnvironment(unsigned log_level, const QString& sLogFilePath )
 	/* Base */
 	H2Core::Base::bootstrap( pLogger, true );
 	/* Filesystem */
-	H2Core::Filesystem::bootstrap( pLogger, test_helper->getDataDir() );
+	H2Core::Filesystem::bootstrap(
+		pLogger, test_helper->getDataDir(), "", sLogFilePath );
 	H2Core::Filesystem::info();
 	
 	/* Use fake audio driver */
@@ -121,15 +122,16 @@ int main( int argc, char **argv)
 			sLogFilePath = fi.absoluteFilePath();
 		}
 	}
+	else {
+		sLogFilePath = QString( "%1%2test.log" )
+			.arg( QDir::currentPath() ).arg( QDir::separator() );
+	}
 	
-	unsigned logLevelOpt = H2Core::Logger::None;
-	if( parser.isSet(verboseOption) || parser.isSet( outputFileOption ) ){
-		if( !sVerbosityString.isEmpty() )
-		{
-			logLevelOpt =  H2Core::Logger::parse_log_level( sVerbosityString.toLocal8Bit() );
-		} else {
-			logLevelOpt = H2Core::Logger::Error|H2Core::Logger::Warning|H2Core::Logger::Info;
-		}
+	auto logLevelOpt = H2Core::Logger::Error | H2Core::Logger::Warning |
+		H2Core::Logger::Info | H2Core::Logger::Debug ;
+	if ( ! sVerbosityString.isEmpty() ) {
+		logLevelOpt =  H2Core::Logger::parse_log_level(
+			sVerbosityString.toLocal8Bit() );
 	}
 
 	setupEnvironment( logLevelOpt, sLogFilePath );

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -164,7 +164,6 @@ int main( int argc, char **argv)
 	// Ensure the log is written properly
 	auto pLogger = H2Core::Logger::get_instance();
 	pLogger->flush();
-	delete pLogger;
 
 	auto durationSeconds = std::chrono::duration_cast<std::chrono::seconds>( stop - start );
 	auto durationMilliSeconds =

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -63,7 +63,7 @@ void setupEnvironment(unsigned log_level, const QString& sLogFilePath,
 	H2Core::Base::bootstrap( pLogger, true );
 	/* Filesystem */
 	H2Core::Filesystem::bootstrap(
-		pLogger, test_helper->getDataDir(), sUserDataFolder, sLogFilePath );
+		pLogger, test_helper->getDataDir(), sUserDataFolder, "", sLogFilePath );
 	H2Core::Filesystem::info();
 	
 	/* Use fake audio driver */


### PR DESCRIPTION
Adds the new CLI option `--user-data` for both `hydrogen` and `h2cli` to provide an alternate version of the whole user-level data folder.

During some unit test issues I encountered while porting the Qt6 support to the `main` branch I noticed that an user-level drumkit leaked into the test setup. This should not happen. Thus, the test setup will get a transient user-level test folder from now on.