### PR TITLE
SoundLibraryDatabase: add installed kits in AppImage too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [1.2.6] - XXXX-XX-XX
 
+### Added
+
+- The AppImage version does now provide all drumkits in
+  `/usr/share/hydrogen/data/drumkits/` and
+  `/usr/local/share/hydrogen/data/drumkits/` via the "Sound Library" as session
+  kits.
+
 ### Changed
 
 - Sample loading in songs has been made more portable.
@@ -11,7 +18,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fix velocity automation for patterns that are not of size 4/4 (#2171).
-- Fix saving and loading of sample files (#2174).
+- Fix saving and loading of sample files introduced in 1.2.5 (#2174).
 
 ## [1.2.5] - 2025-07-17
 

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -870,8 +870,6 @@ QString Filesystem::prepare_sample_path( const QString& sSamplePath )
 		// Sample is located in a drumkit folder. Just return basename.
 		QString sShortenedPath = sSamplePathCleaned.right(
 			sSamplePathCleaned.size() - nIndexMatch );
-		INFOLOG( QString( "Shortening sample path [%1] to [%2]" )
-				 .arg( sSamplePath ).arg( sShortenedPath ) );
 
 		return std::move( sShortenedPath );
 	}

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -83,6 +83,29 @@ void SoundLibraryDatabase::updateDrumkits( bool bTriggerEvent ) {
 		drumkitPaths <<
 			Filesystem::absolute_path( Filesystem::usr_drumkits_dir() + sDrumkitName );
 	}
+
+#ifdef H2CORE_HAVE_APPIMAGE
+	// When starting Hydrogen as an AppImage, all drumkits installed via the
+	// package manager are not part of the system drumkit folder of this
+	// instance. Instead, we treat them as custom drumkit.
+	const auto additionalDirs = QStringList()
+		<< "/usr/share/hydrogen/data/drumkits"
+		<< "/usr/local/share/hydrogen/data/drumkits";
+	for ( const auto& ssDir : additionalDirs ) {
+		if ( Filesystem::dir_exists( ssDir, true ) ) {
+			for ( const auto& ssEntry : QDir( ssDir ).entryList(
+					  QDir::Dirs | QDir::Readable | QDir::NoDotAndDotDot ) ) {
+				const auto sFilePath = QString( "%1/%2" ).arg( ssDir )
+					.arg( ssEntry );
+				if ( Filesystem::drumkit_valid( sFilePath ) &&
+					 ! m_customDrumkitPaths.contains( sFilePath ) ) {
+					m_customDrumkitPaths << sFilePath;
+				}
+			}
+		}
+	}
+#endif
+
 	// custom drumkits added by the user
 	for ( const auto& sDrumkitPath : m_customDrumkitPaths ) {
 		if ( ! drumkitPaths.contains( sDrumkitPath ) ) {


### PR DESCRIPTION
while debugging it proved a little bit inconvenient that the AppImage version of Hydrogen does not list the drumkits installed on the system. Since it ships its own system drumkit folder, it is not totally wrong. But we could still list all kits installed as session kits. Otherwise, the user would need to load them manually into the session. And especially for new users installing the debian package containing a bunch of kits this might be too difficult