### PR TITLE
HydrogenApp: fix event listener update

### DIFF
--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -32,8 +32,9 @@
 
 #include <iostream>
 #include <cstdint>
-#include <vector>
 #include <memory>
+#include <set>
+#include <vector>
 
 #include <QtGui>
 #include <QtWidgets>
@@ -188,10 +189,12 @@ signals:
 	void changePreferences( H2Core::Preferences::Changes changes );
 	void onPreferencesChanged( H2Core::Preferences::Changes changes );
 
-private slots:
-	void propagatePreferences();
+	private slots:
+		void propagatePreferences();
 
 	private:
+		void updateEventListeners();
+
 		static HydrogenApp *		m_pInstance;	///< HydrogenApp instance
 
 #ifdef H2CORE_HAVE_LADSPA
@@ -214,23 +217,25 @@ private slots:
 		SampleEditor *				m_pSampleEditor;
 		Director *					m_pDirector;
 		QTimer *					m_pEventQueueTimer;
-		std::vector<EventListener*> 	m_EventListeners;
+		std::vector<EventListener*> m_eventListeners;
+		std::set<EventListener*> m_eventListenersToAdd;
+		std::set<EventListener*> m_eventListenersToRemove;
 		QTabWidget *				m_pTab;
 		QSplitter *					m_pSplitter;
 		QVBoxLayout *				m_pMainVBox;
-	std::shared_ptr<CommonStrings>				m_pCommonStrings;
+		std::shared_ptr<CommonStrings>				m_pCommonStrings;
 
 		bool						m_bHideKeyboardCursor;
 		QTimer *					m_pPreferencesUpdateTimer;
 		int						    m_nPreferencesUpdateTimeout;
-	H2Core::Preferences::Changes m_bufferedChanges;  
+		H2Core::Preferences::Changes m_bufferedChanges;
 
 		// implement EngineListener interface
 		void engineError(uint nErrorCode);
 
 		void setupSinglePanedInterface();
 		virtual void songModifiedEvent() override;
-	virtual void XRunEvent() override;
+		virtual void XRunEvent() override;
 
 		/** Handles the loading and saving of the H2Core::Preferences
 		 * from the core part of H2Core::Hydrogen.


### PR DESCRIPTION
previously adding and removing `EventListener` in `HydrogenApp` was decoupled from their handling in `HydrogenApp::onEventQueueTimer`. This can quite some troubles since due to the handling of individual events listener can be removed or added. `onEventQueueTimer` accesses each listener via its index in a `std::vector`. On `Event::Type::UpdateSong` various listeners will be added/removed. In one local test case the number dropped from 169 to 123 causing the loop over all listener to skip a couple of them - like the `PatternEditorPanel` and `PlayerControl`. This resulted in visual artifacts.

Instead, we now use two queues in which we enroll all listeners to be added or removed. The actual update of the vector of active listeners will be done on the next event encountered.