### PR TITLE
Fix the section / date format of the manpage

### DIFF
--- a/linux/hydrogen.1
+++ b/linux/hydrogen.1
@@ -1,4 +1,4 @@
-.TH HYDROGEN "July 29, 2025" "Hydrogen 1.2.6" "User Commands"
+.TH HYDROGEN "1" "July 29, 2025" "Hydrogen 1.2.6" "User Commands"
 .SH NAME
 hydrogen \- a simple drum machine/step sequencer.
 .SH SYNOPSIS

--- a/linux/hydrogen.1
+++ b/linux/hydrogen.1
@@ -1,4 +1,4 @@
-.TH HYDROGEN "29" "July 2025" "Hydrogen 1.2.6" "User Commands"
+.TH HYDROGEN "July 29, 2025" "Hydrogen 1.2.6" "User Commands"
 .SH NAME
 hydrogen \- a simple drum machine/step sequencer.
 .SH SYNOPSIS


### PR DESCRIPTION
Since the master branch does contain an older manpage than in the 1.2.6 release i changed in the 1.2.6 artifacts.
Please apply it in the right branch. Thanks :)