### PR TITLE
Fix NSM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,13 @@ All notable changes to this project will be documented in this file.
 - `LASH` support has been dropped (#1649).
 - `cmake` option `MAX_NOTES` has been dropped.
 
+## [1.2.7] - XXXX-XX-XX
+
+### Fixed
+
+- OSC endpoint `/Hydrogen/SAVE_PREFERENCES` does now actually save the
+  preferences (instead of the song).
+
 ## [1.2.6] - 2025-07-29
 
 ### Added

--- a/src/core/OscServer.cpp
+++ b/src/core/OscServer.cpp
@@ -1358,8 +1358,8 @@ bool OscServer::init()
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "", SAVE_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG", "f", SAVE_SONG_Handler);
 	m_pServerThread->add_method("/Hydrogen/SAVE_SONG_AS", "s", SAVE_SONG_AS_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_PREFERENCES", "", SAVE_SONG_Handler);
-	m_pServerThread->add_method("/Hydrogen/SAVE_PREFERENCES", "f", SAVE_SONG_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_PREFERENCES", "", SAVE_PREFERENCES_Handler);
+	m_pServerThread->add_method("/Hydrogen/SAVE_PREFERENCES", "f", SAVE_PREFERENCES_Handler);
 	m_pServerThread->add_method("/Hydrogen/QUIT", "", QUIT_Handler);
 	m_pServerThread->add_method("/Hydrogen/QUIT", "f", QUIT_Handler);
 

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2373,7 +2373,7 @@ void MainForm::updatePreferencesEvent( int nValue ) {
 	if ( nValue == 0 ) {
 		// Write the state of the GUI to the Preferences.
 		saveWindowProperties();
-		CoreActionController::savePreferences();
+		Preferences::get_instance()->save();
 	}
 	else if ( nValue == 1 ) {
 		


### PR DESCRIPTION
Whenever the session was saved or switched in NSM, Hydrogen did enter an infinite loop.