### PR TITLE
Base editor and drawing in `DrumPatternEditor` and `PianoRollEditor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,15 +109,18 @@ All notable changes to this project will be documented in this file.
   - Notes not associated with an instrument of the current kit are now visible
     and can be handled like regular notes.
   - Pattern name is now shown together with other active patterns tab bar.
-  - Property drawing (NotePropertiesRuler) is now only bound to right mouse
+  - Property drawing in the properties ruler is now only bound to right mouse
     button.
+  - Right-click drag in drum pattern and piano roll editor does not alter note properties anymore but draws notes.
+  - Whether left mouse button interactions to select, draw, or editing existing
+    notes can be set by buttons in the left-most part of the toolbar.
+  - Note editing does now alter either note length or property. Not both.
   - Cursor, selection lasso, and selected and hovered notes are now synced
     between among all editors.
   - Property changes based on wheel and key event on the same set of notes as
     well as property drawing can now be undone/redone in a single action.
   - PianoRoll does now have a proper sidebar including per-line action in right
     click popup menu.
-  - Right-click drag does now alter either note length or property.
   - The hear notes button does now also affect sounds triggered by clicking the
     sidebar of the pattern editor.
 - InstrumentEditor:

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -558,31 +558,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Entrada</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1414,6 +1389,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Mode seleccionar</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Mode dibuix</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5753,14 +5743,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Editor de cançó</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Mode seleccionar</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Mode dibuix</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -3171,14 +3171,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>No s&apos;ha seleccionat cap patró</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -3169,14 +3169,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Vybrat vlatnosti noty</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Vstup</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Režim výběru</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Režim zadávání</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5751,14 +5741,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Move the selected pattern up</source>
         <translation>Přesunout vybraný patern nahoru</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Režim výběru</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Režim zadávání</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -3205,14 +3205,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Eigenschaften der Note wählen</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation>Piano-Roll anzeigen</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Schlagzeug-Editor anzeigen</translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation>Viertel</translation>
     </message>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -560,31 +560,6 @@ B</translation>
         <translation>Sample Ausw.</translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Länge</translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Res</translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation>Hören</translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation>Quant</translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Input</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation>MIDI-In</translation>
@@ -1416,6 +1391,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Auswahlmodus</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Zeichenmodus</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5807,14 +5797,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Lied-Editor</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Auswahlmodus</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Zeichenmodus</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Προβολή του επεξεργαστή κρουστών</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3166,10 +3166,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Κβαντισμός των γενόμενων του πληκτρολόγιου ή του ΜΙΝΤΙ στο πλέγμα</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation>Εστίαση</translation>
     </message>
@@ -3200,10 +3196,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>Κβαντισμός των εισερχομένων γενομένων του πληκτρολογίου ή του ΜΙΝΤΙ = Ανενεργός</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Προβολή του επεξεργαστή κρουστών</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Εισαγόμενο</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Κατάσταση λειτουργίας επιλογής</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Κατάσταση λειτουργίας σχεδίασης</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5810,14 +5800,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Move the selected pattern up</source>
         <translation>Μετακίνηση, προς τα πάνω, της επιλεγμένης μήτρας</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Κατάσταση λειτουργίας επιλογής</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Κατάσταση λειτουργίας σχεδίασης</translation>
     </message>
     <message>
         <source>Pattern %1</source>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -557,31 +557,6 @@ B</source>
         <translation></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation></translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5735,14 +5725,6 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Move the selected pattern up</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -3126,10 +3126,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation></translation>
     </message>
@@ -3159,10 +3155,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5735,14 +5725,6 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Move the selected pattern up</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -3126,10 +3126,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation></translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation></translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation></translation>
     </message>
@@ -3159,10 +3155,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     </message>
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
-        <translation></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
         <translation></translation>
     </message>
     <message>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -560,31 +560,6 @@ B</translation>
         <translation>Sel. Sample</translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Tam.</translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Res</translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation>Oír</translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation>Cuant</translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Entrada</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation>Ent MIDI</translation>
@@ -1417,6 +1392,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Seleccionar modo</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Modo dibujo</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5820,14 +5810,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Editor de canciones</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Seleccionar modo</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Modo dibujo</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -3212,14 +3212,6 @@ Debería funcionar correctamente mientras utilices el GMRockKit, y no uses tresi
         <translation>No se ha seleccionado un patrón</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation>Mostrar editor del piano roll</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Mostrar drum editor</translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation>negra</translation>
     </message>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -559,31 +559,6 @@ B</translation>
         <translation>Sél. échant</translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Tail</translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Rés</translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation>Écou</translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation>Quant</translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Entrée</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation>En-MIDI</translation>
@@ -1416,6 +1391,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Mode sélection</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Mode dessin</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5821,14 +5811,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear pattern sequence</source>
         <translation>Effacer la séquence de motifs</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Mode sélection</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Mode dessin</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -3213,14 +3213,6 @@ L&apos;exportation LilyPond est une fonctionnalité expérimentale.
         <translation>Quantifier les événements entrant du clavier/MIDI = inactif</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation>Afficher l&apos;éditeur piano-roll</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Afficher l&apos;éditeur de batterie</translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation>noire</translation>
     </message>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Amosar o editor de baterías</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3195,14 +3195,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>Cuantizar eventos teclado/MIDI entrantes = Non</translation>
-    </message>
-    <message>
-        <source>Show piano roll editor</source>
-        <translation>Amosar o editor da pianola</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Amosar o editor de baterías</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Entrada</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Seleccionar modo</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Modo de debuxo</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5790,14 +5780,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear pattern sequence</source>
         <translation>Eliminar a secuencia do patrón</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Seleccionar modo</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Modo de debuxo</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -3153,10 +3153,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Kvantiziranje nadolazećih klavijaturnih/midi sesija = Neaktivno</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation>Povećaj pogled</translation>
     </message>
@@ -3171,10 +3167,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Select note properties</source>
         <translation>Odaberni karakteristike note</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Ulaz</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Odaberi Mod</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Crtački Mod</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5751,14 +5741,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Editor pjesme</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Odaberi Mod</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Crtački Mod</translation>
     </message>
     <message>
         <source>Pattern %1</source>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Bemenet</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5741,14 +5731,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear pattern sequence</source>
         <translation>Motívum törlése</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -3163,14 +3163,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Ingresso</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Modalità di selezione</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Modalità di modifica</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5755,14 +5745,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Editor di canzone</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Modalità di selezione</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Modalità di modifica</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Mostra editor batteria</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3170,14 +3170,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Select note properties</source>
         <translation>Seleziona proprietà nota</translation>
-    </message>
-    <message>
-        <source>Show piano roll editor</source>
-        <translation>Mostra editor del piano</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Mostra editor batteria</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -558,31 +558,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>入力</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1414,6 +1389,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>選択モード</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>ドローモード</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5788,14 +5778,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>ソングエディタ</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>選択モード</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>ドローモード</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -654,7 +654,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>ドラムエディターの表示</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3193,14 +3193,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Select note properties</source>
         <translation>ノートのプロパティーを選択</translation>
-    </message>
-    <message>
-        <source>Show piano roll editor</source>
-        <translation>ピアノロールエディターの表示</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>ドラムエディターの表示</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Ingang</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Selectie mode</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Teken mode</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5748,14 +5738,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear pattern sequence</source>
         <translation>Wis patroon sequenties</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Selectie mode</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Teken mode</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -3170,14 +3170,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Selecteer noot opties</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Wejście</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Tryb zaznaczania</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Tryb rysowania</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5744,14 +5734,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Move the selected pattern up</source>
         <translation>Przesuwa wybrany układ rytmiczny w górę</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Tryb zaznaczania</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Tryb rysowania</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -3166,14 +3166,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation>Wybór właściwości nut</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -560,31 +560,6 @@ B</translation>
         <translation>Sel. Amostra</translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Tamanho</translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation>Res</translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation>Ouvir</translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation>Quant</translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Entrada</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation>MIDI-In</translation>
@@ -1416,6 +1391,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Selecionar modo</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Modo desenho</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5818,14 +5808,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear pattern sequence</source>
         <translation>Limpar sequência de padrões</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Selecionar modo</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Modo desenho</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -3210,14 +3210,6 @@ Deveria funcionar corretamente dado que você usou o GMRockKit e que você não 
         <translation>Selecionar propriedades da nota</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation>Exibir editor de piano automático</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Exibir editor de bateria</translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation>semínima</translation>
     </message>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Показать редактор перкуссии</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3193,14 +3193,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Select note properties</source>
         <translation>Выбрать свойства ноты</translation>
-    </message>
-    <message>
-        <source>Show piano roll editor</source>
-        <translation>Показать матричный редактор</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Показать редактор перкуссии</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Вход</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Выделять паттерны</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Рисовать паттерны</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5780,14 +5770,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Редактор композиций</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Выделять паттерны</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Рисовать паттерны</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Улаз</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Режим одабирања</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Режим цртања</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5799,14 +5789,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Clear pattern sequence</source>
         <translation>Обриши исцртана поља у свим мустрама</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Режим одабирања</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Режим цртања</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Прикажи уредника бубња</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3189,14 +3189,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>Квантизуј долазне догађаје МИДИ/клавијатуре = Искљ</translation>
-    </message>
-    <message>
-        <source>Show piano roll editor</source>
-        <translation>Прикажи уредника са клав. диркама</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Прикажи уредника бубња</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Val läge</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5743,18 +5733,10 @@ p, li { white-space: pre-wrap; }
         <translation>Flytta upp valt mönster</translation>
     </message>
     <message>
-        <source>Select mode</source>
-        <translation>Val läge</translation>
-    </message>
-    <message>
         <source>Warning, this will erase your pattern sequence.
 Are you sure?</source>
         <translation>Varning, detta kommer att radera din mönster sekvens.
 Är du säker?</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>stacked pattern mode</source>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -3163,14 +3163,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>quarter</source>
         <translation type="unfinished"></translation>
     </message>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>Вхід</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1413,6 +1388,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>Режим вибору</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>Режим малювання</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5804,14 +5794,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Song Editor</source>
         <translation>Редактор композицій</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>Режим вибору</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>Режим малювання</translation>
     </message>
     <message>
         <source>Warning, this will erase your pattern sequence.

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Показати редактор перкусії</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3194,14 +3194,6 @@ It should work like a charm provided that you use the GMRockKit, and that you do
     <message>
         <source>Select note properties</source>
         <translation>Вибрати властивості ноти</translation>
-    </message>
-    <message>
-        <source>Show piano roll editor</source>
-        <translation>Показати матричний редактор</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>Показати редактор перкусії</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -653,7 +653,7 @@ Name of note property adjustable in NotePropertiesRuler, using * humanization in
     <message>
         <source>Show drumkit editor</source>
         <extracomment>Displayed when hovering over the button in the PatternEditorPanel to activate the DrumkitEditor.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>显示鼓编辑器</translation>
     </message>
     <message>
         <source>Show piano roll editor</source>
@@ -3164,10 +3164,6 @@ LilyPond 导出是一项实验性功能。
         <translation>量化 键盘/MIDI 事件到网格</translation>
     </message>
     <message>
-        <source>Show piano roll editor</source>
-        <translation>显示钢琴卷帘编辑器</translation>
-    </message>
-    <message>
         <source>Zoom in</source>
         <translation>放大</translation>
     </message>
@@ -3198,10 +3194,6 @@ LilyPond 导出是一项实验性功能。
     <message>
         <source>Quantize incoming keyboard/midi events = Off</source>
         <translation>量化传入的键盘/MIDI 事件：关</translation>
-    </message>
-    <message>
-        <source>Show drum editor</source>
-        <translation>显示鼓编辑器</translation>
     </message>
     <message>
         <source>quarter</source>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -557,31 +557,6 @@ B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Size</source>
-        <extracomment>Text displayed left of the pattern size LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Res</source>
-        <extracomment>Text displayed left of the resolution LCD combo in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hear</source>
-        <extracomment>Text displayed left of the button to activate the playback of inserted notes in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Quant</source>
-        <extracomment>Text displayed left of the button to toggle the quantization in the panel of the Pattern Editor.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <extracomment>Text displayed left of the button to switch between the Drum Pattern Editor and the Piano Roll Editor in the panel of the Pattern Editor.</extracomment>
-        <translation>输入</translation>
-    </message>
-    <message>
         <source>MIDI-In</source>
         <extracomment>Text displayed in the Player Control to indicate incoming MIDI events. Designed to hold seven characters but not that flexible.</extracomment>
         <translation type="unfinished"></translation>
@@ -1414,6 +1389,21 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>Edit layer</source>
         <extracomment>Representing editing an instrument layer in the undo history. Both the * name of the layer and the corresponding instrument will be appended.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables lasso-selection * and element moving using left-click mouse interaction.</extracomment>
+        <translation>选择模式</translation>
+    </message>
+    <message>
+        <source>Draw mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables toggling elements * or changing their properties (in the note ruler) while left-click * dragging mouse interaction.</extracomment>
+        <translation>绘图模式</translation>
+    </message>
+    <message>
+        <source>Edit mode</source>
+        <extracomment>Text displayed as tooltip on the button which enables changing element * properties, like note length in the pattern editor using left-click * dragging mouse interaction.</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5804,14 +5794,6 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Move the selected pattern up</source>
         <translation>上移所选样式</translation>
-    </message>
-    <message>
-        <source>Select mode</source>
-        <translation>选择模式</translation>
-    </message>
-    <message>
-        <source>Draw mode</source>
-        <translation>绘图模式</translation>
     </message>
     <message>
         <source>View playback track</source>

--- a/data/img/scalable/icons/black/edit.svg
+++ b/data/img/scalable/icons/black/edit.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="22"
+   height="22"
+   viewBox="0 0 5.8208332 5.8208335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="10.949107"
+     inkscape:cy="11.269514"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     showguides="false"
+     inkscape:window-width="1916"
+     inkscape:window-height="1161"
+     inkscape:window-x="1920"
+     inkscape:window-y="18"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833"
+       spacingx="0.13229167"
+       spacingy="0.13229167"
+       empspacing="4" />
+    <sodipodi:guide
+       position="0,5.8208333"
+       orientation="0,22"
+       id="guide1472"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,5.8208333"
+       orientation="22,0"
+       id="guide1474"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,0"
+       orientation="0,-22"
+       id="guide1476"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="-22,0"
+       id="guide1478"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,5.8208333"
+       orientation="0,22"
+       id="guide1480"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,5.8208333"
+       orientation="22,0"
+       id="guide1482"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,0"
+       orientation="0,-22"
+       id="guide1484"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="-22,0"
+       id="guide1486"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-opacity:0.5;stroke:#000000;stroke-width:1.05833333;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       id="path3276"
+       sodipodi:type="arc"
+       sodipodi:cx="2.5163238"
+       sodipodi:cy="3.3071668"
+       sodipodi:rx="1.656185"
+       sodipodi:ry="1.653515"
+       sodipodi:start="0.081980663"
+       sodipodi:end="4.6955266"
+       sodipodi:arc-type="arc"
+       d="M 4.1669465,3.4425713 A 1.656185,1.653515 0 0 1 2.4351487,4.9586945 1.656185,1.653515 0 0 1 0.86035303,3.2805707 1.656185,1.653515 0 0 1 2.4883979,1.6538869"
+       sodipodi:open="true"
+       inkscape:transform-center-x="-0.64312022"
+       inkscape:transform-center-y="0.41877609" />
+    <path
+       id="rect6953"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 4.5359028,0.64028002 0.2282714,-0.2374822 c 0.181664,-0.18899427 0.4741637,-0.18899427 0.6558277,-1.2e-7 0.1816638,0.18899431 0.1816638,0.49329611 0,0.6822905 v 0 l -0.2286041,0.237828" />
+    <path
+       id="path10118"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 4.343379,0.79375079 -2.3590034,2.35843751 1e-7,0.6842696 0.6842695,-1e-7 2.3584375,-2.3584376 z"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+</svg>

--- a/data/img/scalable/icons/white/edit.svg
+++ b/data/img/scalable/icons/white/edit.svg
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="22"
+   height="22"
+   viewBox="0 0 5.8208332 5.8208335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="45.254834"
+     inkscape:cx="10.949107"
+     inkscape:cy="11.269514"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     units="px"
+     showguides="false"
+     inkscape:window-width="1916"
+     inkscape:window-height="1161"
+     inkscape:window-x="1920"
+     inkscape:window-y="18"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833"
+       spacingx="0.13229167"
+       spacingy="0.13229167"
+       empspacing="4" />
+    <sodipodi:guide
+       position="0,5.8208333"
+       orientation="0,22"
+       id="guide1472"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,5.8208333"
+       orientation="22,0"
+       id="guide1474"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,0"
+       orientation="0,-22"
+       id="guide1476"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="-22,0"
+       id="guide1478"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,5.8208333"
+       orientation="0,22"
+       id="guide1480"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,5.8208333"
+       orientation="22,0"
+       id="guide1482"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="5.8208333,0"
+       orientation="0,-22"
+       id="guide1484"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="0,0"
+       orientation="-22,0"
+       id="guide1486"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-opacity:0.5;stroke:#ffffff;stroke-width:1.05833333;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       id="path3276"
+       sodipodi:type="arc"
+       sodipodi:cx="2.5163238"
+       sodipodi:cy="3.3071668"
+       sodipodi:rx="1.656185"
+       sodipodi:ry="1.653515"
+       sodipodi:start="0.081980663"
+       sodipodi:end="4.6955266"
+       sodipodi:arc-type="arc"
+       d="M 4.1669465,3.4425713 A 1.656185,1.653515 0 0 1 2.4351487,4.9586945 1.656185,1.653515 0 0 1 0.86035303,3.2805707 1.656185,1.653515 0 0 1 2.4883979,1.6538869"
+       sodipodi:open="true"
+       inkscape:transform-center-x="-0.64312022"
+       inkscape:transform-center-y="0.41877609" />
+    <path
+       id="rect6953"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 4.5359028,0.64028002 0.2282714,-0.2374822 c 0.181664,-0.18899427 0.4741637,-0.18899427 0.6558277,-1.2e-7 0.1816638,0.18899431 0.1816638,0.49329611 0,0.6822905 v 0 l -0.2286041,0.237828" />
+    <path
+       id="path10118"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+       d="m 4.343379,0.79375079 -2.3590034,2.35843751 1e-7,0.6842696 0.6842695,-1e-7 2.3584375,-2.3584376 z"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+</svg>

--- a/docs/decisions/0007-introduce-base-editor.md
+++ b/docs/decisions/0007-introduce-base-editor.md
@@ -1,0 +1,76 @@
+---
+status: accepted
+date: 2025-05-23
+deciders: phil (theGreatWhiteShark)
+---
+
+# AD: Introduce BaseEditor
+
+## Context and Problem Statement
+
+Originally, all our editors - `DrumPatternEditor`, `PianoRollEditor`,
+`NotePropertiesRuler`, `SongEditor`, `AutomationPathView`, as well as pan and
+volume automation in `TargetWaveDisplay` within the `SampleEditor` - had their
+unique code base and their individual UX. Each part felt a little different.
+
+Since version `1.1.0` Hydrogen features a common selection handling in song and
+all pattern editors. It feels much more coherent this way. In the preparation
+for the `2.0` all the editors in the pattern editor region have been align in
+both UI and UX. But it still does not feel like one consistent application.
+
+For `2.0` the UX of all remaining editors will be aligned as well. Interacting
+with a pattern square in `SongEditor` should feel the same as interacting with
+notes in `DrumPatternEditor`. In the same vain our horizontal editors should
+behave the same, regardless of whether the user is interacting with a note in
+`NotePropertiesRuler`, an automation node in `AutomationPathView`, or an
+envelope point in `TargetWaveDisplay`.
+
+## Decision Drivers
+
+* UX should be as intuitive as possible.
+* UX changes with time and Hydrogen could keep up (e.g. optimized for touch
+  interaction).
+* Maintenance should be as simple.
+
+## Considered Options
+
+1. We could take the UX of the pattern editor and implement similar code in all
+   other editors.
+2. We introduce a common base class, like `BaseEditor`.
+
+## Decision Outcome
+
+I tend towards 2. It's a lot of work. But implementing and testing 1. would be
+an almost equivalent pile of work. In addition, codifying the requirement of a
+shared UX makes maintaining more easy. Else, it would be very easy to forget to
+apply a patch to a particular editor.
+
+While at it, `AutomationPathView` and `TargetWaveDisplay` should be ported to a
+shared code base. After all, automation of pan and volume is just a special case
+of the more general automation view. The latter should also be made ready to
+handle various automation targets while being touched. Just the overall
+velocity - as up to `1.2.X` - does not really justify the presence of this
+widget.
+
+What should be part of the common base?
+
+- Keyboard arrow movement (plus modifiers)
+- Selection via keyboard and mouse
+- Highlighting of selected elements
+- Lasso rendering
+- Hovering of elements via keyboard and mouse as well as a shared cursor margins.
+- Mouse and keyboard based moving of selected elements
+- Left-click moving of single elements (selected or not)
+- Right-click popup menu (if applicable)
+- Right-click drawing
+
+
+### Consequences
+
+* Based on the recent work in `PatternEditor` a common base class called
+  `BaseEditor` - itself a child class of `Selection` - will be split off.
+* First, all pattern editors will be ported to the new base class.
+* Second, the `SongEditor` will be ported.
+* The automation code base will be reviewed and ported to `BaseEditor`.
+* `TargetWaveDisplay` code base will be dropped in favor for inheriting a shared
+  automation code.

--- a/docs/decisions/0007-introduce-base-editor.md
+++ b/docs/decisions/0007-introduce-base-editor.md
@@ -36,7 +36,7 @@ envelope point in `TargetWaveDisplay`.
 
 1. We could take the UX of the pattern editor and implement similar code in all
    other editors.
-2. We introduce a common base class, like `BaseEditor`.
+2. We introduce a common base class, like `Editor::Base`.
 
 ## Decision Outcome
 
@@ -68,9 +68,9 @@ What should be part of the common base?
 ### Consequences
 
 * Based on the recent work in `PatternEditor` a common base class called
-  `BaseEditor` - itself a child class of `Selection` - will be split off.
+  `Editor::Base` - itself a child class of `Selection` - will be split off.
 * First, all pattern editors will be ported to the new base class.
 * Second, the `SongEditor` will be ported.
-* The automation code base will be reviewed and ported to `BaseEditor`.
+* The automation code base will be reviewed and ported to `Editor::Base`.
 * `TargetWaveDisplay` code base will be dropped in favor for inheriting a shared
   automation code.

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -55,6 +55,8 @@
 #define LENGTH_ENTIRE_SAMPLE    -1
 #define PITCH_DEFAULT           0.0f /* C2 */
 #define PITCH_INVALID           666
+#define PITCH_MAX               KEYS_PER_OCTAVE * OCTAVE_MAX + KEY_MAX
+#define PITCH_MIN               KEYS_PER_OCTAVE * OCTAVE_MIN + KEY_MIN
 #define PROBABILITY_MIN         0.0f
 #define PROBABILITY_DEFAULT     1.0f
 #define PROBABILITY_MAX         1.0f

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -126,6 +126,17 @@ CommonStrings::CommonStrings(){
 	/*: Text displayed on the button activating Song Mode for playback. Its
 	  size is designed to hold four characters and is slightly flexible.*/
 	m_sSongModeButton = tr( "Song" );
+	/*: Text displayed as tooltip on the button which enables lasso-selection
+	 *  and element moving using left-click mouse interaction. */
+	m_sSelectModeButton = tr( "Select mode" );
+	/*: Text displayed as tooltip on the button which enables toggling elements
+	 *  or changing their properties (in the note ruler) while left-click
+	 *  dragging mouse interaction. */
+	m_sDrawModeButton = tr( "Draw mode" );
+	/*: Text displayed as tooltip on the button which enables changing element
+	 *  properties, like note length in the pattern editor using left-click
+	 *  dragging mouse interaction. */
+	m_sEditModeButton = tr( "Edit mode" );
 
 	/*: Text displayed below the rotary to adjust the attack of the
 	  ADSR in the Instrument Editor. Designed to hold six characters
@@ -220,22 +231,6 @@ CommonStrings::CommonStrings(){
 	 Instrument Editor. Designed to hold eleven characters but not
 	 that flexible.*/
 	m_sSampleSelectionLabel = tr( "Sample Sel." );
-	/*: Text displayed left of the pattern size LCD combo in the panel
-	 of the Pattern Editor.*/
-	m_sPatternSizeLabel = tr( "Size" );
-	/*: Text displayed left of the resolution LCD combo in the panel
-	 of the Pattern Editor.*/
-	m_sResolutionLabel = tr( "Res" );
-	/*: Text displayed left of the button to activate the playback of
-	 inserted notes in the panel of the Pattern Editor.*/
-	m_sHearNotesLabel = tr( "Hear" );
-	/*: Text displayed left of the button to toggle the quantization
-	 in the panel of the Pattern Editor.*/
-	m_sQuantizeEventsLabel = tr( "Quant" );
-	/*: Text displayed left of the button to switch between the
-	 Drum Pattern Editor and the Piano Roll Editor in the panel
-	 of the Pattern Editor.*/
-	m_sShowPianoLabel = tr( "Input" );
 	/*: Text displayed in the Player Control to indicate incoming MIDI
 	  events. Designed to hold seven characters but not that
 	  flexible.*/

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -73,6 +73,9 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getInstrumentRackButton() const { return m_sInstrumentRackButton; }
 	const QString& getPatternModeButton() const { return m_sPatternModeButton; }
 	const QString& getSongModeButton() const { return m_sSongModeButton; }
+	const QString& getSelectModeButton() const { return m_sSelectModeButton; }
+	const QString& getDrawModeButton() const { return m_sDrawModeButton; }
+	const QString& getEditModeButton() const { return m_sEditModeButton; }
 	const QString& getAttackLabel() const { return m_sAttackLabel; }
 	const QString& getDecayLabel() const { return m_sDecayLabel; }
 	const QString& getSustainLabel() const { return m_sSustainLabel; }
@@ -96,11 +99,6 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getLayerGainLabel() const { return m_sLayerGainLabel; }
 	const QString& getComponentGainLabel() const { return m_sComponentGainLabel; }
 	const QString& getSampleSelectionLabel() const { return m_sSampleSelectionLabel; }
-	const QString& getPatternSizeLabel() const { return m_sPatternSizeLabel; }
-	const QString& getResolutionLabel() const { return m_sResolutionLabel; }
-	const QString& getHearNotesLabel() const { return m_sHearNotesLabel; }
-	const QString& getQuantizeEventsLabel() const { return m_sQuantizeEventsLabel; }
-	const QString& getShowPianoLabel() const { return m_sShowPianoLabel; }
 	const QString& getMidiInLabel() const { return m_sMidiInLabel; }
 	const QString& getCpuLabel() const { return m_sCpuLabel; }
 	const QString& getBPMLabel() const { return m_sBPMLabel; }
@@ -367,6 +365,9 @@ private:
 	QString m_sInstrumentRackButton;
 	QString m_sPatternModeButton;
 	QString m_sSongModeButton;
+	QString m_sSelectModeButton;
+	QString m_sDrawModeButton;
+	QString m_sEditModeButton;
 	QString m_sAttackLabel;
 	QString m_sDecayLabel;
 	QString m_sSustainLabel;
@@ -390,11 +391,6 @@ private:
 	QString m_sLayerGainLabel;
 	QString m_sComponentGainLabel;
 	QString m_sSampleSelectionLabel;
-	QString m_sPatternSizeLabel;
-	QString m_sResolutionLabel;
-	QString m_sHearNotesLabel;
-	QString m_sQuantizeEventsLabel;
-	QString m_sShowPianoLabel;
 	QString m_sMidiInLabel;
 	QString m_sCpuLabel;
 	QString m_sBPMLabel;

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -52,6 +52,7 @@
 #include "SampleEditor/SampleEditor.h"
 #include "UndoActions.h"
 #include "Widgets/AutomationPathView.h"
+#include "Widgets/EditorDefs.h"
 #include "Widgets/InfoBar.h"
 
 
@@ -1177,7 +1178,7 @@ void HydrogenApp::onEventQueueTimer()
 								 /*isDelete*/ true,
 								 /*isNoteOff*/ false,
 								 pOldNote->getInstrument() != nullptr,
-								 PatternEditor::AddNoteAction::None ) );
+								 Editor::Action::None ) );
 		}
 		
 		// add the new note
@@ -1196,7 +1197,7 @@ void HydrogenApp::onEventQueueTimer()
 							 /*isDelete*/ false,
 							 /*isNoteOff*/ false,
 							 row.bMappedToDrumkit,
-							 PatternEditor::AddNoteAction::Playback ) );
+							 Editor::Action::Playback ) );
 		endUndoMacro();
 
 		pQueue->m_addMidiNoteVector.erase( pQueue->m_addMidiNoteVector.begin() );

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1431,7 +1431,7 @@ void MainForm::action_drumkit_addInstrument(
 	pPatternEditorPanel->setSelectedRowDB(
 		pSong->getDrumkit()->getInstruments()->size() - 1 );
 	pPatternEditorPanel->updateEditors();
-	pPatternEditorPanel->ensureVisible();
+	pPatternEditorPanel->ensureCursorIsVisible();
 }
 
 void MainForm::action_drumkit_deleteInstrument( int nInstrumentIndex )

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -41,11 +41,14 @@
 #include <stack>
 
 using namespace H2Core;
+using namespace Editor;
 
 DrumPatternEditor::DrumPatternEditor( QWidget* parent )
- : PatternEditor( parent, BaseEditor::EditorType::Grid )
+	: PatternEditor( parent )
 {
-	m_editor = PatternEditor::Editor::DrumPattern;
+	m_type = Editor::Type::Grid;
+	m_instance = Editor::Instance::DrumPattern;
+
 	const auto pPref = H2Core::Preferences::get_instance();
 
 	m_nGridHeight = pPref->getPatternEditorGridHeight();
@@ -67,10 +70,10 @@ void DrumPatternEditor::updateEditor( bool bPatternOnly )
 	if ( m_nEditorHeight != nTargetHeight ) {
 		m_nEditorHeight = nTargetHeight;
 		resize( m_nEditorWidth, m_nEditorHeight );
-		m_update = Update::Background;
+		m_update = Editor::Update::Background;
 	}
 
-	BaseEditor::updateEditor( bPatternOnly );
+	Editor::Base<Elem>::updateEditor( bPatternOnly );
 }
 
 ///
@@ -160,7 +163,7 @@ void DrumPatternEditor::keyPressEvent( QKeyEvent *ev )
 			nSelectedRow, KEY_INVALID, OCTAVE_INVALID,
 			/*bDoAdd*/ true, /*bDoDelete*/true,
 			/* bIsNoteOff */ false,
-			PatternEditor::AddNoteAction::Playback );
+			Editor::Action::Playback );
 	}
 	else if ( ev->key() == Qt::Key_Delete ) {
 		// Key: Delete / Backspace: delete selected notes, or note under
@@ -175,7 +178,7 @@ void DrumPatternEditor::keyPressEvent( QKeyEvent *ev )
 				nSelectedRow, KEY_INVALID, OCTAVE_INVALID,
 				/*bDoAdd=*/false, /*bDoDelete=*/true,
 				/* bIsNoteOff */ false,
-				PatternEditor::AddNoteAction::None );
+				Editor::Action::None );
 		}
 	}
 	else {

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -68,7 +68,7 @@ void DrumPatternEditor::updateEditor( bool bPatternOnly )
 		m_update = Update::Background;
 	}
 
-	PatternEditor::updateEditor( bPatternOnly );
+	BaseEditor::updateEditor( bPatternOnly );
 }
 
 ///

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -43,7 +43,7 @@
 using namespace H2Core;
 
 DrumPatternEditor::DrumPatternEditor( QWidget* parent )
- : PatternEditor( parent )
+ : PatternEditor( parent, BaseEditor::EditorType::Grid )
 {
 	m_editor = PatternEditor::Editor::DrumPattern;
 	const auto pPref = H2Core::Preferences::get_instance();

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -52,6 +52,8 @@ DrumPatternEditor::DrumPatternEditor( QWidget* parent )
 	m_nEditorHeight = m_pPatternEditorPanel->getRowNumberDB() * m_nGridHeight;
 	m_nActiveWidth = m_nEditorWidth;
 	resize( m_nEditorWidth, m_nEditorHeight );
+
+	updatePixmapSize();
 }
 
 DrumPatternEditor::~DrumPatternEditor()
@@ -279,20 +281,7 @@ void DrumPatternEditor::createBackground() {
 		selectedRowColor = selectedRowColor.darker( PatternEditor::nOutOfFocusDim );
 	}
 
-	// Resize pixmap if pixel ratio has changed
-	qreal pixelRatio = devicePixelRatio();
-	if ( m_pBackgroundPixmap->width() != m_nEditorWidth ||
-		 m_pBackgroundPixmap->height() != m_nEditorHeight ||
-		 m_pBackgroundPixmap->devicePixelRatio() != pixelRatio ) {
-		delete m_pBackgroundPixmap;
-		m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
-										   m_nEditorHeight * pixelRatio );
-		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
-		delete m_pPatternPixmap;
-		m_pPatternPixmap = new QPixmap( m_nEditorWidth  * pixelRatio,
-										m_nEditorHeight * pixelRatio );
-		m_pPatternPixmap->setDevicePixelRatio( pixelRatio );
-	}
+	updatePixmapSize();
 
 	m_pBackgroundPixmap->fill( backgroundInactiveColor );
 

--- a/src/gui/src/PatternEditor/DrumPatternEditor.h
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.h
@@ -48,21 +48,23 @@ class DrumPatternEditor : public PatternEditor,
 		DrumPatternEditor( QWidget* parent );
 		~DrumPatternEditor();
 
+		void moveCursorDown( QKeyEvent* ev, Editor::Step step );
+		void moveCursorUp( QKeyEvent* ev, Editor::Step step );
+
 		// Selected notes are indexed by their address to ensure that a
 		// note is definitely uniquely identified. This carries the risk
 		// that state pointers to deleted notes may find their way into
 		// the selection.
-		virtual std::vector<SelectionIndex> elementsIntersecting( const QRect& r ) override;
+		std::vector<SelectionIndex> elementsIntersecting( const QRect& r ) override;
 
 	public slots:
-		virtual void updateEditor( bool bPatternOnly = false ) override;
-		virtual void selectAll() override;
+		void updateEditor( bool bPatternOnly = false ) override;
+		void selectAll() override;
 
 	private:
-	void createBackground() override;
+		void createBackground() override;
 
-		virtual void keyPressEvent (QKeyEvent *ev) override;
-		virtual void paintEvent(QPaintEvent *ev) override;
+		void paintEvent(QPaintEvent *ev) override;
 
 		QString renameCompo( const QString& OriginalName );
 };

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -433,30 +433,6 @@ void NotePropertiesRuler::mouseClickEvent( QMouseEvent *ev ) {
 	PatternEditor::mouseClickEvent( ev );
 }
 
-void NotePropertiesRuler::mouseDragStartEvent( QMouseEvent *ev ) {
-	auto pEv = static_cast<MouseEvent*>( ev );
-
-	if ( m_selection.isMoving() ) {
-		prepareUndoAction( ev );
-		selectionMoveUpdateEvent( ev );
-	}
-	else if ( ev->buttons() == Qt::RightButton ) {
-		propertyDrawStart( ev );
-		propertyDrawUpdate( ev );
-	}
-}
-
-void NotePropertiesRuler::mouseDragUpdateEvent( QMouseEvent *ev ) {
-	if ( ev->buttons() == Qt::RightButton ) {
-		propertyDrawUpdate( ev );
-	}
-}
-
-void NotePropertiesRuler::mouseDragEndEvent( QMouseEvent *ev ) {
-	propertyDrawEnd();
-}
-
-
 void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 	if ( pPattern == nullptr ) {

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -133,7 +133,7 @@ void KeyOctaveLabel::paintEvent( QPaintEvent* pEvent ) {
 NotePropertiesRuler::NotePropertiesRuler( QWidget *parent,
 										  PatternEditor::Property property,
 										  Layout layout )
-	: PatternEditor( parent )
+	: PatternEditor( parent, BaseEditor::EditorType::Horizontal )
 	, m_nDrawPreviousColumn( -1 )
 	, m_layout( layout )
 {
@@ -245,7 +245,7 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 	// current selection, we alter the values of all selected notes. It not, we
 	// discard the selection.
 	const auto notesUnderPoint = getElementsAtPoint(
-		pEv->position().toPoint(), getCursorMargin( nullptr ), pPattern );
+		pEv->position().toPoint(), getCursorMargin( nullptr ) );
 	if ( notesUnderPoint.size() == 0 ) {
 		return;
 	}
@@ -443,16 +443,16 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 
 	// We only show status messages for notes at point.
 	std::vector< std::shared_ptr<Note> > notesStatusMessage;
-	for ( const auto& ppNote : m_notesHoveredOnDragStart ) {
+	for ( const auto& ppNote : m_elementsHoveredOnDragStart ) {
 		if ( ppNote != nullptr && m_selection.isSelected( ppNote ) ) {
 			notesStatusMessage.push_back( ppNote );
 		}
 	}
 
 	// Move cursor to dragged note(s).
-	if ( m_notesHoveredOnDragStart.size() > 0 ) {
+	if ( m_elementsHoveredOnDragStart.size() > 0 ) {
 		m_pPatternEditorPanel->setCursorColumn(
-			m_notesHoveredOnDragStart[ 0 ]->getPosition() );
+			m_elementsHoveredOnDragStart[ 0 ]->getPosition() );
 	}
 
 	if ( bValueChanged ) {
@@ -505,8 +505,8 @@ void NotePropertiesRuler::selectionMoveCancelEvent() {
 		}
 	}
 
-	if ( m_notesHoveredOnDragStart.size() != 0 ) {
-		triggerStatusMessage( m_notesHoveredOnDragStart, m_property );
+	if ( m_elementsHoveredOnDragStart.size() != 0 ) {
+		triggerStatusMessage( m_elementsHoveredOnDragStart, m_property );
 	}
 
 	m_oldNotes.clear();
@@ -540,7 +540,7 @@ void NotePropertiesRuler::prepareUndoAction( QMouseEvent* pEvent )
 	updateModifiers( pEvent );
 
 	const auto notesUnderPoint = getElementsAtPoint(
-		pEv->position().toPoint(), getCursorMargin( pEvent ), pPattern );
+		pEv->position().toPoint(), getCursorMargin( pEvent ) );
 	for ( const auto& ppNote : notesUnderPoint ) {
 		if ( ppNote != nullptr ) {
 			m_oldNotes[ ppNote ] = std::make_shared<Note>( ppNote );
@@ -888,7 +888,7 @@ void NotePropertiesRuler::keyPressEvent( QKeyEvent *ev )
 		// the current selection, we alter the values of all selected notes. It
 		// not, we discard the selection.
 		const auto notesUnderPoint =
-			getElementsAtPoint( getCursorPosition(), 0, pPattern );
+			getElementsAtPoint( getCursorPosition(), 0 );
 		if ( notesUnderPoint.size() == 0 ) {
 			return;
 		}

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -133,13 +133,15 @@ void KeyOctaveLabel::paintEvent( QPaintEvent* pEvent ) {
 NotePropertiesRuler::NotePropertiesRuler( QWidget *parent,
 										  PatternEditor::Property property,
 										  Layout layout )
-	: PatternEditor( parent, BaseEditor::EditorType::Horizontal )
+	: PatternEditor( parent )
 	, m_nDrawPreviousColumn( -1 )
 	, m_layout( layout )
 {
+	m_type = Editor::Type::Horizontal;
+	m_instance = Editor::Instance::NotePropertiesRuler;
+
 	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	m_property = property;
-	m_editor = PatternEditor::Editor::NotePropertiesRuler;
 
 	m_fGridWidth = (Preferences::get_instance())->getPatternEditorGridWidth();
 	m_nEditorWidth = PatternEditor::nMargin + m_fGridWidth * 4 * 4 *
@@ -339,8 +341,8 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 			m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
 		}
 
-		if ( m_update != BaseEditor::Update::Background ) {
-			m_update = BaseEditor::Update::Content;
+		if ( m_update != Editor::Update::Background ) {
+			m_update = Editor::Update::Content;
 		}
 		update();
 	}
@@ -459,8 +461,8 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 
 	if ( bValueChanged ) {
 		triggerStatusMessage( notesStatusMessage, m_property );
-		if ( m_update != BaseEditor::Update::Background ) {
-			m_update = BaseEditor::Update::Content;
+		if ( m_update != Editor::Update::Background ) {
+			m_update = Editor::Update::Content;
 		}
 		update();
 
@@ -475,8 +477,8 @@ void NotePropertiesRuler::selectionMoveEndEvent( QInputEvent *ev ) {
 	//! The "move" has already been reflected in the notes. Now just complete Undo event.
 	addUndoAction( "" );
 
-	if ( m_update != BaseEditor::Update::Background ) {
-		m_update = BaseEditor::Update::Content;
+	if ( m_update != Editor::Update::Background ) {
+		m_update = Editor::Update::Content;
 	}
 	update();
 }
@@ -519,8 +521,8 @@ void NotePropertiesRuler::propertyDrawStart( QMouseEvent *ev )
 	setCursor( Qt::CrossCursor );
 	prepareUndoAction( ev );
 
-	if ( m_update != BaseEditor::Update::Background ) {
-		m_update = BaseEditor::Update::Content;
+	if ( m_update != Editor::Update::Background ) {
+		m_update = Editor::Update::Content;
 	}
 	update();
 }
@@ -696,8 +698,8 @@ void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
 
 	if ( bValueChanged ) {
 		Hydrogen::get_instance()->setIsModified( true );
-		if ( m_update != BaseEditor::Update::Background ) {
-			m_update = BaseEditor::Update::Content;
+		if ( m_update != Editor::Update::Background ) {
+			m_update = Editor::Update::Content;
 		}
 		update();
 		if ( m_property == PatternEditor::Property::Velocity ) {
@@ -714,8 +716,8 @@ void NotePropertiesRuler::propertyDrawEnd()
 	addUndoAction( "NotePropertiesRuler::propertyDraw" );
 	unsetCursor();
 
-	if ( m_update != BaseEditor::Update::Background ) {
-		m_update = BaseEditor::Update::Content;
+	if ( m_update != Editor::Update::Background ) {
+		m_update = Editor::Update::Content;
 	}
 	update();
 }

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -337,8 +337,8 @@ void NotePropertiesRuler::wheelEvent(QWheelEvent *ev )
 			m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
 		}
 
-		if ( m_update != Update::Background ) {
-			m_update = Update::Pattern;
+		if ( m_update != BaseEditor::Update::Background ) {
+			m_update = BaseEditor::Update::Content;
 		}
 		update();
 	}
@@ -457,8 +457,8 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent *ev ) {
 
 	if ( bValueChanged ) {
 		triggerStatusMessage( notesStatusMessage, m_property );
-		if ( m_update != Update::Background ) {
-			m_update = Update::Pattern;
+		if ( m_update != BaseEditor::Update::Background ) {
+			m_update = BaseEditor::Update::Content;
 		}
 		update();
 
@@ -473,8 +473,8 @@ void NotePropertiesRuler::selectionMoveEndEvent( QInputEvent *ev ) {
 	//! The "move" has already been reflected in the notes. Now just complete Undo event.
 	addUndoAction( "" );
 
-	if ( m_update != Update::Background ) {
-		m_update = Update::Pattern;
+	if ( m_update != BaseEditor::Update::Background ) {
+		m_update = BaseEditor::Update::Content;
 	}
 	update();
 }
@@ -517,8 +517,8 @@ void NotePropertiesRuler::propertyDrawStart( QMouseEvent *ev )
 	setCursor( Qt::CrossCursor );
 	prepareUndoAction( ev );
 
-	if ( m_update != Update::Background ) {
-		m_update = Update::Pattern;
+	if ( m_update != BaseEditor::Update::Background ) {
+		m_update = BaseEditor::Update::Content;
 	}
 	update();
 }
@@ -694,8 +694,8 @@ void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
 
 	if ( bValueChanged ) {
 		Hydrogen::get_instance()->setIsModified( true );
-		if ( m_update != Update::Background ) {
-			m_update = Update::Pattern;
+		if ( m_update != BaseEditor::Update::Background ) {
+			m_update = BaseEditor::Update::Content;
 		}
 		update();
 		if ( m_property == PatternEditor::Property::Velocity ) {
@@ -712,8 +712,8 @@ void NotePropertiesRuler::propertyDrawEnd()
 	addUndoAction( "NotePropertiesRuler::propertyDraw" );
 	unsetCursor();
 
-	if ( m_update != Update::Background ) {
-		m_update = Update::Pattern;
+	if ( m_update != BaseEditor::Update::Background ) {
+		m_update = BaseEditor::Update::Content;
 	}
 	update();
 }

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -416,9 +416,9 @@ void NotePropertiesRuler::mouseClickEvent( QMouseEvent *ev ) {
 
 	if ( ev->button() == Qt::LeftButton ) {
 		// Treat single click as an instantaneous drag
-		propertyDrawStart( ev );
-		propertyDrawUpdate( ev );
-		propertyDrawEnd();
+		mouseDrawStart( ev );
+		mouseDrawUpdate( ev );
+		mouseDrawEnd();
 
 		updateModifiers( ev );
 
@@ -551,7 +551,7 @@ void NotePropertiesRuler::selectionMoveCancelEvent() {
 	m_oldNotes.clear();
 }
 
-void NotePropertiesRuler::propertyDrawStart( QMouseEvent *ev )
+void NotePropertiesRuler::mouseDrawStart( QMouseEvent *ev )
 {
 	setCursor( Qt::CrossCursor );
 	prepareUndoAction( ev );
@@ -596,7 +596,7 @@ void NotePropertiesRuler::prepareUndoAction( QMouseEvent* pEvent )
 //! complete an undo action until the notes final value has been set. This
 //! occurs either when the mouse is released, or when the pointer moves off of
 //! the note's column.
-void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
+void NotePropertiesRuler::mouseDrawUpdate( QMouseEvent *ev )
 {
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 	if ( pPattern == nullptr ) {
@@ -641,7 +641,7 @@ void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
 
 	if ( m_nDrawPreviousColumn != nRealColumn ) {
 		// Complete current undo action, and start a new one.
-		addUndoAction( "NotePropertiesRuler::propertyDraw" );
+		addUndoAction( "NotePropertiesRuler::mouseDraw" );
 		for ( const auto& ppNote : notesSinceLastAction ) {
 			m_oldNotes[ ppNote ] = std::make_shared<Note>( ppNote );
 		}
@@ -745,10 +745,10 @@ void NotePropertiesRuler::propertyDrawUpdate( QMouseEvent *ev )
 	}
 }
 
-void NotePropertiesRuler::propertyDrawEnd()
+void NotePropertiesRuler::mouseDrawEnd()
 {
 	m_nDrawPreviousColumn = -1;
-	addUndoAction( "NotePropertiesRuler::propertyDraw" );
+	addUndoAction( "NotePropertiesRuler::mouseDraw" );
 	unsetCursor();
 
 	if ( m_update != Editor::Update::Background ) {

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -155,6 +155,8 @@ NotePropertiesRuler::NotePropertiesRuler( QWidget *parent,
 	resize( m_nEditorWidth, m_nEditorHeight );
 	setMinimumHeight( m_nEditorHeight );
 
+	updatePixmapSize();
+
 	setFocusPolicy( Qt::StrongFocus );
 
 	// Generic pattern editor menu contains some operations that don't apply
@@ -1404,19 +1406,7 @@ void NotePropertiesRuler::createBackground()
 		lineColor = lineColor.darker( PatternEditor::nOutOfFocusDim );
 	}
 
-	const qreal pixelRatio = devicePixelRatio();
-	if ( m_pBackgroundPixmap->width() != m_nEditorWidth ||
-		 m_pBackgroundPixmap->height() != m_nEditorHeight ||
-		 m_pBackgroundPixmap->devicePixelRatio() != pixelRatio ) {
-		delete m_pBackgroundPixmap;
-		m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio ,
-										   m_nEditorHeight * pixelRatio );
-		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
-		delete m_pPatternPixmap;
-		m_pPatternPixmap = new QPixmap( m_nEditorWidth  * pixelRatio,
-										m_nEditorHeight * pixelRatio );
-		m_pPatternPixmap->setDevicePixelRatio( pixelRatio );
-	}
+	updatePixmapSize();
 
 	m_pBackgroundPixmap->fill( backgroundInactiveColor );
 
@@ -1542,7 +1532,7 @@ void NotePropertiesRuler::drawPattern() {
 
 	const qreal pixelRatio = devicePixelRatio();
 
-	QPainter p( m_pPatternPixmap );
+	QPainter p( m_pContentPixmap );
 	// copy the background image
 	p.drawPixmap( rect(), *m_pBackgroundPixmap,
 						QRectF( pixelRatio * rect().x(),

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -165,9 +165,14 @@ NotePropertiesRuler::NotePropertiesRuler( QWidget *parent,
 	// here, and we will want to add menu options specific to this later.
 	delete m_pPopupMenu;
 	m_pPopupMenu = new QMenu( this );
-	m_pPopupMenu->addAction( tr( "Select &all" ), this, [&]() { selectAll(); } );
+	m_pPopupMenu->addAction( tr( "Select &all" ), this, [&]() {
+		selectAll();
+		updateVisibleComponents( true );
+	} );
 	m_pPopupMenu->addAction( tr( "Clear selection" ), this, [&]() {
-		m_selection.clearSelection(); } );
+		m_selection.clearSelection();
+		updateVisibleComponents( true );
+	} );
 
 	// Create a small sidebar containing labels
 	if ( layout == Layout::KeyOctave ) {
@@ -1607,9 +1612,6 @@ void NotePropertiesRuler::selectAll()
 	for ( const auto& ppNote : notes ) {
 		m_selection.addToSelection( ppNote );
 	}
-
-	m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
-	m_pPatternEditorPanel->getVisiblePropertiesRuler()->updateEditor( true );
 }
 
 std::set< std::shared_ptr<H2Core::Note> > NotePropertiesRuler::getAllNotes() const {

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -110,9 +110,9 @@ class NotePropertiesRuler : public PatternEditor,
 		//! updated live during the draw gesture, with 'undo' information being
 		//! written at the end.
 		//! @{
-		void propertyDrawStart( QMouseEvent *ev );
-		void propertyDrawUpdate( QMouseEvent *ev );
-		void propertyDrawEnd();
+		void propertyDrawStart( QMouseEvent *ev ) override;
+		void propertyDrawUpdate( QMouseEvent *ev ) override;
+		void propertyDrawEnd() override;
 		//! @}
 
 		//! @name PatternEditor interfaces
@@ -120,9 +120,6 @@ class NotePropertiesRuler : public PatternEditor,
 		virtual bool canMoveElements() const override { return false; };
 		virtual std::vector<SelectionIndex> elementsIntersecting( const QRect& r ) override;
 		virtual void mouseClickEvent( QMouseEvent *ev ) override;
-		virtual void mouseDragStartEvent( QMouseEvent *ev ) override;
-		virtual void mouseDragUpdateEvent( QMouseEvent *ev ) override;
-		virtual void mouseDragEndEvent( QMouseEvent *ev ) override;
 		virtual void selectionMoveUpdateEvent( QMouseEvent *ev ) override;
 		virtual void selectionMoveEndEvent( QInputEvent *ev ) override;
 		virtual void selectionMoveCancelEvent() override;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -105,14 +105,13 @@ class NotePropertiesRuler : public PatternEditor,
 
 		//! @name Property draw (right-click drag) gestures
 		//! 
-		//! The user can right-click drag notes (or just left-click a single one)
-		//! on a note's bar or dot to change that property. Properties are
-		//! updated live during the draw gesture, with 'undo' information being
-		//! written at the end.
+		//! The user can right-click drag on a note's bar or dot to change that
+		//! property. Properties are updated live during the draw gesture, with
+		//! 'undo' information being written at the end.
 		//! @{
-		void propertyDrawStart( QMouseEvent *ev ) override;
-		void propertyDrawUpdate( QMouseEvent *ev ) override;
-		void propertyDrawEnd() override;
+		void mouseDrawStart( QMouseEvent *ev ) override;
+		void mouseDrawUpdate( QMouseEvent *ev ) override;
+		void mouseDrawEnd() override;
 		//! @}
 
 		//! @name PatternEditor interfaces

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -97,6 +97,9 @@ class NotePropertiesRuler : public PatternEditor,
 		NotePropertiesRuler(const NotePropertiesRuler&) = delete;
 		NotePropertiesRuler& operator=( const NotePropertiesRuler& rhs ) = delete;
 
+		void moveCursorDown( QKeyEvent* ev, Editor::Step step ) override;
+		void moveCursorUp( QKeyEvent* ev, Editor::Step step ) override;
+
 		void updateColors();
 		void updateFont();
 
@@ -158,7 +161,6 @@ class NotePropertiesRuler : public PatternEditor,
 
 		void paintEvent(QPaintEvent *ev) override;
 		void wheelEvent(QWheelEvent *ev) override;
-		void keyPressEvent( QKeyEvent *ev ) override;
 		void addUndoAction( const QString& sUndoContext );
 		void prepareUndoAction( QMouseEvent* pEvent );
 
@@ -180,6 +182,7 @@ class NotePropertiesRuler : public PatternEditor,
 		bool adjustNotePropertyDelta(
 			std::vector< std::shared_ptr<H2Core::Note> > notes, float fDelta,
 			bool bKey );
+		void applyCursorDelta( float fDelta );
 
 		int m_nDrawPreviousColumn;
 		Layout m_layout;

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.h
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.h
@@ -97,31 +97,22 @@ class NotePropertiesRuler : public PatternEditor,
 		NotePropertiesRuler(const NotePropertiesRuler&) = delete;
 		NotePropertiesRuler& operator=( const NotePropertiesRuler& rhs ) = delete;
 
-		void moveCursorDown( QKeyEvent* ev, Editor::Step step ) override;
-		void moveCursorUp( QKeyEvent* ev, Editor::Step step ) override;
-
 		void updateColors();
 		void updateFont();
 
-		//! @name Property draw (right-click drag) gestures
-		//! 
-		//! The user can right-click drag on a note's bar or dot to change that
-		//! property. Properties are updated live during the draw gesture, with
-		//! 'undo' information being written at the end.
+		//! @name Editor::Base interfaces
 		//! @{
+		bool canMoveElements() const override { return false; };
+		std::vector<SelectionIndex> elementsIntersecting( const QRect& r ) override;
+		void mouseClickEvent( QMouseEvent *ev ) override;
+		void selectionMoveUpdateEvent( QMouseEvent *ev ) override;
+		void selectionMoveEndEvent( QInputEvent *ev ) override;
+		void selectionMoveCancelEvent() override;
+		void moveCursorDown( QKeyEvent* ev, Editor::Step step ) override;
+		void moveCursorUp( QKeyEvent* ev, Editor::Step step ) override;
 		void mouseDrawStart( QMouseEvent *ev ) override;
 		void mouseDrawUpdate( QMouseEvent *ev ) override;
 		void mouseDrawEnd() override;
-		//! @}
-
-		//! @name PatternEditor interfaces
-		//! @{
-		virtual bool canMoveElements() const override { return false; };
-		virtual std::vector<SelectionIndex> elementsIntersecting( const QRect& r ) override;
-		virtual void mouseClickEvent( QMouseEvent *ev ) override;
-		virtual void selectionMoveUpdateEvent( QMouseEvent *ev ) override;
-		virtual void selectionMoveEndEvent( QInputEvent *ev ) override;
-		virtual void selectionMoveCancelEvent() override;
 		//! @}
 
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -74,7 +74,11 @@ PatternEditor::PatternEditor( QWidget *pParent, BaseEditor::EditorType editorTyp
 	m_fGridWidth = pPref->getPatternEditorGridWidth();
 	m_nEditorWidth = PatternEditor::nMargin + m_fGridWidth * 4 * 4 *
 		H2Core::nTicksPerQuarter;
+	m_nEditorHeight = height();
 	m_nActiveWidth = m_nEditorWidth;
+
+	updateWidth();
+	updatePixmapSize();
 
 	setFocusPolicy(Qt::StrongFocus);
 	setMouseTracking( true );
@@ -93,31 +97,10 @@ PatternEditor::PatternEditor( QWidget *pParent, BaseEditor::EditorType editorTyp
 		popupMenuAboutToShow(); } );
 	connect( m_pPopupMenu, &QMenu::aboutToHide, [&]() {
 		popupMenuAboutToHide(); } );
-
-
-	updateWidth();
-
-	qreal pixelRatio = devicePixelRatio();
-	m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
-									   height() * pixelRatio );
-	m_pPatternPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
-									height() * pixelRatio );
-	m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
-	m_pPatternPixmap->setDevicePixelRatio( pixelRatio );
-
-	DEBUGLOG( BaseEditor::editorTypeToQString( m_editorType ) );
 }
 
-PatternEditor::~PatternEditor()
-{
+PatternEditor::~PatternEditor() {
 	m_draggedNotes.clear();
-
-	if ( m_pPatternPixmap != nullptr ) {
-		delete m_pPatternPixmap;
-	}
-	if ( m_pBackgroundPixmap != nullptr ) {
-		delete m_pBackgroundPixmap;
-	}
 }
 
 void PatternEditor::zoomIn()
@@ -2263,7 +2246,7 @@ void PatternEditor::paintEvent( QPaintEvent* ev )
 	}
 
 	QPainter painter( this );
-	painter.drawPixmap( ev->rect(), *m_pPatternPixmap,
+	painter.drawPixmap( ev->rect(), *m_pContentPixmap,
 						QRectF( pixelRatio * ev->rect().x(),
 								pixelRatio * ev->rect().y(),
 								pixelRatio * ev->rect().width(),
@@ -2306,7 +2289,7 @@ void PatternEditor::drawPattern()
 {
 	const qreal pixelRatio = devicePixelRatio();
 
-	QPainter p( m_pPatternPixmap );
+	QPainter p( m_pContentPixmap );
 	// copy the background image
 	p.drawPixmap( rect(), *m_pBackgroundPixmap,
 						QRectF( pixelRatio * rect().x(),
@@ -2546,9 +2529,6 @@ void PatternEditor::drawBorders( QPainter& p ) {
 	}
 }
 
-void PatternEditor::createBackground() {
-}
-
 bool PatternEditor::updateWidth() {
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 	auto pPattern = m_pPatternEditorPanel->getPattern();
@@ -2591,6 +2571,8 @@ bool PatternEditor::updateWidth() {
 		m_nActiveWidth = nActiveWidth;
 
 		resize( m_nEditorWidth, m_nEditorHeight );
+
+		updatePixmapSize();
 
 		return true;
 	}

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1933,7 +1933,15 @@ void PatternEditor::scrolled( int nValue ) {
 	update();
 }
 
-void PatternEditor::updateCursorHoveredElements() {
+void PatternEditor::ensureCursorIsVisible() {
+	m_pPatternEditorPanel->ensureCursorIsVisible();
+}
+
+void PatternEditor::updateKeyboardHoveredElements() {
+	updateHoveredNotesKeyboard( true );
+}
+
+void PatternEditor::updateMouseHoveredElements() {
 	const QPoint globalPos = QCursor::pos();
 	const QPoint widgetPos = mapFromGlobal( globalPos );
 	if ( ( widgetPos.x() < 0 || widgetPos.x() >= width() ||
@@ -1950,6 +1958,12 @@ void PatternEditor::updateCursorHoveredElements() {
 			Qt::LeftButton, Qt::NoModifier );
 		updateHoveredNotesMouse( pEvent, false );
 	}
+}
+
+void PatternEditor::updateAllComponents() {
+	m_pPatternEditorPanel->getSidebar()->updateEditor();
+	m_pPatternEditorPanel->getPatternEditorRuler()->update();
+	updateVisibleComponents();
 }
 
 void PatternEditor::updateVisibleComponents() {
@@ -2134,35 +2148,6 @@ void PatternEditor::keyPressEvent( QKeyEvent *ev, bool bFullUpdate )
 
 	if ( ! ev->isAccepted() ) {
 		ev->accept();
-	}
-}
-
-void PatternEditor::handleKeyboardCursor( bool bVisible ) {
-	auto pHydrogenApp = HydrogenApp::get_instance();
-	const bool bOldCursorHidden = pHydrogenApp->hideKeyboardCursor();
-
-	pHydrogenApp->setHideKeyboardCursor( ! bVisible );
-
-	// Only update on state changes
-	if ( bOldCursorHidden != pHydrogenApp->hideKeyboardCursor() ) {
-		updateHoveredNotesKeyboard();
-		if ( bVisible ) {
-			m_selection.updateKeyboardCursorPosition();
-			m_pPatternEditorPanel->ensureVisible();
-
-			if ( m_selection.isLasso() && m_update !=
-				 BaseEditor::Update::Background ) {
-				// Since the event was used to alter the note selection, we need
-				// to repainting all note symbols (including whether or not they
-				// are selected).
-				m_update = BaseEditor::Update::Content;
-			}
-		}
-
-		m_pPatternEditorPanel->getSidebar()->updateEditor();
-		m_pPatternEditorPanel->getPatternEditorRuler()->update();
-		m_pPatternEditorPanel->getVisibleEditor()->update();
-		m_pPatternEditorPanel->getVisiblePropertiesRuler()->update();
 	}
 }
 
@@ -3508,7 +3493,7 @@ void PatternEditor::setCursorPitch( int nCursorPitch ) {
 	}
 
 	if ( ! HydrogenApp::get_instance()->hideKeyboardCursor() ) {
-		m_pPatternEditorPanel->ensureVisible();
+		m_pPatternEditorPanel->ensureCursorIsVisible();
 		m_pPatternEditorPanel->getSidebar()->updateEditor();
 		m_pPatternEditorPanel->getPatternEditorRuler()->update();
 		m_pPatternEditorPanel->getVisiblePropertiesRuler()->update();

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -105,11 +105,10 @@ PatternEditor::PatternEditor( QWidget *pParent )
 	m_pPopupMenu->addAction( tr( "Select &all" ), this,
 							 [&]() { selectAll();
 								 updateVisibleComponents( true ); } );
-	m_selectionActions.push_back(
-		m_pPopupMenu->addAction( tr( "Clear selection" ), this, [&]() {
-			m_selection.clearSelection();
-			updateVisibleComponents( true );
-		} ) );
+	m_pPopupMenu->addAction( tr( "Clear selection" ), this, [&]() {
+		m_selection.clearSelection();
+		updateVisibleComponents( true );
+	} );
 	connect( m_pPopupMenu, &QMenu::aboutToShow, [&]() {
 		popupMenuAboutToShow(); } );
 	connect( m_pPopupMenu, &QMenu::aboutToHide, [&]() {

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1938,9 +1938,8 @@ void PatternEditor::updateKeyboardHoveredElements() {
 void PatternEditor::updateMouseHoveredElements( QMouseEvent* ev ) {
 	const QPoint globalPos = QCursor::pos();
 	const QPoint widgetPos = mapFromGlobal( globalPos );
-	if ( ( widgetPos.x() < 0 || widgetPos.x() >= width() ||
-		   widgetPos.y() < 0 || widgetPos.y() >= height() ) ||
-		! hasFocus() ) {
+	if ( widgetPos.x() < 0 || widgetPos.x() >= width() ||
+		 widgetPos.y() < 0 || widgetPos.y() >= height() ) {
 		// Outside of the current widget. Clear all hovered notes.
 		std::vector< std::pair< std::shared_ptr<Pattern>,
 								std::vector< std::shared_ptr<Note> > > > empty;

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -2316,7 +2316,7 @@ void PatternEditor::updatePosition( float fTick ) {
 	}
 }
 
-void PatternEditor::mouseDragStartEvent( QMouseEvent *ev ) {
+void PatternEditor::editPropertyStart( QMouseEvent *ev ) {
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 	if ( pPattern == nullptr ) {
 		return;
@@ -2377,7 +2377,7 @@ void PatternEditor::mouseDragStartEvent( QMouseEvent *ev ) {
 	}
 }
 
-void PatternEditor::mouseDragUpdateEvent( QMouseEvent *ev ) {
+void PatternEditor::editPropertyUpdate( QMouseEvent *ev ) {
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 	if ( pPattern == nullptr || m_draggedNotes.size() == 0 ) {
 		return;
@@ -2482,7 +2482,7 @@ void PatternEditor::mouseDragUpdateEvent( QMouseEvent *ev ) {
 	m_pPatternEditorPanel->updateEditors( true );
 }
 
-void PatternEditor::mouseDragEndEvent( QMouseEvent* ev ) {
+void PatternEditor::editPropertyEnd( QMouseEvent* ev ) {
 
 	UNUSED( ev );
 	unsetCursor();

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -56,7 +56,6 @@ using namespace H2Core;
 PatternEditor::PatternEditor( QWidget *pParent )
 	: Object()
 	, Editor::Base<Elem>( pParent )
-	, m_bEntered( false )
 	, m_nTick( -1 )
 	, m_property( Property::None )
 	, m_nCursorPitch( 0 )
@@ -2111,56 +2110,6 @@ void PatternEditor::keyReleaseEvent( QKeyEvent *ev ) {
 	// user might position a note carefully and it jumps to different place
 	// because she released the Alt modifier slightly earlier than the mouse
 	// button.
-}
-
-#ifdef H2CORE_HAVE_QT6
-void PatternEditor::enterEvent( QEnterEvent *ev ) {
-#else
-void PatternEditor::enterEvent( QEvent *ev ) {
-#endif
-	UNUSED( ev );
-	m_bEntered = true;
-
-	// Update focus, hovered notes and selection color.
-	m_pPatternEditorPanel->updateEditors( true );
-}
-
-void PatternEditor::leaveEvent( QEvent *ev ) {
-	UNUSED( ev );
-	m_bEntered = false;
-
-	if ( m_pPatternEditorPanel->getHoveredNotes().size() > 0 ) {
-		std::vector< std::pair< std::shared_ptr<Pattern>,
-								std::vector< std::shared_ptr<Note> > > > empty;
-		// Takes care of the update.
-		m_pPatternEditorPanel->setHoveredNotesMouse( empty );
-	}
-
-	// Ending the enclosing undo context. This is key to enable the Undo/Redo
-	// buttons in the main menu again and it feels like a good rule of thumb to
-	// consider an action done whenever the user moves mouse or cursor away from
-	// the widget.
-	HydrogenApp::get_instance()->endUndoContext();
-
-	// Update focus, hovered notes and selection color.
-	m_pPatternEditorPanel->updateEditors( true );
-}
-
-void PatternEditor::focusInEvent( QFocusEvent *ev ) {
-	UNUSED( ev );
-	if ( ev->reason() == Qt::TabFocusReason ||
-		 ev->reason() == Qt::BacktabFocusReason ) {
-		handleKeyboardCursor( true );
-	}
-
-	// Update hovered notes, cursor, background color, selection color...
-	m_pPatternEditorPanel->updateEditors();
-}
-
-void PatternEditor::focusOutEvent( QFocusEvent *ev ) {
-	UNUSED( ev );
-	// Update hovered notes, cursor, background color, selection color...
-	m_pPatternEditorPanel->updateEditors();
 }
 
 void PatternEditor::paintEvent( QPaintEvent* ev )

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -919,7 +919,7 @@ void PatternEditor::mousePressEvent( QMouseEvent *ev ) {
 			   ev->button() == Qt::RightButton ) ) ) {
 		if ( ! m_selection.isEmpty() ) {
 			m_selection.clearSelection();
-			updateVisibleComponents();
+			updateVisibleComponents( true );
 		}
 		return;
 	}
@@ -1048,40 +1048,16 @@ void PatternEditor::mouseClickEvent( QMouseEvent *ev )
 	update();
 }
 
-void PatternEditor::mouseMoveEvent( QMouseEvent *ev )
-{
+void PatternEditor::mouseMoveEvent( QMouseEvent *ev ) {
 	if ( m_pPatternEditorPanel->getPattern() == nullptr ) {
 		return;
 	}
 
-	if ( m_elementsToSelect.size() > 0 ) {
-		if ( ev->buttons() == Qt::LeftButton ||
-			 ev->buttons() == Qt::RightButton ) {
-			m_selection.clearSelection();
-			for ( const auto& ppNote : m_elementsToSelect ) {
-				m_selection.addToSelection( ppNote );
-			}
-		}
-		else {
-			m_elementsToSelect.clear();
-		}
-	}
+	BaseEditor::mouseMoveEvent( ev );
 
-	updateModifiers( ev );
-
-	// Check which note is hovered.
-	updateHoveredNotesMouse( ev );
-
-	if ( ev->buttons() != Qt::NoButton ) {
-		m_selection.mouseMoveEvent( ev );
-		if ( m_selection.isMoving() ) {
-			m_pPatternEditorPanel->getVisibleEditor()->update();
-			m_pPatternEditorPanel->getVisiblePropertiesRuler()->update();
-			}
-		else if ( syncLasso() ) {
-			m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
-			m_pPatternEditorPanel->getVisiblePropertiesRuler()->updateEditor( true );
-		}
+	if ( ev->buttons() != Qt::NoButton && ! m_selection.isMoving() &&
+		syncLasso() ) {
+		updateVisibleComponents( true );
 	}
 }
 
@@ -1941,7 +1917,7 @@ void PatternEditor::updateKeyboardHoveredElements() {
 	updateHoveredNotesKeyboard( true );
 }
 
-void PatternEditor::updateMouseHoveredElements() {
+void PatternEditor::updateMouseHoveredElements( QMouseEvent* ev ) {
 	const QPoint globalPos = QCursor::pos();
 	const QPoint widgetPos = mapFromGlobal( globalPos );
 	if ( ( widgetPos.x() < 0 || widgetPos.x() >= width() ||
@@ -1952,6 +1928,9 @@ void PatternEditor::updateMouseHoveredElements() {
 								std::vector< std::shared_ptr<Note> > > > empty;
 		m_pPatternEditorPanel->setHoveredNotesMouse( empty );
 	}
+	else if ( ev != nullptr ) {
+		updateHoveredNotesMouse( ev, false );
+	}
 	else {
 		auto pEvent = new QMouseEvent(
 			QEvent::MouseButtonRelease, widgetPos, globalPos, Qt::LeftButton,
@@ -1960,15 +1939,15 @@ void PatternEditor::updateMouseHoveredElements() {
 	}
 }
 
-void PatternEditor::updateAllComponents() {
+void PatternEditor::updateAllComponents( bool bContentOnly ) {
 	m_pPatternEditorPanel->getSidebar()->updateEditor();
 	m_pPatternEditorPanel->getPatternEditorRuler()->update();
-	updateVisibleComponents();
+	updateVisibleComponents( bContentOnly );
 }
 
-void PatternEditor::updateVisibleComponents() {
-	m_pPatternEditorPanel->getVisibleEditor()->updateEditor( true );
-	m_pPatternEditorPanel->getVisiblePropertiesRuler()->updateEditor( true );
+void PatternEditor::updateVisibleComponents( bool bContentOnly ) {
+	m_pPatternEditorPanel->getVisibleEditor()->updateEditor( bContentOnly );
+	m_pPatternEditorPanel->getVisiblePropertiesRuler()->updateEditor( bContentOnly );
 }
 
 int PatternEditor::granularity() const {

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -103,10 +103,13 @@ PatternEditor::PatternEditor( QWidget *pParent )
 	m_selectionActions.push_back( m_pPopupMenu->addAction( tr( "A&lign to grid" ), this, SLOT( alignToGrid() ) ) );
 	m_selectionActions.push_back( m_pPopupMenu->addAction( tr( "Randomize velocity" ), this, SLOT( randomizeVelocity() ) ) );
 	m_pPopupMenu->addAction( tr( "Select &all" ), this,
-							 [&]() { selectAll(); } );
+							 [&]() { selectAll();
+								 updateVisibleComponents( true ); } );
 	m_selectionActions.push_back(
 		m_pPopupMenu->addAction( tr( "Clear selection" ), this, [&]() {
-			m_selection.clearSelection(); } ) );
+			m_selection.clearSelection();
+			updateVisibleComponents( true );
+		} ) );
 	connect( m_pPopupMenu, &QMenu::aboutToShow, [&]() {
 		popupMenuAboutToShow(); } );
 	connect( m_pPopupMenu, &QMenu::aboutToHide, [&]() {
@@ -346,7 +349,7 @@ void PatternEditor::undoDeselectAndOverwriteNotes(
 	}
 	pHydrogen->getAudioEngine()->unlock();
 	pHydrogen->setIsModified( true );
-	m_pPatternEditorPanel->updateEditors( true );
+	updateVisibleComponents( true );
 }
 
 void PatternEditor::editNotePropertiesAction( const Property& property,

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -99,11 +99,6 @@ public:
 	void zoomOut();
 		void zoomLasso( float fOldGridWidth );
 
-	//! Clear the pattern editor selection
-	void clearSelection() {
-		m_selection.clearSelection();
-	}
-
 	/** Move or copy notes.
 	 *
 	 * Moves or copies notes at the end of a Selection move, handling the
@@ -133,19 +128,6 @@ public:
 
 	//! Deselecting notes
 	virtual bool checkDeselectElements( const std::vector<SelectionIndex>& elements ) override;
-
-	//! Change the mouse cursor during mouse gestures
-	virtual void startMouseLasso( QMouseEvent *ev ) override {
-		setCursor( Qt::CrossCursor );
-	}
-
-	virtual void startMouseMove( QMouseEvent *ev ) override {
-		setCursor( Qt::DragMoveCursor );
-	}
-
-	virtual void endMouseGesture() override {
-		unsetCursor();
-	}
 
 	//! Deselect some notes, and "overwrite" some others.
 	void deselectAndOverwriteNotes( const std::vector< std::shared_ptr<H2Core::Note> >& selected,
@@ -229,7 +211,6 @@ public:
 			const Property& property, bool bSquash = false );
 
 		QPoint getCursorPosition();
-		void handleKeyboardCursor( bool bVisible );
 
 		/** Ensure the selection lassos of the other editors match the one of
 		 * this instance. */
@@ -279,7 +260,10 @@ protected:
 		 * which of the editors currently holds focus. */
 		static constexpr int nOutOfFocusDim = 110;
 
-		void updateCursorHoveredElements() override;
+		void ensureCursorIsVisible() override;
+		void updateKeyboardHoveredElements() override;
+		void updateMouseHoveredElements() override;
+		void updateAllComponents() override;
 		void updateVisibleComponents() override;
 
 	//! Granularity of grid positioning (in ticks)

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -193,8 +193,6 @@ public:
 			const std::vector< std::shared_ptr<H2Core::Note> > notes,
 			const Property& property, bool bSquash = false );
 
-		QPoint getCursorPosition();
-
 		/** Ensure the selection lassos of the other editors match the one of
 		 * this instance. */
 		bool syncLasso();
@@ -204,13 +202,23 @@ public:
 
 		void setCursorPitch( int nCursorPitch );
 
+		void ensureCursorIsVisible() override;
+		void handleElements( QInputEvent* ev, Editor::Action action ) override;
+		void deleteElements( std::vector< std::shared_ptr<H2Core::Note>> ) override;
+		void copy() override;
+		void paste() override;
+		void moveCursorLeft( QKeyEvent* ev, Editor::Step step ) override;
+		void moveCursorRight( QKeyEvent* ev, Editor::Step step ) override;
+		QPoint getCursorPosition() override;
+		void setCursorTo( std::shared_ptr<H2Core::Note> ) override;
+		void setCursorTo( QMouseEvent* ev ) override;
+		void setupPopupMenu() override;
+		void updateKeyboardHoveredElements() override;
+		void updateMouseHoveredElements( QMouseEvent* ev ) override;
+		void updateAllComponents( bool bContentOnly ) override;
+		void updateVisibleComponents( bool bContentOnly ) override;
+
 public slots:
-	virtual void selectAll() = 0;
-	virtual void selectNone();
-	void deleteSelection( bool bHandleSetupTeardown = true );
-	virtual void copy( bool bHandleSetupTeardown = true );
-	void paste();
-	virtual void cut();
 	virtual void alignToGrid();
 	virtual void randomizeVelocity();
 	void selectAllNotesInRow( int nRow, int nPitch = PITCH_INVALID );
@@ -242,17 +250,6 @@ protected:
 		 * case the widget is not in focus. This should help users to determine
 		 * which of the editors currently holds focus. */
 		static constexpr int nOutOfFocusDim = 110;
-
-		void ensureCursorIsVisible() override;
-		void addElement( QMouseEvent* ev ) override;
-		void deleteElements( std::vector< std::shared_ptr<H2Core::Note>> ) override;
-		void setCursorTo( std::shared_ptr<H2Core::Note> ) override;
-		void setCursorTo( QMouseEvent* ev ) override;
-		void setupPopupMenu() override;
-		void updateKeyboardHoveredElements() override;
-		void updateMouseHoveredElements( QMouseEvent* ev ) override;
-		void updateAllComponents( bool bContentOnly ) override;
-		void updateVisibleComponents( bool bContentOnly ) override;
 
 	//! Granularity of grid positioning (in ticks)
 	int granularity() const;
@@ -334,10 +331,7 @@ protected:
 	 */
 	virtual bool updateWidth() override;
 
-		/** @param bFullUpdate if `false`, just a simple update() of the widget
-		 *   will be triggered. If `true`, the background will be updated as
-		 *   well. */
-		void keyPressEvent ( QKeyEvent *ev, bool bFullUpdate = false );
+		virtual void keyPressEvent ( QKeyEvent* ev ) override;
 		virtual void keyReleaseEvent (QKeyEvent *ev) override;
 		virtual void paintEvent( QPaintEvent* ev ) override;
 

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -65,89 +65,33 @@ class PatternEditor : public Editor::Base<std::shared_ptr<H2Core::Note>>,
 public:
 		typedef std::shared_ptr<H2Core::Note> Elem;
 
-	enum class Property {
-		Velocity = 0,
-		Pan = 1,
-		LeadLag = 2,
-		KeyOctave = 3,
-		Probability = 4,
-		/** For this property there is no dedicated NotePropertiesEditor
-		 * instance but we solely use it within undo/redo actions.*/
-		Length = 5,
-		/** For this property there is no dedicated NotePropertiesEditor
-		 * instance but we solely use it within undo/redo actions.*/
-		Type = 6,
-		/** For this property there is no dedicated NotePropertiesEditor
-		 * instance but we solely use it within undo/redo actions.*/
-		InstrumentId = 7,
-		None = 8
-	};
-	static QString propertyToQString( const Property& property );
-
-	PatternEditor( QWidget *pParent );
-	~PatternEditor();
-
-	float getGridWidth() const { return m_fGridWidth; }
-	unsigned getGridHeight() const { return m_nGridHeight; }
-	//! Zoom in / out on the time axis
-	void zoomIn();
-	void zoomOut();
-		void zoomLasso( float fOldGridWidth );
-
-	/** Move or copy notes.
-	 *
-	 * Moves or copies notes at the end of a Selection move, handling the
-	 * behaviours necessary for out-of-range moves or copies.*/
-	virtual void selectionMoveEndEvent( QInputEvent *ev ) override;
-
-	//! Calculate colour to use for note representation based on note velocity. 
-	static QColor computeNoteColor( float velocity );
-
-
-	//! Merge together the selection groups of two PatternEditor objects to share a common selection.
-	void mergeSelectionGroups( PatternEditor *pPatternEditor ) {
-		m_selection.merge( &pPatternEditor->m_selection );
-	}
-
-	//! Ensure that the Selection contains only valid elements.
-	virtual void validateSelection() override;
-
-	//! Update the status of modifier keys in response to input events.
-	virtual void updateModifiers( QInputEvent *ev ) override;
-
-		virtual std::vector<SelectionIndex> getElementsAtPoint(
-			const QPoint& point, int nCursorMargin,
-			std::shared_ptr<H2Core::Pattern> pPattern = nullptr ) override;
-
-		virtual int getCursorMargin( QInputEvent* pEvent ) const override;
-
-	//! Deselecting notes
-	virtual bool checkDeselectElements( const std::vector<SelectionIndex>& elements ) override;
-
-	//! Deselect some notes, and "overwrite" some others.
-	void deselectAndOverwriteNotes( const std::vector< std::shared_ptr<H2Core::Note> >& selected,
-									const std::vector< std::shared_ptr<H2Core::Note> >& overwritten );
-
-	void undoDeselectAndOverwriteNotes( const std::vector< std::shared_ptr<H2Core::Note> >& selected,
-										const std::vector< std::shared_ptr<H2Core::Note> >& overwritten );
-
-	//! Raw Qt mouse events are passed to the Selection
-	virtual void mousePressEvent( QMouseEvent *ev ) override;
-	virtual void mouseMoveEvent( QMouseEvent *ev ) override;
-	virtual void mouseReleaseEvent( QMouseEvent *ev ) override;
-		virtual void mouseClickEvent( QMouseEvent *ev ) override;
-	
-		virtual QRect getKeyboardCursorRect() override;
-
 		/** Area taken available for an addition sidebar or button */
 		static constexpr int nMarginSidebar = 32;
 		/** #nMarginSidebar + some additional space to contain a margin and half
 		 * of the notes on first grid point. */
 		static constexpr int nMargin = nMarginSidebar + 10;
 
-	/** Caches the AudioEngine::m_nPatternTickPosition in the member
-		variable #m_nTick and triggers an update(). */
-	void updatePosition( float fTick );
+		enum class Property {
+			Velocity = 0,
+			Pan = 1,
+			LeadLag = 2,
+			KeyOctave = 3,
+			Probability = 4,
+			/** For this property there is no dedicated NotePropertiesEditor
+			 * instance but we solely use it within undo/redo actions.*/
+			Length = 5,
+			/** For this property there is no dedicated NotePropertiesEditor
+			 * instance but we solely use it within undo/redo actions.*/
+			Type = 6,
+			/** For this property there is no dedicated NotePropertiesEditor
+			 * instance but we solely use it within undo/redo actions.*/
+			InstrumentId = 7,
+			None = 8
+		};
+		static QString propertyToQString( const Property& property );
+
+		PatternEditor( QWidget *pParent );
+		~PatternEditor();
 
 		static void addOrRemoveNoteAction( int nPosition,
 										   int nInstrumentId,
@@ -165,48 +109,108 @@ public:
 										   bool bIsMappedToDrumkit,
 										   Editor::Action action );
 
+		//! Deselect some notes, and "overwrite" some others.
+		void deselectAndOverwriteNotes(
+			const std::vector< std::shared_ptr<H2Core::Note> >& selected,
+			const std::vector< std::shared_ptr<H2Core::Note> >& overwritten );
+
+		void undoDeselectAndOverwriteNotes(
+			const std::vector< std::shared_ptr<H2Core::Note> >& selected,
+			const std::vector< std::shared_ptr<H2Core::Note> >& overwritten );
+
 		/** For notes in #PianoRollEditor and the note key version of
 		 * #NotePropertiesEditor @a nOldKey and @a nOldOctave will be
 		 * used to find the actual #H2Core::Note to alter. In the latter
 		 * adjusting note/octave can be done too. This is covered using @a
 		 * nNewKey and @a nNewOctave. */
-	static void editNotePropertiesAction( const Property& property,
-										  int nPatternNumber,
-										  int nPosition,
-										  int nOldInstrumentId,
-										  int nNewInstrumentId,
-										  const QString& sOldType,
-										  const QString& sNewType,
-										  float fVelocity,
-										  float fPan,
-										  float fLeadLag,
-										  float fProbability,
-										  int nLength,
-										  int nNewKey,
-										  int nOldKey,
-										  int nNewOctave,
-										  int nOldOctave );
-		void triggerStatusMessage(
-			const std::vector< std::shared_ptr<H2Core::Note> > notes,
-			const Property& property, bool bSquash = false );
+		static void editNotePropertiesAction( const Property& property,
+											  int nPatternNumber,
+											  int nPosition,
+											  int nOldInstrumentId,
+											  int nNewInstrumentId,
+											  const QString& sOldType,
+											  const QString& sNewType,
+											  float fVelocity,
+											  float fPan,
+											  float fLeadLag,
+											  float fProbability,
+											  int nLength,
+											  int nNewKey,
+											  int nOldKey,
+											  int nNewOctave,
+											  int nOldOctave );
 
-		/** Ensure the selection lassos of the other editors match the one of
-		 * this instance. */
-		bool syncLasso();
+		float getGridWidth() const { return m_fGridWidth; }
+		unsigned getGridHeight() const { return m_nGridHeight; }
+
 		bool isSelectionMoving() const;
+
+		//! Merge together the selection groups of two PatternEditor objects to
+		//! share a common selection.
+		void mergeSelectionGroups( PatternEditor *pPatternEditor ) {
+			m_selection.merge( &pPatternEditor->m_selection );
+		}
 
 		QPoint movingGridOffset() const;
 
 		void setCursorPitch( int nCursorPitch );
 
-		void ensureCursorIsVisible() override;
+		/** Ensure the selection lassos of the other editors match the one of
+		 * this instance. */
+		bool syncLasso();
+
+		void triggerStatusMessage(
+			const std::vector< std::shared_ptr<H2Core::Note> > notes,
+			const Property& property, bool bSquash = false );
+
+		/** Caches the AudioEngine::m_nPatternTickPosition in the member
+			variable #m_nTick and triggers an update(). */
+		void updatePosition( float fTick );
+
+		// Zoom in / out on the time axis
+		void zoomIn();
+		void zoomLasso( float fOldGridWidth );
+		void zoomOut();
+
+		//! Raw Qt mouse events are passed to the Selection.
+		virtual void keyPressEvent( QKeyEvent* ev ) override;
+		virtual void keyReleaseEvent(QKeyEvent *ev) override;
+		virtual void mousePressEvent( QMouseEvent *ev ) override;
+		virtual void mouseMoveEvent( QMouseEvent *ev ) override;
+		virtual void mouseReleaseEvent( QMouseEvent *ev ) override;
+		virtual void mouseClickEvent( QMouseEvent *ev ) override;
+		virtual void paintEvent( QPaintEvent* ev ) override;
+	
+		//! @name SelectionWidget interfaces
+		//! @{
+		//! Deselecting notes
+		bool checkDeselectElements(
+			const std::vector< std::shared_ptr<H2Core::Note> >& elements ) override;
+		int getCursorMargin( QInputEvent* pEvent ) const override;
+		//! Update the status of modifier keys in response to input events.
+		virtual std::vector<SelectionIndex> getElementsAtPoint(
+			const QPoint& point, int nCursorMargin,
+			std::shared_ptr<H2Core::Pattern> pPattern = nullptr ) override;
+		QRect getKeyboardCursorRect() override;
+		/** Move or copy notes.
+		 *
+		 * Moves or copies notes at the end of a Selection move, handling the
+		 * behaviours necessary for out-of-range moves or copies.*/
+		virtual void selectionMoveEndEvent( QInputEvent *ev ) override;
+		//! Ensure that the Selection contains only valid elements.
+		virtual void validateSelection() override;
+		//! @)
+
+		// @name Editor::Base interfaces
+		//! @{
 		void handleElements( QInputEvent* ev, Editor::Action action ) override;
 		void deleteElements( std::vector< std::shared_ptr<H2Core::Note>> ) override;
 		void copy() override;
 		void paste() override;
+		void ensureCursorIsVisible() override;
+		QPoint getCursorPosition() override;
 		void moveCursorLeft( QKeyEvent* ev, Editor::Step step ) override;
 		void moveCursorRight( QKeyEvent* ev, Editor::Step step ) override;
-		QPoint getCursorPosition() override;
 		void setCursorTo( std::shared_ptr<H2Core::Note> ) override;
 		void setCursorTo( QMouseEvent* ev ) override;
 		void setupPopupMenu() override;
@@ -218,12 +222,19 @@ public:
 		void mouseEditEnd() override;
 		void updateAllComponents( bool bContentOnly ) override;
 		void updateVisibleComponents( bool bContentOnly ) override;
+		void updateModifiers( QInputEvent *ev ) override;
+		/**
+		 * Adjusts #m_nActiveWidth and #m_nEditorWidth to the current
+		 * state of the editor.
+		 */
+		bool updateWidth() override;
+		//! @}
 
 public slots:
-	virtual void alignToGrid();
-	virtual void randomizeVelocity();
-	void selectAllNotesInRow( int nRow, int nPitch = PITCH_INVALID );
-	void scrolled( int nValue );
+		virtual void alignToGrid();
+		virtual void randomizeVelocity();
+		void selectAllNotesInRow( int nRow, int nPitch = PITCH_INVALID );
+		void scrolled( int nValue );
 
 protected:
 		enum NoteStyle {
@@ -247,23 +258,85 @@ protected:
 			EffectiveLength = 0x020,
 		};
 
-		/** Scaling factor by which the background colors will be made darker in
-		 * case the widget is not in focus. This should help users to determine
-		 * which of the editors currently holds focus. */
-		static constexpr int nOutOfFocusDim = 110;
-
-	//! Granularity of grid positioning (in ticks)
-	int granularity() const;
-
-	float m_fGridWidth;
-	unsigned m_nGridHeight;
-
 		enum class DragType {
 			None,
 			Length,
 			Property
 		};
 		static QString DragTypeToQString( DragType dragType );
+
+		/** Scaling factor by which the background colors will be made darker in
+		 * case the widget is not in focus. This should help users to determine
+		 * which of the editors currently holds focus. */
+		static constexpr int nOutOfFocusDim = 110;
+
+
+		//! Colour to use for rendering and outlining notes
+		void applyColor( std::shared_ptr<H2Core::Note> pNote, QPen* pNotePen,
+						 QBrush* pNoteBrush, QPen* pNoteTailPen,
+						 QBrush* pNoteTailBrush, QPen* pHighlightPen,
+						 QBrush* pHighlightBrush, QPen* pMovingPen,
+						 QBrush* pMovingBrush, NoteStyle noteStyle ) const;
+		//! Calculate colour to use for note representation based on note
+		//! velocity.
+		static QColor computeNoteColor( float velocity );
+		void drawBorders( QPainter& p );
+		void drawFocus( QPainter& p );
+		//! Draw lines for note grid.
+		void drawGridLines( QPainter &p,
+							const Qt::PenStyle& style = Qt::SolidLine ) const;
+		/** * Draw a note
+		 *
+		 * @param p Painting device
+		 * @param pNote Particular note to draw
+		 * @param noteStyle Whether the @a pNote is contained in the pattern
+		 *   currently shown in the pattern editor (the one selected in the song
+		 *   editor), currently hovered, or selected. */
+		void drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
+					   NoteStyle noteStyle ) const;
+		/** Update #m_pContentPixmap based on #m_pBackgroundPixmap to show the
+		 * latest content of all active pattern. */
+		virtual void drawPattern();
+		/** If there are multiple notes at the same position and column, the one
+		 * with lowest pitch (bottom-most one in PianoRollEditor) will be
+		 * rendered up front. If a subset of notes at this point is selected,
+		 * the note with lowest pitch within the selection is used. */
+		void sortAndDrawNotes( QPainter& p,
+							   std::vector< std::shared_ptr<H2Core::Note> > notes,
+							   NoteStyle baseStyle );
+
+
+		/** If the note is left of a NoteOff of the same instrument or of a note
+		 * within the same mute group, its sample will only be rendered till
+		 * that next note is encountered. We will indicate this behavior by
+		 * drawing an effective (more dim) tail of the note. */
+		int calculateEffectiveNoteLength( std::shared_ptr<H2Core::Note> pNote ) const;
+
+		/** Checks whether the note would be played back when picked up by the
+		 * audio engine. */
+		bool checkNotePlayback( std::shared_ptr<H2Core::Note> pNote ) const;
+
+		/** Function in the same vein as getColumn() but calculates both column
+		 * and row information from the provided event position. */
+		void eventPointToColumnRow( const QPoint& point, int* pColumn,
+									int* pRow, int* pRealColumn = nullptr,
+									bool bUseFineGrained = false ) const;
+
+		//! Granularity of grid positioning (in ticks)
+		int granularity() const;
+
+		void updateHoveredNotesMouse( QMouseEvent* pEvent,
+									  bool bUpdateEditors = true );
+		void updateHoveredNotesKeyboard( bool bUpdateEditors = true );
+
+		PatternEditorPanel* m_pPatternEditorPanel;
+		Property m_property;
+
+		QList< QAction * > m_selectionActions;
+
+		float m_fGridWidth;
+		unsigned m_nGridHeight;
+
 		/** Specifies whether the user interaction is altering the length
 		 * (horizontal) or the currently selected property (vertical) of a
 		 * note. */
@@ -281,62 +354,7 @@ protected:
 		int m_nDragY;
 		QPoint m_dragStart;
 
-	PatternEditorPanel* m_pPatternEditorPanel;
-
-	QList< QAction * > m_selectionActions;
-
-		/** Function in the same vein as getColumn() but calculates both column
-		 * and row information from the provided event position. */
-		void eventPointToColumnRow( const QPoint& point, int* pColumn,
-									int* pRow, int* pRealColumn = nullptr,
-									bool bUseFineGrained = false ) const;
-
-	//! Draw lines for note grid.
-	void drawGridLines( QPainter &p, const Qt::PenStyle& style = Qt::SolidLine ) const;
-
-	//! Colour to use for rendering and outlining notes
-	void applyColor( std::shared_ptr<H2Core::Note> pNote, QPen* pNotePen,
-					 QBrush* pNoteBrush, QPen* pNoteTailPen,
-					 QBrush* pNoteTailBrush, QPen* pHighlightPen,
-					 QBrush* pHighlightBrush, QPen* pMovingPen,
-					 QBrush* pMovingBrush, NoteStyle noteStyle ) const;
-
-		/** If there are multiple notes at the same position and column, the one
-		 * with lowest pitch (bottom-most one in PianoRollEditor) will be
-		 * rendered up front. If a subset of notes at this point is selected,
-		 * the note with lowest pitch within the selection is used. */
-		void sortAndDrawNotes( QPainter& p,
-							   std::vector< std::shared_ptr<H2Core::Note> > notes,
-							   NoteStyle baseStyle );
-	/**
-	 * Draw a note
-	 *
-	 * @param p Painting device
-	 * @param pNote Particular note to draw
-	 * @param noteStyle Whether the @a pNote is contained in the pattern
-	 *   currently shown in the pattern editor (the one selected in the song
-	 *   editor), currently hovered, or selected.
-	 */
-	void drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
-				   NoteStyle noteStyle ) const;
-
-		/** Update #m_pContentPixmap based on #m_pBackgroundPixmap to show the
-		 * latest content of all active pattern. */
-		virtual void drawPattern();
-		void drawFocus( QPainter& p );
-		void drawBorders( QPainter& p );
-
-	/**
-	 * Adjusts #m_nActiveWidth and #m_nEditorWidth to the current
-	 * state of the editor.
-	 */
-	virtual bool updateWidth() override;
-
-		virtual void keyPressEvent ( QKeyEvent* ev ) override;
-		virtual void keyReleaseEvent (QKeyEvent *ev) override;
-		virtual void paintEvent( QPaintEvent* ev ) override;
-
-	int m_nTick;
+		int m_nTick;
 
 		// Row the keyboard cursor is residing in.
 		//
@@ -344,23 +362,6 @@ protected:
 		// #DrumPatternEditor #PatternEditorPanel::m_nSelectedRowDB is used
 		// instead and #NotePropertiesPanel does only contain a single row.
 		int m_nCursorPitch;
-
-	Property m_property;
-
-
-		void updateHoveredNotesMouse( QMouseEvent* pEvent,
-									  bool bUpdateEditors = true );
-		void updateHoveredNotesKeyboard( bool bUpdateEditors = true );
-
-		/** Checks whether the note would be played back when picked up by the
-		 * audio engine. */
-		bool checkNotePlayback( std::shared_ptr<H2Core::Note> pNote ) const;
-
-		/** If the note is left of a NoteOff of the same instrument or of a note
-		 * within the same mute group, its sample will only be rendered till
-		 * that next note is encountered. We will indicate this behavior by
-		 * drawing an effective (more dim) tail of the note. */
-		int calculateEffectiveNoteLength( std::shared_ptr<H2Core::Note> pNote ) const;
 };
 
 #endif // PATERN_EDITOR_H

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -285,12 +285,6 @@ protected:
 	//! Granularity of grid positioning (in ticks)
 	int granularity() const;
 
-	uint m_nEditorHeight;
-	uint m_nEditorWidth;
-
-	// width of the editor covered by the current pattern.
-	int m_nActiveWidth;
-
 	float m_fGridWidth;
 	unsigned m_nGridHeight;
 
@@ -359,22 +353,17 @@ protected:
 	void drawNote( QPainter &p, std::shared_ptr<H2Core::Note> pNote,
 				   NoteStyle noteStyle ) const;
 
-		/** Update #m_pPatternPixmap based on #m_pBackgroundPixmap to show the
+		/** Update #m_pContentPixmap based on #m_pBackgroundPixmap to show the
 		 * latest content of all active pattern. */
 		virtual void drawPattern();
 		void drawFocus( QPainter& p );
 		void drawBorders( QPainter& p );
-	/** Updates #m_pBackgroundPixmap. */
-	virtual void createBackground();
-	QPixmap* m_pBackgroundPixmap;
-	QPixmap* m_pPatternPixmap;
-
 
 	/**
 	 * Adjusts #m_nActiveWidth and #m_nEditorWidth to the current
 	 * state of the editor.
 	 */
-	bool updateWidth() override;
+	virtual bool updateWidth() override;
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -217,6 +217,9 @@ public:
 		bool updateKeyboardHoveredElements() override;
 		bool updateMouseHoveredElements( QMouseEvent* ev ) override;
 		Editor::Input getInput() const override;
+		virtual void mouseDrawStart( QMouseEvent* ev ) override;
+		virtual void mouseDrawUpdate( QMouseEvent* ev ) override;
+		virtual void mouseDrawEnd() override;
 		void mouseEditStart( QMouseEvent* ev ) override;
 		void mouseEditUpdate( QMouseEvent* ev ) override;
 		void mouseEditEnd() override;
@@ -351,6 +354,11 @@ protected:
 		QPoint m_dragStart;
 
 		int m_nTick;
+		QPointF m_drawPreviousPosition;
+		int m_nDrawPreviousColumn;
+		int m_nDrawPreviousKey;
+		int m_nDrawPreviousOctave;
+		int m_nDrawPreviousRow;
 
 		// Row the keyboard cursor is residing in.
 		//

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -214,8 +214,8 @@ public:
 		void setCursorTo( std::shared_ptr<H2Core::Note> ) override;
 		void setCursorTo( QMouseEvent* ev ) override;
 		void setupPopupMenu() override;
-		void updateKeyboardHoveredElements() override;
-		void updateMouseHoveredElements( QMouseEvent* ev ) override;
+		bool updateKeyboardHoveredElements() override;
+		bool updateMouseHoveredElements( QMouseEvent* ev ) override;
 		Editor::Input getInput() const override;
 		void mouseEditStart( QMouseEvent* ev ) override;
 		void mouseEditUpdate( QMouseEvent* ev ) override;
@@ -324,10 +324,6 @@ protected:
 
 		//! Granularity of grid positioning (in ticks)
 		int granularity() const;
-
-		void updateHoveredNotesMouse( QMouseEvent* pEvent,
-									  bool bUpdateEditors = true );
-		void updateHoveredNotesKeyboard( bool bUpdateEditors = true );
 
 		PatternEditorPanel* m_pPatternEditorPanel;
 		Property m_property;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -262,9 +262,9 @@ protected:
 
 		void ensureCursorIsVisible() override;
 		void updateKeyboardHoveredElements() override;
-		void updateMouseHoveredElements() override;
-		void updateAllComponents() override;
-		void updateVisibleComponents() override;
+		void updateMouseHoveredElements( QMouseEvent* ev ) override;
+		void updateAllComponents( bool bContentOnly ) override;
+		void updateVisibleComponents( bool bContentOnly ) override;
 
 	//! Granularity of grid positioning (in ticks)
 	int granularity() const;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -89,21 +89,6 @@ public:
 	};
 	static QString propertyToQString( const Property& property );
 
-		/** Specifies which parts of the editor need updating on a paintEvent().
-		 * Bigger numerical values imply updating elements with lower ones as
-		 * well.*/
-		enum class Update {
-			/** Just paint transient elements, like hovered notes, cursor, focus
-			 * or lasso. */
-			None = 0,
-			/** Update pattern notes including selection of a cached background
-			 * image. */
-			Pattern = 1,
-			/** Update the background image. */
-			Background = 2
-		};
-		static QString updateToQString( const Update& update );
-
 	PatternEditor( QWidget *pParent, BaseEditor::EditorType editorType );
 	~PatternEditor();
 
@@ -139,12 +124,6 @@ public:
 
 	//! Update the status of modifier keys in response to input events.
 	virtual void updateModifiers( QInputEvent *ev ) override;
-
-	//! Update a widget in response to a change in selection
-	virtual void updateWidget() override {
-		updateEditor( true );
-	}
-
 
 		virtual std::vector<SelectionIndex> getElementsAtPoint(
 			const QPoint& point, int nCursorMargin,
@@ -262,7 +241,6 @@ public:
 		void setCursorPitch( int nCursorPitch );
 
 public slots:
-	virtual void updateEditor( bool bPatternOnly = false );
 	virtual void selectAll() = 0;
 	virtual void selectNone();
 	void deleteSelection( bool bHandleSetupTeardown = true );
@@ -391,14 +369,12 @@ protected:
 	QPixmap* m_pBackgroundPixmap;
 	QPixmap* m_pPatternPixmap;
 
-		/** Which parts of the editor to update in the next paint event. */
-		Update m_update;
 
 	/**
 	 * Adjusts #m_nActiveWidth and #m_nEditorWidth to the current
 	 * state of the editor.
 	 */
-	bool updateWidth();
+	bool updateWidth() override;
 
 	/** Indicates whether the mouse pointer entered the widget.*/
 	bool m_bEntered;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -137,9 +137,9 @@ public:
 	virtual void mouseReleaseEvent( QMouseEvent *ev ) override;
 		virtual void mouseClickEvent( QMouseEvent *ev ) override;
 	
-	virtual void mouseDragStartEvent( QMouseEvent *ev ) override;
-	virtual void mouseDragUpdateEvent( QMouseEvent *ev ) override;
-	virtual void mouseDragEndEvent( QMouseEvent *ev ) override;
+	void editPropertyStart( QMouseEvent *ev );
+	void editPropertyUpdate( QMouseEvent *ev );
+	void editPropertyEnd( QMouseEvent *ev );
 		virtual QRect getKeyboardCursorRect() override;
 
 		/** Area taken available for an addition sidebar or button */

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -334,21 +334,11 @@ protected:
 	 */
 	virtual bool updateWidth() override;
 
-	/** Indicates whether the mouse pointer entered the widget.*/
-	bool m_bEntered;
 		/** @param bFullUpdate if `false`, just a simple update() of the widget
 		 *   will be triggered. If `true`, the background will be updated as
 		 *   well. */
 		void keyPressEvent ( QKeyEvent *ev, bool bFullUpdate = false );
 		virtual void keyReleaseEvent (QKeyEvent *ev) override;
-#ifdef H2CORE_HAVE_QT6
-		virtual void enterEvent( QEnterEvent *ev ) override;
-#else
-		virtual void enterEvent( QEvent *ev ) override;
-#endif
-	virtual void leaveEvent( QEvent *ev ) override;
-	virtual void focusInEvent( QFocusEvent *ev ) override;
-	virtual void focusOutEvent( QFocusEvent *ev ) override;
 		virtual void paintEvent( QPaintEvent* ev ) override;
 
 	int m_nTick;

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -137,9 +137,6 @@ public:
 	virtual void mouseReleaseEvent( QMouseEvent *ev ) override;
 		virtual void mouseClickEvent( QMouseEvent *ev ) override;
 	
-	void editPropertyStart( QMouseEvent *ev );
-	void editPropertyUpdate( QMouseEvent *ev );
-	void editPropertyEnd( QMouseEvent *ev );
 		virtual QRect getKeyboardCursorRect() override;
 
 		/** Area taken available for an addition sidebar or button */
@@ -215,6 +212,10 @@ public:
 		void setupPopupMenu() override;
 		void updateKeyboardHoveredElements() override;
 		void updateMouseHoveredElements( QMouseEvent* ev ) override;
+		Editor::Input getInput() const override;
+		void mouseEditStart( QMouseEvent* ev ) override;
+		void mouseEditUpdate( QMouseEvent* ev ) override;
+		void mouseEditEnd() override;
 		void updateAllComponents( bool bContentOnly ) override;
 		void updateVisibleComponents( bool bContentOnly ) override;
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -2163,8 +2163,8 @@ void PatternEditorPanel::updateQuantization( QInputEvent* pEvent ) {
 			}
 		}
 
-		getVisibleEditor()->updateEditor();
-		getVisiblePropertiesRuler()->updateEditor();
+		getVisibleEditor()->updateEditor( false );
+		getVisiblePropertiesRuler()->updateEditor( false );
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1638,9 +1638,12 @@ void PatternEditorPanel::propertiesComboChanged( int nSelected )
 	}
 }
 
-int PatternEditorPanel::getCursorColumn()
-{
+int PatternEditorPanel::getCursorColumn() const {
 	return m_nCursorColumn;
+}
+
+int PatternEditorPanel::getCursorIncrement() const {
+	return m_nCursorIncrement;
 }
 
 void PatternEditorPanel::ensureCursorIsVisible()
@@ -2296,7 +2299,8 @@ void PatternEditorPanel::printDB() const {
 void PatternEditorPanel::addOrRemoveNotes( int nPosition, int nRow, int nKey,
 										   int nOctave, bool bDoAdd,
 										   bool bDoDelete, bool bIsNoteOff,
-										   Editor::Action action ) {
+										   Editor::Action action,
+										   const QString& sUndoContext ) {
 	auto pHydrogenApp = HydrogenApp::get_instance();
 	const auto pCommonStrings = pHydrogenApp->getCommonStrings();
 	if ( m_pPattern == nullptr ) {
@@ -2375,12 +2379,12 @@ void PatternEditorPanel::addOrRemoveNotes( int nPosition, int nRow, int nKey,
 				/* bIsDelete */ false,
 				bIsNoteOff,
 				row.bMappedToDrumkit,
-				action ) );
+				action ), sUndoContext );
 	}
 	else {
 		// delete notes
 		pHydrogenApp->beginUndoMacro(
-			pCommonStrings->getActionDeleteNotes() );
+			pCommonStrings->getActionDeleteNotes(), sUndoContext );
 		for ( const auto& ppNote : oldNotes ) {
 			pHydrogenApp->pushUndoCommand(
 				new SE_addOrRemoveNoteAction(
@@ -2398,9 +2402,9 @@ void PatternEditorPanel::addOrRemoveNotes( int nPosition, int nRow, int nKey,
 					/* bIsDelete */ true,
 					ppNote->getNoteOff(),
 					ppNote->getInstrument() != nullptr,
-					action ) );
+					action ), sUndoContext );
 		}
-		pHydrogenApp->endUndoMacro();
+		pHydrogenApp->endUndoMacro( sUndoContext );
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1181,7 +1181,7 @@ void PatternEditorPanel::updateInstance() {
 		m_pSidebar->dimRows( false );
 
 		m_pDrumPatternEditor->updateEditor();
-}
+	}
 	else if ( m_instance == Editor::Instance::PianoRoll ) {
 		m_pDrumPatternBtn->setChecked( false );
 		m_pPianoRollBtn->setChecked( true );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -2202,7 +2202,7 @@ void PatternEditorPanel::printDB() const {
 void PatternEditorPanel::addOrRemoveNotes( int nPosition, int nRow, int nKey,
 										   int nOctave, bool bDoAdd,
 										   bool bDoDelete, bool bIsNoteOff,
-										   PatternEditor::AddNoteAction action ) {
+										   Editor::Action action ) {
 	auto pHydrogenApp = HydrogenApp::get_instance();
 	const auto pCommonStrings = pHydrogenApp->getCommonStrings();
 	if ( m_pPattern == nullptr ) {
@@ -2251,7 +2251,8 @@ void PatternEditorPanel::addOrRemoveNotes( int nPosition, int nRow, int nKey,
 		// Play back added notes.
 		if ( Preferences::get_instance()->getHearNewNotes() &&
 			 row.bMappedToDrumkit &&
-			 action & PatternEditor::AddNoteAction::Playback ) {
+			 ( static_cast<char>(action) &
+			   static_cast<char>(Editor::Action::Playback) ) ) {
 			auto pSelectedInstrument = getSelectedInstrument();
 			if ( pSelectedInstrument != nullptr &&
 				 pSelectedInstrument->hasSamples() ) {
@@ -2395,7 +2396,7 @@ void PatternEditorPanel::clearNotesInRow( int nRow, int nPattern, int nPitch,
 						/* bIsDelete */ true,
 						ppNote->getNoteOff(),
 						ppNote->getInstrument() != nullptr,
-						PatternEditor::AddNoteAction::None ) );
+						Editor::Action::None ) );
 			}
 		}
 	}
@@ -2479,7 +2480,7 @@ void PatternEditorPanel::fillNotesInRow( int nRow, FillNotes every, int nPitch )
 			addOrRemoveNotes( nnPosition, nRow, nKey, nOctave,
 							  true /* bDoAdd */, false /* bDoDelete */,
 							  false /* bIsNoteOff */,
-							  PatternEditor::AddNoteAction::None );
+							  Editor::Action::None );
 		}
 		pHydrogenApp->endUndoMacro();
 	}
@@ -2671,7 +2672,7 @@ void PatternEditorPanel::pasteNotesToRowOfAllPatterns( int nRow, int nPitch ) {
 							/* bIsDelete */ false,
 							ppNote->getNoteOff(),
 							row.bMappedToDrumkit,
-							PatternEditor::AddNoteAction::None ) );
+							Editor::Action::None ) );
 				}
 			}
 		}

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -2154,15 +2154,6 @@ void PatternEditorPanel::updateQuantization( QInputEvent* pEvent ) {
 	if ( bQuantized != m_bQuantized ) {
 		m_bQuantized = bQuantized;
 
-		if ( pEvent != nullptr ) {
-			QKeyEvent* pKeyEvent = dynamic_cast<QKeyEvent*>( pEvent );
-			if ( pKeyEvent != nullptr ) {
-				// Re-quantize keyboard cursor (moved notes will be re-quantized
-				// automatically via movingGridOffset).
-				moveCursorLeft( pKeyEvent, Editor::Step::None );
-			}
-		}
-
 		getVisibleEditor()->updateEditor( false );
 		getVisiblePropertiesRuler()->updateEditor( false );
 	}

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -208,12 +208,15 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pToolbarSidebarLayout->addWidget( pBtnContainer );
 	auto pBtnContainerLayout = new QHBoxLayout( pBtnContainer );
 	pBtnContainerLayout->setContentsMargins( 2, 1, 2, 1 );
-	pBtnContainerLayout->setSpacing( 4 );
+	pBtnContainerLayout->setSpacing( 3 );
 
-	const auto buttonSize = QSize( PatternEditorPanel::nToolbarGroupHeight ,
+	const auto buttonSize = QSize( PatternEditorPanel::nToolbarGroupHeight + 1,
 								   PatternEditorPanel::nToolbarGroupHeight - 4 );
-	const auto iconSize = QSize( PatternEditorPanel::nToolbarGroupHeight - 2,
+	const auto iconSize = QSize( PatternEditorPanel::nToolbarGroupHeight - 1,
 								 PatternEditorPanel::nToolbarGroupHeight - 6 );
+
+	const auto buttonSizeOutside = buttonSize + QSize( 0, 2 );
+	const auto iconSizeOutside = iconSize + QSize( 0, 2 );
 
 	m_pEditModeGroup = new QWidget( pBtnContainer );
 	m_pEditModeGroup->setFocusPolicy( Qt::ClickFocus );
@@ -222,7 +225,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pBtnContainerLayout->addWidget( m_pEditModeGroup );
 	auto pEditModeGroupLayout = new QHBoxLayout( m_pEditModeGroup );
 	pEditModeGroupLayout->setContentsMargins( 2, 1, 2, 1 );
-	pEditModeGroupLayout->setSpacing( 2 );
+	pEditModeGroupLayout->setSpacing( 1 );
 
 	m_pSelectBtn = new Button(
 		m_pEditModeGroup, buttonSize, Button::Type::Toggle, "select.svg", "",
@@ -251,8 +254,8 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pBtnContainerLayout->addStretch();
 
 	m_pHearNotesBtn = new Button(
-		pBtnContainer, buttonSize, Button::Type::Toggle, "speaker.svg", "",
-		iconSize, tr( "Hear new notes" ), false, false );
+		pBtnContainer, buttonSizeOutside, Button::Type::Toggle, "speaker.svg", "",
+		iconSizeOutside, tr( "Hear new notes" ), false, false );
 	connect( m_pHearNotesBtn, SIGNAL( clicked() ),
 			 this, SLOT( hearNotesBtnClick() ) );
 	m_pHearNotesBtn->setChecked( pPref->getHearNewNotes() );
@@ -261,8 +264,8 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pBtnContainerLayout->addWidget( m_pHearNotesBtn );
 
 	m_pQuantizeEventsBtn = new Button(
-		pBtnContainer, buttonSize, Button::Type::Toggle, "quantization.svg",
-		"", iconSize, tr( "Quantize keyboard/midi events to grid" ), false,
+		pBtnContainer, buttonSizeOutside, Button::Type::Toggle, "quantization.svg",
+		"", iconSizeOutside, tr( "Quantize keyboard/midi events to grid" ), false,
 		false );
 	m_pQuantizeEventsBtn->setChecked( pPref->getQuantizeEvents() );
 	m_pQuantizeEventsBtn->setObjectName( "QuantizeEventsBtn" );
@@ -281,7 +284,7 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	pBtnContainerLayout->addWidget( m_pInstanceGroup );
 	auto pInstanceGroupLayout = new QHBoxLayout( m_pInstanceGroup );
 	pInstanceGroupLayout->setContentsMargins( 2, 1, 2, 1 );
-	pInstanceGroupLayout->setSpacing( 2 );
+	pInstanceGroupLayout->setSpacing( 1 );
 
 	m_pDrumPatternBtn = new Button(
 		m_pInstanceGroup, buttonSize, Button::Type::Toggle, "drum.svg", "",

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1051,8 +1051,10 @@ bool PatternEditorPanel::hasPatternEditorFocus() const {
 void PatternEditorPanel::setInput( Editor::Input input ) {
 	if ( m_input != input ) {
 		m_input = input;
-		updateInput();
 	}
+
+	// Always update button state to ensure the proper one remains toggled.
+	updateInput();
 }
 
 void PatternEditorPanel::setInstance( Editor::Instance instance ) {
@@ -1060,8 +1062,9 @@ void PatternEditorPanel::setInstance( Editor::Instance instance ) {
 		 ( instance == Editor::Instance::DrumPattern ||
 		   instance == Editor::Instance::PianoRoll ) ) {
 		m_instance = instance;
-		updateInstance();
 	}
+	// Always update button state to ensure the proper one remains toggled.
+	updateInstance();
 }
 
 PatternEditor* PatternEditorPanel::getVisibleEditor() const {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -2201,44 +2201,34 @@ void PatternEditorPanel::updateTypeLabelVisibility() {
 	m_pSidebar->updateTypeLabelVisibility( bVisible );
 }
 
-void PatternEditorPanel::setHoveredNotesMouse(
+bool PatternEditorPanel::setHoveredNotesMouse(
 	std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 							std::vector< std::shared_ptr<H2Core::Note> > >
-			   > hoveredNotes,
-	bool bUpdateEditors )
+			   > hoveredNotes )
 {
 	if ( hoveredNotes == m_hoveredNotesMouse ) {
-		return;
+		return false;
 	}
 
 	m_hoveredNotesMouse = hoveredNotes;
-
 	updateHoveredNotes();
 
-	if ( bUpdateEditors ) {
-		getVisibleEditor()->update();
-		getVisiblePropertiesRuler()->update();
-	}
+	return true;
 }
 
-void PatternEditorPanel::setHoveredNotesKeyboard(
+bool PatternEditorPanel::setHoveredNotesKeyboard(
 	std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 							std::vector< std::shared_ptr<H2Core::Note> > >
-			   > hoveredNotes,
-	bool bUpdateEditors )
+			   > hoveredNotes )
 {
 	if ( hoveredNotes == m_hoveredNotesKeyboard ) {
-		return;
+		return false;
 	}
 
 	m_hoveredNotesKeyboard = hoveredNotes;
-
 	updateHoveredNotes();
 
-	if ( bUpdateEditors ) {
-		getVisibleEditor()->updateEditor( true );
-		getVisiblePropertiesRuler()->updateEditor( true );
-	}
+	return true;
 }
 
 void PatternEditorPanel::updateHoveredNotes() {

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1741,7 +1741,9 @@ void PatternEditorPanel::moveCursorRight( QKeyEvent* pEvent, Editor::Step step )
 		nStep = Editor::nPageSize;
 		break;
 	case Editor::Step::Document:
-		setCursorColumn( m_pPattern->getLength() );
+		setCursorColumn( std::floor( m_pPattern->getLength() /
+									 m_nCursorIncrement ) * m_nCursorIncrement -
+						 m_nCursorIncrement );
 		return;
 	}
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -979,7 +979,7 @@ void PatternEditorPanel::selectedInstrumentChangedEvent()
 		m_nSelectedRowDB = Hydrogen::get_instance()->getSelectedInstrumentNumber();
 	}
 
-	ensureVisible();
+	ensureCursorIsVisible();
 	updateEditors();
 	resizeEvent( nullptr );	// force a scrollbar update
 }
@@ -1024,7 +1024,7 @@ void PatternEditorPanel::showDrumEditor()
 	m_pSidebar->dimRows( false );
 
 	m_pDrumPatternEditor->updateEditor(); // force an update
-	ensureVisible();
+	ensureCursorIsVisible();
 
 	getVisiblePropertiesRuler()->syncLasso();
 
@@ -1048,7 +1048,7 @@ void PatternEditorPanel::showPianoRollEditor()
 	m_pSidebar->dimRows( true );
 
 	m_pPianoRollEditor->updateEditor(); // force an update
-	ensureVisible();
+	ensureCursorIsVisible();
 
 	getVisiblePropertiesRuler()->syncLasso();
 
@@ -1122,7 +1122,7 @@ void PatternEditorPanel::zoomInBtnClicked()
 	getVisiblePropertiesRuler()->zoomLasso( fOldGridWidth );
 	getVisibleEditor()->zoomLasso( fOldGridWidth );
 
-	ensureVisible();
+	ensureCursorIsVisible();
 
 	updateEditors();
 	resizeEvent( nullptr );
@@ -1148,7 +1148,7 @@ void PatternEditorPanel::zoomOutBtnClicked()
 	getVisiblePropertiesRuler()->zoomLasso( fOldGridWidth );
 	getVisibleEditor()->zoomLasso( fOldGridWidth );
 
-	ensureVisible();
+	ensureCursorIsVisible();
 
 	updateEditors();
 	resizeEvent( nullptr );
@@ -1587,7 +1587,7 @@ int PatternEditorPanel::getCursorColumn()
 	return m_nCursorColumn;
 }
 
-void PatternEditorPanel::ensureVisible()
+void PatternEditorPanel::ensureCursorIsVisible()
 {
 	if ( m_pEditorScrollView->isVisible() ) {
 		const auto pos = m_pDrumPatternEditor->getCursorPosition();
@@ -1616,7 +1616,7 @@ void PatternEditorPanel::setCursorColumn( int nCursorColumn,
 	m_nCursorColumn = nCursorColumn;
 
 	if ( bUpdateEditors && ! HydrogenApp::get_instance()->hideKeyboardCursor() ) {
-		ensureVisible();
+		ensureCursorIsVisible();
 		m_pSidebar->updateEditor();
 		m_pPatternEditorRuler->update();
 		getVisibleEditor()->update();

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -215,7 +215,7 @@ class PatternEditorPanel : public QWidget,
 
 		/** Scrolls the viewport of the current editor until the selected row
 		 * (containingt the cursor, if shown) is visible. */
-		void ensureVisible();
+		void ensureCursorIsVisible();
 		/** The row of the particular editor is maintained by the editor itself
 		 * and can be accessed via #PatternEditor::getCursorPosition. */
 		int getCursorColumn();

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -35,6 +35,7 @@
 
 #include "PatternEditor.h"
 #include "../EventListener.h"
+#include "../Widgets/EditorDefs.h"
 #include "../Widgets/LCDCombo.h"
 #include "../Widgets/WidgetWithScalableFont.h"
 
@@ -246,8 +247,8 @@ class PatternEditorPanel : public QWidget,
 		void addOrRemoveNotes( int nPosition, int nRow, int nKey = KEY_INVALID,
 							   int nOctave = OCTAVE_INVALID, bool bDoAdd = true,
 							   bool bDoDelete = true, bool bIsNoteOff = false,
-							   PatternEditor::AddNoteAction action =
-							   PatternEditor::AddNoteAction::None );
+							   Editor::Action action =
+							   Editor::Action::None );
 
 		/**
 		 * Determines whether to pattern editor should show further

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -331,16 +331,16 @@ class PatternEditorPanel : public QWidget,
 		const std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 									  std::vector< std::shared_ptr<H2Core::Note> > >
 						   >& getHoveredNotes() const;
-		void setHoveredNotesMouse(
+		/** @returns true in case the set of hovered elements did change. */
+		bool setHoveredNotesMouse(
 			std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 								    std::vector< std::shared_ptr<H2Core::Note> > >
-					   > hoveredNotes,
-			bool bUpdateEditors = true );
-		void setHoveredNotesKeyboard(
+					   > hoveredNotes );
+		/** @returns true in case the set of hovered elements did change. */
+		bool setHoveredNotesKeyboard(
 			std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 								    std::vector< std::shared_ptr<H2Core::Note> > >
-					   > hoveredNotes,
-			bool bUpdateEditors = true );
+					   > hoveredNotes );
 
 		/** @returns `true` in case any of the child editors or sidebar has
 		 * focus.*/

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -349,9 +349,10 @@ class PatternEditorPanel : public QWidget,
 		Editor::Input getInput() const;
 		void setInput( Editor::Input input);
 
+		Editor::Instance getInstance() const;
+		void setInstance( Editor::Instance instance);
+
 	public slots:
-		void showDrumEditor();
-		void showPianoRollEditor();
 		void onPreferencesChanged( const H2Core::Preferences::Changes& changes );
 
 	private slots:
@@ -360,8 +361,6 @@ class PatternEditorPanel : public QWidget,
 
 		void hearNotesBtnClick();
 		void quantizeEventsBtnClick();
-
-		void showDrumEditorBtnClick();
 
 		void syncToExternalHorizontalScrollbar(int);
 		void contentsMoving(int dummy);
@@ -380,6 +379,7 @@ class PatternEditorPanel : public QWidget,
 	private:
 
 		void updateInput();
+		void updateInstance();
 		void updatePatternInfo();
 		void updatePatternsToShow();
 		void updateStyleSheet();
@@ -391,6 +391,7 @@ class PatternEditorPanel : public QWidget,
 		std::vector< std::shared_ptr<H2Core::Pattern> > m_patternsToShow;
 
 		Editor::Input m_input;
+		Editor::Instance m_instance;
 
 		/** Number corresponding to #m_pPattern. */
 		int m_nPatternNumber;
@@ -545,6 +546,9 @@ inline const std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 }
 inline Editor::Input PatternEditorPanel::getInput() const {
 	return m_input;
+}
+inline Editor::Instance PatternEditorPanel::getInstance() const {
+	return m_instance;
 }
 
 #endif

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -222,8 +222,9 @@ class PatternEditorPanel : public QWidget,
 		void ensureCursorIsVisible();
 		/** The row of the particular editor is maintained by the editor itself
 		 * and can be accessed via #PatternEditor::getCursorPosition. */
-		int getCursorColumn();
+		int getCursorColumn() const;
 		void setCursorColumn( int nCursorColumn, bool bUpdateEditors = true );
+		int getCursorIncrement() const;
 		void moveCursorLeft( QKeyEvent* pEvent, Editor::Step step );
 		void moveCursorRight( QKeyEvent* pEvent, Editor::Step step );
 
@@ -250,8 +251,8 @@ class PatternEditorPanel : public QWidget,
 		void addOrRemoveNotes( int nPosition, int nRow, int nKey = KEY_INVALID,
 							   int nOctave = OCTAVE_INVALID, bool bDoAdd = true,
 							   bool bDoDelete = true, bool bIsNoteOff = false,
-							   Editor::Action action =
-							   Editor::Action::None );
+							   Editor::Action action = Editor::Action::None,
+							   const QString& sUndoContext = "" );
 
 		/**
 		 * Determines whether to pattern editor should show further

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -346,6 +346,9 @@ class PatternEditorPanel : public QWidget,
 		 * focus.*/
 		bool hasPatternEditorFocus() const;
 
+		Editor::Input getInput() const;
+		void setInput( Editor::Input input);
+
 	public slots:
 		void showDrumEditor();
 		void showPianoRollEditor();
@@ -376,6 +379,7 @@ class PatternEditorPanel : public QWidget,
 
 	private:
 
+		void updateInput();
 		void updatePatternInfo();
 		void updatePatternsToShow();
 		void updateStyleSheet();
@@ -385,6 +389,8 @@ class PatternEditorPanel : public QWidget,
 
 		/** All patterns currently playing. They are cached in here or  */
 		std::vector< std::shared_ptr<H2Core::Pattern> > m_patternsToShow;
+
+		Editor::Input m_input;
 
 		/** Number corresponding to #m_pPattern. */
 		int m_nPatternNumber;
@@ -408,7 +414,7 @@ class PatternEditorPanel : public QWidget,
 
 		/** Contains all buttons */
 		QWidget* m_pToolbarSidebar;
-		QWidget* m_pEditModeGroup;
+		QWidget* m_pInputModeGroup;
 		Button* m_pSelectBtn;
 		Button* m_pDrawBtn;
 		Button* m_pEditBtn;
@@ -536,6 +542,9 @@ inline const std::vector< std::pair< std::shared_ptr<H2Core::Pattern>,
 									 std::vector< std::shared_ptr<H2Core::Note> > >
 						  >& PatternEditorPanel::getHoveredNotes() const {
 	return m_hoveredNotes;
+}
+inline Editor::Input PatternEditorPanel::getInput() const {
+	return m_input;
 }
 
 #endif

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -221,8 +221,8 @@ class PatternEditorPanel : public QWidget,
 		 * and can be accessed via #PatternEditor::getCursorPosition. */
 		int getCursorColumn();
 		void setCursorColumn( int nCursorColumn, bool bUpdateEditors = true );
-		void moveCursorLeft( QKeyEvent* pEvent, int n = 1 );
-		void moveCursorRight( QKeyEvent* pEvent, int n = 1 );
+		void moveCursorLeft( QKeyEvent* pEvent, Editor::Step step );
+		void moveCursorRight( QKeyEvent* pEvent, Editor::Step step );
 
 		void updateEditors( bool bPatternOnly = false );
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -137,6 +137,9 @@ class PatternEditorPanel : public QWidget,
 	Q_OBJECT
 
 	public:
+		static constexpr int nToolbarHeight = 28;
+		static constexpr int nToolbarGroupHeight = nToolbarHeight - 4;
+
 		explicit PatternEditorPanel(QWidget *parent);
 		~PatternEditorPanel();
 
@@ -402,27 +405,27 @@ class PatternEditorPanel : public QWidget,
 		ClickableLabel*		m_pDrumkitLabel;
 
 		QTabBar* m_pTabBar;
-		QWidget* m_pToolBar;
-	QWidget* m_pSizeResol;
-	QWidget* m_pRec;
 
-	LCDSpinBox* m_pLCDSpinBoxNumerator;
-	LCDSpinBox* m_pLCDSpinBoxDenominator;
-
-		// Editor top
-		LCDCombo *			m_pResolutionCombo;
-		Button *		__show_drum_btn;
-		Button *		__show_piano_btn;
-	Button *		m_pHearNotesBtn;
-	Button *		m_pQuantizeEventsBtn;
+		/** Contains all buttons */
+		QWidget* m_pToolbarSidebar;
+		QWidget* m_pEditModeGroup;
+		Button* m_pSelectBtn;
+		Button* m_pDrawBtn;
+		Button* m_pEditBtn;
+		Button* m_pHearNotesBtn;
+		Button* m_pQuantizeEventsBtn;
+		QWidget* m_pInstanceGroup;
+		Button* m_pDrumPatternBtn;
+		Button*	m_pPianoRollBtn;
 		Button* m_pPatchBayBtn;
-	
-		ClickableLabel*		m_pPatternSizeLbl;
-		ClickableLabel*		m_pResolutionLbl;
-		ClickableLabel*		m_pHearNotesLbl;
-		ClickableLabel*		m_pQuantizeEventsLbl;
-		ClickableLabel*		m_pShowPianoLbl;
-		// ~Editor top
+
+		/** Contains the pattern size and resolution widget. */
+		QWidget* m_pToolbar;
+		QWidget* m_pSizeGroup;
+		LCDSpinBox* m_pLCDSpinBoxNumerator;
+		LCDSpinBox* m_pLCDSpinBoxDenominator;
+		QWidget* m_pResolutionGroup;
+		LCDCombo* m_pResolutionCombo;
 
 		//note properties combo
 		LCDCombo *			m_pPropertiesCombo;

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -470,6 +470,8 @@ PianoRollEditor::PianoRollEditor( QWidget *pParent )
 
 	resize( m_nEditorWidth, m_nEditorHeight );
 
+	updatePixmapSize();
+
 	// Create the sidebar of labels
 	m_pPitchSidebar = new PitchSidebar( this, m_nEditorHeight, m_nGridHeight );
 }
@@ -557,20 +559,7 @@ void PianoRollEditor::createBackground()
 		selectedRowColor = selectedRowColor.darker( PatternEditor::nOutOfFocusDim );
 	}
 
-	// Resize pixmap if pixel ratio has changed
-	qreal pixelRatio = devicePixelRatio();
-	if ( m_pBackgroundPixmap->width() != m_nEditorWidth ||
-		 m_pBackgroundPixmap->height() != m_nEditorHeight ||
-		 m_pBackgroundPixmap->devicePixelRatio() != pixelRatio ) {
-		delete m_pBackgroundPixmap;
-		m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
-										   m_nEditorHeight * pixelRatio );
-		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
-		delete m_pPatternPixmap;
-		m_pPatternPixmap = new QPixmap( m_nEditorWidth  * pixelRatio,
-										m_nEditorHeight * pixelRatio );
-		m_pPatternPixmap->setDevicePixelRatio( pixelRatio );
-	}
+	updatePixmapSize();
 
 	m_pBackgroundPixmap->fill( backgroundInactiveColor );
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -453,7 +453,7 @@ void PitchSidebar::rowPressed( QMouseEvent* pEvent, PitchLabel* pLabel ) {
 ////////////////////////////////////////////////////////////////////////////////
 
 PianoRollEditor::PianoRollEditor( QWidget *pParent )
-	: PatternEditor( pParent )
+	: PatternEditor( pParent, BaseEditor::EditorType::Grid )
 {
 	m_editor = PatternEditor::Editor::PianoRoll;
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -453,9 +453,10 @@ void PitchSidebar::rowPressed( QMouseEvent* pEvent, PitchLabel* pLabel ) {
 ////////////////////////////////////////////////////////////////////////////////
 
 PianoRollEditor::PianoRollEditor( QWidget *pParent )
-	: PatternEditor( pParent, BaseEditor::EditorType::Grid )
+	: PatternEditor( pParent )
 {
-	m_editor = PatternEditor::Editor::PianoRoll;
+	m_type = Editor::Type::Grid;
+	m_instance = Editor::Instance::PianoRoll;
 
 	const auto pPref = H2Core::Preferences::get_instance();
 	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
@@ -743,7 +744,7 @@ void PianoRollEditor::keyPressEvent( QKeyEvent * ev )
 			Note::pitchToKey( nPitch ), Note::pitchToOctave( nPitch ),
 			/* bDoAdd */ true, /* bDoDelete */ true,
 			/* bIsNoteOff */ false,
-			PatternEditor::AddNoteAction::Playback );
+			Editor::Action::Playback );
 	}
 	else if ( ev->key() == Qt::Key_Delete ) {
 		// Key: Delete: delete selection or note at keyboard cursor
@@ -760,7 +761,7 @@ void PianoRollEditor::keyPressEvent( QKeyEvent * ev )
 				Note::pitchToKey( nPitch ), Note::pitchToOctave( nPitch ),
 				/* bDoAdd */ false, /* bDoDelete */ true,
 				/* bIsNoteOff */ false,
-				PatternEditor::AddNoteAction::None );
+				Editor::Action::None );
 		}
 	}
 	else {

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -512,7 +512,7 @@ void PianoRollEditor::moveCursorDown( QKeyEvent* ev, Editor::Step step ) {
 		return;
 	}
 
-	setCursorPitch( std::max( m_nCursorPitch - nStep * KEYS_PER_OCTAVE,
+	setCursorPitch( std::max( m_nCursorPitch - nStep,
 							  PITCH_MIN ) );
 }
 
@@ -537,7 +537,7 @@ void PianoRollEditor::moveCursorUp( QKeyEvent* ev, Editor::Step step ) {
 		return;
 	}
 
-	setCursorPitch( std::min( m_nCursorPitch + nStep * KEYS_PER_OCTAVE,
+	setCursorPitch( std::min( m_nCursorPitch + nStep,
 							  PITCH_MAX ) );
 }
 

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -754,6 +754,5 @@ std::vector<PianoRollEditor::SelectionIndex> PianoRollEditor::elementsIntersecti
 			}
 		}
 	}
-	updateEditor( true );
 	return std::move( result );
 }

--- a/src/gui/src/PatternEditor/PianoRollEditor.h
+++ b/src/gui/src/PatternEditor/PianoRollEditor.h
@@ -119,6 +119,9 @@ class PianoRollEditor: public PatternEditor,
 
 		QPoint noteToPoint( std::shared_ptr<H2Core::Note> pNote ) const;
 
+		void moveCursorDown( QKeyEvent* ev, Editor::Step step ) override;
+		void moveCursorUp( QKeyEvent* ev, Editor::Step step ) override;
+
 		void updateFont();
 		void updateStyleSheet();
 
@@ -129,7 +132,6 @@ class PianoRollEditor: public PatternEditor,
 		void createBackground() override;
 
 		virtual void paintEvent(QPaintEvent *ev) override;
-		virtual void keyPressEvent ( QKeyEvent * ev ) override;
 
 		PitchSidebar* m_pPitchSidebar;
 };

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -643,7 +643,10 @@ public:
 			}
 
 		}
-		m_pWidget->mouseDragStartEvent( ev );
+
+		if ( m_selectionState == Idle ) {
+			m_pWidget->mouseDragStartEvent( ev );
+		}
 	}
 
 	void mouseDragUpdate( QMouseEvent *ev ) {

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -103,9 +103,9 @@ public:
 	//!
 	//! @{
 	virtual void mouseClickEvent( QMouseEvent *ev ) = 0;
-	virtual void mouseDragStartEvent( QMouseEvent *ev ) = 0;
-	virtual void mouseDragUpdateEvent( QMouseEvent *ev ) = 0;
-	virtual void mouseDragEndEvent( QMouseEvent *ev ) = 0;
+	virtual void mouseDrawStartEvent( QMouseEvent *ev ) = 0;
+	virtual void mouseDrawUpdateEvent( QMouseEvent *ev ) = 0;
+	virtual void mouseDrawEndEvent( QMouseEvent *ev ) = 0;
 	virtual void selectionMoveUpdateEvent( QMouseEvent *ev ) {};
 	virtual void selectionMoveEndEvent( QInputEvent *ev ) = 0;
 	virtual void selectionMoveCancelEvent() {};
@@ -629,7 +629,7 @@ public:
 					m_pWidget->startMouseMove( ev );
 				}
 			} else if ( bHitAny && m_pWidget->canDragElements() ) {
-				// Allow mouseDragStartEvent to handle anything
+				// Allow mouseDrawStartEvent to handle anything
 
 			} else {
 				//  Didn't hit anything. Start new selection drag.
@@ -645,7 +645,7 @@ public:
 		}
 
 		if ( m_selectionState == Idle ) {
-			m_pWidget->mouseDragStartEvent( ev );
+			m_pWidget->mouseDrawStartEvent( ev );
 		}
 	}
 
@@ -681,7 +681,7 @@ public:
 		}
 		else {
 			// Pass drag update to widget
-			m_pWidget->mouseDragUpdateEvent( ev );
+			m_pWidget->mouseDrawUpdateEvent( ev );
 		}
 	}
 
@@ -703,7 +703,7 @@ public:
 
 		} else {
 			// Pass drag end to widget
-			m_pWidget->mouseDragEndEvent( ev );
+			m_pWidget->mouseDrawEndEvent( ev );
 		}
 	}
 	//! @}

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -830,15 +830,15 @@ void SongEditor::mouseMoveEvent(QMouseEvent *ev)
 	}
 }
 
-void SongEditor::mouseDragStartEvent( QMouseEvent *ev )
+void SongEditor::mouseDrawStartEvent( QMouseEvent *ev )
 {
 }
 
-void SongEditor::mouseDragUpdateEvent( QMouseEvent *ev )
+void SongEditor::mouseDrawUpdateEvent( QMouseEvent *ev )
 {
 }
 
-void SongEditor::mouseDragEndEvent( QMouseEvent *ev )
+void SongEditor::mouseDrawEndEvent( QMouseEvent *ev )
 {
 	unsetCursor();
 }

--- a/src/gui/src/SongEditor/SongEditor.h
+++ b/src/gui/src/SongEditor/SongEditor.h
@@ -106,9 +106,9 @@ class SongEditor : public QWidget
 			const QPoint& point, int nCursorMargin,
 			std::shared_ptr<H2Core::Pattern> pPattern = nullptr ) override;
 		virtual void mouseClickEvent( QMouseEvent *ev ) override;
-		virtual void mouseDragStartEvent( QMouseEvent *ev ) override;
-		virtual void mouseDragUpdateEvent( QMouseEvent *ev ) override;
-		virtual void mouseDragEndEvent( QMouseEvent *ev ) override;
+		virtual void mouseDrawStartEvent( QMouseEvent *ev ) override;
+		virtual void mouseDrawUpdateEvent( QMouseEvent *ev ) override;
+		virtual void mouseDrawEndEvent( QMouseEvent *ev ) override;
 		virtual void selectionMoveEndEvent( QInputEvent *ev ) override;
 		virtual void updateModifiers( QInputEvent *ev );
 		virtual bool canDragElements() override {

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -125,14 +125,14 @@ SongEditorPanel::SongEditorPanel(QWidget *pParent)
 	// shown unpressed.
 	m_pSelectionModeBtn = new Button(
 		pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "select.svg", "",
-		QSize( 17, 16 ), tr( "Select mode" ) );
+		QSize( 17, 16 ), pCommonStrings->getSelectModeButton() );
 	m_pSelectionModeBtn->move( 116, 25 );
 	connect( m_pSelectionModeBtn, &QPushButton::clicked,
 			 [=](){ activateSelectMode( true ); } );
 
 	m_pDrawModeBtn = new Button(
 		pBackPanel, QSize( 25, 21 ), Button::Type::Toggle, "draw.svg", "",
-		QSize( 17, 16 ), tr( "Draw mode" ) );
+		QSize( 17, 16 ), pCommonStrings->getDrawModeButton() );
 	m_pDrawModeBtn->move( 116, 25 );
 	connect( m_pDrawModeBtn, &QPushButton::clicked,
 			 [=](){ activateSelectMode( false ); } );

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -57,6 +57,7 @@
 #include "SongEditor/SongEditorPositionRuler.h"
 #include "SoundLibrary/SoundLibraryPanel.h"
 #include "Widgets/AutomationPathView.h"
+#include "Widgets/EditorDefs.h"
 
 
 //=====================================================================================================================================
@@ -520,8 +521,8 @@ public:
 							  bool bIsDelete,
 							  bool bIsNoteOff,
 							  bool bIsMappedToDrumkit,
-							  PatternEditor::AddNoteAction addNoteAction =
-							  PatternEditor::AddNoteAction::None
+							  Editor::Action addNoteAction =
+							  Editor::Action::None
  ){
 
 		if ( bIsDelete ){
@@ -583,7 +584,7 @@ public:
 											  m_bIsMappedToDrumkit,
 											  m_addNoteAction );
 		// Only on the first redo the corresponding action is triggered.
-		m_addNoteAction = PatternEditor::AddNoteAction::None;
+		m_addNoteAction = Editor::Action::None;
 	}
 private:
 	int m_nColumn;
@@ -600,7 +601,7 @@ private:
 	bool m_bIsDelete;
 	bool m_bIsNoteOff;
 	bool m_bIsMappedToDrumkit;
-	PatternEditor::AddNoteAction m_addNoteAction;
+	Editor::Action m_addNoteAction;
 };
 
 // Deselect some notes and overwrite them

--- a/src/gui/src/Widgets/BaseEditor.h
+++ b/src/gui/src/Widgets/BaseEditor.h
@@ -104,9 +104,28 @@ class BaseEditor : public SelectionWidget<Elem>, public QWidget
 			: QWidget( pParent )
 			, m_editorType( type )
 			, m_selection( this )
+			, m_nActiveWidth( width() )
+			, m_nEditorHeight( height() )
+			, m_nEditorWidth( width() )
 			, m_bCopyNotMove( false )
-			, m_update( Update::Background ) {}
-		virtual ~BaseEditor() {}
+			, m_update( Update::Background )
+		{
+			qreal pixelRatio = devicePixelRatio();
+			m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
+											   m_nEditorHeight * pixelRatio );
+			m_pContentPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
+											m_nEditorHeight * pixelRatio );
+			m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
+			m_pContentPixmap->setDevicePixelRatio( pixelRatio );
+		}
+		virtual ~BaseEditor() {
+			if ( m_pContentPixmap != nullptr ) {
+				delete m_pContentPixmap;
+			}
+			if ( m_pBackgroundPixmap != nullptr ) {
+				delete m_pBackgroundPixmap;
+			}
+		}
 
 		virtual void updateCursorHoveredElements() {
 			___ERRORLOG( "To be implemented by parent" );
@@ -126,6 +145,11 @@ class BaseEditor : public SelectionWidget<Elem>, public QWidget
 		virtual bool updateWidth() {
 			___ERRORLOG( "To be implemented by parent" );
 			return false;
+		}
+
+		/** Updates #m_pBackgroundPixmap. */
+		virtual void createBackground() {
+			___ERRORLOG( "To be implemented by parent" );
 		}
 
 // 		//! Clear the pattern editor selection
@@ -189,6 +213,23 @@ class BaseEditor : public SelectionWidget<Elem>, public QWidget
 				else if ( ! m_bCopyNotMove && cursor().shape() != Qt::DragMoveCursor ) {
 					setCursor( QCursor( Qt::DragMoveCursor ) );
 				}
+			}
+		}
+
+		void updatePixmapSize() {
+			// Resize pixmap if pixel ratio has changed
+			qreal pixelRatio = devicePixelRatio();
+			if ( m_pBackgroundPixmap->width() != m_nEditorWidth ||
+				 m_pBackgroundPixmap->height() != m_nEditorHeight ||
+				 m_pBackgroundPixmap->devicePixelRatio() != pixelRatio ) {
+				delete m_pBackgroundPixmap;
+				m_pBackgroundPixmap = new QPixmap( m_nEditorWidth * pixelRatio,
+												   m_nEditorHeight * pixelRatio );
+				m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
+				delete m_pContentPixmap;
+				m_pContentPixmap = new QPixmap( m_nEditorWidth  * pixelRatio,
+												m_nEditorHeight * pixelRatio );
+				m_pContentPixmap->setDevicePixelRatio( pixelRatio );
 			}
 		}
 
@@ -344,14 +385,14 @@ class BaseEditor : public SelectionWidget<Elem>, public QWidget
 
 		//! The Selection object.
 		Selection<Elem> m_selection;
-// 	uint m_nEditorHeight;
-// 	uint m_nEditorWidth;
 
-// 	// width of the editor covered by the current pattern.
-// 	int m_nActiveWidth;
+		QPixmap* m_pBackgroundPixmap;
+		QPixmap* m_pContentPixmap;
 
-// 	float m_fGridWidth;
-// 	unsigned m_nGridHeight;
+		// width of the editor covered by the current pattern.
+		int m_nActiveWidth;
+		int m_nEditorHeight;
+		int m_nEditorWidth;
 
  	bool m_bCopyNotMove;
 

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -516,10 +516,6 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			}
 
 			updateVisibleComponents( true );
-
-			if ( ! ev->isAccepted() ) {
-				ev->accept();
-			}
 		}
 
 		virtual void mouseDrawStartEvent( QMouseEvent *ev ) override {

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -705,6 +705,10 @@ class Base : public SelectionWidget<Elem>, public QWidget
 				showPopupMenu( ev );
 			}
 
+			// Since we move the cursor, we also have the check whether is
+			// hovers an element at the new position.
+			updateKeyboardHoveredElements();
+
 			// New cursor position, selection and hovered notes update.
 			updateVisibleComponents( true );
 		}

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -104,6 +104,14 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			___ERRORLOG( "To be implemented by parent" );
 		}
 
+		virtual std::vector<Elem> getElementsAtPoint(
+			const QPoint& point, int nCursorMargin,
+			std::shared_ptr<H2Core::Pattern> pPattern = nullptr )
+		{
+			___ERRORLOG( "To be implemented by parent" );
+			return std::vector<Elem>();
+		}
+
 		/** Serialize and copy all currently selected elements. */
 		virtual void copy() {
 			___ERRORLOG( "To be implemented by parent" );
@@ -296,14 +304,6 @@ class Base : public SelectionWidget<Elem>, public QWidget
 
  		virtual int getCursorMargin( QInputEvent* pEvent ) const override {
 			return Editor::nDefaultCursorMargin;
-		}
-
-		virtual std::vector<Elem> getElementsAtPoint(
-			const QPoint& point, int nCursorMargin,
-			std::shared_ptr<H2Core::Pattern> pPattern = nullptr )
-		{
-			___ERRORLOG( "To be implemented by parent" );
-			return std::vector<Elem>();
 		}
 
  		void handleKeyboardCursor( bool bVisible ) {

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -146,13 +146,13 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			___ERRORLOG( "To be implemented by parent" );
 		}
 
-		virtual void propertyDrawStart( QMouseEvent* ev ) {
+		virtual void mouseDrawStart( QMouseEvent* ev ) {
 			___ERRORLOG( "To be implemented by parent" );
 		}
-		virtual void propertyDrawUpdate( QMouseEvent* ev ) {
+		virtual void mouseDrawUpdate( QMouseEvent* ev ) {
 			___ERRORLOG( "To be implemented by parent" );
 		}
-		virtual void propertyDrawEnd() {
+		virtual void mouseDrawEnd() {
 			___ERRORLOG( "To be implemented by parent" );
 		}
 
@@ -438,16 +438,17 @@ class Base : public SelectionWidget<Elem>, public QWidget
 		}
 
 		virtual void mouseDrawStartEvent( QMouseEvent *ev ) override {
-			propertyDrawStart( ev );
-			propertyDrawUpdate( ev );
+			setCursor( Qt::CrossCursor );
+			mouseDrawStart( ev );
 		}
 
 		virtual void mouseDrawUpdateEvent( QMouseEvent *ev ) override {
-			propertyDrawUpdate( ev );
+			mouseDrawUpdate( ev );
 		}
 
 		virtual void mouseDrawEndEvent( QMouseEvent *ev ) override {
-			propertyDrawEnd();
+			unsetCursor();
+			mouseDrawEnd();
 		}
 
  		void handleKeyboardCursor( bool bVisible ) {

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -174,8 +174,6 @@ class Base : public SelectionWidget<Elem>, public QWidget
 				m_update = Update::Background;
 			}
 
-			updateMouseHoveredElements( nullptr );
-
 			// redraw
 			update();
 		}

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -155,11 +155,15 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			___ERRORLOG( "To be implemented by parent" );
 		}
 
-		virtual void updateKeyboardHoveredElements() {
+		/** @returns true in case the set of hovered elements did change. */
+		virtual bool updateKeyboardHoveredElements() {
 			___ERRORLOG( "To be implemented by parent" );
+			return false;
 		}
-		virtual void updateMouseHoveredElements( QMouseEvent* ev ) {
+		/** @returns true in case the set of hovered elements did change. */
+		virtual bool updateMouseHoveredElements( QMouseEvent* ev ) {
 			___ERRORLOG( "To be implemented by parent" );
+			return false;
 		}
 
 		virtual Editor::Input getInput() const {
@@ -622,7 +626,7 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			updateModifiers( ev );
 
 			// Check which elements are hovered.
-			updateMouseHoveredElements( ev );
+			bool bUpdate = updateMouseHoveredElements( ev );
 
 			if ( ev->buttons() != Qt::NoButton ) {
 				if ( getInput() == Editor::Input::Draw &&
@@ -636,9 +640,13 @@ class Base : public SelectionWidget<Elem>, public QWidget
 				else {
 					m_selection.mouseMoveEvent( ev );
 					if ( m_selection.isMoving() ) {
-						updateVisibleComponents( true );
+						bUpdate = true;
 					}
 				}
+			}
+
+			if ( bUpdate ) {
+				updateVisibleComponents( true );
 			}
 		}
  		virtual void mouseReleaseEvent( QMouseEvent *ev ) override {
@@ -701,7 +709,8 @@ class Base : public SelectionWidget<Elem>, public QWidget
 				showPopupMenu( ev );
 			}
 
-			update();
+			// New cursor position, selection and hovered notes update.
+			updateVisibleComponents( true );
 		}
 
 		void popupMenuAboutToHide() {
@@ -747,7 +756,9 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			// have to ensure not to display some glitchy elements previously
 			// hovered by mouse which are not present anymore (e.g. since they
 			// were aligned to a different position).
-			updateMouseHoveredElements( nullptr );
+			if ( updateMouseHoveredElements( nullptr ) ) {
+				updateVisibleComponents( true );
+			}
 		}
 
 		void showPopupMenu( QMouseEvent* pEvent ){

--- a/src/gui/src/Widgets/EditorBase.h
+++ b/src/gui/src/Widgets/EditorBase.h
@@ -146,6 +146,16 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			___ERRORLOG( "To be implemented by parent" );
 		}
 
+		virtual void propertyDrawStart( QMouseEvent* ev ) {
+			___ERRORLOG( "To be implemented by parent" );
+		}
+		virtual void propertyDrawUpdate( QMouseEvent* ev ) {
+			___ERRORLOG( "To be implemented by parent" );
+		}
+		virtual void propertyDrawEnd() {
+			___ERRORLOG( "To be implemented by parent" );
+		}
+
 		/** In contrast to Selection::updateWidget() this method indicates a
 		 * state change in the overall editor and triggers an update of all its
 		 * visible components, e.g. including its ruler and sidebar. */
@@ -427,10 +437,18 @@ class Base : public SelectionWidget<Elem>, public QWidget
 			update();
 		}
 
-// 		virtual void mouseDragStartEvent( QMouseEvent *ev ) override;
-// 		virtual void mouseDragUpdateEvent( QMouseEvent *ev ) override;
-// 		virtual void mouseDragEndEvent( QMouseEvent *ev ) override;
-// 		virtual QRect getKeyboardCursorRect() override;
+		virtual void mouseDrawStartEvent( QMouseEvent *ev ) override {
+			propertyDrawStart( ev );
+			propertyDrawUpdate( ev );
+		}
+
+		virtual void mouseDrawUpdateEvent( QMouseEvent *ev ) override {
+			propertyDrawUpdate( ev );
+		}
+
+		virtual void mouseDrawEndEvent( QMouseEvent *ev ) override {
+			propertyDrawEnd();
+		}
 
  		void handleKeyboardCursor( bool bVisible ) {
 			auto pHydrogenApp = HydrogenApp::get_instance();

--- a/src/gui/src/Widgets/EditorDefs.h
+++ b/src/gui/src/Widgets/EditorDefs.h
@@ -43,20 +43,21 @@ namespace Editor {
 	}
 
 	enum class Instance {
-		DrumPattern = 0,
-		PianoRoll = 1,
-		NotePropertiesRuler = 2,
-		None = 3
+		None = 0,
+		DrumPattern = 1,
+		PianoRoll = 2,
+		NotePropertiesRuler = 3
 	};
 	static QString instanceToQString( const Instance& instance ) {
 		switch ( instance ) {
+		case Instance::None:
+			return "None";
 		case Instance::DrumPattern:
 			return "DrumPattern";
 		case Instance::PianoRoll:
 			return "PianoRoll";
 		case Instance::NotePropertiesRuler:
 			return "NotePropertiesRuler";
-		case Instance::None:
 		default:
 			return QString( "Unknown instance [%1]" )
 				.arg( static_cast<int>(instance) ) ;

--- a/src/gui/src/Widgets/EditorDefs.h
+++ b/src/gui/src/Widgets/EditorDefs.h
@@ -1,0 +1,113 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2002-2020 by the Hydrogen Team
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#ifndef EDITOR_DEFS_H
+#define EDITOR_DEFS_H
+
+#include <QString>
+
+namespace Editor {
+	enum class Type {
+		Horizontal,
+		Grid
+	};
+	static QString tpeToQString( const Type& type ) {
+		switch( type ) {
+		case Type::Horizontal:
+			return QString( "Horizontal" );
+		case Type::Grid:
+			return QString( "Grid" );
+		default:
+			return QString( "Unknown editor type [%1]" )
+				.arg( static_cast<int>(type) );
+		}
+	}
+
+	enum class Instance {
+		DrumPattern = 0,
+		PianoRoll = 1,
+		NotePropertiesRuler = 2,
+		None = 3
+	};
+	static QString instanceToQString( const Instance& instance ) {
+		switch ( instance ) {
+		case Instance::DrumPattern:
+			return "DrumPattern";
+		case Instance::PianoRoll:
+			return "PianoRoll";
+		case Instance::NotePropertiesRuler:
+			return "NotePropertiesRuler";
+		case Instance::None:
+		default:
+			return QString( "Unknown instance [%1]" )
+				.arg( static_cast<int>(instance) ) ;
+		}
+	}
+
+	/** Specifies which parts of the editor need updating on a paintEvent().
+	 * Bigger numerical values imply updating elements with lower ones as
+	 * well.*/
+	enum class Update {
+		/** Just paint transient elements, like hovered notes, cursor, focus
+		 * or lasso. */
+		None = 0,
+		/** Update notes, pattern, etc. including selection of a cached
+		 * background image. */
+		Content = 1,
+		/** Update the background image. */
+		Background = 2
+	};
+	static QString updateToQString( const Update& update ) {
+		switch ( update ) {
+			case Update::Background:
+				return "Background";
+			case Update::Content:
+				return "Pattern";
+			case Update::None:
+				return "None";
+			default:
+				return QString( "Unknown update [%1]" )
+					.arg( static_cast<int>(update) ) ;
+		}
+	}
+
+	/** Additional action to perform on the first redo() call of
+	 * #SE_addOrRemoveNotes. */
+	enum class Action {
+		None = 0x000,
+		/** Add the new note to the current selection. */
+		AddToSelection = 0x001,
+		/** Move cursor to focus newly added note. */
+		MoveCursorTo = 0x002,
+		/** Play back the new note in case hear notes is enabled. */
+		Playback = 0x004
+	};
+
+	/** Distance in pixel the cursor is allowed to be away from a note to still
+	 * be associated with it.
+	 *
+	 * Note that for very small resolutions a smaller margin will be used to
+	 * still allow adding notes to adjacent grid cells. */
+	static constexpr int nDefaultCursorMargin = 10;
+}
+
+#endif // EDITOR_DEFS_H

--- a/src/gui/src/Widgets/EditorDefs.h
+++ b/src/gui/src/Widgets/EditorDefs.h
@@ -167,6 +167,34 @@ namespace Editor {
 	static constexpr int nWordSize = 5;
 	static constexpr int nPageSize = 15;
 
+	/** Specifies what happens on left-mouse button interaction. */
+	enum class Input {
+		/** Clicking will delete an existing element or create a new one and
+		 * dragging will either move the clicked note (and its corresponding
+		 * selection) or start a new lasso for selection. */
+		Select = 0,
+		/** Clicking will delete an existing element or create a new one and
+		 * dragging will delete existing/add new elements on all encountered
+		 * grid points. For horizontal editors, this might change the values of
+		 * existing elements instead. */
+		Draw = 1,
+		/** Clicking will delete an existing element or create a new one and
+		 * dragging will change the properties of the clicked element. */
+		Edit = 2
+	};
+	static QString inputToQString( const Input& input ) {
+		switch ( input ) {
+		case Input::Select:
+			return "Select";
+		case Input::Draw:
+			return "Draw";
+		case Input::Edit:
+			return "Edit";
+		default:
+			return QString( "Unknown input [%1]" ).arg( static_cast<int>(input) );
+		}
+	}
+
 	/** Distance in pixel the cursor is allowed to be away from a note to still
 	 * be associated with it.
 	 *

--- a/src/gui/src/Widgets/EditorDefs.h
+++ b/src/gui/src/Widgets/EditorDefs.h
@@ -78,20 +78,18 @@ namespace Editor {
 	};
 	static QString updateToQString( const Update& update ) {
 		switch ( update ) {
-			case Update::Background:
-				return "Background";
-			case Update::Content:
-				return "Pattern";
-			case Update::None:
-				return "None";
-			default:
-				return QString( "Unknown update [%1]" )
-					.arg( static_cast<int>(update) ) ;
+		case Update::Background:
+			return "Background";
+		case Update::Content:
+			return "Content";
+		case Update::None:
+			return "None";
+		default:
+			return QString( "Unknown update [%1]" )
+				.arg( static_cast<int>(update) ) ;
 		}
 	}
 
-	/** Additional action to perform on the first redo() call of
-	 * #SE_addOrRemoveNotes. */
 	enum class Action {
 		None = 0x000,
 		/** Add the new note to the current selection. */
@@ -99,8 +97,75 @@ namespace Editor {
 		/** Move cursor to focus newly added note. */
 		MoveCursorTo = 0x002,
 		/** Play back the new note in case hear notes is enabled. */
-		Playback = 0x004
+		Playback = 0x004,
+		/** Add a new element */
+		AddElements = 0x008,
+		/** Deletes an existing elements */
+		DeleteElements = 0x010,
+		/** If an elements exists, delete it. If not, create a new one. */
+		ToggleElements = 0x020
 	};
+	static QString actionToQString( const Action& action ) {
+		QStringList actions;
+		if ( static_cast<char>(action) & static_cast<char>(Action::None) ) {
+			actions << "None";
+		}
+		if ( static_cast<char>(action) &
+			 static_cast<char>(Action::AddToSelection) ) {
+			actions << "AddToSelection";
+		}
+		if ( static_cast<char>(action) &
+			 static_cast<char>(Action::MoveCursorTo) ) {
+			actions << "MoveCursorTo";
+		}
+		if ( static_cast<char>(action) &
+			 static_cast<char>(Action::Playback) ) {
+			actions << "Playback";
+		}
+		if ( static_cast<char>(action) &
+			 static_cast<char>(Action::AddElements) ) {
+			actions << "AddElements";
+		}
+		if ( static_cast<char>(action) &
+			 static_cast<char>(Action::DeleteElements) ) {
+			actions << "DeleteElements";
+		}
+		if ( static_cast<char>(action) &
+			 static_cast<char>(Action::ToggleElements) ) {
+			actions << "ToggleElements";
+		}
+		return actions.join( ", " );
+	}
+
+	/** Symbolic step sizes employed on keyboard interactions. */
+	enum class Step {
+		None = 0,
+		Tiny = 1,
+		Character = 2,
+		Word = 3,
+		Page = 4,
+		Document = 5
+	};
+	static QString stepToQString( const Step& step ) {
+		switch ( step ) {
+		case Step::None:
+			return "None";
+		case Step::Tiny:
+			return "Tiny";
+		case Step::Character:
+			return "Character";
+		case Step::Word:
+			return "Word";
+		case Step::Page:
+			return "Page";
+		case Step::Document:
+			return "Document";
+		default:
+			return QString( "Unknown step [%1]" ).arg( static_cast<int>(step) ) ;
+		}
+	}
+	static constexpr int nWordSize = 5;
+	static constexpr int nPageSize = 15;
 
 	/** Distance in pixel the cursor is allowed to be away from a note to still
 	 * be associated with it.

--- a/src/gui/src/Widgets/EditorDefs.h
+++ b/src/gui/src/Widgets/EditorDefs.h
@@ -174,13 +174,11 @@ namespace Editor {
 		 * dragging will either move the clicked note (and its corresponding
 		 * selection) or start a new lasso for selection. */
 		Select = 0,
-		/** Clicking will delete an existing element or create a new one and
-		 * dragging will delete existing/add new elements on all encountered
+		/** Dragging will delete existing/add new elements on all encountered
 		 * grid points. For horizontal editors, this might change the values of
 		 * existing elements instead. */
 		Draw = 1,
-		/** Clicking will delete an existing element or create a new one and
-		 * dragging will change the properties of the clicked element. */
+		/** Dragging will change the properties of the clicked element. */
 		Edit = 2
 	};
 	static QString inputToQString( const Input& input ) {


### PR DESCRIPTION
A base class `Editor::Base` was introduced. It contains the most user interactions and basic UX previously update in the `PatternEditor`. The goal is to base `SongEditor` and `AutomationPathView` on the very same class in order to get a more consistent UX when interacting with one of our editors.

A long the way (towards consistency) some changes were made:
- the panel of the pattern editor was reworked. Labels were dropped (not present in other editors either) and the buttons have been moved to the sidebar - like in the song editor.

  old: 
![patterneditortoolbar-old](https://github.com/user-attachments/assets/e899fe6b-2dd7-43d0-aa12-cbfe0465a206)

  new:
![patterneditortoolbar-new](https://github.com/user-attachments/assets/6e70956a-704b-4f94-bf29-8445ff3ce324)

- buttons - like the one switching between drum pattern and piano roll - do not change icons anymore. Instead, both of them are placed next to each other and only one can be toggled. I always found the switching behavior quite irritating. In most places a _toggled_ buttons represent the presence of a state.
- there are now buttons for select, draw, and edit left mouse button interaction mode (select and draw are known from the song editor)
- right-click drag in `DrumPatternEditor` and `PianoRollEditor` does not alter the property/length of a note anymore but draws notes similar to the song editor and note properties ruler. To change the length of a note, the edit button + left-click drag has to be used
- in select mode (default) right-click dragging will perform drawing. This is the current UX in `NotePropertiesRuler` and will be the most useful in `SongEditor`. Therefore, it is used in `DrumPatternEditor` and `PianoRollEditor` as well.

---

Full ADR: 

# AD: Introduce BaseEditor

## Context and Problem Statement

Originally, all our editors - `DrumPatternEditor`, `PianoRollEditor`, `NotePropertiesRuler`, `SongEditor`, `AutomationPathView`, as well as pan and volume automation in `TargetWaveDisplay` within the `SampleEditor` - had their unique code base and their individual UX. Each part felt a little different.

Since version `1.1.0` Hydrogen features a common selection handling in song and all pattern editors. It feels much more coherent this way. In the preparation for the `2.0` all the editors in the pattern editor region have been align in both UI and UX. But it still does not feel like one consistent application.

For `2.0` the UX of all remaining editors will be aligned as well. Interacting with a pattern square in `SongEditor` should feel the same as interacting with notes in `DrumPatternEditor`. In the same vain our horizontal editors should behave the same, regardless of whether the user is interacting with a note in `NotePropertiesRuler`, an automation node in `AutomationPathView`, or an envelope point in `TargetWaveDisplay`.

## Decision Drivers

* UX should be as intuitive as possible.
* UX changes with time and Hydrogen could keep up (e.g. optimized for touch   interaction).
* Maintenance should be as simple.

## Considered Options

1. We could take the UX of the pattern editor and implement similar code in all other editors.
2. We introduce a common base class, like `Editor::Base`.

## Decision Outcome

I tend towards 2. It's a lot of work. But implementing and testing 1. would be an almost equivalent pile of work. In addition, codifying the requirement of a shared UX makes maintaining more easy. Else, it would be very easy to forget to apply a patch to a particular editor.

While at it, `AutomationPathView` and `TargetWaveDisplay` should be ported to a shared code base. After all, automation of pan and volume is just a special case of the more general automation view. The latter should also be made ready to handle various automation targets while being touched. Just the overall velocity - as up to `1.2.X` - does not really justify the presence of this widget.

What should be part of the common base?

- Keyboard arrow movement (plus modifiers)
- Selection via keyboard and mouse
- Highlighting of selected elements
- Lasso rendering
- Hovering of elements via keyboard and mouse as well as a shared cursor margins.
- Mouse and keyboard based moving of selected elements
- Left-click moving of single elements (selected or not)
- Right-click popup menu (if applicable)
- Right-click drawing


### Consequences

* Based on the recent work in `PatternEditor` a common base class called `Editor::Base` - itself a child class of `Selection` - will be split off.
* First, all pattern editors will be ported to the new base class.
* Second, the `SongEditor` will be ported.
* The automation code base will be reviewed and ported to `Editor::Base`.
* `TargetWaveDisplay` code base will be dropped in favor for inheriting a shared automation code.
