### PR TITLE
make Theme std::shared_ptr

### DIFF
--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -597,9 +597,12 @@ public:
 	bool			m_bShowExportDrumkitCopyleftWarning;
 	bool			m_bShowExportDrumkitAttributionWarning;
 
-	const Theme& getTheme() const;
-	Theme& getThemeWritable();
-	void setTheme( const Theme& pTheme );
+	const std::shared_ptr<const Theme> getTheme() const;
+	const std::shared_ptr<const ColorTheme> getColorTheme() const;
+	const std::shared_ptr<const InterfaceTheme> getInterfaceTheme() const;
+	const std::shared_ptr<const FontTheme> getFontTheme() const;
+	std::shared_ptr<Theme> getThemeWritable();
+	void setTheme( std::shared_ptr<Theme> pTheme );
 
 	const std::shared_ptr<Shortcuts> getShortcuts() const;
 	void setShortcuts( const std::shared_ptr<Shortcuts> pShortcuts );
@@ -747,7 +750,7 @@ private:
     int						m_nMidiExportMode;
     bool					m_bMidiExportUseHumanization;
 
-	Theme					m_theme;
+	std::shared_ptr<Theme>		m_pTheme;
 
 	std::shared_ptr<Shortcuts>  m_pShortcuts;
 	std::shared_ptr<MidiMap> m_pMidiMap;
@@ -1277,14 +1280,23 @@ inline void Preferences::setLastOpenTab(int n){
 	m_nLastOpenTab = n;
 }
 
-inline void Preferences::setTheme( const Theme& theme ) {
-	m_theme = theme;
+inline void Preferences::setTheme( std::shared_ptr<Theme> pTheme ) {
+	m_pTheme = pTheme;
 }
-inline const Theme& Preferences::getTheme() const {
-	return m_theme;
+inline const std::shared_ptr<const Theme> Preferences::getTheme() const {
+	return m_pTheme;
 }
-inline Theme& Preferences::getThemeWritable() {
-	return m_theme;
+inline const std::shared_ptr<const ColorTheme> Preferences::getColorTheme() const {
+	return m_pTheme->m_pColor;
+}
+inline const std::shared_ptr<const InterfaceTheme> Preferences::getInterfaceTheme() const {
+	return m_pTheme->m_pInterface;
+}
+inline const std::shared_ptr<const FontTheme> Preferences::getFontTheme() const {
+	return m_pTheme->m_pFont;
+}
+inline std::shared_ptr<Theme> Preferences::getThemeWritable() {
+	return m_pTheme;
 }
 
 inline const std::shared_ptr<Shortcuts> Preferences::getShortcuts() const {

--- a/src/core/Preferences/Theme.cpp
+++ b/src/core/Preferences/Theme.cpp
@@ -204,62 +204,63 @@ void ColorTheme::saveTo( XMLNode& parent ) const {
 	widgetNode.write_color( "soloTextColor", m_soloTextColor );
 }
 
-ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
-	auto colorTheme = ColorTheme();
+std::shared_ptr<ColorTheme> ColorTheme::loadFrom( const XMLNode& parent,
+												 const bool bSilent ) {
+	auto pColorTheme = std::make_shared<ColorTheme>();
 
 	// SONG EDITOR
 	const XMLNode songEditorNode = parent.firstChildElement( "songEditor" );
 	if ( ! songEditorNode.isNull() ) {
-		colorTheme.m_songEditor_backgroundColor = songEditorNode.read_color(
+		pColorTheme->m_songEditor_backgroundColor = songEditorNode.read_color(
 			"backgroundColor",
-			colorTheme.m_songEditor_backgroundColor, false, false, bSilent );
-		colorTheme.m_songEditor_alternateRowColor = songEditorNode.read_color(
+			pColorTheme->m_songEditor_backgroundColor, false, false, bSilent );
+		pColorTheme->m_songEditor_alternateRowColor = songEditorNode.read_color(
 			"alternateRowColor",
-			colorTheme.m_songEditor_alternateRowColor, false, false, bSilent );
-		colorTheme.m_songEditor_virtualRowColor = songEditorNode.read_color(
+			pColorTheme->m_songEditor_alternateRowColor, false, false, bSilent );
+		pColorTheme->m_songEditor_virtualRowColor = songEditorNode.read_color(
 			"virtualRowColor",
-			colorTheme.m_songEditor_virtualRowColor, false, false, bSilent );
-		colorTheme.m_songEditor_selectedRowColor = songEditorNode.read_color(
+			pColorTheme->m_songEditor_virtualRowColor, false, false, bSilent );
+		pColorTheme->m_songEditor_selectedRowColor = songEditorNode.read_color(
 			"selectedRowColor",
-			colorTheme.m_songEditor_selectedRowColor, false, false, bSilent );
-		colorTheme.m_songEditor_selectedRowTextColor = songEditorNode.read_color(
+			pColorTheme->m_songEditor_selectedRowColor, false, false, bSilent );
+		pColorTheme->m_songEditor_selectedRowTextColor = songEditorNode.read_color(
 			"selectedRowTextColor",
-			colorTheme.m_songEditor_selectedRowTextColor, false, false, bSilent );
-		colorTheme.m_songEditor_lineColor = songEditorNode.read_color(
+			pColorTheme->m_songEditor_selectedRowTextColor, false, false, bSilent );
+		pColorTheme->m_songEditor_lineColor = songEditorNode.read_color(
 			"lineColor",
-			colorTheme.m_songEditor_lineColor, false, false, bSilent );
-		colorTheme.m_songEditor_textColor = songEditorNode.read_color(
+			pColorTheme->m_songEditor_lineColor, false, false, bSilent );
+		pColorTheme->m_songEditor_textColor = songEditorNode.read_color(
 			"textColor",
-			colorTheme.m_songEditor_textColor, false, false, bSilent );
-		colorTheme.m_songEditor_automationBackgroundColor =
+			pColorTheme->m_songEditor_textColor, false, false, bSilent );
+		pColorTheme->m_songEditor_automationBackgroundColor =
 			songEditorNode.read_color(
 				"automationBackgroundColor",
-				colorTheme.m_songEditor_automationBackgroundColor, false, false,
+				pColorTheme->m_songEditor_automationBackgroundColor, false, false,
 				bSilent );
-		colorTheme.m_songEditor_automationLineColor =
+		pColorTheme->m_songEditor_automationLineColor =
 			songEditorNode.read_color(
 				"automationLineColor",
-				colorTheme.m_songEditor_automationLineColor, false, false,
+				pColorTheme->m_songEditor_automationLineColor, false, false,
 				bSilent );
-		colorTheme.m_songEditor_automationNodeColor =
+		pColorTheme->m_songEditor_automationNodeColor =
 			songEditorNode.read_color(
 				"automationNodeColor",
-				colorTheme.m_songEditor_automationNodeColor, false, false,
+				pColorTheme->m_songEditor_automationNodeColor, false, false,
 				bSilent );
-		colorTheme.m_songEditor_stackedModeOnColor =
+		pColorTheme->m_songEditor_stackedModeOnColor =
 			songEditorNode.read_color(
 				"stackedModeOnColor",
-				colorTheme.m_songEditor_stackedModeOnColor, false, false,
+				pColorTheme->m_songEditor_stackedModeOnColor, false, false,
 				bSilent );
-		colorTheme.m_songEditor_stackedModeOnNextColor =
+		pColorTheme->m_songEditor_stackedModeOnNextColor =
 			songEditorNode.read_color(
 				"stackedModeOnNextColor",
-				colorTheme.m_songEditor_stackedModeOnNextColor, false, false,
+				pColorTheme->m_songEditor_stackedModeOnNextColor, false, false,
 				bSilent );
-		colorTheme.m_songEditor_stackedModeOffNextColor =
+		pColorTheme->m_songEditor_stackedModeOffNextColor =
 			songEditorNode.read_color(
 				"stackedModeOffNextColor",
-				colorTheme.m_songEditor_stackedModeOffNextColor, false, false,
+				pColorTheme->m_songEditor_stackedModeOffNextColor, false, false,
 				bSilent );
 	}
 	else {
@@ -269,101 +270,101 @@ ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
 	// PATTERN EDITOR
 	const XMLNode patternEditorNode = parent.firstChildElement( "patternEditor" );
 	if ( ! patternEditorNode.isNull() ) {
-		colorTheme.m_patternEditor_backgroundColor =
+		pColorTheme->m_patternEditor_backgroundColor =
 			patternEditorNode.read_color(
 				"backgroundColor",
-				colorTheme.m_patternEditor_backgroundColor, false, false, bSilent );
-		colorTheme.m_patternEditor_alternateRowColor =
+				pColorTheme->m_patternEditor_backgroundColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_alternateRowColor =
 			patternEditorNode.read_color(
 				"alternateRowColor",
-				colorTheme.m_patternEditor_alternateRowColor, false, false, bSilent );
-		colorTheme.m_patternEditor_selectedRowColor =
+				pColorTheme->m_patternEditor_alternateRowColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_selectedRowColor =
 			patternEditorNode.read_color(
 				"selectedRowColor",
-				colorTheme.m_patternEditor_selectedRowColor, false, false, bSilent );
-		colorTheme.m_patternEditor_selectedRowTextColor =
+				pColorTheme->m_patternEditor_selectedRowColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_selectedRowTextColor =
 			patternEditorNode.read_color(
 				"selectedRowTextColor",
-				colorTheme.m_patternEditor_selectedRowTextColor, false, false, bSilent );
-		colorTheme.m_patternEditor_octaveRowColor =
+				pColorTheme->m_patternEditor_selectedRowTextColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_octaveRowColor =
 			patternEditorNode.read_color(
 				"octaveRowColor",
-				colorTheme.m_patternEditor_octaveRowColor, false, false, bSilent );
-		colorTheme.m_patternEditor_textColor =
+				pColorTheme->m_patternEditor_octaveRowColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_textColor =
 			patternEditorNode.read_color(
 				"textColor",
-				colorTheme.m_patternEditor_textColor, false, false, bSilent );
-		colorTheme.m_patternEditor_noteVelocityFullColor =
+				pColorTheme->m_patternEditor_textColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_noteVelocityFullColor =
 			patternEditorNode.read_color(
 				"noteVelocityFullColor",
-				colorTheme.m_patternEditor_noteVelocityFullColor, false, false,
+				pColorTheme->m_patternEditor_noteVelocityFullColor, false, false,
 				bSilent );
-		colorTheme.m_patternEditor_noteVelocityDefaultColor =
+		pColorTheme->m_patternEditor_noteVelocityDefaultColor =
 			patternEditorNode.read_color(
 				"noteVelocityDefaultColor",
-				colorTheme.m_patternEditor_noteVelocityDefaultColor, false,
+				pColorTheme->m_patternEditor_noteVelocityDefaultColor, false,
 				false, bSilent );
-		colorTheme.m_patternEditor_noteVelocityHalfColor =
+		pColorTheme->m_patternEditor_noteVelocityHalfColor =
 			patternEditorNode.read_color(
 				"noteVelocityHalfColor",
-				colorTheme.m_patternEditor_noteVelocityHalfColor, false, false,
+				pColorTheme->m_patternEditor_noteVelocityHalfColor, false, false,
 				bSilent );
-		colorTheme.m_patternEditor_noteVelocityZeroColor =
+		pColorTheme->m_patternEditor_noteVelocityZeroColor =
 			patternEditorNode.read_color(
 				"noteVelocityZeroColor",
-				colorTheme.m_patternEditor_noteVelocityZeroColor, false, false,
+				pColorTheme->m_patternEditor_noteVelocityZeroColor, false, false,
 				bSilent );
-		colorTheme.m_patternEditor_noteOffColor =
+		pColorTheme->m_patternEditor_noteOffColor =
 			patternEditorNode.read_color(
 				"noteOffColor",
-				colorTheme.m_patternEditor_noteOffColor, false, false, bSilent );
-		colorTheme.m_patternEditor_lineColor =
+				pColorTheme->m_patternEditor_noteOffColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_lineColor =
 			patternEditorNode.read_color(
 				"lineColor",
-				colorTheme.m_patternEditor_lineColor, false, false, bSilent );
-		colorTheme.m_patternEditor_line1Color =
+				pColorTheme->m_patternEditor_lineColor, false, false, bSilent );
+		pColorTheme->m_patternEditor_line1Color =
 			patternEditorNode.read_color(
 				"line1Color",
-				colorTheme.m_patternEditor_line1Color, false, false, bSilent );
-		colorTheme.m_patternEditor_line2Color =
+				pColorTheme->m_patternEditor_line1Color, false, false, bSilent );
+		pColorTheme->m_patternEditor_line2Color =
 			patternEditorNode.read_color(
 				"line2Color",
-				colorTheme.m_patternEditor_line2Color, false, false, bSilent );
-		colorTheme.m_patternEditor_line3Color =
+				pColorTheme->m_patternEditor_line2Color, false, false, bSilent );
+		pColorTheme->m_patternEditor_line3Color =
 			patternEditorNode.read_color(
 				"line3Color",
-				colorTheme.m_patternEditor_line3Color, false, false, bSilent );
-		colorTheme.m_patternEditor_line4Color =
+				pColorTheme->m_patternEditor_line3Color, false, false, bSilent );
+		pColorTheme->m_patternEditor_line4Color =
 			patternEditorNode.read_color(
 				"line4Color",
-				colorTheme.m_patternEditor_line4Color, false, false, bSilent );
-		colorTheme.m_patternEditor_line5Color = patternEditorNode.read_color(
-			"line5Color", colorTheme.m_patternEditor_line5Color, false, false,
+				pColorTheme->m_patternEditor_line4Color, false, false, bSilent );
+		pColorTheme->m_patternEditor_line5Color = patternEditorNode.read_color(
+			"line5Color", pColorTheme->m_patternEditor_line5Color, false, false,
 			bSilent );
-		colorTheme.m_patternEditor_instrumentRowColor =
+		pColorTheme->m_patternEditor_instrumentRowColor =
 			patternEditorNode.read_color(
 				"instrumentRowColor",
-				colorTheme.m_patternEditor_instrumentRowColor, false, false,
+				pColorTheme->m_patternEditor_instrumentRowColor, false, false,
 				bSilent );
-		colorTheme.m_patternEditor_instrumentRowTextColor =
+		pColorTheme->m_patternEditor_instrumentRowTextColor =
 			patternEditorNode.read_color(
 				"instrumentRowTextColor",
-				colorTheme.m_patternEditor_instrumentRowTextColor, false, false,
+				pColorTheme->m_patternEditor_instrumentRowTextColor, false, false,
 				bSilent );
-		colorTheme.m_patternEditor_instrumentAlternateRowColor =
+		pColorTheme->m_patternEditor_instrumentAlternateRowColor =
 			patternEditorNode.read_color(
 				"instrumentAlternateRowColor",
-				colorTheme.m_patternEditor_instrumentAlternateRowColor, false,
+				pColorTheme->m_patternEditor_instrumentAlternateRowColor, false,
 				false, bSilent );
-		colorTheme.m_patternEditor_instrumentSelectedRowColor =
+		pColorTheme->m_patternEditor_instrumentSelectedRowColor =
 			patternEditorNode.read_color(
 				"instrumentSelectedRowColor",
-				colorTheme.m_patternEditor_instrumentSelectedRowColor, false, false,
+				pColorTheme->m_patternEditor_instrumentSelectedRowColor, false, false,
 				bSilent );
-		colorTheme.m_patternEditor_instrumentSelectedRowTextColor =
+		pColorTheme->m_patternEditor_instrumentSelectedRowTextColor =
 			patternEditorNode.read_color(
 				"instrumentSelectedRowTextColor",
-				colorTheme.m_patternEditor_instrumentSelectedRowTextColor, false, false,
+				pColorTheme->m_patternEditor_instrumentSelectedRowTextColor, false, false,
 				bSilent );
 	}
 	else {
@@ -372,14 +373,14 @@ ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
 
 	const XMLNode selectionNode = parent.firstChildElement( "selection" );
 	if ( ! selectionNode.isNull() ) {
-		colorTheme.m_selectionHighlightColor =
+		pColorTheme->m_selectionHighlightColor =
 			selectionNode.read_color(
 				"highlightColor",
-				colorTheme.m_selectionHighlightColor, false, false, bSilent );
-		colorTheme.m_selectionInactiveColor =
+				pColorTheme->m_selectionHighlightColor, false, false, bSilent );
+		pColorTheme->m_selectionInactiveColor =
 			selectionNode.read_color(
 				"inactiveColor",
-				colorTheme.m_selectionInactiveColor, false, false, bSilent );
+				pColorTheme->m_selectionInactiveColor, false, false, bSilent );
 	}
 	else {
 		WARNINGLOG( "<selection> node not found" );
@@ -387,70 +388,70 @@ ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
 
 	const XMLNode paletteNode = parent.firstChildElement( "palette" );
 	if ( ! paletteNode.isNull() ) {
-		colorTheme.m_windowColor =
+		pColorTheme->m_windowColor =
 			paletteNode.read_color(
 				"windowColor",
-				colorTheme.m_windowColor, false, false, bSilent );
-		colorTheme.m_windowTextColor =
+				pColorTheme->m_windowColor, false, false, bSilent );
+		pColorTheme->m_windowTextColor =
 			paletteNode.read_color(
 				"windowTextColor",
-				colorTheme.m_windowTextColor, false, false, bSilent );
-		colorTheme.m_baseColor =
+				pColorTheme->m_windowTextColor, false, false, bSilent );
+		pColorTheme->m_baseColor =
 			paletteNode.read_color(
 				"baseColor",
-				colorTheme.m_baseColor, false, false, bSilent );
-		colorTheme.m_alternateBaseColor =
+				pColorTheme->m_baseColor, false, false, bSilent );
+		pColorTheme->m_alternateBaseColor =
 			paletteNode.read_color(
 				"alternateBaseColor",
-				colorTheme.m_alternateBaseColor, false, false, bSilent );
-		colorTheme.m_textColor =
+				pColorTheme->m_alternateBaseColor, false, false, bSilent );
+		pColorTheme->m_textColor =
 			paletteNode.read_color(
 				"textColor",
-				colorTheme.m_textColor, false, false, bSilent );
-		colorTheme.m_buttonColor =
+				pColorTheme->m_textColor, false, false, bSilent );
+		pColorTheme->m_buttonColor =
 			paletteNode.read_color(
 				"buttonColor",
-				colorTheme.m_buttonColor, false, false, bSilent );
-		colorTheme.m_buttonTextColor =
+				pColorTheme->m_buttonColor, false, false, bSilent );
+		pColorTheme->m_buttonTextColor =
 			paletteNode.read_color(
 				"buttonTextColor",
-				colorTheme.m_buttonTextColor, false, false, bSilent );
-		colorTheme.m_lightColor =
+				pColorTheme->m_buttonTextColor, false, false, bSilent );
+		pColorTheme->m_lightColor =
 			paletteNode.read_color(
 				"lightColor",
-				colorTheme.m_lightColor, false, false, bSilent );
-		colorTheme.m_midLightColor =
+				pColorTheme->m_lightColor, false, false, bSilent );
+		pColorTheme->m_midLightColor =
 			paletteNode.read_color(
 				"midLightColor",
-				colorTheme.m_midLightColor, false, false, bSilent );
-		colorTheme.m_midColor =
+				pColorTheme->m_midLightColor, false, false, bSilent );
+		pColorTheme->m_midColor =
 			paletteNode.read_color(
 				"midColor",
-				colorTheme.m_midColor, false, false, bSilent );
-		colorTheme.m_darkColor =
+				pColorTheme->m_midColor, false, false, bSilent );
+		pColorTheme->m_darkColor =
 			paletteNode.read_color(
 				"darkColor",
-				colorTheme.m_darkColor, false, false, bSilent );
-		colorTheme.m_shadowTextColor =
+				pColorTheme->m_darkColor, false, false, bSilent );
+		pColorTheme->m_shadowTextColor =
 			paletteNode.read_color(
 				"shadowTextColor",
-				colorTheme.m_shadowTextColor, false, false, bSilent );
-		colorTheme.m_highlightColor =
+				pColorTheme->m_shadowTextColor, false, false, bSilent );
+		pColorTheme->m_highlightColor =
 			paletteNode.read_color(
 				"highlightColor",
-				colorTheme.m_highlightColor, false, false, bSilent );
-		colorTheme.m_highlightedTextColor =
+				pColorTheme->m_highlightColor, false, false, bSilent );
+		pColorTheme->m_highlightedTextColor =
 			paletteNode.read_color(
 				"highlightedTextColor",
-				colorTheme.m_highlightedTextColor, false, false, bSilent );
-		colorTheme.m_toolTipBaseColor =
+				pColorTheme->m_highlightedTextColor, false, false, bSilent );
+		pColorTheme->m_toolTipBaseColor =
 			paletteNode.read_color(
 				"toolTipBaseColor",
-				colorTheme.m_toolTipBaseColor, false, false, bSilent );
-		colorTheme.m_toolTipTextColor =
+				pColorTheme->m_toolTipBaseColor, false, false, bSilent );
+		pColorTheme->m_toolTipTextColor =
 			paletteNode.read_color(
 				"toolTipTextColor",
-				colorTheme.m_toolTipTextColor, false, false, bSilent );
+				pColorTheme->m_toolTipTextColor, false, false, bSilent );
 	}
 	else {
 		WARNINGLOG( "<palette> node not found" );
@@ -458,68 +459,68 @@ ColorTheme ColorTheme::loadFrom( const XMLNode& parent, const bool bSilent ) {
 
 	const XMLNode widgetNode = parent.firstChildElement( "widget" );
 	if ( ! widgetNode.isNull() ) {
-		colorTheme.m_accentColor =
+		pColorTheme->m_accentColor =
 			widgetNode.read_color(
 				"accentColor",
-				colorTheme.m_accentColor, false, false, bSilent );
-		colorTheme.m_accentTextColor =
+				pColorTheme->m_accentColor, false, false, bSilent );
+		pColorTheme->m_accentTextColor =
 			widgetNode.read_color(
 				"accentTextColor",
-				colorTheme.m_accentTextColor, false, false, bSilent );
-		colorTheme.m_widgetColor =
+				pColorTheme->m_accentTextColor, false, false, bSilent );
+		pColorTheme->m_widgetColor =
 			widgetNode.read_color(
 				"widgetColor",
-				colorTheme.m_widgetColor, false, false, bSilent );
-		colorTheme.m_widgetTextColor =
+				pColorTheme->m_widgetColor, false, false, bSilent );
+		pColorTheme->m_widgetTextColor =
 			widgetNode.read_color(
 				"widgetTextColor",
-				colorTheme.m_widgetTextColor, false, false, bSilent );
-		colorTheme.m_buttonRedColor =
+				pColorTheme->m_widgetTextColor, false, false, bSilent );
+		pColorTheme->m_buttonRedColor =
 			widgetNode.read_color(
 				"buttonRedColor",
-				colorTheme.m_buttonRedColor, false, false, bSilent );
-		colorTheme.m_buttonRedTextColor =
+				pColorTheme->m_buttonRedColor, false, false, bSilent );
+		pColorTheme->m_buttonRedTextColor =
 			widgetNode.read_color(
 				"buttonRedTextColor",
-				colorTheme.m_buttonRedTextColor, false, false, bSilent );
-		colorTheme.m_spinBoxColor =
+				pColorTheme->m_buttonRedTextColor, false, false, bSilent );
+		pColorTheme->m_spinBoxColor =
 			widgetNode.read_color(
 				"spinBoxColor",
-				colorTheme.m_spinBoxColor, false, false, bSilent );
-		colorTheme.m_spinBoxTextColor =
+				pColorTheme->m_spinBoxColor, false, false, bSilent );
+		pColorTheme->m_spinBoxTextColor =
 			widgetNode.read_color(
 				"spinBoxTextColor",
-				colorTheme.m_spinBoxTextColor, false, false, bSilent );
-		colorTheme.m_playheadColor =
+				pColorTheme->m_spinBoxTextColor, false, false, bSilent );
+		pColorTheme->m_playheadColor =
 			widgetNode.read_color(
 				"playheadColor",
-				colorTheme.m_playheadColor, false, false, bSilent );
-		colorTheme.m_cursorColor =
+				pColorTheme->m_playheadColor, false, false, bSilent );
+		pColorTheme->m_cursorColor =
 			widgetNode.read_color(
 				"cursorColor",
-				colorTheme.m_cursorColor, false, false, bSilent );
-		colorTheme.m_muteColor =
+				pColorTheme->m_cursorColor, false, false, bSilent );
+		pColorTheme->m_muteColor =
 			widgetNode.read_color(
 				"muteColor",
-				colorTheme.m_muteColor, false, false, bSilent );
-		colorTheme.m_muteTextColor =
+				pColorTheme->m_muteColor, false, false, bSilent );
+		pColorTheme->m_muteTextColor =
 			widgetNode.read_color(
 				"muteTextColor",
-				colorTheme.m_muteTextColor, false, false, bSilent );
-		colorTheme.m_soloColor =
+				pColorTheme->m_muteTextColor, false, false, bSilent );
+		pColorTheme->m_soloColor =
 			widgetNode.read_color(
 				"soloColor",
-				colorTheme.m_soloColor, false, false, bSilent );
-		colorTheme.m_soloTextColor =
+				pColorTheme->m_soloColor, false, false, bSilent );
+		pColorTheme->m_soloTextColor =
 			widgetNode.read_color(
 				"soloTextColor",
-				colorTheme.m_soloTextColor, false, false, bSilent );
+				pColorTheme->m_soloTextColor, false, false, bSilent );
 }
 	else {
 		WARNINGLOG( "<widget> node not found" );
 	}
 
