### PR TITLE
FileDialog: no native windows on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file.
 - AppImage build dir is now removed on `build.sh r` (#2129).
 - Fix potential crash with JACK audio driver on startup, teardown, or
   song/drumkit loading.
+- Fix freeze in native file dialogs on Linux (#2165).
   
 ### Removed
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -750,7 +750,6 @@ bool MainForm::action_file_save_as()
 		sPath = Filesystem::songs_dir();
 	}
 
-	//std::auto_ptr<QFileDialog> fd( new QFileDialog );
 	FileDialog fd(this);
 	fd.setFileMode( QFileDialog::AnyFile );
 	fd.setNameFilter( Filesystem::songs_filter_name );

--- a/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPropertiesDialog.cpp
@@ -341,7 +341,14 @@ void SoundLibraryPropertiesDialog::on_imageBrowsePushButton_clicked()
 	// Try to get the drumkit directory and open file browser
 	QString sDrumkitDir = m_pDrumkit->get_path();
 
-	QString sFilePath = QFileDialog::getOpenFileName(this, tr("Open Image"), sDrumkitDir, tr("Image Files (*.png *.jpg *.jpeg)"));
+	QString sFilePath = QFileDialog::getOpenFileName(
+		this, tr("Open Image"), sDrumkitDir,
+		tr("Image Files (*.png *.jpg *.jpeg)"), nullptr
+#if not defined(WIN32) and not defined(__APPLE__) // Linux
+		// See FileDialog.h for details
+		, QFileDialog::DontUseNativeDialog
+#endif
+	);
 
 	// If cancel was clicked just abort
 	if ( sFilePath == nullptr || sFilePath.isEmpty() ) {

--- a/src/gui/src/Widgets/FileDialog.cpp
+++ b/src/gui/src/Widgets/FileDialog.cpp
@@ -24,10 +24,22 @@
 #include "../CommonStrings.h"
 #include "../HydrogenApp.h"
 
+#include <core/config.h>
 #include <core/Helpers/Filesystem.h>
 
 FileDialog::FileDialog( QWidget *pParent )
  : QFileDialog( pParent ) {
+
+#if not defined(WIN32) and not defined(__APPLE__) // Linux
+	// Occassionally users reported freezing of Hydrogen when interactive with
+	// native file dialogs on Linux, e.g. #2165. Qt's bug tracker is full of
+	// such tickets and it seems to be a problem with the interaction of the Qt
+	// library with the underlying windows manager. Since I
+	// (@theGreatWhiteShark) was never able to reproduce this issue and we have
+	// no control of which Qt version will be combined using with window
+	// manager, we will circumvent this issue by avoid all native file dialogs.
+	setOption( QFileDialog::DontUseNativeDialog, true );
+#endif
 }
 
 FileDialog::~FileDialog() {


### PR DESCRIPTION
Occassionally users reported freezing of Hydrogen when interactive with native file dialogs on Linux, e.g. https://github.com/hydrogen-music/hydrogen/issues/2165. Qts bug tracker is full of such tickets and it seems to be a problem with the interaction of the Qt library with the underlying windows manager. Since I (@theGreatWhiteShark) was never able to reproduce this issue and we have no control of which Qt version will be combined using with window manager, we will circumvent this issue by avoid all native file dialogs.

Fixes #2165