### PR TITLE
SampleEditor: Show full sample path in title (#26)

### DIFF
--- a/src/gui/src/SampleEditor/SampleEditor.cpp
+++ b/src/gui/src/SampleEditor/SampleEditor.cpp
@@ -91,14 +91,14 @@ SampleEditor::SampleEditor ( QWidget* pParent,
 	m_fRatio = 1.0f;
 	__rubberband.c_settings = 4;
 
-	const QString sNewFileName = m_pSample->getFileName().section( '/', -1 );
-
 	//init Displays
 	m_pMainSampleWaveDisplay = new MainSampleWaveDisplay( mainSampleview );
 	m_pSampleAdjustView = new DetailWaveDisplay( mainSampleAdjustView );
 	m_pTargetSampleView = new TargetWaveDisplay( targetSampleView );
 
-	setWindowTitle( QString( tr( "SampleEditor " ) + sNewFileName ) );
+	setWindowTitle( QString( tr( "SampleEditor " ) + m_pSample->getFilePath() )
+	);
+
 	setModal( true );
 
 	const auto nFrames = m_pSample->getFrames();


### PR DESCRIPTION
In order to allow users to more easily tweak samples in external editors, the `SampleEditor` does now show the full path to the sample file edited. Previously, it was very hard to tell the location of the backing file without having a look in the .h2song file.

I know this is not quite the solution discussed in issue #26. But I opted for this simpler one due to a couple of reasons:

1. The ticket is 10 years old. User patterns have been changed since then and a lot do prefer to never leave their DAW nowadays. In the old days most Linux users had a zoo of applications started in combination with a session manager. This seems to be an edge case nowadays and not a common use case anymore.
2. With packaging systems, like flatpak, AppVeyor, brew, chocolatey... opening an application is not that simple anymore. It is definitely doable by using an absolute path or checking $PATH for an executable. But if it does not replicate the way the default launcher of the system, user will struggle when using it.
3. Allowing Hydrogen to launch another application will probably make a lot of users believe we support a sophisticated mechanism to update the sample whenever there are edits in the external application. Even happened to one of the beta testers in the ticket.

Fixes #26