### PR TITLE
SoundLibraryPanel: fix pattern load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
   the virtual keyboard anymore.
 - Using bpm, beat counter, and tap tempo MIDI actions or OSC commands while
   timeline is activate does no longer result in countless popups.
+- Pattern loading and deleting via the Sound Library has been fixed.
 
 ## [1.2.6] - 2025-07-29
 

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.cpp
@@ -151,6 +151,7 @@ void SoundLibraryPanel::updateTree()
 	auto pSoundLibraryDatabase = pHydrogen->getSoundLibraryDatabase();
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
+	m_patternRegistry.clear();
 	__sound_library_tree->clear();
 
 	QFont boldFont( pPref->getApplicationFontFamily(), getPointSize( pPref->getFontSize() ) );
@@ -314,6 +315,7 @@ void SoundLibraryPanel::updateTree()
 						pPatternItem->setToolTip( 0, QString( "%1 [%2]" )
 												  .arg( sPatternTooltip )
 												  .arg( pInfo->getDrumkitName() ) );
+						m_patternRegistry[ pPatternItem ] = pInfo;
 					}
 				}
 			}
@@ -814,32 +816,54 @@ void SoundLibraryPanel::on_songLoadAction()
 
 
 void SoundLibraryPanel::on_patternLoadAction() {
+	if ( m_patternRegistry.find( __sound_library_tree->currentItem() ) ==
+		 m_patternRegistry.end() ) {
+		ERRORLOG( QString( "Unable to find pattern corresponding to [%1]" )
+				  .arg( __sound_library_tree->currentItem()->text( 0 ) ) );
+		return;
+	}
 
-	QString sPatternName = __sound_library_tree->currentItem()->text( 0 );
-	QString sDrumkitName = __sound_library_tree->currentItem()->toolTip ( 0 );
+	auto pInfo = m_patternRegistry.at( __sound_library_tree->currentItem() );
+	if ( pInfo == nullptr ) {
+		ERRORLOG( QString( "Invalid pattern info for [%1]" )
+				  .arg( __sound_library_tree->currentItem()->text( 0 ) ) );
+		return;
+	}
+
 	Hydrogen::get_instance()->getCoreActionController()
-		->openPattern( Filesystem::pattern_path( sDrumkitName,
-												 sPatternName ) );
+		->openPattern( pInfo->getPath() );
 }
 
 
-void SoundLibraryPanel::on_patternDeleteAction()
-{
+void SoundLibraryPanel::on_patternDeleteAction() {
+	if ( m_patternRegistry.find( __sound_library_tree->currentItem() ) ==
+		 m_patternRegistry.end() ) {
+		ERRORLOG( QString( "Unable to find pattern corresponding to [%1]" )
+				  .arg( __sound_library_tree->currentItem()->text( 0 ) ) );
+		return;
+	}
+
+	auto pInfo = m_patternRegistry.at( __sound_library_tree->currentItem() );
+	if ( pInfo == nullptr ) {
+		ERRORLOG( QString( "Invalid pattern info for [%1]" )
+				  .arg( __sound_library_tree->currentItem()->text( 0 ) ) );
+		return;
+	}
+
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
-	QString patternPath = __sound_library_tree->currentItem()->text( 1 );
 
 	if ( QMessageBox::information(
 			 this, "Hydrogen",
-			 tr( "Warning, the selected pattern will be deleted from disk.\nAre you sure?"),
+			 tr( "Warning, the selected pattern will be deleted from disk.\nAre you sure?") +
+								  QString( "\n\n%1" ).arg( pInfo->getPath() ),
 			 QMessageBox::Ok | QMessageBox::Cancel,
 			 QMessageBox::Cancel ) == QMessageBox::Cancel ) {
 		return;
 	}
 
-	QFile rmfile( patternPath );
-	bool err = rmfile.remove();
-	if ( err == false ) {
-		ERRORLOG( "Error removing the pattern" );
+	if ( Filesystem::rm( pInfo->getPath() ) ) {
+		ERRORLOG( QString( "Error removing the pattern [%1]" )
+				.arg( pInfo->getPath() ) );
 	}
 
 	H2Core::Hydrogen::get_instance()->getSoundLibraryDatabase()->updatePatterns();

--- a/src/gui/src/SoundLibrary/SoundLibraryPanel.h
+++ b/src/gui/src/SoundLibrary/SoundLibraryPanel.h
@@ -23,6 +23,7 @@
 #ifndef SOUND_LIBRARY_PANEL_H
 #define SOUND_LIBRARY_PANEL_H
 
+#include <map>
 
 #include <QtGui>
 #include <QtWidgets>
@@ -32,6 +33,10 @@
 
 #include "../Widgets/WidgetWithScalableFont.h"
 #include "../EventListener.h"
+
+namespace H2Core {
+	class SoundLibraryInfo;
+}
 
 class SoundLibraryTree;
 class ToggleButton;
@@ -113,9 +118,15 @@ private:
 	 * Used to ensure uniqueness.*/
 	QStringList m_drumkitLabels;
 
-	/** Whether the dialog was constructed via a click in the MainForm
-	 * or as part of the GUI.
-	 */
+	/** Starting with version 2.0 of Hydrogen patterns are not associated with a
+     * specific drumkit anymore and will no longer reside in folders with the
+     * user pattern dir which resemble the drumkit's name. To account for this,
+     * we map each entry of the pattern branch of the sound library tree to a
+     * proper info object containing the corresponding absolute path. */
+	std::map<QTreeWidgetItem*, std::shared_ptr<H2Core::SoundLibraryInfo>> m_patternRegistry;
+
+	/** Whether the dialog was constructed via a click in the MainForm or as
+	 * part of the GUI. */
 	bool m_bInItsOwnDialog;
 };
 


### PR DESCRIPTION
previously, patterns have been loaded by storing two values and compining them later on: the name of the pattern and the name of the drumkit the pattern was created with.

This fragile approach broke when I changed the tool tip of the pattern elements in the SL tree to be more descriptive (since the tooltip was used _as is_ as drumkit name). In addition, this approach does not allow loading arbitrary pattern - one of the main things of version 2.0.

So, in order to fix broken loading and make the 1.2.X release line capable of handling patterns created in version >= 2.0, loading and deleting patterns is now based on their actual path