### PR TITLE
ShotList: do not compile for Qt6

### DIFF
--- a/src/gui/src/ShotList.cpp
+++ b/src/gui/src/ShotList.cpp
@@ -28,6 +28,8 @@
 #include "ShotList.h"
 #include "HydrogenApp.h"
 
+#ifndef H2CORE_HAVE_QT6
+
 ShotList::ShotList( QString sShotsFilename ) {
 	QFile shots( sShotsFilename );
 	m_nNextShot = 0;
@@ -248,3 +250,5 @@ void ShotList::nextShot( void ) {
 	}
 	shoot( m_shots[ m_nNextShot++ ] );
 }
+
+#endif

--- a/src/gui/src/ShotList.h
+++ b/src/gui/src/ShotList.h
@@ -23,9 +23,13 @@
 #ifndef __SHOTLIST_H
 #define __SHOTLIST_H
 
+#include <core/config.h>
+
 #include <QtGui>
 #include <QtWidgets>
 #include "EventListener.h"
+
+#ifndef H2CORE_HAVE_QT6
 
 /// Shot List
 ///
@@ -106,6 +110,18 @@ public slots:
 
 };
 
+#else // H2CORE_HAVE_QT6
+class ShotList : public QObject, public EventListener {
+	Q_OBJECT
+public:
+		ShotList( QStringList shots ){};
+		ShotList( QString sShotsFilename ){};
+		~ShotList(){};
+
+		void shoot() {};
+};
+
+#endif // H2CORE_HAVE_QT6
 
 #endif
 


### PR DESCRIPTION
a temporary measure since the code breaks with Qt 6.9.

The `ShotList` is only internally when creating images for the documentation.

```
C:/projects/hydrogen/src/gui/src/ShotList.h: In member function 'ShotList::Arg::operator QGenericArgument()':
C:/projects/hydrogen/src/gui/src/ShotList.h:72:40: error: could not convert 'QtPrivate::Invoke::argument<bool>(((const char*)"bool"), ((ShotList::Arg*)this)->ShotList::Arg::<anonymous>.ShotList::Arg::<unnamed union>::m_b)' from 'QMetaMethodArgument' to 'QGenericArgument'
   72 |                                 return Q_ARG( bool, m_b );
      |                                        ^~~~~
      |                                        |
      |                                        QMetaMethodArgument
C:/projects/hydrogen/src/gui/src/ShotList.h:75:40: error: could not convert 'QtPrivate::Invoke::argument<bool>(((const char*)"bool"), ((ShotList::Arg*)this)->ShotList::Arg::<anonymous>.ShotList::Arg::<unnamed union>::m_b)' from 'QMetaMethodArgument' to 'QGenericArgument'
   75 |                                 return Q_ARG( bool, m_b );
      |                                        ^~~~~
      |                                        |
      |                                        QMetaMethodArgument
C:/projects/hydrogen/src/gui/src/ShotList.h:80:40: error: could not convert 'QtPrivate::Invoke::argument<int>(((const char*)"int"), ((ShotList::Arg*)this)->ShotList::Arg::<anonymous>.ShotList::Arg::<unnamed union>::m_n)' from 'QMetaMethodArgument' to 'QGenericArgument'
   80 |                                 return Q_ARG( int, m_n );
      |                                        ^~~~~
      |                                        |
      |                                        QMetaMethodArgument
C:/projects/hydrogen/src/gui/src/ShotList.h:82:40: error: could not convert 'QtPrivate::Invoke::argument<QWidget*>(((const char*)"QWidget *"), ((ShotList::Arg*)this)->ShotList::Arg::<anonymous>.ShotList::Arg::<unnamed union>::m_pWidget)' from 'QMetaMethodArgument' to 'QGenericArgument'
   82 |                                 return Q_ARG( QWidget *, m_pWidget );
      |                                        ^~~~~
      |                                        |
      |                                        QMetaMethodArgument
C:/projects/hydrogen/src/gui/src/ShotList.h:85:40: error: could not convert 'QtPrivate::Invoke::argument<QString>(((const char*)"QString"), ((ShotList::Arg*)this)->ShotList::Arg::m_sArg)' from 'QMetaMethodArgument' to 'QGenericArgument'
   85 |                                 return Q_ARG( QString, m_sArg );
      |                                        ^~~~~
      |                                        |
      |                                        QMetaMethodArgument
mingw32-make[2]: *** [src\gui\CMakeFiles\hydrogen.dir\build.make:101: src/gui/CMakeFiles/hydrogen.dir/hydrogen_autogen/mocs_compilation.cpp.obj] Error 1
```
see https://ci.appveyor.com/project/mauser/hydrogen/builds/52068856/job/wvalfcukkko9s13b