### PR TITLE
Fix tempo change handling via MIDI / OSC command with Timeline enabled - support event dropping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file.
   preferences (instead of the song).
 - Keyboard events for settings values on rotaries and faders are not shadowed by
   the virtual keyboard anymore.
+- Using bpm, beat counter, and tap tempo MIDI actions or OSC commands while
+  timeline is activate does no longer result in countless popups.
 
 ## [1.2.6] - 2025-07-29
 

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -259,6 +259,9 @@ public:/**
 	 */
 	Event pop_event();
 
+	/** Removes all events of type @a type from the queue. */
+	void dropEvents( const EventType& type );
+
 	struct AddMidiNoteVector {
 		int m_column;       //position
 		int m_row;          //instrument row

--- a/src/gui/src/PlayerControl.cpp
+++ b/src/gui/src/PlayerControl.cpp
@@ -1094,6 +1094,11 @@ void PlayerControl::tempoChangedEvent( int nValue )
 					H2Core::Hydrogen::Tempo::Jack ) {
 			QMessageBox::warning( this, "Hydrogen", tr("A tempo change via MIDI, OSC, BeatCounter, or TapTempo was detected. It will only take effect when deactivating JACK Timebase support or making Hydrogen take Timebase control.") );
 		}
+
+		// Discard all pending tempo change events in order to not create a
+		// flood of popups. Only after this method returns, the next event will
+		// be handled.
+		EventQueue::get_instance()->dropEvents( EVENT_TEMPO_CHANGED );
 	}
 }
 

--- a/src/tests/EventQueueTest.cpp
+++ b/src/tests/EventQueueTest.cpp
@@ -133,3 +133,38 @@ void EventQueueTest::testThreadedAccess() {
 	CPPUNIT_ASSERT( ev.type == EVENT_NONE );
 	___INFOLOG( "passed" );
 }
+
+void EventQueueTest::testEventDrop() {
+	___INFOLOG( "" );
+	auto pEventQueue = EventQueue::get_instance();
+	// Clear queue of any events from previous tests.
+	Event ev;
+	do {
+		ev = pEventQueue->pop_event();
+	} while ( ev.type != EVENT_NONE );
+	pEventQueue->dropEvents( EVENT_TEMPO_CHANGED );
+
+	// Fill queue with different events
+	const int nEvents = 20;
+	for ( int ii = 0; ii < nEvents; ii++ ) {
+		if ( ii % 2 == 0 ) {
+			pEventQueue->push_event( EVENT_PROGRESS, ii );
+		}
+		else {
+			pEventQueue->push_event( EVENT_TEMPO_CHANGED, ii );
+		}
+	}
+
+	pEventQueue->dropEvents( EVENT_TEMPO_CHANGED );
+
+	// Check that the queue contains the most recent MAX_EVENTS events
+	for ( int ii = 0; ii < nEvents / 2; ii++) {
+		ev = pEventQueue->pop_event();
+		CPPUNIT_ASSERT( ev.type == EVENT_PROGRESS );
+	}
+
+	ev = pEventQueue->pop_event();
+	CPPUNIT_ASSERT( ev.type == EVENT_NONE );
+
+	___INFOLOG( "passed" );
+}

--- a/src/tests/EventQueueTest.h
+++ b/src/tests/EventQueueTest.h
@@ -27,6 +27,7 @@ class EventQueueTest : public CppUnit::TestCase {
 	CPPUNIT_TEST( testPushPop );
 	CPPUNIT_TEST( testOverflow );
 	CPPUNIT_TEST( testThreadedAccess );
+	CPPUNIT_TEST( testEventDrop );
 	CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -39,5 +40,6 @@ public:
 	void testPushPop();
 	void testOverflow();
 	void testThreadedAccess();
+	void testEventDrop();
 
 };

--- a/src/tests/EventQueueTest.h
+++ b/src/tests/EventQueueTest.h
@@ -1,0 +1,43 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses
+ *
+ */
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <core/EventQueue.h>
+
+class EventQueueTest : public CppUnit::TestCase {
+	CPPUNIT_TEST_SUITE( EventQueueTest );
+	CPPUNIT_TEST( testPushPop );
+	CPPUNIT_TEST( testOverflow );
+	CPPUNIT_TEST( testThreadedAccess );
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+
+	static constexpr int nThreads = 16;
+	static constexpr int nCountsPerThread = MAX_EVENTS / nThreads;
+
+	void setUp() override;
+	void tearDown() override;
+	void testPushPop();
+	void testOverflow();
+	void testThreadedAccess();
+
+};

--- a/src/tests/registeredTests.h
+++ b/src/tests/registeredTests.h
@@ -28,7 +28,7 @@
 #include "AutomationPathTest.cpp"
 #include "CoreActionControllerTest.h"
 #include "DrumkitExportTest.h"
-#include "EventQueueTest.cpp"
+#include "EventQueueTest.h"
 #include "FilesystemTest.h"
 #include "ForwardCompatibilityTest.h"
 #include "FunctionalTests.cpp"

--- a/src/tests/registeredTests.h
+++ b/src/tests/registeredTests.h
@@ -28,6 +28,7 @@
 #include "AutomationPathTest.cpp"
 #include "CoreActionControllerTest.h"
 #include "DrumkitExportTest.h"
+#include "EventQueueTest.cpp"
 #include "FilesystemTest.h"
 #include "ForwardCompatibilityTest.h"
 #include "FunctionalTests.cpp"
@@ -51,6 +52,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( AutomationPathSerializerTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( AutomationPathTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( CoreActionControllerTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( DrumkitExportTest );
+CPPUNIT_TEST_SUITE_REGISTRATION( EventQueueTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( FilesystemTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( ForwardCompatibilityTest );
 CPPUNIT_TEST_SUITE_REGISTRATION( FunctionalTest );


### PR DESCRIPTION
`PlayerControl::tempoChangedEvent` creates a popup warning about the tempo change. This dialog blocks the handling of all other events until it is closed.

Dialing a button associated with e.g. a BPM_INCR MIDI action results in a lot of `EVENT_TEMPO_CHANGED` events. Previously, each one of them would result in a separate dialog - spamming the user to such a degree Hydrogen would almost become unusable. Now, all remaining events of that type are discarded once the dialog is closed