### PR TITLE
AppVeyor: update AppImage Pipeline to Ubuntu 18.04

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -375,6 +375,8 @@ for:
       ## Opus and FLAC.
       cp /usr/local/lib/libsndfile.so.1 AppDir/usr/lib || exit 1
 
+      find /usr -name "*libportmidi*"
+      cp /usr/local/lib/libportmidi.so.2 AppDir/usr/lib || exit 1
       LD_LIBRARY_PATH=AppDir/usr/lib/x86_64-linux-gnu/:AppDir/usr/lib:$HOME/Qt/5.15.2/gcc_64/lib ./linuxdeploy-x86_64.AppImage \
         --appdir AppDir \
         --executable AppDir/usr/bin/hydrogen \


### PR DESCRIPTION
The Ubuntu 16.04 image we used for our AppImage creation seems to be no longer available as of 2025-12-21. But we had this coming for a loong time https://www.appveyor.com/updates/2024/03/08/.

We now adopt the oldest possible image - Ubuntu 18.04 - instead.

This is a very unfortunate event. With the adoption of the newer GCC version (`13.1`) within the new image, we also raise the minimal requirements to run the AppImage. But maybe most people will work with newer versions anyway. In case users request for a more ancient version, we could still build the release AppImage locally