-	return colorTheme;
+	return pColorTheme;
 }
 
 QString ColorTheme::toQString( const QString& sPrefix, bool bShort ) const {
@@ -1015,44 +1016,29 @@ QString FontTheme::toQString( const QString& sPrefix, bool bShort ) const {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Theme::Theme( const ColorTheme& colorTheme,
-			  const InterfaceTheme& interfaceTheme,
-			  const FontTheme& fontTheme )
-	: m_color{ colorTheme }
-	, m_interface{ interfaceTheme }
-	, m_font{ fontTheme } {
+Theme::Theme( std::shared_ptr<ColorTheme> pColorTheme,
+			  std::shared_ptr<InterfaceTheme> pInterfaceTheme,
+			  std::shared_ptr<FontTheme> pFontTheme )
+	: m_pColor{ pColorTheme }
+	, m_pInterface{ pInterfaceTheme }
+	, m_pFont{ pFontTheme } {
 }
 
-Theme::Theme( const Theme& other )
-	: m_color{ other.m_color }
-	, m_interface{ other.m_interface}
-	, m_font{ other.m_font } {
+Theme::Theme( const std::shared_ptr<const Theme> pOther )
+	: m_pColor{ pOther->m_pColor }
+	, m_pInterface{ pOther->m_pInterface}
+	, m_pFont{ pOther->m_pFont } {
 }
 
-Theme::Theme( Theme&& other )
-	: m_color{ other.m_color }
-	, m_interface{ other.m_interface }
-	, m_font{ other.m_font }
-{
-}
-
-Theme& Theme::operator=( const Theme& other ) {
-	m_color = other.m_color;
-	m_interface = other.m_interface;
-	m_font = other.m_font;
+Theme Theme::operator=( const std::shared_ptr<const Theme> pOther ) {
+	m_pColor = pOther->m_pColor;
+	m_pInterface = pOther->m_pInterface;
+	m_pFont = pOther->m_pFont;
 
 	return *this;
 }
 
-Theme& Theme::operator=( Theme&& other ) {
-	m_color = std::move( other.m_color );
-	m_interface = std::move( other.m_interface );
-	m_font = std::move( other.m_font );
-
-	return *this;
-}
-
-std::unique_ptr<Theme> Theme::importFrom( const QString& sPath ) {
+std::shared_ptr<Theme> Theme::importFrom( const QString& sPath ) {
 	if ( ! Filesystem::file_exists( sPath ) || ! Filesystem::file_readable( sPath ) ){
 		return nullptr;
 	}
@@ -1076,69 +1062,74 @@ std::unique_ptr<Theme> Theme::importFrom( const QString& sPath ) {
 		ERRORLOG( "'colorTheme' node not found" );
 		return nullptr;
 	}
-	auto colorTheme = ColorTheme::loadFrom( colorThemeNode );
+	auto pColorTheme = ColorTheme::loadFrom( colorThemeNode );
 	
 	XMLNode interfaceNode = rootNode.firstChildElement( "interfaceTheme" );
 	if ( interfaceNode.isNull() ) {
 		ERRORLOG( "'interfaceTheme' node not found" );
 		return nullptr;
 	}
-	auto interfaceTheme = InterfaceTheme();
-	interfaceTheme.m_layout =
+	auto pInterfaceTheme = std::make_shared<InterfaceTheme>();
+	pInterfaceTheme->m_layout =
 		static_cast<InterfaceTheme::Layout>(
 			interfaceNode.read_int( "defaultUILayout",
-									static_cast<int>(InterfaceTheme::Layout::SinglePane),
+									static_cast<int>(pInterfaceTheme->m_layout),
 									false, false ));
-	interfaceTheme.m_uiScalingPolicy =
+	pInterfaceTheme->m_uiScalingPolicy =
 		static_cast<InterfaceTheme::ScalingPolicy>(
 			interfaceNode.read_int( "uiScalingPolicy",
-									static_cast<int>(InterfaceTheme::ScalingPolicy::Smaller),
+									static_cast<int>(pInterfaceTheme->m_uiScalingPolicy),
 									false, false ));
 				
 	// QT Style
-	interfaceTheme.m_sQTStyle =
-		interfaceNode.read_string( "QTStyle", "Fusion", false, false );
+	pInterfaceTheme->m_sQTStyle =
+		interfaceNode.read_string(
+			"QTStyle", pInterfaceTheme->m_sQTStyle, false, false );
 
-	if ( interfaceTheme.m_sQTStyle == "Plastique" ){
-		interfaceTheme.m_sQTStyle = "Fusion";
+	if ( pInterfaceTheme->m_sQTStyle == "Plastique" ){
+		pInterfaceTheme->m_sQTStyle = "Fusion";
 	}
-	interfaceTheme.m_iconColor =
+	pInterfaceTheme->m_iconColor =
 		static_cast<InterfaceTheme::IconColor>(
 			interfaceNode.read_int( "iconColor",
-									static_cast<int>(InterfaceTheme::IconColor::Black),
+									static_cast<int>(pInterfaceTheme->m_iconColor),
 									false, false));
 
 	// Mixer falloff speed
-	interfaceTheme.m_fMixerFalloffSpeed =
+	pInterfaceTheme->m_fMixerFalloffSpeed =
 		interfaceNode.read_float( "mixer_falloff_speed",
-								  InterfaceTheme::FALLOFF_NORMAL, false, false );
+								  pInterfaceTheme->m_fMixerFalloffSpeed,
+								 false, false );
 
 	//SongEditor coloring
-	interfaceTheme.m_coloringMethod =
+	pInterfaceTheme->m_coloringMethod =
 		static_cast<InterfaceTheme::ColoringMethod>(
 			interfaceNode.read_int("SongEditor_ColoringMethod",
-								   static_cast<int>(InterfaceTheme::ColoringMethod::Custom),
+								   static_cast<int>(pInterfaceTheme->m_coloringMethod),
 								   false, false ));
-	std::vector<QColor> colors( interfaceTheme.nMaxPatternColors );
-	for ( int ii = 0; ii < interfaceTheme.nMaxPatternColors; ii++ ) {
+	std::vector<QColor> colors( pInterfaceTheme->nMaxPatternColors );
+	for ( int ii = 0; ii < pInterfaceTheme->nMaxPatternColors; ii++ ) {
 		colors[ ii ] = interfaceNode.read_color( QString( "SongEditor_pattern_color_%1" ).arg( ii ),
-												 colorTheme.m_accentColor,
+												 pInterfaceTheme->m_patternColors[ ii ],
 												 false, false );
 	}
-	interfaceTheme.m_patternColors = colors;
-	interfaceTheme.m_nVisiblePatternColors =
-		interfaceNode.read_int( "SongEditor_visible_pattern_colors", 1, false, false );
-	if ( interfaceTheme.m_nVisiblePatternColors > 50 ) {
-		interfaceTheme.m_nVisiblePatternColors = 50;
-	} else if ( interfaceTheme.m_nVisiblePatternColors < 0 ) {
-		interfaceTheme.m_nVisiblePatternColors = 0;
+	pInterfaceTheme->m_patternColors = colors;
+	pInterfaceTheme->m_nVisiblePatternColors =
+		interfaceNode.read_int( "SongEditor_visible_pattern_colors",
+							   pInterfaceTheme->m_nVisiblePatternColors,
+							   false, false );
+	if ( pInterfaceTheme->m_nVisiblePatternColors > 50 ) {
+		pInterfaceTheme->m_nVisiblePatternColors = 50;
+	} else if ( pInterfaceTheme->m_nVisiblePatternColors < 0 ) {
+		pInterfaceTheme->m_nVisiblePatternColors = 0;
 	}
 
-	interfaceTheme.m_bIndicateNotePlayback = interfaceNode.read_bool(
-		"indicate_note_playback", true, /* inexistent_ok */ true,
-		/* empty_ok */ false );
-	interfaceTheme.m_bIndicateEffectiveNoteLength = interfaceNode.read_bool(
-		"indicate_effective_note_length", true, /* inexistent_ok */ true,
+	pInterfaceTheme->m_bIndicateNotePlayback = interfaceNode.read_bool(
+		"indicate_note_playback", pInterfaceTheme->m_bIndicateNotePlayback,
+		/* inexistent_ok */ true, /* empty_ok */ false );
+	pInterfaceTheme->m_bIndicateEffectiveNoteLength = interfaceNode.read_bool(
+		"indicate_effective_note_length",
+		pInterfaceTheme->m_bIndicateEffectiveNoteLength, /* inexistent_ok */ true,
 		/* empty_ok */ false );
 			
 	XMLNode fontNode = rootNode.firstChildElement( "fontTheme" );
@@ -1147,25 +1138,25 @@ std::unique_ptr<Theme> Theme::importFrom( const QString& sPath ) {
 		return nullptr;
 	}
 
-	auto fontTheme = FontTheme();
+	auto pFontTheme = std::make_shared<FontTheme>();
 	// Font fun
-	fontTheme.m_sApplicationFontFamily =
+	pFontTheme->m_sApplicationFontFamily =
 		fontNode.read_string( "application_font_family",
-							  fontTheme.m_sApplicationFontFamily, false, false );
+							  pFontTheme->m_sApplicationFontFamily, false, false );
 	// The value defaults to m_sApplicationFontFamily on
 	// purpose to provide backward compatibility.
-	fontTheme.m_sLevel2FontFamily =
+	pFontTheme->m_sLevel2FontFamily =
 		fontNode.read_string( "level2_font_family",
-							  fontTheme.m_sLevel2FontFamily, false, false );
-	fontTheme.m_sLevel3FontFamily =
+							  pFontTheme->m_sLevel2FontFamily, false, false );
+	pFontTheme->m_sLevel3FontFamily =
 		fontNode.read_string( "level3_font_family",
-							  fontTheme.m_sLevel3FontFamily, false, false );
-	fontTheme.m_fontSize =
+							  pFontTheme->m_sLevel3FontFamily, false, false );
+	pFontTheme->m_fontSize =
 		static_cast<FontTheme::FontSize>(
 			fontNode.read_int( "font_size",
 							   static_cast<int>(FontTheme::FontSize::Medium), false, false ) );
 
-	return std::make_unique<Theme>(colorTheme, interfaceTheme, fontTheme );
+	return std::make_shared<Theme>(pColorTheme, pInterfaceTheme, pFontTheme );
 }
 
 bool Theme::exportTo( const QString& sPath ) const {
@@ -1177,40 +1168,40 @@ bool Theme::exportTo( const QString& sPath ) const {
 	// hydrogen version
 	rootNode.write_string( "version", QString( get_version().c_str() ) );
 	
-	m_color.saveTo( rootNode );
+	m_pColor->saveTo( rootNode );
 
 	XMLNode interfaceNode = rootNode.createNode( "interfaceTheme" );
 	interfaceNode.write_int( "defaultUILayout",
-							 static_cast<int>(m_interface.m_layout) );
+							 static_cast<int>(m_pInterface->m_layout) );
 	interfaceNode.write_int( "uiScalingPolicy",
-							 static_cast<int>(m_interface.m_uiScalingPolicy) );
-	interfaceNode.write_string( "QTStyle", m_interface.m_sQTStyle );
+							 static_cast<int>(m_pInterface->m_uiScalingPolicy) );
+	interfaceNode.write_string( "QTStyle", m_pInterface->m_sQTStyle );
 	interfaceNode.write_int( "iconColor",
-							 static_cast<int>(m_interface.m_iconColor) );
+							 static_cast<int>(m_pInterface->m_iconColor) );
 	interfaceNode.write_float( "mixer_falloff_speed",
-							   m_interface.m_fMixerFalloffSpeed );
+							   m_pInterface->m_fMixerFalloffSpeed );
 	interfaceNode.write_int( "SongEditor_ColoringMethod",
-							 static_cast<int>(m_interface.m_coloringMethod) );
-	for ( int ii = 0; ii < m_interface.nMaxPatternColors; ii++ ) {
+							 static_cast<int>(m_pInterface->m_coloringMethod) );
+	for ( int ii = 0; ii < m_pInterface->nMaxPatternColors; ii++ ) {
 		interfaceNode.write_color( QString( "SongEditor_pattern_color_%1" ).arg( ii ),
-								   m_interface.m_patternColors[ ii ] );
+								   m_pInterface->m_patternColors[ ii ] );
 	}
 	interfaceNode.write_int( "SongEditor_visible_pattern_colors",
-							 m_interface.m_nVisiblePatternColors );
+							 m_pInterface->m_nVisiblePatternColors );
 	interfaceNode.write_bool( "indicate_note_playback",
-							  m_interface.m_bIndicateNotePlayback );
+							  m_pInterface->m_bIndicateNotePlayback );
 	interfaceNode.write_bool( "indicate_effective_note_length",
-							  m_interface.m_bIndicateEffectiveNoteLength );
+							  m_pInterface->m_bIndicateEffectiveNoteLength );
 
 	XMLNode fontNode = rootNode.createNode( "fontTheme" );
 	fontNode.write_string( "application_font_family",
-						   m_font.m_sApplicationFontFamily );
+						   m_pFont->m_sApplicationFontFamily );
 	fontNode.write_string( "level2_font_family",
-						   m_font.m_sLevel2FontFamily );
+						   m_pFont->m_sLevel2FontFamily );
 	fontNode.write_string( "level3_font_family",
-						   m_font.m_sLevel3FontFamily );
+						   m_pFont->m_sLevel3FontFamily );
 	fontNode.write_int( "font_size",
-						static_cast<int>(m_font.m_fontSize) );
+						static_cast<int>(m_pFont->m_fontSize) );
 
 	return doc.write( sPath );
 }	
