### PR TITLE
AudioEngine: fix velocity automation handling (#2171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix velocity automation for patterns that are not of size 4/4 (#2171).
 - Fix saving and loading of sample files (#2174).
 
 ## [1.2.5] - 2025-07-17

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -2679,8 +2679,17 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 						pCopiedNote->computeNoteStart();
 						
 						if ( pHydrogen->getMode() == Song::Mode::Song ) {
-							const float fPos = static_cast<float>( m_pQueuingPosition->getColumn() ) +
-								pCopiedNote->get_position() % 192 / 192.f;
+							// Onset of the current column + the percentage by
+							// which the current column was already passed. For
+							// large patterns the cursor will move slower and
+							// for shorter faster within a column.
+							const float fPos =
+								static_cast<float>( m_pQueuingPosition->getColumn() ) +
+								( ( pCopiedNote->get_position() -
+									m_pQueuingPosition->getPatternStartTick() ) %
+								  m_pQueuingPosition->getPatternSize() ) /
+								static_cast<float>(m_pQueuingPosition->getPatternSize());
+
 							pCopiedNote->set_velocity( pCopiedNote->get_velocity() *
 													   pAutomationPath->get_value( fPos ) );
 						}


### PR DESCRIPTION
since the introduction of the velocity automation in b74b0de59a8d6544c3cf1d584e88169d6ca32cc8 the whole thing was designed to work with 4/4 sized patterns exclusively.

This patch should allow smooth automation for arbitrary pattern sizes.

Fixes #2171