### PR TITLE
JackAudioDriver: suppress redundant state changes

### DIFF
--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -693,17 +693,18 @@ void JackAudioDriver::updateTransportPosition()
 				else {
 					m_timebaseTracking = TimebaseTracking::Valid;
 
+					if ( m_timebaseState != Timebase::None ) {
 #if JACK_DEBUG
 				J_DEBUGLOG( QString( "Updating Timebase [2] [%1] -> [%2]" )
 							.arg( TimebaseToQString( m_timebaseState ) )
 							.arg( TimebaseToQString( Timebase::None ) ) );
 #endif
-
-					m_timebaseState = Timebase::None;
+						m_timebaseState = Timebase::None;
+						EventQueue::get_instance()->push_event(
+							EVENT_JACK_TIMEBASE_STATE_CHANGED,
+							static_cast<int>(m_timebaseState) );
+					}
 					m_nTimebaseFrameOffset = 0;
-					EventQueue::get_instance()->push_event(
-						EVENT_JACK_TIMEBASE_STATE_CHANGED,
-						static_cast<int>(m_timebaseState) );
 				}
 			}
 		}

--- a/tests/jackTimebase/h2JackTimebase/main.cpp
+++ b/tests/jackTimebase/h2JackTimebase/main.cpp
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
 		Logger* pLogger = Logger::bootstrap( logLevelOpt,
 											sLogFile, true, true );
 		Base::bootstrap( pLogger, pLogger->should_log( Logger::Debug ) );
-		Filesystem::bootstrap( pLogger, "", sConfigFilePath, sLogFile );
+		Filesystem::bootstrap( pLogger, "", "", sConfigFilePath, sLogFile );
 		MidiMap::create_instance();
 		Preferences::create_instance();
 		Preferences* preferences = Preferences::get_instance();


### PR DESCRIPTION
the update of the timebase state was not done lazily in case neither Hydrogen nor another application was in timebase control. This lead to `JackAudioDriver` spamming the `EventQueue` with `EVENT_JACK_TIMEBASE_STATE_CHANGED` events.