### PR TITLE
WidgetWithInput: fix handling of keyboard events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - OSC endpoint `/Hydrogen/SAVE_PREFERENCES` does now actually save the
   preferences (instead of the song).
+- Keyboard events for settings values on rotaries and faders are not shadowed by
+  the virtual keyboard anymore.
 
 ## [1.2.6] - 2025-07-29
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -80,6 +80,8 @@ class MainForm :  public QMainWindow, protected WidgetWithScalableFont<8, 10, 12
 		virtual void undoRedoActionEvent( int nEvent ) override;
 		static void usr1SignalHandler(int unused);
 
+		bool eventFilter( QObject *o, QEvent *e ) override;
+
 public slots:
 		void showPreferencesDialog();
 		void showUserManual();
@@ -278,8 +280,6 @@ public slots:
 		void createMenuBar();
 		
 		void checkNecessaryDirectories();
-
-		bool eventFilter( QObject *o, QEvent *e ) override;
 
 		std::map<int,int>  keycodeInstrumentMap;
 		void initKeyInstMap();

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -55,8 +55,6 @@ Fader::Fader( QWidget *pParent, Type type, QString sBaseTooltip, bool bUseIntSte
 	m_fValue = m_fDefaultValue;
 	updateTooltip();
 
-	installEventFilter( HydrogenApp::get_instance()->getMainForm() );
-
 	if ( type == Type::Vertical ){ 
 		m_nWidgetWidth = 116;
 		m_nWidgetHeight = 23;

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -45,8 +45,6 @@ Rotary::Rotary( QWidget* parent, Type type, QString sBaseTooltip, bool bUseIntSt
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
 			 this, &Rotary::onPreferencesChanged );
 
-	installEventFilter( HydrogenApp::get_instance()->getMainForm() );
-
 	if ( type == Type::Small ) {
 		m_nWidgetWidth = 18;
 		m_nWidgetHeight = 18;

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -25,6 +25,7 @@
 #include "../Compatibility/WheelEvent.h"
 #include "../CommonStrings.h"
 #include "../HydrogenApp.h"
+#include "../MainForm.h"
 #include "MidiSenseWidget.h"
 
 #include <core/Hydrogen.h>
@@ -346,7 +347,9 @@ void WidgetWithInput::keyPressEvent( QKeyEvent *ev ) {
 		QToolTip::hideText();
 		return;
 	} else {
-		// return without showing a tooltop
+		// Return without showing a tooltop. Let MainForm handle the event for
+		// virtual keyboard and shortcuts.
+		HydrogenApp::get_instance()->getMainForm()->eventFilter( this, ev );
 		return;
 	}
 	


### PR DESCRIPTION
`MainForm::eventFilter` must not be called before `WidgetWithInput`. Otherwise, the virtual keyboard shadows some of the keys required to set values for `Rotary` and `Fader`