@@ -1221,20 +1212,20 @@ QString Theme::toQString( const QString& sPrefix, bool bShort ) const {
 	if ( ! bShort ) {
 		sOutput = QString( "%1[Theme]\n" ).arg( sPrefix )
 			.append( QString( "%1%2m_color: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_color.toQString( sPrefix + s, bShort ) ) )
+					 .arg( m_pColor->toQString( sPrefix + s, bShort ) ) )
 			.append( QString( "%1%2m_interface: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_interface.toQString( sPrefix + s, bShort ) ) )
+					 .arg( m_pInterface->toQString( sPrefix + s, bShort ) ) )
 			.append( QString( "%1%2m_font: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_font.toQString( sPrefix + s, bShort ) ) );
+					 .arg( m_pFont->toQString( sPrefix + s, bShort ) ) );
 	}
 	else {
 		sOutput = QString( "[Theme] " )
-			.append( QString( "m_color: %1" )
-					 .arg( m_color.toQString( "", bShort ) ) )
-			.append( QString( ", m_interface: %1" )
-					 .arg( m_interface.toQString( "", bShort ) ) )
-			.append( QString( ", m_font: %1" )
-					 .arg( m_font.toQString( "", bShort ) ) );
+			.append( QString( "m_pColor: %1" )
+					 .arg( m_pColor->toQString( "", bShort ) ) )
+			.append( QString( ", m_pInterface: %1" )
+					 .arg( m_pInterface->toQString( "", bShort ) ) )
+			.append( QString( ", m_pFont: %1" )
+					 .arg( m_pFont->toQString( "", bShort ) ) );
 	}
 
 	return sOutput;

--- a/src/core/Preferences/Theme.h
+++ b/src/core/Preferences/Theme.h
@@ -44,14 +44,12 @@ class ColorTheme : public H2Core::Object<ColorTheme>
 	H2_OBJECT(ColorTheme)
 public:
 	ColorTheme();
-	ColorTheme( const ColorTheme& other ) = default;
-	ColorTheme& operator=( const ColorTheme& other ) = default;
-	ColorTheme( ColorTheme&& other ) = default;
-	ColorTheme& operator=( ColorTheme&& other ) = default;
+	ColorTheme( std::shared_ptr<ColorTheme> pOther ) = delete;
+	ColorTheme operator=( std::shared_ptr<ColorTheme> pOther ) = delete;
 
 	void saveTo( XMLNode& parent ) const;
-	static ColorTheme loadFrom( const XMLNode& parent,
-								const bool bSilent = false );
+	static std::shared_ptr<ColorTheme> loadFrom( const XMLNode& parent,
+												const bool bSilent = false );
 
 	QString toQString( const QString& sPrefix = "",
 					   bool bShort = true ) const override;
@@ -119,7 +117,7 @@ public:
 	QColor m_midColor;
 	/** Between Button and Dark.*/
 	QColor m_darkColor;
-	/** A very dark color. By default, the shadow color is Qt::black.*/
+	/** A very dark color. By delete, the shadow color is Qt::black.*/
 	QColor m_shadowTextColor;
 	/** A color to indicate a selected item or the current item.*/
 	QColor m_highlightColor;
@@ -153,10 +151,8 @@ class InterfaceTheme : public H2Core::Object<InterfaceTheme>
 	H2_OBJECT(InterfaceTheme)
 public:
 	InterfaceTheme();
-	InterfaceTheme( const InterfaceTheme& other ) = default;
-	InterfaceTheme& operator=( const InterfaceTheme& other ) = default;
-	InterfaceTheme( InterfaceTheme&& other ) = default;
-	InterfaceTheme& operator=( InterfaceTheme&& other ) = default;
+	InterfaceTheme( std::shared_ptr<InterfaceTheme> pOther ) = delete;
+	InterfaceTheme operator=( std::shared_ptr<InterfaceTheme> pOther ) = delete;
 
 	static float FALLOFF_SLOW;
 	static float FALLOFF_NORMAL;
@@ -215,10 +211,8 @@ class FontTheme : public H2Core::Object<FontTheme>
 	H2_OBJECT(FontTheme)
 public:
 	FontTheme();
-	FontTheme( const FontTheme& other ) = default;
-	FontTheme& operator=( const FontTheme& other ) = default;
-	FontTheme( FontTheme&& other ) = default;
-	FontTheme& operator=( FontTheme&& other ) = default;
+	FontTheme( std::shared_ptr<FontTheme> pOther ) = delete;
+	FontTheme operator=( std::shared_ptr<FontTheme> pOther ) = delete;
 
 	/** Enables custom scaling of the font size in the GUI.*/
 	enum class FontSize {
@@ -241,25 +235,22 @@ public:
 class Theme : public H2Core::Object<Theme> {
 	H2_OBJECT(Theme)
 public:
-	Theme( const ColorTheme& colorTheme = ColorTheme(),
-		   const InterfaceTheme& interfaceTheme = InterfaceTheme(),
-		   const FontTheme& fontTheme = FontTheme() );
+	Theme( std::shared_ptr<ColorTheme> pColorTheme,
+		   std::shared_ptr<InterfaceTheme> pInterfaceTheme,
+		   std::shared_ptr<FontTheme> pFontTheme );
 
-	Theme( const Theme& other );
-	Theme& operator=( const Theme& other );
+	Theme( const std::shared_ptr<const Theme> pOther );
+	Theme operator=( const std::shared_ptr<const Theme> pOther );
 
-	Theme( Theme&& other );
-	Theme& operator=( Theme&& other );
-
-	static std::unique_ptr<Theme> importFrom( const QString& sPath );
+	static std::shared_ptr<Theme> importFrom( const QString& sPath );
 	bool exportTo( const QString& sPath ) const;
 
 	QString toQString( const QString& sPrefix = "",
 					   bool bShort = true ) const override;
 
-	ColorTheme m_color;
-	InterfaceTheme m_interface;
-	FontTheme m_font;
+	std::shared_ptr<ColorTheme> m_pColor;
+	std::shared_ptr<InterfaceTheme> m_pInterface;
+	std::shared_ptr<FontTheme> m_pFont;
 };
 
 };

--- a/src/gui/src/Director.cpp
+++ b/src/gui/src/Director.cpp
@@ -76,13 +76,12 @@ Director::Director ( QWidget* pParent )
 	
 	setWindowTitle ( tr ( "Director" ) );
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
 	auto pPos = H2Core::Hydrogen::get_instance()->getAudioEngine()
 		->getTransportPosition();
 	
 	m_nBar = pPos->getBar();
 	m_nBeat = pPos->getBeat();
-	m_Color = theme.m_color.m_accentColor;
+	m_Color = Preferences::get_instance()->getColorTheme()->m_accentColor;
 	m_Color.setAlpha( 0 );
 	m_nFlashingArea = width() * 5/100;
 
@@ -153,7 +152,7 @@ void Director::timelineUpdateEvent( int nValue ) {
 
 void Director::updateBBT()
 {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 	auto pPos = Hydrogen::get_instance()->getAudioEngine()->getTransportPosition();
 
 	// 1000 ms / bpm / 60s
@@ -164,13 +163,13 @@ void Director::updateBBT()
 	m_nBeat = pPos->getBeat();
 
 	if ( m_nBeat == 1 ) {	//foregroundcolor "rect" for first blink
-		m_Color = theme.m_color.m_buttonRedColor;
+		m_Color = pColorTheme->m_buttonRedColor;
 	}
 	else {	//foregroundcolor "rect" for all other blinks
 		if ( m_nBeat %2 == 0 ) {
 			m_nFlashingArea = width() * 52.5/100;
 		}
-		m_Color = theme.m_color.m_accentColor;
+		m_Color = pColorTheme->m_accentColor;
 	}
 }
 
@@ -228,7 +227,7 @@ void Director::updateMetronomBackground()
 
 void Director::updateFontSize( FontUpdate update ) {
 	const QString sFontFamily =
-		H2Core::Preferences::get_instance()->getTheme().m_font.m_sApplicationFontFamily;
+		H2Core::Preferences::get_instance()->getFontTheme()->m_sApplicationFontFamily;
 
 	// Reduce the pixelsize of the font till it fits the width of its
 	// enclosing rectangle.
@@ -285,8 +284,9 @@ void Director::paintEvent( QPaintEvent* ev )
 {
 	QPainter painter(this);
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
-	const QString sFontFamily = theme.m_font.m_sApplicationFontFamily;
+	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
+	const QString sFontFamily = pPref->getFontTheme()->m_sApplicationFontFamily;
 
 	//draw the songname
 	painter.setFont( m_fontSongName );
@@ -294,14 +294,14 @@ void Director::paintEvent( QPaintEvent* ev )
 
 
 	//draw the metronome
-	painter.setPen( QPen( theme.m_color.m_highlightColor, 1 , Qt::SolidLine ) );
+	painter.setPen( QPen( pColorTheme->m_highlightColor, 1 , Qt::SolidLine ) );
 	painter.setBrush( m_Color );
 	painter.drawRect( m_nFlashingArea, height() * 25/100, width() * 42.5/100,
 					  height() * 35/100);
 
 
 	//draw bars
-	QColor textColor = theme.m_color.m_windowTextColor;
+	QColor textColor = pColorTheme->m_windowTextColor;
 	painter.setPen( textColor );
 	painter.setFont(QFont( sFontFamily, height() * 25/100 ));
 	QRect r1(QPoint( width() * 5/100 , height() * 25/100 ), QSize( width() * 42.5/100, height() * 35/100));

--- a/src/gui/src/FilesystemInfoForm.cpp
+++ b/src/gui/src/FilesystemInfoForm.cpp
@@ -36,17 +36,17 @@ FilesystemInfoForm::FilesystemInfoForm( QWidget *parent ) :
 {
 	ui->setupUi(this);
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pPref = H2Core::Preferences::get_instance();
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( theme.m_interface.m_iconColor ==
+	if ( pPref->getInterfaceTheme()->m_iconColor ==
 		 H2Core::InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 	} else {
 		sIconPath.append( "/icons/black/" );
 	}
 
-	QColor windowColor = theme.m_color.m_windowColor;
-	QColor windowTextColor = theme.m_color.m_windowTextColor;
+	const QColor windowColor = pPref->getColorTheme()->m_windowColor;
+	const QColor windowTextColor = pPref->getColorTheme()->m_windowTextColor;
 
 	ui->tmpDirWarningButton->setIcon( QIcon( sIconPath + "warning.svg" ) );
 	ui->tmpDirWarningButton->setToolTip( tr( "Filesystem is not writable!" ) );

--- a/src/gui/src/Footer/Footer.cpp
+++ b/src/gui/src/Footer/Footer.cpp
@@ -167,7 +167,7 @@ void Footer::updateCpuLoad() {
 
 void Footer::updateCpuLoadLabelWidth() {
 	const int nMargin = 4 * getPointSize(
-		H2Core::Preferences::get_instance()->getTheme().m_font.m_fontSize );
+		H2Core::Preferences::get_instance()->getFontTheme()->m_fontSize );
 	const QString sText{ "CPU: 100%" };
 
 	m_pCpuGroup->setFixedWidth(
@@ -175,22 +175,20 @@ void Footer::updateCpuLoadLabelWidth() {
 }
 
 void Footer::updateFont() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
 	QFont newFont = font();
-	newFont.setFamily( theme.m_font.m_sLevel3FontFamily );
-	newFont.setPointSize( getPointSize( theme.m_font.m_fontSize ) );
+	newFont.setFamily( pFontTheme->m_sLevel3FontFamily );
+	newFont.setPointSize( getPointSize( pFontTheme->m_fontSize ) );
 	setFont( newFont );
 }
 
 void Footer::updateStyleSheet() {
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
-
-	const QColor colorText = colorTheme.m_windowTextColor;
-	const QColor colorFooter = colorTheme.m_baseColor;
-	const QColor colorRed = colorTheme.m_buttonRedColor;
+	const QColor colorText = pColorTheme->m_windowTextColor;
+	const QColor colorFooter = pColorTheme->m_baseColor;
+	const QColor colorRed = pColorTheme->m_buttonRedColor;
 
 	setStyleSheet( QString( "\
 QWidget#MainFooter {\

--- a/src/gui/src/Footer/StatusMessageDisplay.cpp
+++ b/src/gui/src/Footer/StatusMessageDisplay.cpp
@@ -72,10 +72,10 @@ void StatusMessageDisplay::onPreferencesChanged( const H2Core::Preferences::Chan
 // integrate into the current GUI design using the active LCDDisplay
 // foreground and background colors.
 void StatusMessageDisplay::updateStyleSheet() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
-	QColor textColor = theme.m_color.m_windowTextColor;
-	QColor backgroundColor = theme.m_color.m_windowColor.lighter( 134 );
+	QColor textColor = pColorTheme->m_windowTextColor;
+	QColor backgroundColor = pColorTheme->m_windowColor.lighter( 134 );
 
 	QString sStyleSheet = QString( "\
 QLineEdit { \
@@ -90,14 +90,13 @@ QLineEdit { \
 }
 
 void StatusMessageDisplay::paintEvent( QPaintEvent *ev ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
-
 	LCDDisplay::paintEvent( ev );
 
 	if ( m_bEntered || hasFocus() ) {
 		QPainter painter(this);
 
-		QColor colorHighlightActive = theme.m_color.m_highlightColor;
+		QColor colorHighlightActive = H2Core::Preferences::get_instance()
+			->getColorTheme()->m_highlightColor;
 
 		// If the mouse is placed on the widget but the user hasn't
 		// clicked it yet, the highlight will be done more transparent to

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -239,7 +239,7 @@ HydrogenApp::~HydrogenApp()
 void HydrogenApp::setupSinglePanedInterface()
 {
 	const auto pPref = Preferences::get_instance();
-	InterfaceTheme::Layout layout = pPref->getTheme().m_interface.m_layout;
+	InterfaceTheme::Layout layout = pPref->getInterfaceTheme()->m_layout;
 
 	// MAINFORM
 	WindowProperties mainFormProp = pPref->getMainFormProperties();
@@ -738,8 +738,7 @@ void HydrogenApp::showMixer(bool show)
 		 *   otherwise open mixer window
 		 */
 
-	auto layout = Preferences::get_instance()->
-		getTheme().m_interface.m_layout;
+	auto layout = Preferences::get_instance()->getInterfaceTheme()->m_layout;
 
 	if ( layout == InterfaceTheme::Layout::Tabbed ) {
 		m_pTab->setCurrentIndex( 2 );
@@ -758,8 +757,7 @@ void HydrogenApp::showInstrumentRack(bool show)
 		 *   Switch to pattern editor/instrument tab in tabbed mode,
 		 *   otherwise hide instrument panel
 		 */
-	auto layout = Preferences::get_instance()->
-		getTheme().m_interface.m_layout;
+	auto layout = Preferences::get_instance()->getInterfaceTheme()->m_layout;
 
 	if ( layout == InterfaceTheme::Layout::Tabbed ) {
 		m_pTab->setCurrentIndex( 1 );
@@ -1327,7 +1325,7 @@ void HydrogenApp::updatePreferencesEvent( int nValue ) {
 		// selections etc.
 		// But we won't change the layout!
 		const auto pPref = Preferences::get_instance();
-		auto layout = pPref->getTheme().m_interface.m_layout;
+		auto layout = pPref->getInterfaceTheme()->m_layout;
 
 		WindowProperties audioEngineInfoProp = pPref->getAudioEngineInfoProperties();
 		setWindowProperties( m_pAudioEngineInfoForm, audioEngineInfoProp,

--- a/src/gui/src/InstrumentEditor/ComponentView.cpp
+++ b/src/gui/src/InstrumentEditor/ComponentView.cpp
@@ -421,34 +421,34 @@ ComponentView::~ComponentView() {
 }
 
 void ComponentView::updateColors() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
-	m_pComponentMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pComponentMuteBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
 	m_pComponentMuteBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_muteTextColor );
-	m_pComponentSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+		pColorTheme->m_muteTextColor );
+	m_pComponentSoloBtn->setCheckedBackgroundColor( pColorTheme->m_soloColor );
 	m_pComponentSoloBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_soloTextColor );
+		pColorTheme->m_soloTextColor );
 
-	m_pLayerMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pLayerMuteBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
 	m_pLayerMuteBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_muteTextColor );
-	m_pLayerSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+		pColorTheme->m_muteTextColor );
+	m_pLayerSoloBtn->setCheckedBackgroundColor( pColorTheme->m_soloColor );
 	m_pLayerSoloBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_soloTextColor );
+		pColorTheme->m_soloTextColor );
 }
 
 void ComponentView::updateStyleSheet() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
-	const QColor headerColor = theme.m_color.m_windowColor;
-	const QColor headerTextColor = theme.m_color.m_windowTextColor;
+	const QColor headerColor = pColorTheme->m_windowColor;
+	const QColor headerTextColor = pColorTheme->m_windowTextColor;
 	const QColor borderHeaderLightColor = headerColor.lighter(
 		Skin::nListBackgroundLightBorderScaling );
 	const QColor borderHeaderDarkColor = headerColor.darker(
 		Skin::nListBackgroundDarkBorderScaling );
 
-	const QColor layerColor = theme.m_color.m_baseColor;
+	const QColor layerColor = pColorTheme->m_baseColor;
 	const QColor borderLayerLightColor = layerColor.lighter(
 		Skin::nListBackgroundLightBorderScaling );
 	const QColor borderLayerDarkColor = layerColor.darker(

--- a/src/gui/src/InstrumentEditor/ComponentsEditor.cpp
+++ b/src/gui/src/InstrumentEditor/ComponentsEditor.cpp
@@ -172,7 +172,7 @@ void ComponentsEditor::updateEditor() {
 void ComponentsEditor::updateStyleSheet() {
 	setStyleSheet( QString( "QWidget#ComponentsEditor {background-color: %1;}" )
 				   .arg( H2Core::Preferences::get_instance()->
-						 getTheme().m_color.m_windowColor.name() ) );
+						 getColorTheme()->m_windowColor.name() ) );
 
 	for ( auto& ppComponentView : m_componentViews ) {
 		ppComponentView->updateStyleSheet();

--- a/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditor.cpp
@@ -363,12 +363,12 @@ InstrumentEditor::~InstrumentEditor() {
 }
 
 void InstrumentEditor::updateColors() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
 	m_pFilterBypassBtn->setCheckedBackgroundColor(
-		theme.m_color.m_muteColor );
+		pColorTheme->m_muteColor );
 	m_pFilterBypassBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_muteTextColor );
+		pColorTheme->m_muteTextColor );
 }
 
 void InstrumentEditor::updateEditor() {

--- a/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
+++ b/src/gui/src/InstrumentEditor/InstrumentEditorPanel.cpp
@@ -159,7 +159,7 @@ void InstrumentEditorPanel::onPreferencesChanged( const H2Core::Preferences::Cha
 		m_pInstrumentEditor->updateColors();
 		m_pInstrumentEditor->setStyleSheet(
 			QString( "QLabel { background: %1 }" )
-			.arg( pPref->getTheme().m_color.m_windowColor.name() ) );
+			.arg( pPref->getColorTheme()->m_windowColor.name() ) );
 		m_pComponentsEditor->updateColors();
 		m_pComponentsEditor->updateStyleSheet();
 	}

--- a/src/gui/src/InstrumentEditor/LayerPreview.cpp
+++ b/src/gui/src/InstrumentEditor/LayerPreview.cpp
@@ -94,19 +94,19 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 	};
 
 	auto pPref = H2Core::Preferences::get_instance();
-	const auto gradientDefault = createGradient(
-		pPref->getTheme().m_color.m_accentColor );
-	const auto gradientMute = createGradient(
-		pPref->getTheme().m_color.m_muteColor );
-	const auto gradientSolo = createGradient(
-		pPref->getTheme().m_color.m_soloColor );
+	const auto pColorTheme = pPref->getColorTheme();
+	const auto pFontTheme = pPref->getFontTheme();
 
-	QFont fontText( pPref->getTheme().m_font.m_sLevel2FontFamily,
-					getPointSize( pPref->getTheme().m_font.m_fontSize ) );
-	QFont fontButton( pPref->getTheme().m_font.m_sLevel2FontFamily,
+	const auto gradientDefault = createGradient( pColorTheme->m_accentColor );
+	const auto gradientMute = createGradient( pColorTheme->m_muteColor );
+	const auto gradientSolo = createGradient( pColorTheme->m_soloColor );
+
+	QFont fontText( pFontTheme->m_sLevel2FontFamily,
+					getPointSize( pFontTheme->m_fontSize ) );
+	QFont fontButton( pFontTheme->m_sLevel2FontFamily,
 					  getPointSizeButton() );
 	
-	p.fillRect( ev->rect(), pPref->getTheme().m_color.m_windowColor );
+	p.fillRect( ev->rect(), pColorTheme->m_windowColor );
 
 	auto pComponent = m_pComponentView->getComponent();
 	const int nSelectedLayer = m_pComponentView->getSelectedLayer();
@@ -124,9 +124,9 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 	QColor layerLabelColor, highlightColor;
 	QLinearGradient segmentGradient;
 	if ( pComponent != nullptr ) {
-		highlightColor = pPref->getTheme().m_color.m_highlightColor;
+		highlightColor = pColorTheme->m_highlightColor;
 	} else {
-		highlightColor = pPref->getTheme().m_color.m_lightColor;
+		highlightColor = pColorTheme->m_lightColor;
 	}
 
 	int nLayer = 0;
@@ -157,11 +157,11 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 								static_cast<float>(nColorScalingWidth) ) ) -
 					nColorScalingWidth + 100;
 				layerLabelColor =
-					pPref->getTheme().m_color.m_windowColor.lighter( nColorScaling );
+					pColorTheme->m_windowColor.lighter( nColorScaling );
 
 				// Header
 				p.fillRect( x1, 0, x2 - x1, 19, layerLabelColor );
-				p.setPen( pPref->getTheme().m_color.m_windowTextColor );
+				p.setPen( pColorTheme->m_windowTextColor );
 				p.setFont( fontButton );
 				p.drawText( x1, 0, x2 - x1, 20, Qt::AlignCenter, QString("%1").arg( i + 1 ) );
 
@@ -170,13 +170,13 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 					p.setPen( highlightColor );
 				}
 				else {
-					p.setPen( pPref->getTheme().m_color.m_windowTextColor.darker( 145 ) );
+					p.setPen( pColorTheme->m_windowTextColor.darker( 145 ) );
 				}
 				p.drawRect( x1, 1, x2 - x1 - 1, 18 );	// bordino in alto
 					
 				// layer view
 				p.fillRect( 0, y, width(), LayerPreview::nLayerHeight,
-							pPref->getTheme().m_color.m_windowColor );
+							pColorTheme->m_windowColor );
 				if ( pSample != nullptr ) {
 					if ( pLayer->getIsMuted() ) {
 						segmentGradient = gradientMute;
@@ -192,7 +192,7 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 				}
 				else {
 					p.fillRect( x1, y, x2 - x1, LayerPreview::nLayerHeight,
-								pPref->getTheme().m_color.m_buttonRedColor );
+								pColorTheme->m_buttonRedColor );
 				}
 
 				nLayer++;
@@ -200,16 +200,16 @@ void LayerPreview::paintEvent(QPaintEvent *ev)
 			else {
 				// layer view
 				p.fillRect( 0, y, width(), LayerPreview::nLayerHeight,
-							pPref->getTheme().m_color.m_windowColor );
+							pColorTheme->m_windowColor );
 			}
 		}
 		else {
 			// layer view
 			p.fillRect( 0, y, width(), LayerPreview::nLayerHeight,
-						pPref->getTheme().m_color.m_windowColor );
+						pColorTheme->m_windowColor );
 		}
 
-		QColor layerTextColor = pPref->getTheme().m_color.m_windowTextColor;
+		QColor layerTextColor = pColorTheme->m_windowTextColor;
 		layerTextColor.setAlpha( 155 );
 		p.setPen( layerTextColor );
 		p.setFont( fontText );
@@ -491,7 +491,7 @@ int LayerPreview::getPointSizeButton() const
 	
 	int nPointSize;
 	
-	switch( pPref->getTheme().m_font.m_fontSize ) {
+	switch( pPref->getFontTheme()->m_fontSize ) {
 	case H2Core::FontTheme::FontSize::Small:
 		nPointSize = 6;
 		break;

--- a/src/gui/src/InstrumentEditor/WaveDisplay.cpp
+++ b/src/gui/src/InstrumentEditor/WaveDisplay.cpp
@@ -63,20 +63,21 @@ void WaveDisplay::paintEvent( QPaintEvent *ev ) {
 
 void WaveDisplay::createBackground( QPainter* painter ) {
 	auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
 	const QColor borderColor = Qt::black;
 	QColor textColor, backgroundColor, waveFormColor;
 	if ( m_pLayer != nullptr && m_pLayer->getIsMuted() ) {
-		textColor = pPref->getTheme().m_color.m_muteTextColor;
-		backgroundColor = pPref->getTheme().m_color.m_muteColor;
+		textColor = pColorTheme->m_muteTextColor;
+		backgroundColor = pColorTheme->m_muteColor;
 	}
 	else if ( m_pLayer != nullptr && m_pLayer->getIsSoloed() ){
-		textColor = pPref->getTheme().m_color.m_soloTextColor;
-		backgroundColor = pPref->getTheme().m_color.m_soloColor;
+		textColor = pColorTheme->m_soloTextColor;
+		backgroundColor = pColorTheme->m_soloColor;
 	}
 	else {
-		textColor = pPref->getTheme().m_color.m_accentTextColor;
-		backgroundColor = pPref->getTheme().m_color.m_accentColor;
+		textColor = pColorTheme->m_accentTextColor;
+		backgroundColor = pColorTheme->m_accentColor;
 	}
 	textColor.setAlpha( 200 );
 
@@ -107,8 +108,8 @@ void WaveDisplay::createBackground( QPainter* painter ) {
 		}
 	}
 	
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-				getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+				getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	font.setWeight( QFont::Bold );
 	painter->setFont( font );
 	painter->setPen( textColor );

--- a/src/gui/src/InstrumentRack.cpp
+++ b/src/gui/src/InstrumentRack.cpp
@@ -35,7 +35,7 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
  : QWidget( pParent )
  , Object()
 {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
 	setFixedWidth( InstrumentRack::nWidth );
@@ -45,8 +45,8 @@ InstrumentRack::InstrumentRack( QWidget *pParent )
 	pVBoxMainLayout->setSpacing( 0 );
 	pVBoxMainLayout->setContentsMargins( 0, 0, 0, 0 );
 
-	QFont fontButtons( theme.m_font.m_sApplicationFontFamily,
-					   getPointSize( theme.m_font.m_fontSize ) );
+	QFont fontButtons( pFontTheme->m_sApplicationFontFamily,
+					   getPointSize( pFontTheme->m_fontSize ) );
 
 	// TAB buttons
 
@@ -110,11 +110,11 @@ InstrumentRack::~InstrumentRack()
 }
 
 void InstrumentRack::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
 	if ( changes & H2Core::Preferences::Changes::Font ) {
-		QFont fontButtons( theme.m_font.m_sApplicationFontFamily,
-						   getPointSize( theme.m_font.m_fontSize ) );
+		QFont fontButtons( pFontTheme->m_sApplicationFontFamily,
+						   getPointSize( pFontTheme->m_fontSize ) );
 		m_pShowInstrumentEditorBtn->setFont( fontButtons );
 		m_pShowSoundLibraryBtn->setFont( fontButtons );
 	}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -145,7 +145,8 @@ MainForm::MainForm( QApplication * pQApplication, const QString& sSongFilename,
 	openFile( Filesystem::Type::Playlist, sPlaylistFilename,
 			  pPref->getLastPlaylistFilename() );
 
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+			   getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	setFont( font );
 	m_pQApp->setFont( font );
 
@@ -1869,10 +1870,10 @@ void MainForm::closeAll(){
 
 void MainForm::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {
 	if ( changes & H2Core::Preferences::Changes::Font ) {
-		const auto theme = H2Core::Preferences::get_instance()->getTheme();
+		const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 	
-		QFont font( theme.m_font.m_sApplicationFontFamily,
-					getPointSize( theme.m_font.m_fontSize ) );
+		QFont font( pFontTheme->m_sApplicationFontFamily,
+					getPointSize( pFontTheme->m_fontSize ) );
 		m_pQApp->setFont( font );
 		menuBar()->setFont( font );
 

--- a/src/gui/src/MainToolBar/BpmTap.cpp
+++ b/src/gui/src/MainToolBar/BpmTap.cpp
@@ -410,7 +410,7 @@ void BpmTap::updateBpmTap() {
 void BpmTap::updateIcons() {
 	QColor color;
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 		color = Qt::white;
@@ -434,11 +434,11 @@ void BpmTap::updateIcons() {
 
 void BpmTap::updateStyleSheet() {
 
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme =
+		H2Core::Preferences::get_instance()->getColorTheme();
 
-	const QColor colorText = colorTheme.m_windowTextColor;
-	const QColor colorLabel = colorTheme.m_windowColor;
+	const QColor colorText = pColorTheme->m_windowTextColor;
+	const QColor colorLabel = pColorTheme->m_windowColor;
 
 	QColor colorBackgroundPressed, colorBackgroundHovered;
 	if ( Skin::moreBlackThanWhite( m_backgroundColor ) ) {

--- a/src/gui/src/MainToolBar/MainToolBar.cpp
+++ b/src/gui/src/MainToolBar/MainToolBar.cpp
@@ -553,13 +553,13 @@ void MainToolBar::metronomeEvent( int nValue ) {
 		m_pMetronomeButton->setStyleSheet( QString( "\
 #MetronomeButton {				 \
    background-color: %1;\
-}" ).arg( pPref->getTheme().m_color.m_highlightColor.name() ) );
+}" ).arg( pPref->getColorTheme()->m_highlightColor.name() ) );
 	}
 	else {
 		m_pMetronomeButton->setStyleSheet( QString( "\
 #MetronomeButton {\
    background-color: %1;\
-}" ).arg( pPref->getTheme().m_color.m_accentColor.name() ) );
+}" ).arg( pPref->getColorTheme()->m_accentColor.name() ) );
 	}
 
 	// Percentage [0,1] the button stays highlighted over the duration of a
@@ -910,7 +910,7 @@ void MainToolBar::updateJackTransport() {
 
 void MainToolBar::updateJackTimebase()
 {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	const bool bVisible = pHydrogen->hasJackAudioDriver();
@@ -931,7 +931,7 @@ void MainToolBar::updateJackTimebase()
 			m_pJackTimebaseButton->setStyleSheet( QString( "\
 #JackTimebaseButton {\
     background-color: %1;\
-}" ).arg( theme.m_color.m_highlightColor.name() ) );
+}" ).arg( pColorTheme->m_highlightColor.name() ) );
 			m_pJackTimebaseButton->setToolTip(
 				pCommonStrings->getJackTimebaseControllerToolTip() );
 			break;
@@ -941,7 +941,7 @@ void MainToolBar::updateJackTimebase()
 			m_pJackTimebaseButton->setStyleSheet( QString( "\
 #JackTimebaseButton {\
     background-color: %1;\
-}" ).arg( theme.m_color.m_buttonRedColor.name() ) );
+}" ).arg( pColorTheme->m_buttonRedColor.name() ) );
 			m_pJackTimebaseButton->setToolTip(
 				pCommonStrings->getJackTimebaseListenerToolTip() );
 			break;
@@ -1007,7 +1007,7 @@ void MainToolBar::onPreferencesChanged( const H2Core::Preferences::Changes& chan
 
 void MainToolBar::updateIcons() {
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 	} else {
@@ -1046,11 +1046,11 @@ void MainToolBar::updateIcons() {
 
 void MainToolBar::updateStyleSheet() {
 
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme =
+		H2Core::Preferences::get_instance()->getColorTheme();
 
 	const QColor colorBackground =
-		colorTheme.m_songEditor_backgroundColor.darker( 110 );
+		pColorTheme->m_songEditor_backgroundColor.darker( 110 );
 
 	QColor colorBackgroundChecked, colorBackgroundHovered;
 	if ( Skin::moreBlackThanWhite( colorBackground ) ) {

--- a/src/gui/src/MainToolBar/MidiActionTable.cpp
+++ b/src/gui/src/MainToolBar/MidiActionTable.cpp
@@ -157,7 +157,7 @@ void MidiActionTable::insertNewRow( std::shared_ptr<MidiAction> pAction,
 	setRowCount( ++m_nRowCount );
 
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( H2Core::Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( H2Core::Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 H2Core::InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 	} else {

--- a/src/gui/src/MainToolBar/MidiControlButton.cpp
+++ b/src/gui/src/MainToolBar/MidiControlButton.cpp
@@ -119,7 +119,7 @@ void MidiControlButton::updateActivation() {
 
 void MidiControlButton::updateIcons() {
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 	} else {
@@ -148,9 +148,9 @@ void MidiControlButton::paintEvent( QPaintEvent* pEvent ) {
 	QToolButton::paintEvent( pEvent );
 
 	const auto highlightColor =
-		H2Core::Preferences::get_instance()->getTheme().m_color.m_highlightColor;
+		H2Core::Preferences::get_instance()->getColorTheme()->m_highlightColor;
 	const auto disabledColor =
-		H2Core::Preferences::get_instance()->getTheme().m_color.m_lightColor;
+		H2Core::Preferences::get_instance()->getColorTheme()->m_lightColor;
 
 	QPainter painter( this );
 

--- a/src/gui/src/MainToolBar/MidiControlDialog.cpp
+++ b/src/gui/src/MainToolBar/MidiControlDialog.cpp
@@ -477,11 +477,12 @@ void MidiControlDialog::showEvent( QShowEvent* pEvent ) {
 
 void MidiControlDialog::updateFont() {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pFontTheme = pPref->getFontTheme();
 
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-				getPointSize( pPref->getTheme().m_font.m_fontSize ) );
-	QFont childFont( pPref->getTheme().m_font.m_sLevel2FontFamily,
-					 getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pFontTheme->m_sApplicationFontFamily,
+				getPointSize( pFontTheme->m_fontSize ) );
+	QFont childFont( pFontTheme->m_sLevel2FontFamily,
+					 getPointSize( pFontTheme->m_fontSize ) );
 	setFont( font );
 
 	// In order to affect the fonts of all child widgets in the table as well,
@@ -499,7 +500,7 @@ font-size: %2; \
 
 void MidiControlDialog::updateIcons() {
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 	} else {

--- a/src/gui/src/Mixer/LadspaFXLine.cpp
+++ b/src/gui/src/Mixer/LadspaFXLine.cpp
@@ -122,10 +122,10 @@ LadspaFXLine::~LadspaFXLine() {
 }
 
 void LadspaFXLine::updateColors() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
-	m_pBypassBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
-	m_pBypassBtn->setCheckedBackgroundTextColor( theme.m_color.m_muteTextColor );
+	m_pBypassBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
+	m_pBypassBtn->setCheckedBackgroundTextColor( pColorTheme->m_muteTextColor );
 }
 
 void LadspaFXLine::updateLine() {

--- a/src/gui/src/Mixer/MasterLine.cpp
+++ b/src/gui/src/Mixer/MasterLine.cpp
@@ -157,11 +157,11 @@ MasterLine::~MasterLine() {
 }
 
 void MasterLine::updateColors() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
-	m_pMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pMuteBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
 	m_pMuteBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_muteTextColor );
+		pColorTheme->m_muteTextColor );
 }
 
 void MasterLine::updateLine() {
@@ -197,7 +197,7 @@ void MasterLine::updateLine() {
 void MasterLine::updatePeaks() {
 	const auto pPref = Preferences::get_instance();
 	const float fFallOffSpeed =
-		pPref->getTheme().m_interface.m_fMixerFalloffSpeed;
+		pPref->getInterfaceTheme()->m_fMixerFalloffSpeed;
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pAudioEngine = pHydrogen->getAudioEngine();
 

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -356,7 +356,7 @@ void Mixer::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) 
 	}
 
 	if ( changes & H2Core::Preferences::Changes::Font ) {
-		setFont( QFont( pPref->getTheme().m_font.m_sApplicationFontFamily, 10 ) );
+		setFont( QFont( pPref->getFontTheme()->m_sApplicationFontFamily, 10 ) );
 	}
 }
 

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -204,14 +204,14 @@ MixerLine::~MixerLine() {
 }
 
 void MixerLine::updateColors() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
-	m_pMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
+	m_pMuteBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
 	m_pMuteBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_muteTextColor );
-	m_pSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
+		pColorTheme->m_muteTextColor );
+	m_pSoloBtn->setCheckedBackgroundColor( pColorTheme->m_soloColor );
 	m_pSoloBtn->setCheckedBackgroundTextColor(
-		theme.m_color.m_soloTextColor );
+		pColorTheme->m_soloTextColor );
 }
 
 void MixerLine::updateLine() {
@@ -264,7 +264,7 @@ void MixerLine::updatePeaks()
 	}
 	auto pPref = Preferences::get_instance();
 	const float fFallOffSpeed =
-		pPref->getTheme().m_interface.m_fMixerFalloffSpeed;
+		pPref->getInterfaceTheme()->m_fMixerFalloffSpeed;
 
 	float fNewPeak_L = m_pInstrument->getPeak_L();
 	float fNewPeak_R = m_pInstrument->getPeak_R();

--- a/src/gui/src/PatternEditor/DrumPatternEditor.cpp
+++ b/src/gui/src/PatternEditor/DrumPatternEditor.cpp
@@ -194,33 +194,34 @@ void DrumPatternEditor::selectAll()
 
 void DrumPatternEditor::createBackground() {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
-	QColor lineColor( pPref->getTheme().m_color.m_patternEditor_lineColor );
+	QColor lineColor( pColorTheme->m_patternEditor_lineColor );
 	// Row clicked by the user.
 	QColor selectedRowColor(
-		pPref->getTheme().m_color.m_patternEditor_selectedRowColor );
+		pColorTheme->m_patternEditor_selectedRowColor );
 
 	// Rows for which there is a corresponding instrument in the current
 	// drumkit.
 	QColor backgroundColor(
-		pPref->getTheme().m_color.m_patternEditor_backgroundColor );
+		pColorTheme->m_patternEditor_backgroundColor );
 	QColor alternateRowColor(
-		pPref->getTheme().m_color.m_patternEditor_alternateRowColor );
+		pColorTheme->m_patternEditor_alternateRowColor );
 
 	// Everything beyond the current pattern (used when another, larger pattern
 	// is played as well).
 	const QColor lineInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor.darker( 170 ) );
+		pColorTheme->m_windowTextColor.darker( 170 ) );
 
 	// Indicate chosen editor mode.
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Pattern ) {
 		backgroundInactiveColor =
-			pPref->getTheme().m_color.m_windowColor.lighter(
+			pColorTheme->m_windowColor.lighter(
 				Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = pPref->getTheme().m_color.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	if ( ! hasFocus() ) {

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -81,25 +81,25 @@ void KeyOctaveLabel::updateColors() {
 		QColor backgroundColor;
 		if ( m_bAlternateBackground ) {
 			backgroundColor =
-				pPref->getTheme().m_color.m_patternEditor_alternateRowColor;
+				pPref->getColorTheme()->m_patternEditor_alternateRowColor;
 		}
 		else {
 			backgroundColor =
-				pPref->getTheme().m_color.m_patternEditor_octaveRowColor;
+				pPref->getColorTheme()->m_patternEditor_octaveRowColor;
 		}
 		m_backgroundColor =
 			backgroundColor.darker( Skin::nListBackgroundColorScaling );
 	}
 
 	setStyleSheet( QString( "QLabel{ color: %1; }" )
-				   .arg( pPref->getTheme().m_color.m_patternEditor_textColor.name() ) );
+				   .arg( pPref->getColorTheme()->m_patternEditor_textColor.name() ) );
 }
 
 void KeyOctaveLabel::updateFont() {
 	auto pPref = Preferences::get_instance();
 
 	int nMargin;
-    switch( pPref->getTheme().m_font.m_fontSize ) {
+    switch( pPref->getFontTheme()->m_fontSize ) {
     case H2Core::FontTheme::FontSize::Small:
 		nMargin = 2;
 		break;
@@ -111,7 +111,7 @@ void KeyOctaveLabel::updateFont() {
 		break;
 	}
 
-	QFont font( pPref->getTheme().m_font.m_sLevel2FontFamily );
+	QFont font( pPref->getFontTheme()->m_sLevel2FontFamily );
 	font.setPixelSize( NotePropertiesRuler::nKeyLineHeight - nMargin );
 	font.setBold( true );
 
@@ -1080,26 +1080,24 @@ void NotePropertiesRuler::scrolled( int nValue ) {
 void NotePropertiesRuler::drawDefaultBackground( QPainter& painter, int nHeight,
 												 int nIncrement ) {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
-	QColor lineColor(
-		pPref->getTheme().m_color.m_patternEditor_line5Color );
-	QColor backgroundColor(
-		pPref->getTheme().m_color.m_patternEditor_backgroundColor );
+	QColor lineColor( pColorTheme->m_patternEditor_line5Color );
+	QColor backgroundColor( pColorTheme->m_patternEditor_backgroundColor );
 
 	// Everything beyond the current pattern (used when another, larger pattern
 	// is played as well).
 	const QColor lineInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor.darker( 170 ) );
+		pColorTheme->m_windowTextColor.darker( 170 ) );
 
 	// Indicate chosen editor mode.
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Pattern ) {
-		backgroundInactiveColor =
-			pPref->getTheme().m_color.m_windowColor.lighter(
-				Skin::nEditorActiveScaling );
+		backgroundInactiveColor = pColorTheme->m_windowColor.lighter(
+			Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = pPref->getTheme().m_color.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	if ( ! hasFocus() ) {
@@ -1404,30 +1402,29 @@ void NotePropertiesRuler::sortAndDrawNotes( QPainter& p,
 void NotePropertiesRuler::createBackground()
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 
-	QColor lineColor(
-		pPref->getTheme().m_color.m_patternEditor_lineColor );
-	QColor textColor( pPref->getTheme().m_color.m_patternEditor_textColor );
+	QColor lineColor( pColorTheme->m_patternEditor_lineColor );
+	QColor textColor( pColorTheme->m_patternEditor_textColor );
 	const QColor alternateRowColor =
-		pPref->getTheme().m_color.m_patternEditor_alternateRowColor;
+		pColorTheme->m_patternEditor_alternateRowColor;
 	const QColor octaveColor =
-		pPref->getTheme().m_color.m_patternEditor_octaveRowColor;
+		pColorTheme->m_patternEditor_octaveRowColor;
 
 	// Everything beyond the current pattern (used when another, larger pattern
 	// is played as well).
 	const QColor lineInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor.darker( 170 ) );
+		pColorTheme->m_windowTextColor.darker( 170 ) );
 
 	// Indicate chosen editor mode.
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Pattern ) {
-		backgroundInactiveColor =
-			pPref->getTheme().m_color.m_windowColor.lighter(
-				Skin::nEditorActiveScaling );
+		backgroundInactiveColor = pColorTheme->m_windowColor.lighter(
+			Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = pPref->getTheme().m_color.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	if ( ! hasFocus() ) {

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -1038,7 +1038,7 @@ void PatternEditor::paintEvent( QPaintEvent* ev ) {
 	if ( ! HydrogenApp::get_instance()->hideKeyboardCursor() &&
 		 m_pPatternEditorPanel->hasPatternEditorFocus() &&
 		 pPattern != nullptr ) {
-		QColor cursorColor( pPref->getTheme().m_color.m_cursorColor );
+		QColor cursorColor( pPref->getColorTheme()->m_cursorColor );
 		if ( ! hasFocus() ) {
 			cursorColor.setAlpha( Skin::nInactiveCursorAlpha );
 		}
@@ -2809,8 +2809,8 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 								QPen* pMovingPen, QBrush* pMovingBrush,
 								NoteStyle noteStyle ) const
 {
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme =
+		H2Core::Preferences::get_instance()->getColorTheme();
 
 	const auto backgroundPenStyle = Qt::DotLine;
 	const auto backgroundBrushStyle = Qt::Dense4Pattern;
@@ -2826,7 +2826,7 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 	if ( ! pNote->getNoteOff() ) {
 		noteFillColor = PatternEditor::computeNoteColor( pNote->getVelocity() );
 	} else {
-		noteFillColor = colorTheme.m_patternEditor_noteOffColor;
+		noteFillColor = pColorTheme->m_patternEditor_noteOffColor;
 	}
 
 	// color base note will be filled with
@@ -2860,7 +2860,7 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 		// Use a more subtle version of the note off color. As this color is
 		// surrounded by the note outline - which is always black - we do not
 		// have to check the value but can always go for a more lighter color.
-		QColor effectiveLengthColor( colorTheme.m_patternEditor_noteOffColor );
+		QColor effectiveLengthColor( pColorTheme->m_patternEditor_noteOffColor );
 		effectiveLengthColor = effectiveLengthColor.lighter( 125 );
 		pNoteTailBrush->setColor( effectiveLengthColor );
 	}
@@ -2872,10 +2872,10 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 	// Highlight color
 	QColor selectionColor;
 	if ( m_pPatternEditorPanel->hasPatternEditorFocus() ) {
-		selectionColor = colorTheme.m_selectionHighlightColor;
+		selectionColor = pColorTheme->m_selectionHighlightColor;
 	}
 	else {
-		selectionColor = colorTheme.m_selectionInactiveColor;
+		selectionColor = pColorTheme->m_selectionInactiveColor;
 	}
 
 	QColor highlightColor;
@@ -2885,7 +2885,7 @@ void PatternEditor::applyColor( std::shared_ptr<H2Core::Note> pNote,
 	}
 	else if ( noteStyle & NoteStyle::NoPlayback ) {
 		// Notes that won't be played back maintain their special color.
-		highlightColor = colorTheme.m_muteColor;
+		highlightColor = pColorTheme->m_muteColor;
 
 		// The color of the mute button itself would be too flash and draw too
 		// much attention to the note which are probably the ones the user does
@@ -2959,11 +2959,12 @@ QColor PatternEditor::computeNoteColor( float fVelocity ) {
 	float fRed, fGreen, fBlue;
 
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
-	QColor fullColor = pPref->getTheme().m_color.m_patternEditor_noteVelocityFullColor;
-	QColor defaultColor = pPref->getTheme().m_color.m_patternEditor_noteVelocityDefaultColor;
-	QColor halfColor = pPref->getTheme().m_color.m_patternEditor_noteVelocityHalfColor;
-	QColor zeroColor = pPref->getTheme().m_color.m_patternEditor_noteVelocityZeroColor;
+	QColor fullColor = pColorTheme->m_patternEditor_noteVelocityFullColor;
+	QColor defaultColor = pColorTheme->m_patternEditor_noteVelocityDefaultColor;
+	QColor halfColor = pColorTheme->m_patternEditor_noteVelocityHalfColor;
+	QColor zeroColor = pColorTheme->m_patternEditor_noteVelocityZeroColor;
 
 	// The colors defined in the Preferences correspond to fixed
 	// velocity values. In case the velocity lies between two of those
@@ -3006,11 +3007,11 @@ QColor PatternEditor::computeNoteColor( float fVelocity ) {
 
 void PatternEditor::drawBorders( QPainter& p ) {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
-	const QColor borderColor(
-		pPref->getTheme().m_color.m_patternEditor_lineColor );
+	const QColor borderColor( pColorTheme->m_patternEditor_lineColor );
 	const QColor borderInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor.darker( 170 ) );
+		pColorTheme->m_windowTextColor.darker( 170 ) );
 
 	p.setPen( borderColor );
 	p.drawLine( 0, 0, m_nActiveWidth, 0 );
@@ -3039,7 +3040,7 @@ void PatternEditor::drawFocus( QPainter& p ) {
 
 	const auto pPref = H2Core::Preferences::get_instance();
 
-	QColor color = pPref->getTheme().m_color.m_highlightColor;
+	QColor color = pPref->getColorTheme()->m_highlightColor;
 
 	// If the mouse is placed on the widget but the user hasn't clicked it yet,
 	// the highlight will be done more transparent to indicate that keyboard
@@ -3121,19 +3122,20 @@ void PatternEditor::drawFocus( QPainter& p ) {
 void PatternEditor::drawGridLines( QPainter &p, const Qt::PenStyle& style ) const
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 	const std::vector<QColor> colorsActive = {
-		QColor( pPref->getTheme().m_color.m_patternEditor_line1Color ),
-		QColor( pPref->getTheme().m_color.m_patternEditor_line2Color ),
-		QColor( pPref->getTheme().m_color.m_patternEditor_line3Color ),
-		QColor( pPref->getTheme().m_color.m_patternEditor_line4Color ),
-		QColor( pPref->getTheme().m_color.m_patternEditor_line5Color ),
+		QColor( pColorTheme->m_patternEditor_line1Color ),
+		QColor( pColorTheme->m_patternEditor_line2Color ),
+		QColor( pColorTheme->m_patternEditor_line3Color ),
+		QColor( pColorTheme->m_patternEditor_line4Color ),
+		QColor( pColorTheme->m_patternEditor_line5Color ),
 	};
 	const std::vector<QColor> colorsInactive = {
-		QColor( pPref->getTheme().m_color.m_windowTextColor.darker( 170 ) ),
-		QColor( pPref->getTheme().m_color.m_windowTextColor.darker( 190 ) ),
-		QColor( pPref->getTheme().m_color.m_windowTextColor.darker( 210 ) ),
-		QColor( pPref->getTheme().m_color.m_windowTextColor.darker( 230 ) ),
-		QColor( pPref->getTheme().m_color.m_windowTextColor.darker( 250 ) ),
+		QColor( pColorTheme->m_windowTextColor.darker( 170 ) ),
+		QColor( pColorTheme->m_windowTextColor.darker( 190 ) ),
+		QColor( pColorTheme->m_windowTextColor.darker( 210 ) ),
+		QColor( pColorTheme->m_windowTextColor.darker( 230 ) ),
+		QColor( pColorTheme->m_windowTextColor.darker( 250 ) ),
 	};
 
 	// In case quantization as turned off, notes can be moved at all possible
@@ -3497,10 +3499,10 @@ void PatternEditor::drawPattern() {
 		return;
 	}
 	const auto pPref = H2Core::Preferences::get_instance();
-	const QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-					  getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	const QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+					  getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	const QColor textColor(
-		pPref->getTheme().m_color.m_patternEditor_noteVelocityDefaultColor );
+		pPref->getColorTheme()->m_patternEditor_noteVelocityDefaultColor );
 	QColor textBackgroundColor( textColor );
 	textBackgroundColor.setAlpha( 150 );
 
@@ -3646,7 +3648,7 @@ int PatternEditor::calculateEffectiveNoteLength(
 
 	// Check for the closest note off or note of the same mute group.
 	if ( Preferences::get_instance()->
-		 getTheme().m_interface.m_bIndicateEffectiveNoteLength ) {
+		 getInterfaceTheme()->m_bIndicateEffectiveNoteLength ) {
 
 		const auto pInstrument = pNote->getInstrument();
 
@@ -3719,7 +3721,7 @@ int PatternEditor::calculateEffectiveNoteLength(
 
 bool PatternEditor::checkNotePlayback( std::shared_ptr<H2Core::Note> pNote ) const {
 	if ( ! Preferences::get_instance()->
-		 getTheme().m_interface.m_bIndicateNotePlayback ) {
+		 getInterfaceTheme()->m_bIndicateNotePlayback ) {
 		return true;
 	}
 

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -153,8 +153,8 @@ PatternEditorPanel::PatternEditorPanel( QWidget *pParent )
 	m_bIsUsingTriplets = pPref->isPatternEditorUsingTriplets();
 	m_bQuantized = pPref->getQuantizeEvents();
 
-	QFont boldFont( pPref->getTheme().m_font.m_sApplicationFontFamily,
-					getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont boldFont( pPref->getFontTheme()->m_sApplicationFontFamily,
+					getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	boldFont.setBold( true );
 
 	////////////////////////////////////////////////////////////////////////////
@@ -683,10 +683,10 @@ void PatternEditorPanel::createEditors() {
 
 void PatternEditorPanel::updateDrumkitLabel( )
 {
-	const auto pTheme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
-	QFont font( pTheme.m_font.m_sApplicationFontFamily,
-				getPointSize( pTheme.m_font.m_fontSize ) );
+	QFont font( pFontTheme->m_sApplicationFontFamily,
+				getPointSize( pFontTheme->m_fontSize ) );
 	font.setBold( true );
 	m_pDrumkitLabel->setFont( font );
 
@@ -1034,7 +1034,7 @@ void PatternEditorPanel::zoomOutBtnClicked()
 void PatternEditorPanel::updateIcons() {
 	QColor color;
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 		color = Qt::white;
@@ -1704,7 +1704,8 @@ void PatternEditorPanel::onPreferencesChanged( const H2Core::Preferences::Change
 		
 		// It's sufficient to check the properties of just one label
 		// because they will always carry the same.
-		QFont boldFont( pPref->getTheme().m_font.m_sApplicationFontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+		QFont boldFont( pPref->getFontTheme()->m_sApplicationFontFamily,
+					   getPointSize( pPref->getFontTheme()->m_fontSize ) );
 		boldFont.setBold( true );
 		m_pDrumkitLabel->setFont( boldFont );
 		m_pTabBar->setFont( boldFont );
@@ -1728,26 +1729,26 @@ void PatternEditorPanel::onPreferencesChanged( const H2Core::Preferences::Change
 
 void PatternEditorPanel::updateStyleSheet() {
 
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme =
+		H2Core::Preferences::get_instance()->getColorTheme();
 
 	const QColor colorDrumkit =
-		colorTheme.m_patternEditor_instrumentAlternateRowColor.darker( 120 );
+		pColorTheme->m_patternEditor_instrumentAlternateRowColor.darker( 120 );
 	const QColor colorDrumkitText =
-		colorTheme.m_patternEditor_instrumentRowTextColor;
+		pColorTheme->m_patternEditor_instrumentRowTextColor;
 	const QColor colorPatternLabel =
-		colorTheme.m_patternEditor_alternateRowColor.darker( 120 );
+		pColorTheme->m_patternEditor_alternateRowColor.darker( 120 );
 	const QColor colorToolBar =
-		colorTheme.m_patternEditor_selectedRowColor.darker( 134 );
-	const QColor colorPatternText = colorTheme.m_patternEditor_textColor;
+		pColorTheme->m_patternEditor_selectedRowColor.darker( 134 );
+	const QColor colorPatternText = pColorTheme->m_patternEditor_textColor;
 
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Pattern ) {
-		backgroundInactiveColor = colorTheme.m_windowColor.lighter(
+		backgroundInactiveColor = pColorTheme->m_windowColor.lighter(
 			Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = colorTheme.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	QColor colorToolBarChecked, colorToolBarHovered;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -56,7 +56,7 @@ PatternEditorRuler::PatternEditorRuler( QWidget* parent )
 
 	const auto pPref = Preferences::get_instance();
 
-	QColor backgroundColor( pPref->getTheme().m_color.m_patternEditor_backgroundColor );
+	QColor backgroundColor( pPref->getColorTheme()->m_patternEditor_backgroundColor );
 
 	m_fGridWidth = pPref->getPatternEditorGridWidth();
 
@@ -286,6 +286,7 @@ void PatternEditorRuler::invalidateBackground()
 void PatternEditorRuler::createBackground()
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
 	// Resize pixmap if pixel ratio has changed
 	qreal pixelRatio = devicePixelRatio();
@@ -297,11 +298,11 @@ void PatternEditorRuler::createBackground()
 		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
 	}
 
-	QColor backgroundColor( pPref->getTheme().m_color.m_patternEditor_alternateRowColor.darker( 120 ) );
-	QColor textColor = pPref->getTheme().m_color.m_patternEditor_textColor;
+	QColor backgroundColor( pColorTheme->m_patternEditor_alternateRowColor.darker( 120 ) );
+	QColor textColor = pColorTheme->m_patternEditor_textColor;
 	textColor.setAlpha( 220 );
 	
-	QColor lineColor = pPref->getTheme().m_color.m_patternEditor_lineColor;
+	QColor lineColor = pColorTheme->m_patternEditor_lineColor;
 
 	QPainter painter( m_pBackgroundPixmap );
 	
@@ -311,12 +312,13 @@ void PatternEditorRuler::createBackground()
 	if ( m_nRulerWidth - m_nWidthActive != 0 ) {
 		painter.fillRect( m_nWidthActive, 0, m_nRulerWidth - m_nWidthActive,
 						  m_nRulerHeight,
-						  pPref->getTheme().m_color.m_midLightColor );
+						  pColorTheme->m_midLightColor );
 	}
 
 	// numbers
 
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+			   getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	painter.setFont(font);
 
 	const int nResolution = m_pPatternEditorPanel->getResolution();
@@ -354,6 +356,7 @@ void PatternEditorRuler::createBackground()
 void PatternEditorRuler::paintEvent( QPaintEvent *ev)
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 	auto pHydrogenApp = HydrogenApp::get_instance();
 
 	if (!isVisible()) {
@@ -380,7 +383,7 @@ void PatternEditorRuler::paintEvent( QPaintEvent *ev)
 			PatternEditor::nMargin - 4 - m_fGridWidth * 5;
 
 		// Middle line to indicate the selected tick
-		painter.setPen( QPen( pPref->getTheme().m_color.m_cursorColor, 2 ) );
+		painter.setPen( QPen( pColorTheme->m_cursorColor, 2 ) );
 		painter.setRenderHint( QPainter::Antialiasing );
 		painter.drawLine( nCursorX + m_fGridWidth * 5 + 4, height() - 6,
 						  nCursorX + m_fGridWidth * 5 + 4, height() - 13 );

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -66,7 +66,7 @@ SidebarLabel::SidebarLabel( QWidget* pParent, Type type, const QSize& size,
 	, m_bShowCursor( false )
 	, m_bDimed( false )
 {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	setFixedWidth( size.width() );
 	setFixedHeight( size.height() );
@@ -76,9 +76,9 @@ SidebarLabel::SidebarLabel( QWidget* pParent, Type type, const QSize& size,
 	setContentsMargins( 1, 1, 1, 1 );
 
 	updateFont();
-	setColor( theme.m_color.m_patternEditor_backgroundColor,
-			  theme.m_color.m_patternEditor_textColor,
-			  theme.m_color.m_cursorColor );
+	setColor( pColorTheme->m_patternEditor_backgroundColor,
+			  pColorTheme->m_patternEditor_textColor,
+			  pColorTheme->m_cursorColor );
 	updateStyle();
 }
 
@@ -177,7 +177,7 @@ void SidebarLabel::paintEvent( QPaintEvent* ev )
 		const auto pPref = Preferences::get_instance();
 
 		int nLineWidth, nHeight;
-		switch ( pPref->getTheme().m_font.m_fontSize ) {
+		switch ( pPref->getFontTheme()->m_fontSize ) {
 		case H2Core::FontTheme::FontSize::Small:
 			nHeight = height() - 11;
             nLineWidth = 2;
@@ -195,7 +195,7 @@ void SidebarLabel::paintEvent( QPaintEvent* ev )
             return;
 		}
 
-		QColor color = m_bEntered ? pPref->getTheme().m_color.m_highlightColor :
+		QColor color = m_bEntered ? pPref->getColorTheme()->m_highlightColor :
 			m_textBaseColor;
 
 		if ( m_bDimed ) {
@@ -269,10 +269,10 @@ void SidebarLabel::paintEvent( QPaintEvent* ev )
 }
 
 void SidebarLabel::updateFont() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
-	const QString sFontFamily = theme.m_font.m_sLevel2FontFamily;
-	const auto fontSize = theme.m_font.m_fontSize;
+	const QString sFontFamily = pFontTheme->m_sLevel2FontFamily;
+	const auto fontSize = pFontTheme->m_fontSize;
 
 	int nShrinkage = 7;
 	switch ( fontSize ) {
@@ -342,8 +342,6 @@ void SidebarLabel::setDimed( bool bDimed ) {
 }
 
 void SidebarLabel::updateStyle() {
-	const auto colorTheme = Preferences::get_instance()->getTheme().m_color;
-
 	m_textColor = m_textBaseColor;
 	if ( m_bDimed && m_type == Type::Type ) {
 		m_textColor = m_textColor.darker( SidebarLabel::nDimScaling );
@@ -378,8 +376,8 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 	pHBox->setSpacing( 0 );
 	pHBox->setContentsMargins( 0, 0, 0, 0 );
 
-	QFont nameFont( pPref->getTheme().m_font.m_sLevel2FontFamily,
-					getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont nameFont( pPref->getFontTheme()->m_sLevel2FontFamily,
+					getPointSize( pPref->getFontTheme()->m_fontSize ) );
 
 	m_pInstrumentNameLbl = new SidebarLabel(
 		this, SidebarLabel::Type::Instrument,
@@ -753,53 +751,53 @@ void SidebarRow::setDimed( bool bDimed ) {
 }
 
 void SidebarRow::updateStyleSheet() {
-	const auto colorTheme = Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
 	QColor textColor, textPatternColor, backgroundPatternColor, backgroundColor;
 	if ( m_bIsSelected ) {
 		backgroundPatternColor =
-			colorTheme.m_patternEditor_selectedRowColor.darker(
+			pColorTheme->m_patternEditor_selectedRowColor.darker(
 				Skin::nListBackgroundColorScaling );
 		backgroundColor =
-			colorTheme.m_patternEditor_instrumentSelectedRowColor;
-		textPatternColor = colorTheme.m_patternEditor_selectedRowTextColor;
-		textColor = colorTheme.m_patternEditor_instrumentSelectedRowTextColor;
+			pColorTheme->m_patternEditor_instrumentSelectedRowColor;
+		textPatternColor = pColorTheme->m_patternEditor_selectedRowTextColor;
+		textColor = pColorTheme->m_patternEditor_instrumentSelectedRowTextColor;
 	}
 	else if ( m_row.bAlternate ) {
 		backgroundPatternColor =
-			colorTheme.m_patternEditor_alternateRowColor.darker(
+			pColorTheme->m_patternEditor_alternateRowColor.darker(
 				Skin::nListBackgroundColorScaling );
 		backgroundColor =
-			colorTheme.m_patternEditor_instrumentAlternateRowColor;
-		textPatternColor = colorTheme.m_patternEditor_textColor;
-		textColor = colorTheme.m_patternEditor_instrumentRowTextColor;
+			pColorTheme->m_patternEditor_instrumentAlternateRowColor;
+		textPatternColor = pColorTheme->m_patternEditor_textColor;
+		textColor = pColorTheme->m_patternEditor_instrumentRowTextColor;
 	}
 	else {
 		backgroundPatternColor =
-			colorTheme.m_patternEditor_backgroundColor.darker(
+			pColorTheme->m_patternEditor_backgroundColor.darker(
 				Skin::nListBackgroundColorScaling );
 		backgroundColor =
-			colorTheme.m_patternEditor_instrumentRowColor;
-		textPatternColor = colorTheme.m_patternEditor_textColor;
-		textColor = colorTheme.m_patternEditor_instrumentRowTextColor;
+			pColorTheme->m_patternEditor_instrumentRowColor;
+		textPatternColor = pColorTheme->m_patternEditor_textColor;
+		textColor = pColorTheme->m_patternEditor_instrumentRowTextColor;
 	}
 
 	// Indicate chosen editor mode.
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Pattern ) {
-		backgroundInactiveColor = colorTheme.m_windowColor.lighter(
+		backgroundInactiveColor = pColorTheme->m_windowColor.lighter(
 			Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = colorTheme.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	setColor( backgroundInactiveColor );
 
 	m_pInstrumentNameLbl->setColor(
-		backgroundColor, textColor, colorTheme.m_cursorColor );
+		backgroundColor, textColor, pColorTheme->m_cursorColor );
 	m_pTypeLbl->setColor(
-		backgroundPatternColor, textPatternColor, colorTheme.m_cursorColor );
+		backgroundPatternColor, textPatternColor, pColorTheme->m_cursorColor );
 }
 
 void SidebarRow::updateTypeLabelVisibility( bool bVisible ) {
@@ -952,12 +950,12 @@ void SidebarRow::mousePressEvent(QMouseEvent *ev)
 }
 
 void SidebarRow::updateColors() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
-	m_pMuteBtn->setCheckedBackgroundColor( theme.m_color.m_muteColor );
-	m_pMuteBtn->setCheckedBackgroundTextColor( theme.m_color.m_muteTextColor );
-	m_pSoloBtn->setCheckedBackgroundColor( theme.m_color.m_soloColor );
-	m_pSoloBtn->setCheckedBackgroundTextColor( theme.m_color.m_soloTextColor );
+	m_pMuteBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
+	m_pMuteBtn->setCheckedBackgroundTextColor( pColorTheme->m_muteTextColor );
+	m_pSoloBtn->setCheckedBackgroundColor( pColorTheme->m_soloColor );
+	m_pSoloBtn->setCheckedBackgroundTextColor( pColorTheme->m_soloTextColor );
 }
 
 void SidebarRow::updateFont() {

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -49,8 +49,6 @@ PitchLabel::PitchLabel( QWidget* pParent, const QString& sText, int nHeight )
 	, m_sText( sText )
 	, m_bSelected( false )
 {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
-
 	setFixedWidth( PatternEditor::nMarginSidebar );
 	setFixedHeight( nHeight );
 	setText( sText );
@@ -58,7 +56,8 @@ PitchLabel::PitchLabel( QWidget* pParent, const QString& sText, int nHeight )
 	setIndent( 2 );
 
 	updateFont();
-	setBackgroundColor( theme.m_color.m_patternEditor_backgroundColor );
+	setBackgroundColor( H2Core::Preferences::get_instance()->getColorTheme()->
+		m_patternEditor_backgroundColor );
 	updateStyleSheet();
 }
 
@@ -77,16 +76,15 @@ void PitchLabel::setBackgroundColor( const QColor& backgroundColor ) {
 
 
 void PitchLabel::updateStyleSheet() {
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
 	QColor textColor;
 	if ( m_bSelected ) {
-		textColor = colorTheme.m_patternEditor_selectedRowTextColor;
+		textColor = pColorTheme->m_patternEditor_selectedRowTextColor;
 	} else {
-		textColor = colorTheme.m_patternEditor_textColor;
+		textColor = pColorTheme->m_patternEditor_textColor;
 	}
-	const auto cursorColor = colorTheme.m_cursorColor;
+	const auto cursorColor = pColorTheme->m_cursorColor;
 
 	if ( m_textColor == textColor && m_cursorColor == cursorColor ) {
 		return;
@@ -152,10 +150,10 @@ void PitchLabel::paintEvent( QPaintEvent* ev )
 
 void PitchLabel::updateFont() {
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
 	float fScalingFactor = 1.0;
-    switch ( theme.m_font.m_fontSize ) {
+    switch ( pFontTheme->m_fontSize ) {
     case H2Core::FontTheme::FontSize::Small:
 		fScalingFactor = 0.8;
 		break;
@@ -170,7 +168,7 @@ void PitchLabel::updateFont() {
 	const int nMargin = 1;
 	int nPixelSize = std::round( ( height() - nMargin ) * fScalingFactor );
 
-	QFont font( theme.m_font.m_sLevel2FontFamily );
+	QFont font( pFontTheme->m_sLevel2FontFamily );
 	font.setBold( true );
 	font.setPixelSize( nPixelSize );
 
@@ -459,8 +457,8 @@ PianoRollEditor::PianoRollEditor( QWidget *pParent )
 	m_instance = Editor::Instance::PianoRoll;
 
 	const auto pPref = H2Core::Preferences::get_instance();
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-				getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+				getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	setFont( font );
 	
 	m_nGridHeight = 13;
@@ -596,32 +594,29 @@ void PianoRollEditor::paintEvent(QPaintEvent *ev)
 void PianoRollEditor::createBackground()
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
 	auto pPattern = m_pPatternEditorPanel->getPattern();
 	
-	QColor backgroundColor(
-		pPref->getTheme().m_color.m_patternEditor_backgroundColor );
-	QColor alternateRowColor(
-		pPref->getTheme().m_color.m_patternEditor_alternateRowColor );
-	QColor octaveColor = pPref->getTheme().m_color.m_patternEditor_octaveRowColor;
-	QColor lineColor( pPref->getTheme().m_color.m_patternEditor_lineColor );
+	QColor backgroundColor( pColorTheme->m_patternEditor_backgroundColor );
+	QColor alternateRowColor( pColorTheme->m_patternEditor_alternateRowColor );
+	QColor octaveColor = pColorTheme->m_patternEditor_octaveRowColor;
+	QColor lineColor( pColorTheme->m_patternEditor_lineColor );
 	// Row clicked by the user.
-	QColor selectedRowColor(
-		pPref->getTheme().m_color.m_patternEditor_selectedRowColor );
+	QColor selectedRowColor( pColorTheme->m_patternEditor_selectedRowColor );
 
 	// Everything beyond the current pattern (used when another, larger pattern
 	// is played as well).
 	const QColor lineInactiveColor(
-		pPref->getTheme().m_color.m_windowTextColor.darker( 170 ) );
+		pColorTheme->m_windowTextColor.darker( 170 ) );
 	// Indicate chosen editor mode.
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Pattern ) {
-		backgroundInactiveColor =
-			pPref->getTheme().m_color.m_windowColor.lighter(
-				Skin::nEditorActiveScaling );
+		backgroundInactiveColor = pColorTheme->m_windowColor.lighter(
+			Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = pPref->getTheme().m_color.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	if ( ! hasFocus() ) {

--- a/src/gui/src/PlaylistEditor/PlaylistEditor.cpp
+++ b/src/gui/src/PlaylistEditor/PlaylistEditor.cpp
@@ -74,8 +74,8 @@ PlaylistEditor::PlaylistEditor( QWidget* pParent )
 
 	const auto pPref = H2Core::Preferences::get_instance();
 	
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-				getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+				getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	setFont( font );
 	m_pPlaylistTable->setFont( font );
 	for ( int ii = 0; ii < m_pPlaylistTable->horizontalHeader()->count(); ii++ ) {
@@ -185,7 +185,8 @@ void PlaylistEditor::populateMenuBar() {
 	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 	const auto pPref = H2Core::Preferences::get_instance();
 	const auto pShortcuts = pPref->getShortcuts();
-	const QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	const QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+					 getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	
 	// menubar
 	m_pMenubar->clear();
@@ -1096,7 +1097,7 @@ void PlaylistEditor::update() {
 
 void PlaylistEditor::updateIcons() {
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 	} else {
@@ -1110,10 +1111,10 @@ void PlaylistEditor::updateIcons() {
 }
 
 void PlaylistEditor::updateStyleSheet() {
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme =
+		H2Core::Preferences::get_instance()->getColorTheme();
 
-	const QColor colorBackground = colorTheme.m_baseColor;
+	const QColor colorBackground = pColorTheme->m_baseColor;
 
 	QColor colorBackgroundChecked, colorBackgroundHovered;
 	if ( Skin::moreBlackThanWhite( colorBackground ) ) {
@@ -1184,8 +1185,8 @@ void PlaylistEditor::onPreferencesChanged( const H2Core::Preferences::Changes& c
 
 	if ( changes & H2Core::Preferences::Changes::Font ) {
 		
-		QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-					getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+		QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+					getPointSize( pPref->getFontTheme()->m_fontSize ) );
 		setFont( font );
 		m_pMenubar->setFont( font );
 		m_pPlaylistMenu->setFont( font );
@@ -1419,23 +1420,23 @@ void PlaylistTableWidget::update() {
 	// Highlight cells corresponding to non-existing song files to indicate to
 	// the user that something is wrong.
 	auto colorNonExisting = [=]( QTableWidgetItem* pItem ) {
-		const auto colorTheme =
-			H2Core::Preferences::get_instance()->getTheme().m_color;
-		pItem->setBackground( QBrush( colorTheme.m_buttonRedColor ) );
-		pItem->setForeground( QBrush( colorTheme.m_buttonRedTextColor ) );
+		const auto pColorTheme =
+			H2Core::Preferences::get_instance()->getColorTheme();
+		pItem->setBackground( QBrush( pColorTheme->m_buttonRedColor ) );
+		pItem->setForeground( QBrush( pColorTheme->m_buttonRedTextColor ) );
 	};
 	auto colorDefault = [=]( QTableWidgetItem* pItem ) {
 		pItem->setBackground( QBrush( ) );
 		pItem->setForeground( QBrush( ) );
 	};
 	auto colorActive = [=]( QTableWidgetItem* pItem ) {
-		const auto colorTheme =
-			H2Core::Preferences::get_instance()->getTheme().m_color;
+		const auto pColorTheme =
+			H2Core::Preferences::get_instance()->getColorTheme();
 
 		// Highlighting of non-existing file has higher priority.
-		if ( pItem->background().color() != colorTheme.m_buttonRedColor ) {
-			pItem->setBackground( QBrush( colorTheme.m_accentColor ) );
-			pItem->setForeground( QBrush( colorTheme.m_accentTextColor ) );
+		if ( pItem->background().color() != pColorTheme->m_buttonRedColor ) {
+			pItem->setBackground( QBrush( pColorTheme->m_accentColor ) );
+			pItem->setForeground( QBrush( pColorTheme->m_accentTextColor ) );
 		}
 	};
 

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.h
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.h
@@ -168,7 +168,7 @@ private:
 	void setAudioDriverInfoPulseAudio();
 	void writeAudioDriverPreferences();
 	void writeMidiDriverPreferences();
-	void updateAppearanceTab( const H2Core::Theme& pTheme );
+	void updateAppearanceTab( std::shared_ptr<H2Core::Theme> pTheme );
 
 	void initializeShortcutsTab();
 	void updateShortcutsTab();
@@ -187,8 +187,10 @@ private:
 	std::vector<std::pair<H2Core::Shortcuts::Action,QKeySequence>> m_lastShortcutsSelected;
 
 	void setIndexedTreeItemDirty( IndexedTreeItem* pItem );
-	std::unique_ptr<QColor> getColorById( int nId, const H2Core::ColorTheme& uiStyle ) const;
-	void setColorById( int nId, const QColor& color, H2Core::ColorTheme& uiStyle );
+	std::unique_ptr<QColor> getColorById(
+		int nId, std::shared_ptr<H2Core::ColorTheme> pColorTheme ) const;
+	void setColorById( int nId, const QColor& color,
+					  std::shared_ptr<H2Core::ColorTheme> pColorTheme );
 	void updateColorTree();
 	/**
 	 * Introduce a temporal smoothing. Otherwise, moving the slider
@@ -196,8 +198,8 @@ private:
 	 * triggering a recoloring of the whole GUI.
 	 */
 	void triggerColorSliderTimer();
-	H2Core::Theme m_currentTheme;
-	H2Core::Theme m_previousTheme;
+	std::shared_ptr<H2Core::Theme> m_pCurrentTheme;
+	std::shared_ptr<H2Core::Theme> m_pPreviousTheme;
 	std::unique_ptr<QColor> m_pCurrentColor;
 	int m_nCurrentId;
 	QTimer* m_pColorSliderTimer;

--- a/src/gui/src/Selection.h
+++ b/src/gui/src/Selection.h
@@ -546,7 +546,7 @@ public:
 	//! Paint selection-related elements (ie lasso)
 	void paintSelection( QPainter *painter ) {
 		if ( m_selectionState == MouseLasso || m_selectionState == KeyboardLasso ) {
-			QPen pen( H2Core::Preferences::get_instance()->getTheme().m_color.
+			QPen pen( H2Core::Preferences::get_instance()->getColorTheme()->
 					  m_selectionHighlightColor );
 			pen.setStyle( Qt::DotLine );
 			pen.setWidth(2);

--- a/src/gui/src/Skin.cpp
+++ b/src/gui/src/Skin.cpp
@@ -58,7 +58,7 @@ void Skin::drawPlayhead( QPainter* p, int x, int y, bool bHovered ) {
 				 y + Skin::nPlayheadHeight ),
 	};
 
-	QColor playheadColor( H2Core::Preferences::get_instance()->getTheme().m_color.m_playheadColor );
+	QColor playheadColor( H2Core::Preferences::get_instance()->getColorTheme()->m_playheadColor );
 	if ( bHovered ) {
 		playheadColor = Skin::makeTextColorInactive( playheadColor );
 	}
@@ -71,9 +71,7 @@ void Skin::drawPlayhead( QPainter* p, int x, int y, bool bHovered ) {
 
 void Skin::drawStackedIndicator( QPainter* p, int x, int y,
 								 const Skin::Stacked& stacked ) {
-
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	const QPointF points[3] = {
 		QPointF( x, y ),
@@ -92,13 +90,13 @@ void Skin::drawStackedIndicator( QPainter* p, int x, int y,
 		fillColor.setAlpha( 0 );
 		break;
 	case Skin::Stacked::OffNext:
-		fillColor = colorTheme.m_songEditor_stackedModeOffNextColor;
+		fillColor = pColorTheme->m_songEditor_stackedModeOffNextColor;
 		break;
 	case Skin::Stacked::On:
-		fillColor = colorTheme.m_songEditor_stackedModeOnColor;
+		fillColor = pColorTheme->m_songEditor_stackedModeOnColor;
 		break;
 	case Skin::Stacked::OnNext:
-		fillColor = colorTheme.m_songEditor_stackedModeOnNextColor;
+		fillColor = pColorTheme->m_songEditor_stackedModeOnNextColor;
 		break;
 	}
 
@@ -110,31 +108,30 @@ void Skin::drawStackedIndicator( QPainter* p, int x, int y,
 }
 
 QString Skin::getGlobalStyleSheet() {
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	const int nFactorGradient = 120;
 	const int nHover = 10;
 	
 	const QColor buttonBackgroundLight =
-		colorTheme.m_widgetColor.lighter( nFactorGradient );
+		pColorTheme->m_widgetColor.lighter( nFactorGradient );
 	const QColor buttonBackgroundDark =
-		colorTheme.m_widgetColor.darker( nFactorGradient );
+		pColorTheme->m_widgetColor.darker( nFactorGradient );
 	const QColor buttonBackgroundLightHover =
-		colorTheme.m_widgetColor.lighter( nFactorGradient + nHover );
+		pColorTheme->m_widgetColor.lighter( nFactorGradient + nHover );
 	const QColor buttonBackgroundDarkHover =
-		colorTheme.m_widgetColor.darker( nFactorGradient + nHover );
+		pColorTheme->m_widgetColor.darker( nFactorGradient + nHover );
 
 	const QColor buttonBackgroundCheckedLight =
-		colorTheme.m_accentColor.lighter( nFactorGradient );
+		pColorTheme->m_accentColor.lighter( nFactorGradient );
 	const QColor buttonBackgroundCheckedDark =
-		colorTheme.m_accentColor.darker( nFactorGradient );
+		pColorTheme->m_accentColor.darker( nFactorGradient );
 	const QColor buttonBackgroundCheckedLightHover =
-		colorTheme.m_accentColor.lighter( nFactorGradient + nHover );
+		pColorTheme->m_accentColor.lighter( nFactorGradient + nHover );
 	const QColor buttonBackgroundCheckedDarkHover =
-		colorTheme.m_accentColor.darker( nFactorGradient + nHover );
-	const QColor buttonTextChecked = colorTheme.m_accentTextColor;
-	const QColor spinBoxSelection = colorTheme.m_spinBoxColor.darker( 120 );
+		pColorTheme->m_accentColor.darker( nFactorGradient + nHover );
+	const QColor buttonTextChecked = pColorTheme->m_accentTextColor;
+	const QColor spinBoxSelection = pColorTheme->m_spinBoxColor.darker( 120 );
 	
 	return QString( "\
 QToolTip { \
@@ -182,8 +179,8 @@ QDoubleSpinBox, QSpinBox { \
     selection-background-color: %16; \
 }"
 					)
-		.arg( colorTheme.m_toolTipTextColor.name() )
-		.arg( colorTheme.m_toolTipBaseColor.name() )
+		.arg( pColorTheme->m_toolTipTextColor.name() )
+		.arg( pColorTheme->m_toolTipBaseColor.name() )
 		.arg( buttonTextChecked.name() )
 		.arg( buttonBackgroundLight.name() ).arg( buttonBackgroundDark.name() )
 		.arg( buttonBackgroundLightHover.name() )
@@ -192,10 +189,10 @@ QDoubleSpinBox, QSpinBox { \
 		.arg( buttonBackgroundCheckedDark.name() )
 		.arg( buttonBackgroundCheckedLightHover.name() )
 		.arg( buttonBackgroundCheckedDarkHover.name() )
-		.arg( colorTheme.m_widgetTextColor.name() )
-		.arg( colorTheme.m_widgetColor.name() )
-		.arg( colorTheme.m_spinBoxTextColor.name() )
-		.arg( colorTheme.m_spinBoxColor.name() )
+		.arg( pColorTheme->m_widgetTextColor.name() )
+		.arg( pColorTheme->m_widgetColor.name() )
+		.arg( pColorTheme->m_spinBoxTextColor.name() )
+		.arg( pColorTheme->m_spinBoxColor.name() )
 		.arg( spinBoxSelection.name() );
 }
 
@@ -242,28 +239,27 @@ bool Skin::moreBlackThanWhite( const QColor& color ) {
 }
 
 void Skin::setPalette( QApplication *pQApp ) {
-	const auto colorTheme =
-		H2Core::Preferences::get_instance()->getTheme().m_color;
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	// create the default palette
 	QPalette defaultPalette;
 
-	defaultPalette.setColor( QPalette::Window, colorTheme.m_windowColor );
-	defaultPalette.setColor( QPalette::WindowText, colorTheme.m_windowTextColor );
-	defaultPalette.setColor( QPalette::Base, colorTheme.m_baseColor );
-	defaultPalette.setColor( QPalette::AlternateBase, colorTheme.m_alternateBaseColor );
-	defaultPalette.setColor( QPalette::Text, colorTheme.m_textColor );
-	defaultPalette.setColor( QPalette::Button, colorTheme.m_buttonColor );
-	defaultPalette.setColor( QPalette::ButtonText, colorTheme.m_buttonTextColor );
-	defaultPalette.setColor( QPalette::Light, colorTheme.m_lightColor );
-	defaultPalette.setColor( QPalette::Midlight, colorTheme.m_midLightColor );
-	defaultPalette.setColor( QPalette::Dark, colorTheme.m_darkColor );
-	defaultPalette.setColor( QPalette::Mid, colorTheme.m_midColor );
-	defaultPalette.setColor( QPalette::Shadow, colorTheme.m_shadowTextColor );
-	defaultPalette.setColor( QPalette::Highlight, colorTheme.m_highlightColor );
-	defaultPalette.setColor( QPalette::HighlightedText, colorTheme.m_highlightedTextColor );
-	defaultPalette.setColor( QPalette::ToolTipBase, colorTheme.m_toolTipBaseColor );
-	defaultPalette.setColor( QPalette::ToolTipText, colorTheme.m_toolTipTextColor );
+	defaultPalette.setColor( QPalette::Window, pColorTheme->m_windowColor );
+	defaultPalette.setColor( QPalette::WindowText, pColorTheme->m_windowTextColor );
+	defaultPalette.setColor( QPalette::Base, pColorTheme->m_baseColor );
+	defaultPalette.setColor( QPalette::AlternateBase, pColorTheme->m_alternateBaseColor );
+	defaultPalette.setColor( QPalette::Text, pColorTheme->m_textColor );
+	defaultPalette.setColor( QPalette::Button, pColorTheme->m_buttonColor );
+	defaultPalette.setColor( QPalette::ButtonText, pColorTheme->m_buttonTextColor );
+	defaultPalette.setColor( QPalette::Light, pColorTheme->m_lightColor );
+	defaultPalette.setColor( QPalette::Midlight, pColorTheme->m_midLightColor );
+	defaultPalette.setColor( QPalette::Dark, pColorTheme->m_darkColor );
+	defaultPalette.setColor( QPalette::Mid, pColorTheme->m_midColor );
+	defaultPalette.setColor( QPalette::Shadow, pColorTheme->m_shadowTextColor );
+	defaultPalette.setColor( QPalette::Highlight, pColorTheme->m_highlightColor );
+	defaultPalette.setColor( QPalette::HighlightedText, pColorTheme->m_highlightedTextColor );
+	defaultPalette.setColor( QPalette::ToolTipBase, pColorTheme->m_toolTipBaseColor );
+	defaultPalette.setColor( QPalette::ToolTipText, pColorTheme->m_toolTipTextColor );
 
 	// Desaturate disabled widgets by blending with the alternate colour
 	for ( QPalette::ColorRole role : { QPalette::Window, QPalette::Base, QPalette::AlternateBase, QPalette::Dark,
@@ -282,7 +278,7 @@ void Skin::setPalette( QApplication *pQApp ) {
 
 void Skin::setPlayheadPen( QPainter* p, bool bHovered ) {
 
-	QColor playheadColor( H2Core::Preferences::get_instance()->getTheme().m_color.m_playheadColor );
+	QColor playheadColor( H2Core::Preferences::get_instance()->getColorTheme()->m_playheadColor );
 	if ( bHovered ) {
 		playheadColor = Skin::makeTextColorInactive( playheadColor );
 	}

--- a/src/gui/src/SongEditor/SongEditor.cpp
+++ b/src/gui/src/SongEditor/SongEditor.cpp
@@ -1006,7 +1006,7 @@ void SongEditor::paintEvent( QPaintEvent *ev ) {
 	// Draw cursor
 	if ( ! HydrogenApp::get_instance()->hideKeyboardCursor() &&
 		 m_pSongEditorPanel->hasSongEditorFocus() ) {
-		QPen cursorPen( pPref->getTheme().m_color.m_cursorColor );
+		QPen cursorPen( pPref->getColorTheme()->m_cursorColor );
 		cursorPen.setWidth( 2 );
 		painter.setRenderHint( QPainter::Antialiasing );
 		painter.setPen( cursorPen );
@@ -1027,7 +1027,7 @@ void SongEditor::drawFocus( QPainter& painter ) {
 		return;
 	}
 	
-	QColor color = H2Core::Preferences::get_instance()->getTheme().m_color.m_highlightColor;
+	QColor color = H2Core::Preferences::get_instance()->getColorTheme()->m_highlightColor;
 
 	// If the mouse is placed on the widget but the user hasn't
 	// clicked it yet, the highlight will be done more transparent to
@@ -1059,6 +1059,7 @@ void SongEditor::scrolled( int nValue ) {
 
 void SongEditor::createBackground() {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	if ( pSong == nullptr ) {
@@ -1071,7 +1072,7 @@ void SongEditor::createBackground() {
 
 	updatePixmapSize();
 
-	m_pBackgroundPixmap->fill( pPref->getTheme().m_color.m_songEditor_backgroundColor );
+	m_pBackgroundPixmap->fill( pColorTheme->m_songEditor_backgroundColor );
 
 	QPainter p( m_pBackgroundPixmap );
 	
@@ -1085,14 +1086,14 @@ void SongEditor::createBackground() {
 		
 		if ( ii == nSelectedPatternNumber ) {
 			p.fillRect( 0, y, nMaxPatternSequence * m_nGridWidth, m_nGridHeight,
-						pPref->getTheme().m_color.m_songEditor_selectedRowColor );
+						pColorTheme->m_songEditor_selectedRowColor );
 		} else {
 			p.fillRect( 0, y, nMaxPatternSequence * m_nGridWidth, m_nGridHeight,
-						pPref->getTheme().m_color.m_songEditor_alternateRowColor );
+						pColorTheme->m_songEditor_alternateRowColor );
 		}
 	}
 
-	p.setPen( QPen( pPref->getTheme().m_color.m_songEditor_lineColor, 1,
+	p.setPen( QPen( pColorTheme->m_songEditor_lineColor, 1,
 					Qt::DotLine ) );
 
 	// vertical lines
@@ -1304,7 +1305,7 @@ void SongEditor::drawPattern( QPainter& painter, std::shared_ptr<GridCell> pCell
 	}
 	auto pPatternList = pSong->getPatternList();
 	const auto pPref = Preferences::get_instance();
-	const auto colorTheme = pPref->getTheme().m_color;
+	const auto pColorTheme = pPref->getColorTheme();
 
 	if ( m_selection.isSelected( pCell ) ) {
 		cellStyle = static_cast<CellStyle>(cellStyle | CellStyle::Selected);
@@ -1331,7 +1332,7 @@ void SongEditor::drawPattern( QPainter& painter, std::shared_ptr<GridCell> pCell
 		 *            chosen internally.
 		 * Custom: Number of steps as well as the colors used are defined
 		 *            by the user. */
-		if ( pPref->getTheme().m_interface.m_coloringMethod ==
+		if ( pPref->getInterfaceTheme()->m_coloringMethod ==
 			 H2Core::InterfaceTheme::ColoringMethod::Automatic ) {
 			// beware of the division by zero..
 			const int nSteps = std::max( 1, pPatternList->size() );
@@ -1342,10 +1343,10 @@ void SongEditor::drawPattern( QPainter& painter, std::shared_ptr<GridCell> pCell
 		else {
 			const int nIndex = std::clamp(
 				pCell->getRow() %
-				pPref->getTheme().m_interface.m_nVisiblePatternColors,
+				pPref->getInterfaceTheme()->m_nVisiblePatternColors,
 				0, InterfaceTheme::nMaxPatternColors );
-			cellColor = pPref->getTheme()
-				.m_interface.m_patternColors[ nIndex ].toHsv();
+			cellColor = pPref->getInterfaceTheme()
+				->m_patternColors[ nIndex ].toHsv();
 		}
 
 		if ( cellStyle & CellStyle::Virtual ) {
@@ -1358,9 +1359,9 @@ void SongEditor::drawPattern( QPainter& painter, std::shared_ptr<GridCell> pCell
 		if ( cellStyle & ( CellStyle::Selected | CellStyle::Hovered ) ) {
 			QColor highlightColor;
 			if ( m_pSongEditorPanel->hasSongEditorFocus() || m_bEntered ) {
-				highlightColor = colorTheme.m_selectionHighlightColor;
+				highlightColor = pColorTheme->m_selectionHighlightColor;
 			} else {
-				highlightColor = colorTheme.m_selectionInactiveColor;
+				highlightColor = pColorTheme->m_selectionInactiveColor;
 			}
 
 			if ( cellStyle & CellStyle::Hovered ) {

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -464,11 +464,10 @@ void SongEditorPanel::updatePlayHeadPosition()
 }
 
 void SongEditorPanel::highlightPatternEditorLocked() {
-	const auto theme = Preferences::get_instance()->getTheme();
 	m_pPatternEditorLockedButton->setStyleSheet( QString( "\
 #PatternEditorLockedButton {\
     background-color: %1;\
-}" ).arg( theme.m_color.m_buttonRedColor.name() ) );
+}" ).arg( Preferences::get_instance()->getColorTheme()->m_buttonRedColor.name() ) );
 
 	m_pHighlightLockedTimer->start( 250 );
 }
@@ -481,7 +480,7 @@ void SongEditorPanel::updatePlaybackFaderPeaks()
 
 	
 	bool bShowPeaks = pPref->showInstrumentPeaks();
-	float fallOff = pPref->getTheme().m_interface.m_fMixerFalloffSpeed;
+	float fallOff = pPref->getInterfaceTheme()->m_fMixerFalloffSpeed;
 	
 	// fader
 	float fOldPeak_L = m_pPlaybackTrackFader->getPeak_L();
@@ -1118,7 +1117,7 @@ void SongEditorPanel::resizeEvent( QResizeEvent *ev )
 void SongEditorPanel::updateIcons() {
 	QColor color;
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 		color = Qt::white;
@@ -1145,7 +1144,7 @@ void SongEditorPanel::updateJacktimebaseState() {
 void SongEditorPanel::updatePatternEditorLocked() {
 	QColor color;
 	QString sIconPath( Skin::getSvgImagePath() );
-	if ( Preferences::get_instance()->getTheme().m_interface.m_iconColor ==
+	if ( Preferences::get_instance()->getInterfaceTheme()->m_iconColor ==
 		 InterfaceTheme::IconColor::White ) {
 		sIconPath.append( "/icons/white/" );
 		color = Qt::white;
@@ -1200,17 +1199,17 @@ void SongEditorPanel::updatePatternMode() {
 }
 
 void SongEditorPanel::updateStyleSheet() {
-	const auto colorTheme = Preferences::get_instance()->getTheme().m_color;
-	const QColor colorToolBar = colorTheme.m_songEditor_backgroundColor;
-	const QColor colorToolBarText = colorTheme.m_songEditor_textColor;
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
+	const QColor colorToolBar = pColorTheme->m_songEditor_backgroundColor;
+	const QColor colorToolBarText = pColorTheme->m_songEditor_textColor;
 
 	QColor backgroundInactiveColor;
 	if ( Hydrogen::get_instance()->getMode() == Song::Mode::Song ) {
-		backgroundInactiveColor = colorTheme.m_windowColor.lighter(
+		backgroundInactiveColor = pColorTheme->m_windowColor.lighter(
 		 	Skin::nEditorActiveScaling );
 	}
 	else {
-		backgroundInactiveColor = colorTheme.m_windowColor;
+		backgroundInactiveColor = pColorTheme->m_windowColor;
 	}
 
 	setStyleSheet( QString( "\
@@ -1266,9 +1265,9 @@ QToolButton:hover, QToolButton:pressed {\
 							   .arg( colorToolBarChecked.name() )
 							   .arg( colorToolBarHovered.name() ) );
 
-	m_pMutePlaybackBtn->setCheckedBackgroundColor( colorTheme.m_muteColor );
+	m_pMutePlaybackBtn->setCheckedBackgroundColor( pColorTheme->m_muteColor );
 	m_pMutePlaybackBtn->setCheckedBackgroundTextColor(
-		colorTheme.m_muteTextColor );
+		pColorTheme->m_muteTextColor );
 
 }
 

--- a/src/gui/src/SongEditor/SongEditorPatternList.cpp
+++ b/src/gui/src/SongEditor/SongEditorPatternList.cpp
@@ -279,7 +279,7 @@ void SongEditorPatternList::paintEvent( QPaintEvent *ev )
 		const auto cursorPoint = pSongEditor->gridPointToPoint(
 			pSongEditor->getCursorPosition() );
 
-		QPen cursorPen( pPref->getTheme().m_color.m_cursorColor );
+		QPen cursorPen( pPref->getColorTheme()->m_cursorColor );
 		cursorPen.setWidth( 2 );
 		painter.setPen( cursorPen );
 		painter.setBrush( Qt::NoBrush );
@@ -292,10 +292,12 @@ void SongEditorPatternList::paintEvent( QPaintEvent *ev )
 void SongEditorPatternList::createBackground()
 {
 	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 	auto pHydrogen = Hydrogen::get_instance();
 	m_bBackgroundInvalid = false;
 
-	QFont boldTextFont( pPref->getTheme().m_font.m_sLevel2FontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont boldTextFont( pPref->getFontTheme()->m_sLevel2FontFamily,
+					   getPointSize( pPref->getFontTheme()->m_fontSize ) );
 	boldTextFont.setBold( true );
 
 	//Do not redraw anything if Export is active.
@@ -329,19 +331,19 @@ void SongEditorPatternList::createBackground()
 		this->resize( SongEditorPatternList::nWidth, newHeight );
 	}
 
-	QColor backgroundColor = pPref->getTheme().m_color.m_songEditor_backgroundColor.darker( 120 );
-	QColor backgroundColorSelected = pPref->getTheme().m_color.m_songEditor_selectedRowColor.darker( 114 );
+	QColor backgroundColor = pColorTheme->m_songEditor_backgroundColor.darker( 120 );
+	QColor backgroundColorSelected = pColorTheme->m_songEditor_selectedRowColor.darker( 114 );
 	QColor backgroundColorAlternate =
-		pPref->getTheme().m_color.m_songEditor_alternateRowColor.darker( 132 );
+		pColorTheme->m_songEditor_alternateRowColor.darker( 132 );
 	QColor backgroundColorVirtual =
-		pPref->getTheme().m_color.m_songEditor_virtualRowColor;
+		pColorTheme->m_songEditor_virtualRowColor;
 
 	QPainter p( m_pBackgroundPixmap );
 
 
 	// Offset the pattern list by one pixel to align the dark shadows
 	// at the bottom of each row with the grid lines in the song editor.
-	p.fillRect( QRect( 0, 0, width(), 1 ), pPref->getTheme().m_color.m_windowColor );
+	p.fillRect( QRect( 0, 0, width(), 1 ), pColorTheme->m_windowColor );
 	
 	p.setFont( boldTextFont );
 	for ( int ii = 0; ii < nPatterns; ii++ ) {
@@ -402,10 +404,10 @@ void SongEditorPatternList::createBackground()
 	/// paint the foreground (pattern name etc.)
 	for ( int i = 0; i < nPatterns; i++ ) {
 		if ( i == nSelectedPattern ) {
-			p.setPen( pPref->getTheme().m_color.m_songEditor_selectedRowTextColor );
+			p.setPen( pColorTheme->m_songEditor_selectedRowTextColor );
 		}
 		else {
-			p.setPen( pPref->getTheme().m_color.m_songEditor_textColor );
+			p.setPen( pColorTheme->m_songEditor_textColor );
 		}
 
 		int text_y = i * m_nGridHeight;

--- a/src/gui/src/SongEditor/SongEditorPositionRuler.cpp
+++ b/src/gui/src/SongEditor/SongEditorPositionRuler.cpp
@@ -113,6 +113,9 @@ void SongEditorPositionRuler::setGridWidth( int width )
 void SongEditorPositionRuler::createBackground()
 {
 	const auto pPref = Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
+	const auto pFontTheme = pPref->getFontTheme();
+
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pSong = pHydrogen->getSong();
 	if ( pSong == nullptr ) {
@@ -121,17 +124,17 @@ void SongEditorPositionRuler::createBackground()
 	auto pTimeline = pHydrogen->getTimeline();
 	auto tagVector = pTimeline->getAllTags();
 	
-	QColor textColor( pPref->getTheme().m_color.m_songEditor_textColor );
+	QColor textColor( pColorTheme->m_songEditor_textColor );
 	QColor textColorAlpha( textColor );
 	textColorAlpha.setAlpha( 45 );
 
-	QColor backgroundColor = pPref->getTheme().m_color.m_songEditor_alternateRowColor.darker( 115 );
-	QColor backgroundInactiveColor = pPref->getTheme().m_color.m_midLightColor;
+	QColor backgroundColor = pColorTheme->m_songEditor_alternateRowColor.darker( 115 );
+	QColor backgroundInactiveColor = pColorTheme->m_midLightColor;
 	QColor backgroundColorTempoMarkers = backgroundColor.darker( 120 );
 
-	QColor colorHighlight = pPref->getTheme().m_color.m_highlightColor;
+	QColor colorHighlight = pColorTheme->m_highlightColor;
 
-	QColor lineColor = pPref->getTheme().m_color.m_songEditor_lineColor;
+	QColor lineColor = pColorTheme->m_songEditor_lineColor;
 	QColor lineColorAlpha( lineColor );
 	lineColorAlpha.setAlpha( 45 );
 		
@@ -145,7 +148,8 @@ void SongEditorPositionRuler::createBackground()
 		m_pBackgroundPixmap->setDevicePixelRatio( pixelRatio );
 	}
 
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pFontTheme->m_sApplicationFontFamily,
+			   getPointSize( pFontTheme->m_fontSize ) );
 
 	QPainter p( m_pBackgroundPixmap );
 	p.setFont( font );
@@ -187,9 +191,9 @@ void SongEditorPositionRuler::createBackground()
 	}
 	
 	// draw tags
-	p.setPen( pPref->getTheme().m_color.m_accentTextColor );
+	p.setPen( pColorTheme->m_accentTextColor );
 	
-	QFont font2( pPref->getTheme().m_font.m_sApplicationFontFamily, 5 );
+	QFont font2( pFontTheme->m_sApplicationFontFamily, 5 );
 	p.setFont( font2 );
 		
 	for ( const auto& ttag : tagVector ){
@@ -197,7 +201,7 @@ void SongEditorPositionRuler::createBackground()
 		QRect rect( x, height() / 2 - 1 - m_nTagHeight,
 					m_nGridWidth - 6, m_nTagHeight );
 
-		p.fillRect( rect, pPref->getTheme().m_color.m_highlightColor.darker( 135 ) );
+		p.fillRect( rect, pColorTheme->m_highlightColor.darker( 135 ) );
 		p.drawText( rect, Qt::AlignCenter, "T");
 	}
 	p.setFont( font );
@@ -431,7 +435,8 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 	auto pHydrogen = Hydrogen::get_instance();
 	auto pTimeline = pHydrogen->getTimeline();
 	const auto pPref = Preferences::get_instance();
-	const auto theme = pPref->getTheme();
+	const auto pColorTheme = pPref->getColorTheme();
+	const auto pFontTheme = pPref->getFontTheme();
 	auto tempoMarkerVector = pTimeline->getAllTempoMarkers();
 
 	qreal pixelRatio = devicePixelRatio();
@@ -444,20 +449,21 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		return;
 	}
 	
-	QColor textColor( theme.m_color.m_songEditor_textColor );
+	QColor textColor( pColorTheme->m_songEditor_textColor );
 	QColor textColorAlpha( textColor );
 	textColorAlpha.setAlpha( 45 );
-	QColor highlightColor = theme.m_color.m_highlightColor;
+	QColor highlightColor = pColorTheme->m_highlightColor;
 	QColor colorHovered( highlightColor );
 	colorHovered.setAlpha( 200 );
-	QColor backgroundColor = theme.m_color.m_songEditor_alternateRowColor.darker( 115 );
+	QColor backgroundColor = pColorTheme->m_songEditor_alternateRowColor.darker( 115 );
 	QColor backgroundColorTempoMarkers = backgroundColor.darker( 120 );
 
 	int nPunchInPos = pPref->getPunchInPos();
 	int nPunchOutPos = pPref->getPunchOutPos();
 
 	QPainter painter(this);
-	QFont font( theme.m_font.m_sApplicationFontFamily, getPointSize( theme.m_font.m_fontSize ) );
+	QFont font( pFontTheme->m_sApplicationFontFamily,
+			   getPointSize( pFontTheme->m_fontSize ) );
 	QRectF srcRect(
 			pixelRatio * ev->rect().x(),
 			pixelRatio * ev->rect().y(),
@@ -542,11 +548,11 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		QRect rect( x, height() / 2 - 1 - m_nTagHeight,
 					m_nGridWidth - 6, m_nTagHeight );
 	
-		QFont font2( theme.m_font.m_sApplicationFontFamily, 5 );
+		QFont font2( pFontTheme->m_sApplicationFontFamily, 5 );
 		painter.setFont( font2 );
 		
-		painter.fillRect( rect, theme.m_color.m_highlightColor );
-		painter.setPen( theme.m_color.m_highlightedTextColor );
+		painter.fillRect( rect, pColorTheme->m_highlightColor );
+		painter.setPen( pColorTheme->m_highlightedTextColor );
 		painter.drawText( rect, Qt::AlignCenter, "T");
 
 		painter.setFont( font );
@@ -643,7 +649,7 @@ void SongEditorPositionRuler::paintEvent( QPaintEvent *ev )
 		int nCursorX = columnToX(
 			pSongEditor->getCursorPosition().getColumn() ) + 2;
 
-		QColor cursorColor = theme.m_color.m_cursorColor;
+		QColor cursorColor = pColorTheme->m_cursorColor;
 
 		QPen p( cursorColor );
 		p.setWidth( 2 );
@@ -699,8 +705,8 @@ QRect SongEditorPositionRuler::calcTempoMarkerRect( std::shared_ptr<const Timeli
 		weight = QFont::Bold;
 	}
 	
-	const QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-					  getPointSize( pPref->getTheme().m_font.m_fontSize ), weight );
+	const QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+					  getPointSize( pPref->getFontTheme()->m_fontSize ), weight );
 
 	const int x = columnToX( pTempoMarker->nColumn );
 	int nWidth = QFontMetrics( font ).size(
@@ -741,14 +747,14 @@ void SongEditorPositionRuler::drawTempoMarker( std::shared_ptr<const Timeline::T
 		return;
 	}
 		
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily, getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily, getPointSize( pPref->getFontTheme()->m_fontSize ) );
 		
 	QRect rect = calcTempoMarkerRect( pTempoMarker, bEmphasize );
 
 	// Draw an additional small horizontal line at the top of the
 	// current column to better indicate the position of the tempo
 	// marker (for larger float values e.g. 130.67).
-	QColor textColor( pPref->getTheme().m_color.m_songEditor_textColor );
+	QColor textColor( pPref->getColorTheme()->m_songEditor_textColor );
 
 	if ( pTempoMarker->nColumn == 0 && pTimeline->isFirstTempoMarkerSpecial() ) {
 		textColor = textColor.darker( 150 );

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -119,7 +119,7 @@ SongPropertiesDialog::~SongPropertiesDialog() {
 
 void SongPropertiesDialog::updatePatternLicenseTable() {
 	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 	const auto pSong = H2Core::Hydrogen::get_instance()->getSong();
 
 	licensesTable->setColumnCount( 4 );
@@ -170,8 +170,8 @@ void SongPropertiesDialog::updatePatternLicenseTable() {
 			if ( ! ppPattern->getLicense().isEmpty() &&
 				 ppPattern->getLicense() != pSong->getLicense() ) {
 				QString sHighlight = QString( "color: %1; background-color: %2" )
-					.arg( theme.m_color.m_buttonRedTextColor.name() )
-					.arg( theme.m_color.m_buttonRedColor.name() );
+					.arg( pColorTheme->m_buttonRedTextColor.name() )
+					.arg( pColorTheme->m_buttonRedColor.name() );
 				pNameItem->setStyleSheet( sHighlight );
 				pVersionItem->setStyleSheet( sHighlight );
 				pAuthorItem->setStyleSheet( sHighlight );

--- a/src/gui/src/SoundLibrary/DrumkitPropertiesDialog.cpp
+++ b/src/gui/src/SoundLibrary/DrumkitPropertiesDialog.cpp
@@ -208,8 +208,8 @@ QTextEdit { \
     color: %1; \
     background-color: %2; \
 }" )
-								.arg( pPref->getTheme().m_color.m_windowTextColor.name() )
-								.arg( pPref->getTheme().m_color.m_windowColor.name() ) );
+								.arg( pPref->getColorTheme()->m_windowTextColor.name() )
+								.arg( pPref->getColorTheme()->m_windowColor.name() ) );
 										
 	}
 
@@ -299,7 +299,7 @@ void DrumkitPropertiesDialog::showEvent( QShowEvent *e )
 }
 
 void DrumkitPropertiesDialog::updateLicensesTable() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 	auto pSong = H2Core::Hydrogen::get_instance()->getSong();
 
 	if ( m_pDrumkit == nullptr ){
@@ -337,8 +337,8 @@ void DrumkitPropertiesDialog::updateLicensesTable() {
 			// In case of a license mismatch we highlight the row
 			if ( ccontent->m_license != m_pDrumkit->getLicense() ) {
 				QString sHighlight = QString( "color: %1; background-color: %2" )
-					.arg( theme.m_color.m_buttonRedTextColor.name() )
-					.arg( theme.m_color.m_buttonRedColor.name() );
+					.arg( pColorTheme->m_buttonRedTextColor.name() )
+					.arg( pColorTheme->m_buttonRedColor.name() );
 				pInstrumentItem->setStyleSheet( sHighlight );
 				pComponentItem->setStyleSheet( sHighlight );
 				pSampleItem->setStyleSheet( sHighlight );
@@ -504,13 +504,13 @@ void DrumkitPropertiesDialog::imageLicenseComboBoxChanged( int ) {
 void DrumkitPropertiesDialog::updateImage( const QString& sFilePath )
 {
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	auto colorTheme = Preferences::get_instance()->getTheme().m_color;
+	auto pColorTheme = Preferences::get_instance()->getColorTheme();
 
 	//  Styling used in case we assign text not images.
 	drumkitImageLabel->setStyleSheet(
 		QString( "QLabel { color: %1; background-color: %2;}" )
-		.arg( colorTheme.m_windowTextColor.name() )
-		.arg( colorTheme.m_windowColor.name() ) );
+		.arg( pColorTheme->m_windowTextColor.name() )
+		.arg( pColorTheme->m_windowColor.name() ) );
 	drumkitImageLabel->show();
 
 	if ( ! Filesystem::file_exists( sFilePath, false ) ) {
@@ -981,12 +981,12 @@ void DrumkitPropertiesDialog::on_saveBtn_clicked()
 }
 
 void DrumkitPropertiesDialog::highlightDuplicates() {
-	const auto theme = Preferences::get_instance()->getTheme();
+	const auto pColorTheme = Preferences::get_instance()->getColorTheme();
 	QStringList duplicates;
 
 	const QString sHighlight = QString( "color: %1; background-color: %2" )
-		.arg( theme.m_color.m_buttonRedTextColor.name() )
-		.arg( theme.m_color.m_buttonRedColor.name() );
+		.arg( pColorTheme->m_buttonRedTextColor.name() )
+		.arg( pColorTheme->m_buttonRedColor.name() );
 
 	// Compile a list of all duplicated types.
 	std::set<QString> types;

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -167,17 +167,19 @@ SoundLibraryPanel::~SoundLibraryPanel()
 void SoundLibraryPanel::updateTree()
 {
 	const auto pPref = H2Core::Preferences::get_instance();
-	const auto theme = pPref->getTheme();
+	const auto pFontTheme = pPref->getFontTheme();
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 	auto pSoundLibraryDatabase = pHydrogen->getSoundLibraryDatabase();
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
 	__sound_library_tree->clear();
 
-	QFont boldFont( theme.m_font.m_sApplicationFontFamily, getPointSize( theme.m_font.m_fontSize ) );
+	QFont boldFont( pFontTheme->m_sApplicationFontFamily,
+				   getPointSize( pFontTheme->m_fontSize ) );
 	boldFont.setBold( true );
 
-	QFont childFont( theme.m_font.m_sLevel2FontFamily, getPointSize( theme.m_font.m_fontSize ) );
+	QFont childFont( pFontTheme->m_sLevel2FontFamily,
+					getPointSize( pFontTheme->m_fontSize ) );
 	setFont( childFont );
 	
 	m_pTreeSystemDrumkitsItem = nullptr;
@@ -833,12 +835,14 @@ void SoundLibraryPanel::test_expandedItems()
 }
 
 void SoundLibraryPanel::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 	
 	if ( changes & H2Core::Preferences::Changes::Font ) {
 		
-		QFont font( theme.m_font.m_sLevel2FontFamily, getPointSize( theme.m_font.m_fontSize ) );
-		QFont boldFont( theme.m_font.m_sApplicationFontFamily, getPointSize( theme.m_font.m_fontSize ) );
+		QFont font( pFontTheme->m_sLevel2FontFamily,
+				   getPointSize( pFontTheme->m_fontSize ) );
+		QFont boldFont( pFontTheme->m_sApplicationFontFamily,
+					   getPointSize( pFontTheme->m_fontSize ) );
 		boldFont.setBold( true );
 
 		int ii, jj;

--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -213,15 +213,15 @@ void AutomationPathView::paintEvent(QPaintEvent *ev)
 
 void AutomationPathView::createBackground() {
 	
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 	updateAutomationPath();
 
 	QColor backgroundColor =
-		theme.m_color.m_songEditor_automationBackgroundColor;
+		pColorTheme->m_songEditor_automationBackgroundColor;
 	QColor automationLineColor =
-		theme.m_color.m_songEditor_automationLineColor;
-	QColor nodeColor = theme.m_color.m_songEditor_automationNodeColor;
-	QColor textColor = theme.m_color.m_songEditor_textColor;
+		pColorTheme->m_songEditor_automationLineColor;
+	QColor nodeColor = pColorTheme->m_songEditor_automationNodeColor;
+	QColor textColor = pColorTheme->m_songEditor_textColor;
 
 	// Resize pixmap if pixel ratio has changed
 	qreal pixelRatio = devicePixelRatio();
@@ -284,7 +284,7 @@ void AutomationPathView::createBackground() {
 	QPen circlePen( nodeColor );
 	circlePen.setWidth(1);
 	painter.setPen(circlePen);
-	painter.setBrush(QBrush( theme.m_color.m_windowColor ));
+	painter.setBrush(QBrush( pColorTheme->m_windowColor ));
 
 	for ( const auto& point : *_path) {
 

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -51,8 +51,8 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 	, m_bUseCustomBackgroundColors( false )
 {
 	auto pPref = H2Core::Preferences::get_instance();
-	m_checkedBackgroundColor = pPref->getTheme().m_color.m_accentColor;
-	m_checkedBackgroundTextColor = pPref->getTheme().m_color.m_accentTextColor;
+	m_checkedBackgroundColor = pPref->getColorTheme()->m_accentColor;
+	m_checkedBackgroundTextColor = pPref->getColorTheme()->m_accentTextColor;
 
 	setFocusPolicy( Qt::NoFocus );
 	setSize( size );
@@ -96,7 +96,7 @@ void Button::setIsActive( bool bIsActive ) {
 
 void Button::updateIcon() {
 	if ( H2Core::Preferences::get_instance()->
-		 getTheme().m_interface.m_iconColor ==
+		 getInterfaceTheme()->m_iconColor ==
 		 H2Core::InterfaceTheme::IconColor::White ) {
 		setIcon( QIcon( Skin::getSvgImagePath() + "/icons/white/" + m_sIcon ) );
 	}
@@ -137,7 +137,7 @@ void Button::updateStyleSheet() {
 		return;
 	}
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 	
 	const int nFactorGradient = 126;
 	const int nFactorGradientShadow = 225;
@@ -149,7 +149,7 @@ void Button::updateStyleSheet() {
 	const float y1 = 0;
 	const float y2 = 1;
 
-	const QColor baseColorBackground = theme.m_color.m_widgetColor;
+	const QColor baseColorBackground = pColorTheme->m_widgetColor;
 	const QColor backgroundLight = baseColorBackground.lighter( nFactorGradient );
 	const QColor backgroundDark = baseColorBackground.darker( nFactorGradient );
 	const QColor backgroundLightHover = baseColorBackground.lighter( nFactorGradient + nHover );
@@ -165,8 +165,8 @@ void Button::updateStyleSheet() {
 		backgroundCheckedColor = m_checkedBackgroundColor;
 		backgroundCheckedTextColor = m_checkedBackgroundTextColor;
 	} else {
-		backgroundCheckedColor = theme.m_color.m_accentColor;
-		backgroundCheckedTextColor = theme.m_color.m_accentTextColor;
+		backgroundCheckedColor = pColorTheme->m_accentColor;
+		backgroundCheckedTextColor = pColorTheme->m_accentTextColor;
 	}
 	const QColor backgroundCheckedLight =
 		backgroundCheckedColor.lighter( nFactorGradient );
@@ -185,7 +185,7 @@ void Button::updateStyleSheet() {
 	const QColor backgroundShadowCheckedDarkHover =
 		backgroundCheckedColor.darker( nFactorGradientShadow + nHover );
 
-	const QColor textColor = theme.m_color.m_widgetTextColor;
+	const QColor textColor = pColorTheme->m_widgetTextColor;
 	
 	const QColor backgroundInactiveLight =
 		Skin::makeWidgetColorInactive( backgroundLight );
@@ -381,10 +381,10 @@ void Button::setType( const Type& type ) {
 
 void Button::updateFont() {
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 	
 	float fScalingFactor = 1.0;
-    switch ( theme.m_font.m_fontSize ) {
+    switch ( pFontTheme->m_fontSize ) {
     case H2Core::FontTheme::FontSize::Small:
 		fScalingFactor = 1.2;
 		break;
@@ -419,7 +419,7 @@ void Button::updateFont() {
 		nPixelSize = m_nFixedFontSize;
 	}
 
-	QFont font( theme.m_font.m_sLevel3FontFamily );
+	QFont font( pFontTheme->m_sLevel3FontFamily );
 	font.setPixelSize( nPixelSize );
 
 	if ( m_size.width() > m_size.height() ) {

--- a/src/gui/src/Widgets/ClickableLabel.cpp
+++ b/src/gui/src/Widgets/ClickableLabel.cpp
@@ -42,9 +42,9 @@ ClickableLabel::ClickableLabel( QWidget *pParent, const QSize& size,
 		resize( size );
 	}
 	
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
-	updateFont( theme.m_font.m_sLevel3FontFamily, theme.m_font.m_fontSize );
+	updateFont( pFontTheme->m_sLevel3FontFamily, pFontTheme->m_fontSize );
 	updateStyleSheet();
 
 	setAlignment( Qt::AlignCenter );
@@ -56,13 +56,13 @@ ClickableLabel::ClickableLabel( QWidget *pParent, const QSize& size,
 
 void ClickableLabel::updateStyleSheet() {
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QColor text;
 	if ( m_color == Color::Bright ) {
-		text = theme.m_color.m_windowTextColor;
+		text = pColorTheme->m_windowTextColor;
 	} else {
-		text = theme.m_color.m_widgetTextColor;
+		text = pColorTheme->m_widgetTextColor;
 	}
 
 	setStyleSheet( QString( "QLabel { color: %1; }" ).arg( text.name() ) );
@@ -91,16 +91,16 @@ void ClickableLabel::paintEvent( QPaintEvent *ev ) {
 		return;
 	}
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	if ( m_bEntered || hasFocus() ) {
 		QPainter painter(this);
 
 		QColor colorHighlightActive;
 		if ( isEnabled() ) {
-			colorHighlightActive = theme.m_color.m_highlightColor;
+			colorHighlightActive = pColorTheme->m_highlightColor;
 		} else {
-			colorHighlightActive = theme.m_color.m_lightColor;
+			colorHighlightActive = pColorTheme->m_lightColor;
 		}
 
 		// If the mouse is placed on the widget but the user hasn't
@@ -204,11 +204,11 @@ void ClickableLabel::updateFont( const QString& sFontFamily,
 }
 
 void ClickableLabel::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
 	if ( changes & ( H2Core::Preferences::Changes::Colors |
 					 H2Core::Preferences::Changes::Font ) ) {
-		updateFont( theme.m_font.m_sLevel3FontFamily, theme.m_font.m_fontSize );
+		updateFont( pFontTheme->m_sLevel3FontFamily, pFontTheme->m_fontSize );
 		updateStyleSheet();
 	}
 }
@@ -218,8 +218,8 @@ void ClickableLabel::setText( const QString& sNewText ) {
 		return;
 	}
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
-	
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
+
 	QLabel::setText( sNewText );
-	updateFont( theme.m_font.m_sLevel3FontFamily, theme.m_font.m_fontSize );
+	updateFont( pFontTheme->m_sLevel3FontFamily, pFontTheme->m_fontSize );
 }

--- a/src/gui/src/Widgets/ColorSelectionButton.cpp
+++ b/src/gui/src/Widgets/ColorSelectionButton.cpp
@@ -94,9 +94,9 @@ void ColorSelectionButton::paintEvent( QPaintEvent* ev) {
 		QColor backgroundColor( "#333" );
 		if ( m_bMouseOver ) {
 			if ( isEnabled() ) {
-				backgroundColor = H2Core::Preferences::get_instance()->getTheme().m_color.m_highlightColor;
+				backgroundColor = H2Core::Preferences::get_instance()->getColorTheme()->m_highlightColor;
 			} else {
-				backgroundColor = H2Core::Preferences::get_instance()->getTheme().m_color.m_lightColor;
+				backgroundColor = H2Core::Preferences::get_instance()->getColorTheme()->m_lightColor;
 			}
 		}
 

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -180,15 +180,15 @@ void Fader::mousePressEvent(QMouseEvent *ev)
 
 void Fader::paintEvent( QPaintEvent *ev)
 {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QPainter painter(this);
 	
 	QColor colorHighlightActive;
 	if ( m_bIsActive ) {
-		colorHighlightActive = theme.m_color.m_highlightColor;
+		colorHighlightActive = pColorTheme->m_highlightColor;
 	} else {
-		colorHighlightActive = theme.m_color.m_lightColor;
+		colorHighlightActive = pColorTheme->m_lightColor;
 	}
 	QColor colorGradientNormal( Qt::green );
 	QColor colorGradientWarning( Qt::yellow );

--- a/src/gui/src/Widgets/InfoBar.cpp
+++ b/src/gui/src/Widgets/InfoBar.cpp
@@ -51,7 +51,7 @@ void InfoBar::updateStyleSheet(){
 
 	setStyleSheet( QString( "background: %1;" ) .arg(
 					   H2Core::Preferences::get_instance()->
-					   getTheme().m_color.m_highlightColor.name() ) );
+					   getColorTheme()->m_highlightColor.name() ) );
 }
 
 void InfoBar::onPreferencesChanged( const H2Core::Preferences::Changes& changes ) {

--- a/src/gui/src/Widgets/InstrumentNameWidget.cpp
+++ b/src/gui/src/Widgets/InstrumentNameWidget.cpp
@@ -50,8 +50,8 @@ void InstrumentNameWidget::paintEvent( QPaintEvent* ev ) {
 
 	QPainter p( this );
 	
-	QFont font( pPref->getTheme().m_font.m_sApplicationFontFamily,
-				getPointSize( pPref->getTheme().m_font.m_fontSize ) );
+	QFont font( pPref->getFontTheme()->m_sApplicationFontFamily,
+				getPointSize( pPref->getFontTheme()->m_fontSize ) );
 
 	p.setPen( QColor(230, 230, 230) );
 	p.setFont( font );

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -90,10 +90,11 @@ void LCDCombo::showPopup() {
 }
 
 void LCDCombo::updateStyleSheet() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
-	QColor widgetColor = theme.m_color.m_widgetColor;
-	QColor widgetTextColor = theme.m_color.m_widgetTextColor;
+	QColor widgetColor = pColorTheme->m_widgetColor;
+	QColor widgetTextColor = pColorTheme->m_widgetTextColor;
 	QColor widgetInactiveColor = 
 		Skin::makeWidgetColorInactive( widgetColor );
 	QColor widgetTextInactiveColor =
@@ -118,8 +119,8 @@ QComboBox QAbstractItemView { \
 }")
 				   .arg( widgetTextColor.name() )
 				   .arg( widgetColor.name() )
-				   .arg( theme.m_font.m_sLevel3FontFamily )
-				   .arg( getPointSize( theme.m_font.m_fontSize ) )
+				   .arg( pFontTheme->m_sLevel3FontFamily )
+				   .arg( getPointSize( pFontTheme->m_fontSize ) )
 				   .arg( widgetTextInactiveColor.name() )
 				   .arg( widgetInactiveColor.name() ) );
 }
@@ -133,7 +134,7 @@ void LCDCombo::onPreferencesChanged( const H2Core::Preferences::Changes& changes
 }
 
 void LCDCombo::paintEvent( QPaintEvent *ev ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QComboBox::paintEvent( ev );
 
@@ -142,9 +143,9 @@ void LCDCombo::paintEvent( QPaintEvent *ev ) {
 	
 		QColor colorHighlightActive;
 		if ( m_bIsActive ) {
-			colorHighlightActive = theme.m_color.m_highlightColor;
+			colorHighlightActive = pColorTheme->m_highlightColor;
 		} else {
-			colorHighlightActive = theme.m_color.m_lightColor;
+			colorHighlightActive = pColorTheme->m_lightColor;
 		}
 
 		// If the mouse is placed on the widget but the user hasn't

--- a/src/gui/src/Widgets/LCDDisplay.cpp
+++ b/src/gui/src/Widgets/LCDDisplay.cpp
@@ -51,7 +51,7 @@ LCDDisplay::LCDDisplay( QWidget * pParent, const QSize& size, bool bFixedFont,
 	int nStepSize = 2;
 
 	m_fontPointSizes.resize( 3 );
-	switch ( H2Core::Preferences::get_instance()->getTheme().m_font.m_fontSize ) {
+	switch ( H2Core::Preferences::get_instance()->getFontTheme()->m_fontSize ) {
 	case H2Core::FontTheme::FontSize::Small:
 		m_fontPointSizes[ 0 ] = currentFont.pointSize();
 		break;
@@ -108,35 +108,35 @@ void LCDDisplay::updateFont() {
 		return;
 	}
 
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
 	int nIndex = 1;
-	if ( theme.m_font.m_fontSize == H2Core::FontTheme::FontSize::Small ) {
+	if ( pFontTheme->m_fontSize == H2Core::FontTheme::FontSize::Small ) {
 		nIndex = 0;
-	} else if ( theme.m_font.m_fontSize == H2Core::FontTheme::FontSize::Large ) {
+	} else if ( pFontTheme->m_fontSize == H2Core::FontTheme::FontSize::Large ) {
 		nIndex = 2;
 	}
 
 	QFont newFont = font();
-	newFont.setFamily( theme.m_font.m_sLevel3FontFamily );
+	newFont.setFamily( pFontTheme->m_sLevel3FontFamily );
 	newFont.setPointSize( m_fontPointSizes[ nIndex ] );
 	setFont( newFont );
 }
 
 void LCDDisplay::updateStyleSheet() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QColor textColor, textColorActive;
 	if ( m_bUseRedFont ) {
-		textColor = theme.m_color.m_buttonRedColor;
-		textColorActive = theme.m_color.m_buttonRedColor;
+		textColor = pColorTheme->m_buttonRedColor;
+		textColorActive = pColorTheme->m_buttonRedColor;
 	} else {
-		textColor = theme.m_color.m_windowTextColor;
-		textColorActive = theme.m_color.m_widgetTextColor;
+		textColor = pColorTheme->m_windowTextColor;
+		textColorActive = pColorTheme->m_widgetTextColor;
 	}
-	QColor backgroundColor = theme.m_color.m_windowColor;
+	QColor backgroundColor = pColorTheme->m_windowColor;
 
-	QColor backgroundColorActive = theme.m_color.m_widgetColor;
+	QColor backgroundColorActive = pColorTheme->m_widgetColor;
 
 	QString sStyleSheet = QString( "\
 QLineEdit:enabled { \
@@ -176,7 +176,7 @@ void LCDDisplay::onPreferencesChanged( const H2Core::Preferences::Changes& chang
 }
 
 void LCDDisplay::paintEvent( QPaintEvent *ev ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QLineEdit::paintEvent( ev );
 	updateFont();
@@ -187,9 +187,9 @@ void LCDDisplay::paintEvent( QPaintEvent *ev ) {
 
 		QColor colorHighlightActive;
 		if ( m_bIsActive ) {
-			colorHighlightActive = theme.m_color.m_highlightColor;
+			colorHighlightActive = pColorTheme->m_highlightColor;
 		} else {
-			colorHighlightActive = theme.m_color.m_lightColor;
+			colorHighlightActive = pColorTheme->m_lightColor;
 		}
 
 		// If the mouse is placed on the widget but the user hasn't

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -347,7 +347,7 @@ void LCDSpinBox::mouseReleaseEvent( QMouseEvent* ev ) {
 }
 
 void LCDSpinBox::paintEvent( QPaintEvent *ev ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QDoubleSpinBox::paintEvent( ev );
 
@@ -357,9 +357,9 @@ void LCDSpinBox::paintEvent( QPaintEvent *ev ) {
 
 		QColor colorHighlightActive;
 		if ( m_bIsActive ) {
-			colorHighlightActive = theme.m_color.m_highlightColor;
+			colorHighlightActive = pColorTheme->m_highlightColor;
 		} else {
-			colorHighlightActive = theme.m_color.m_lightColor;
+			colorHighlightActive = pColorTheme->m_lightColor;
 		}
 
 		// If the mouse is placed on the widget but the user hasn't
@@ -392,10 +392,10 @@ void LCDSpinBox::leaveEvent( QEvent* ev ) {
 }
 
 void LCDSpinBox::updateStyleSheet() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
-	QColor spinBoxColor = theme.m_color.m_spinBoxColor;
-	QColor spinBoxTextColor = theme.m_color.m_spinBoxTextColor;
+	QColor spinBoxColor = pColorTheme->m_spinBoxColor;
+	QColor spinBoxTextColor = pColorTheme->m_spinBoxTextColor;
 	QColor selectionColor = spinBoxColor.darker( 120 );
 
 	QColor spinBoxInactiveColor =

--- a/src/gui/src/Widgets/LCDTextEdit.cpp
+++ b/src/gui/src/Widgets/LCDTextEdit.cpp
@@ -45,7 +45,7 @@ LCDTextEdit::LCDTextEdit( QWidget* pParent, bool bIsActive )
 	int nStepSize = 2;
 
 	m_fontPointSizes.resize( 3 );
-	switch ( H2Core::Preferences::get_instance()->getTheme().m_font.m_fontSize ) {
+	switch ( H2Core::Preferences::get_instance()->getFontTheme()->m_fontSize ) {
 	case H2Core::FontTheme::FontSize::Small:
 		m_fontPointSizes[ 0 ] = currentFont.pointSize();
 		break;
@@ -86,28 +86,28 @@ void LCDTextEdit::setIsActive( bool bIsActive ) {
 }
 
 void LCDTextEdit::updateFont() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
 
 	int nIndex = 1;
-	if ( theme.m_font.m_fontSize == H2Core::FontTheme::FontSize::Small ) {
+	if ( pFontTheme->m_fontSize == H2Core::FontTheme::FontSize::Small ) {
 		nIndex = 0;
-	} else if ( theme.m_font.m_fontSize == H2Core::FontTheme::FontSize::Large ) {
+	} else if ( pFontTheme->m_fontSize == H2Core::FontTheme::FontSize::Large ) {
 		nIndex = 2;
 	}
 
-	setFontFamily( theme.m_font.m_sLevel3FontFamily );
+	setFontFamily( pFontTheme->m_sLevel3FontFamily );
 	setFontPointSize( m_fontPointSizes[ nIndex ] );
 	setPlainText( toPlainText() );
 }
 
 void LCDTextEdit::updateStyleSheet() {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
-	QColor textColor = theme.m_color.m_windowTextColor;
-	QColor textColorActive = theme.m_color.m_widgetTextColor;
+	QColor textColor = pColorTheme->m_windowTextColor;
+	QColor textColorActive = pColorTheme->m_widgetTextColor;
 
-	QColor backgroundColor = theme.m_color.m_windowColor;
-	QColor backgroundColorActive = theme.m_color.m_widgetColor;
+	QColor backgroundColor = pColorTheme->m_windowColor;
+	QColor backgroundColorActive = pColorTheme->m_widgetColor;
 
 	QString sStyleSheet = QString( "\
 QTextEdit:enabled { \
@@ -135,7 +135,7 @@ void LCDTextEdit::onPreferencesChanged( const H2Core::Preferences::Changes& chan
 }
 
 void LCDTextEdit::paintEvent( QPaintEvent *ev ) {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pColorTheme = H2Core::Preferences::get_instance()->getColorTheme();
 
 	QTextEdit::paintEvent( ev );
 
@@ -145,9 +145,9 @@ void LCDTextEdit::paintEvent( QPaintEvent *ev ) {
 
 		QColor colorHighlightActive;
 		if ( m_bIsActive ) {
-			colorHighlightActive = theme.m_color.m_highlightColor;
+			colorHighlightActive = pColorTheme->m_highlightColor;
 		} else {
-			colorHighlightActive = theme.m_color.m_lightColor;
+			colorHighlightActive = pColorTheme->m_lightColor;
 		}
 
 		// If the mouse is placed on the widget but the user hasn't

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -93,7 +93,8 @@ Rotary::~ Rotary() {
 
 void Rotary::paintEvent( QPaintEvent* ev )
 {
-	const auto theme = H2Core::Preferences::get_instance()->getTheme();
+	const auto pPref = H2Core::Preferences::get_instance();
+	const auto pColorTheme = pPref->getColorTheme();
 
 	ev->accept();
 	QPainter painter( this );
@@ -105,12 +106,12 @@ void Rotary::paintEvent( QPaintEvent* ev )
 	QColor colorArcCenterSet;
 	QColor colorArcCenterUnset;
 	if ( m_bIsActive ) {
-		colorHighlightActive = theme.m_color.m_highlightColor;
+		colorHighlightActive = pColorTheme->m_highlightColor;
 		colorArc = Qt::red;
 		colorArcCenterSet = Qt::green;
 		colorArcCenterUnset = Qt::gray;
 	} else {
-		colorHighlightActive = theme.m_color.m_lightColor;
+		colorHighlightActive = pColorTheme->m_lightColor;
 		colorArc = Qt::darkGray;
 		colorArcCenterSet = Qt::darkGray;
 		colorArcCenterUnset = Qt::lightGray;
@@ -274,7 +275,7 @@ void Rotary::paintEvent( QPaintEvent* ev )
 		QRectF leftTextRec( 2, 16, 7, 7 );
 		QRectF rightTextRec( 34, 16, 9, 7 );
 
-		QFont font( theme.m_font.m_sApplicationFontFamily );
+		QFont font( pPref->getFontTheme()->m_sApplicationFontFamily );
 		painter.setPen( QPen( colorFont, 3 ) );
 		if ( std::fmod( m_fMin, 1 ) == 0 && std::fabs( m_fMin ) < 10 ) {
 			font.setPixelSize( 7 );

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
 		/* Apply user-specified rounding policy. This is mostly to handle non-integral factors on Windows. */
 		Qt::HighDpiScaleFactorRoundingPolicy policy;
 
-		switch ( pPref->getTheme().m_interface.m_uiScalingPolicy ) {
+		switch ( pPref->getInterfaceTheme()->m_uiScalingPolicy ) {
 		case H2Core::InterfaceTheme::ScalingPolicy::Smaller:
 			policy = Qt::HighDpiScaleFactorRoundingPolicy::RoundPreferFloor;
 			break;
@@ -273,10 +273,10 @@ int main(int argc, char *argv[])
 		// Force layout
 		if ( ! parser.getUiLayout().isEmpty() ) {
 			if ( parser.getUiLayout() == "tabbed" ) {
-				pPref->getThemeWritable().m_interface.m_layout =
+				pPref->getThemeWritable()->m_pInterface->m_layout =
 					H2Core::InterfaceTheme::Layout::Tabbed;
 			} else {
-				pPref->getThemeWritable().m_interface.m_layout =
+				pPref->getThemeWritable()->m_pInterface->m_layout =
 					H2Core::InterfaceTheme::Layout::SinglePane;
 			}
 		}
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
 		// warning dialogs before they are covered by the splash screen.
 		pQApp->processEvents();
 
-		QString family = pPref->getTheme().m_font.m_sApplicationFontFamily;
+		QString family = pPref->getFontTheme()->m_sApplicationFontFamily;
 		pQApp->setFont( QFont( family, 10 ) );
 
 		QTranslator qttor( nullptr );
@@ -342,7 +342,7 @@ int main(int argc, char *argv[])
 		}
 		pQApp->installTranslator( &tor );
 
-		const QString sStyle = pPref->getTheme().m_interface.m_sQTStyle;
+		const QString sStyle = pPref->getInterfaceTheme()->m_sQTStyle;
 		if ( !sStyle.isEmpty() ) {
 			pQApp->setStyle( sStyle );
 		}

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -951,7 +951,10 @@ void XmlTest::testShippedThemes() {
 
 	const QString sTmpFile =
 		H2Core::Filesystem::tmp_file_path( "check-default-theme-XXXX.conf" );
-	const auto pDefaultTheme = std::make_shared<H2Core::Theme>();
+	const auto pDefaultTheme = std::make_shared<H2Core::Theme>(
+		std::make_shared<H2Core::ColorTheme>(),
+		std::make_shared<H2Core::InterfaceTheme>(),
+		std::make_shared<H2Core::FontTheme>() );
 	pDefaultTheme->exportTo( sTmpFile );
 
 	H2TEST_ASSERT_THEME_FILES_EQUAL( sDefaultTheme, sTmpFile );


### PR DESCRIPTION
resource handling did not went as expected and in result we had a large number of `Theme` (and the individual subsets) created during runtime. At one point I also had a bug were an ever increasing amount of themes were created - a huge memory leak. Unfortunately, I was not able to reproduce this one.

While at it I introduced dedicated getter functions in `Preferences` to retrieve individual parts of the theme and make the `loadFrom` part of the `InterfaceTheme` fall back to the values defined in the constructor