### PR TITLE
Instrument: introduce types Id and Type

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -28,6 +28,7 @@
 #include <core/AudioEngine/TransportPosition.h>
 #include <core/Basics/AutomationPath.h>
 #include <core/Basics/Drumkit.h>
+#include <core/Basics/Instrument.h>
 #include <core/Basics/InstrumentComponent.h>
 #include <core/Basics/InstrumentLayer.h>
 #include <core/Basics/InstrumentList.h>
@@ -112,7 +113,7 @@ AudioEngine::AudioEngine()
 	// Get the path to the file of the metronome sound.
 	QString sMetronomeFileName = Filesystem::click_file_path();
 	m_pMetronomeInstrument =
-		std::make_shared<Instrument>( METRONOME_INSTR_ID, "metronome" );
+		std::make_shared<Instrument>( Instrument::MetronomeId, "metronome" );
 
 	auto pLayer =
 		std::make_shared<InstrumentLayer>( Sample::load( sMetronomeFileName ) );

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include <core/Basics/DrumkitMap.h>
+#include <core/Basics/Instrument.h>
 #include <core/Basics/InstrumentList.h>
 #include <core/CoreActionController.h>
 #include <core/License.h>
@@ -36,7 +37,6 @@
 namespace H2Core
 {
 
-class Instrument;
 class XMLDoc;
 class XMLNode;
 
@@ -313,7 +313,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 		void recalculateRubberband( float fBpm );
 
 		/** Returns all types of the contained instruments. */
-		std::set<DrumkitMap::Type> getAllTypes() const;
+		std::set<Instrument::Type> getAllTypes() const;
 
 		/** In case no instrument types are defined in the loaded drumkit, we
 		 * check whether there is a .h2map file shipped with the installation
@@ -326,7 +326,7 @@ class Drumkit : public H2Core::Object<Drumkit>
 		std::shared_ptr<DrumkitMap> toDrumkitMap() const;
 
 		/** This method tell whether an instrument of another kit (specified via
-		 * @a sType and @a nInstrumentId) will be mapped to an instrument of
+		 * @a sType and @a id) will be mapped to an instrument of
 		 * this kit.
 		 *
 		 * This is vital when switching drumkits or importing patterns. If
@@ -334,10 +334,12 @@ class Drumkit : public H2Core::Object<Drumkit>
 		 * to check whether the provided instrument is indeed a different one or
 		 * basically the same with just its type being edited. If so, the new
 		 * type will be stored in @a pNewType. */
-		std::shared_ptr<Instrument> mapInstrument( const QString& sType,
-												   int nInstrumentId,
-												   std::shared_ptr<Drumkit> pOldDrumkit = nullptr,
-												   DrumkitMap::Type* pNewType = nullptr );
+		std::shared_ptr<Instrument> mapInstrument(
+			const QString& sType,
+			Instrument::Id id,
+			std::shared_ptr<Drumkit> pOldDrumkit = nullptr,
+			Instrument::Type* pNewType = nullptr
+		);
 
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of

--- a/src/core/Basics/DrumkitMap.h
+++ b/src/core/Basics/DrumkitMap.h
@@ -23,10 +23,11 @@
 #define H2C_DRUMKIT_MAPPING_H
 
 #include <map>
-#include <vector>
 #include <memory>
 #include <set>
 #include <QString>
+
+#include <core/Basics/Instrument.h>
 #include <core/Object.h>
 
 namespace H2Core
@@ -51,8 +52,6 @@ class DrumkitMap : public H2Core::Object<DrumkitMap>
 	DrumkitMap();
 	DrumkitMap( std::shared_ptr<DrumkitMap> pOther );
 	~DrumkitMap();
-
-	typedef QString Type;
 
 	/**
 	 * Load #H2Core::DrumkitMap from an absolute path.
@@ -102,17 +101,17 @@ class DrumkitMap : public H2Core::Object<DrumkitMap>
 	 */
 	void saveTo( XMLNode& node, bool bSilent = false ) const;
 
-		/**
-		 * \param sType for which to get the corresponding id
-		 * \param pOk set to `true` in case @a sType was found.
-		 */
-		int getId( const Type& sType, bool* pOk ) const;
-	/** Get type for @a nId */
-	Type getType( int nId ) const;
+	/**
+	 * \param sType for which to get the corresponding id
+	 * \param pOk set to `true` in case @a sType was found.
+	 */
+	Instrument::Id getId( const Instrument::Type& sType, bool* pOk ) const;
+	/** Get type for @a id */
+	Instrument::Type getType( Instrument::Id id ) const;
 	/** Returns all unique types found #m_mapping */
-	std::set<Type> getAllTypes() const;
+	std::set<Instrument::Type> getAllTypes() const;
 
-	bool addMapping( int nId, const Type& sType );
+	bool addMapping( Instrument::Id id, const Instrument::Type& sType );
 
 	/** Whether there are mappings present in the map */
 	bool isEmpty() const;
@@ -124,8 +123,8 @@ class DrumkitMap : public H2Core::Object<DrumkitMap>
 	int size() const;
 
 	/** Custom iterators */
-	std::map<int, Type>::iterator begin();
-	std::map<int, Type>::iterator end();
+	std::map<Instrument::Id, Instrument::Type>::iterator begin();
+	std::map<Instrument::Id, Instrument::Type>::iterator end();
 
 	/** Formatted string version for debugging purposes.
 	 * \param sPrefix String prefix which will be added in front of
@@ -140,13 +139,13 @@ class DrumkitMap : public H2Core::Object<DrumkitMap>
 
   private:
 	/**
-	 * Map instrument IDs to instrument type strings (1:1).
+	 * Map instrument IDs to instrument Instrument::type strings (1:1).
 	 *
 	 * Instrument IDs are defined in each individual drumkit while the type
 	 * strings are arbitrary strings using which instruments of different
 	 * kits can be mapped onto each other.
 	 */
-	std::map<int, Type> m_mapping;
+	std::map<Instrument::Id, Instrument::Type> m_mapping;
 
 		/** Used to indicate changes in the underlying XSD file. */
 		static constexpr int nCurrentFormatVersion = 2;
@@ -161,10 +160,10 @@ inline bool DrumkitMap::isEmpty() const {
 inline int DrumkitMap::size() const {
 	return m_mapping.size();
 }
-inline std::map<int, DrumkitMap::Type>::iterator DrumkitMap::begin() {
+inline std::map<Instrument::Id, Instrument::Type>::iterator DrumkitMap::begin() {
 	return m_mapping.begin();
 }
-inline std::map<int, DrumkitMap::Type>::iterator DrumkitMap::end() {
+inline std::map<Instrument::Id, Instrument::Type>::iterator DrumkitMap::end() {
 	return m_mapping.end();
 }
 }; // namespace H2Core

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -27,16 +27,10 @@
 #include <memory>
 
 #include <core/Basics/Adsr.h>
-#include <core/Basics/DrumkitMap.h>
 #include <core/Basics/Event.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/License.h>
 #include <core/Object.h>
-
-#define EMPTY_INSTR_ID -1
-/** Created Instrument will be used as metronome. */
-#define METRONOME_INSTR_ID -2
-#define PLAYBACK_INSTR_ID -3
 
 namespace H2Core {
 
@@ -59,6 +53,16 @@ class Instrument : public H2Core::Object<Instrument> {
 	/** Minimum support pitch value */
 	static constexpr float fPitchMin = -24.5;
 
+	/** Strong type definition to ensure we do not mix up instrument ID and
+	 * instrument index (within the instrument list) when looking up and
+	 * handling instruments. */
+	enum class Id : int {};
+	static constexpr Id EmptyId = Id( -1 );
+	static constexpr Id MetronomeId = Id( -2 );
+	static constexpr Id PlaybackTrackId = Id( -3 );
+
+	typedef QString Type;
+
 	/**
 	 * constructor
 	 * \param id the id of this instrument
@@ -66,7 +70,7 @@ class Instrument : public H2Core::Object<Instrument> {
 	 * \param adsr attack decay sustain release instance
 	 */
 	Instrument(
-		const int id = EMPTY_INSTR_ID,
+		const Id id = Instrument::EmptyId,
 		const QString& name = "",
 		std::shared_ptr<ADSR> adsr = nullptr
 	);
@@ -154,9 +158,9 @@ class Instrument : public H2Core::Object<Instrument> {
 	const QString& getName() const;
 
 	///< set the id of the instrument
-	void setId( const int id );
+	void setId( const Id id );
 	///< get the id of the instrument
-	int getId() const;
+	Id getId() const;
 
 	/** get the ADSR of the instrument */
 	std::shared_ptr<ADSR> getAdsr() const;
@@ -336,8 +340,8 @@ class Instrument : public H2Core::Object<Instrument> {
 
 	int getLongestSampleFrames() const;
 
-	DrumkitMap::Type getType() const;
-	void setType( DrumkitMap::Type type );
+	Instrument::Type getType() const;
+	void setType( Instrument::Type type );
 
 	/** Iteration */
 	std::vector<std::shared_ptr<InstrumentComponent>>::iterator begin();
@@ -357,20 +361,19 @@ class Instrument : public H2Core::Object<Instrument> {
    private:
 	void checkForMissingSamples( Event::Trigger trigger );
 
-	/** Identifier of an instrument, which should be
-	unique. It is set by setId() and accessed via
-	getId().*/
-	int m_nId;
-	/** Name of the Instrument. It is set by setName()
-	and accessed via getName().*/
+	/** Identifier of an instrument, which should be unique. It is set by
+	 * setId() and accessed via getId().*/
+	Id m_id;
+	/** Name of the Instrument. It is set by setName() and accessed via
+	 * getName().*/
 	QString m_sName;
-	DrumkitMap::Type m_type;
+	Instrument::Type m_type;
 	/** Path of the #Drumkit this #Instrument belongs to.
 	 *
-	 * An instrument belonging to a #Drumkit uses relative paths for
-	 * its #Sample. Therefore we have to take care of mapping them to
-	 * absolute paths ourselves in case instruments of several
-	 * drumkits are mixed in one #Song.
+	 * An instrument belonging to a #Drumkit uses relative paths for * its
+	 * #Sample. Therefore we have to take care of mapping them to * absolute
+	 * paths ourselves in case instruments of several * drumkits are mixed in
+	 * one #Song.
 	 */
 	QString m_sDrumkitPath;
 	/** Name of the #Drumkit found at @a m_sDrumkitPath.
@@ -435,13 +438,13 @@ inline const QString& Instrument::getName() const
 {
 	return m_sName;
 }
-inline void Instrument::setId( const int id )
+inline void Instrument::setId( const Instrument::Id id )
 {
-	m_nId = id;
+	m_id = id;
 }
-inline int Instrument::getId() const
+inline Instrument::Id Instrument::getId() const
 {
-	return m_nId;
+	return m_id;
 }
 
 inline std::shared_ptr<ADSR> Instrument::getAdsr() const
@@ -728,12 +731,12 @@ inline void Instrument::setCurrentlyExported( bool isCurrentlyExported )
 	m_bCurrentInstrForExport = isCurrentlyExported;
 }
 
-inline DrumkitMap::Type Instrument::getType() const
+inline Instrument::Type Instrument::getType() const
 {
 	return m_type;
 }
 
-inline void Instrument::setType( DrumkitMap::Type type )
+inline void Instrument::setType( Instrument::Type type )
 {
 	m_type = type;
 }

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -22,7 +22,6 @@
 
 #include "InstrumentList.h"
 
-#include <core/Basics/Instrument.h>
 #include <core/Basics/InstrumentComponent.h>
 #include <core/Basics/InstrumentLayer.h>
 #include <core/Basics/Note.h>
@@ -212,11 +211,12 @@ int InstrumentList::index( std::shared_ptr<Instrument> instr ) const
 	return -1;
 }
 
-std::shared_ptr<Instrument>  InstrumentList::find( const int id ) const
+std::shared_ptr<Instrument> InstrumentList::find( const Instrument::Id id
+) const
 {
-	for( int i=0; i<m_pInstruments.size(); i++ ) {
-		if ( m_pInstruments[i]->getId()==id ) {
-			return m_pInstruments[i];
+	for ( auto& ppInstrument : m_pInstruments ) {
+		if ( ppInstrument != nullptr && ppInstrument->getId() == id ) {
+			return ppInstrument;
 		}
 	}
 	return nullptr;
@@ -329,29 +329,34 @@ void InstrumentList::setDefaultMidiOutNotes()
 	}
 }
 
-QString InstrumentList::toQString( const QString& sPrefix, bool bShort ) const {
+QString InstrumentList::toQString( const QString& sPrefix, bool bShort ) const
+{
 	QString s = Base::sPrintIndention;
 	QString sOutput;
-	if ( ! bShort ) {
+	if ( !bShort ) {
 		sOutput = QString( "%1[InstrumentList]\n" ).arg( sPrefix );
 		for ( const auto& ii : m_pInstruments ) {
 			if ( ii != nullptr ) {
-				sOutput.append( QString( "%1" ).arg( ii->toQString( sPrefix + s, bShort ) ) );
+				sOutput.append(
+					QString( "%1" ).arg( ii->toQString( sPrefix + s, bShort ) )
+				);
 			}
 		}
-	} else {
+	}
+	else {
 		sOutput = QString( "[InstrumentList] " );
 		for ( const auto& ii : m_pInstruments ) {
 			if ( ii != nullptr ) {
-				sOutput.append( QString( "(%1: %2 [%3]) " ).arg( ii->getId() )
-								.arg( ii->getName() ).arg( ii->getType() ) );
+				sOutput.append( QString( "(%1: %2 [%3]) " )
+									.arg( static_cast<int>( ii->getId() ) )
+									.arg( ii->getName() )
+									.arg( ii->getType() ) );
 			}
 		}
 	}
 
 	return sOutput;
 }
-
 
 std::vector<std::shared_ptr<Instrument>>::iterator InstrumentList::begin() {
 	return m_pInstruments.begin();

--- a/src/core/Basics/InstrumentList.h
+++ b/src/core/Basics/InstrumentList.h
@@ -23,8 +23,10 @@
 #ifndef H2C_INSTRUMENT_LIST_H
 #define H2C_INSTRUMENT_LIST_H
 
-#include <vector>
 #include <memory>
+#include <vector>
+
+#include <core/Basics/Instrument.h>
 #include <core/License.h>
 #include <core/Object.h>
 
@@ -32,7 +34,6 @@ namespace H2Core
 {
 
 class XMLNode;
-class Instrument;
 
 /**
  * InstrumentList is a collection of instruments used within a song, a drumkit, ...
@@ -108,7 +109,7 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 		 */
 		bool isValidIndex( int idx ) const;
 		/**
-		 * get an instrument from  the list
+		 * get an instrument from the list
 		 * \param idx the index to get the instrument from
 		 */
 		std::shared_ptr<Instrument> get( int idx ) const;
@@ -129,7 +130,7 @@ class InstrumentList : public H2Core::Object<InstrumentList>
 		 * \param i the id of the instrument to find
 		 * \return 0 if not found
 		 */
-		std::shared_ptr<Instrument> find( const int i ) const;
+		std::shared_ptr<Instrument> find( const Instrument::Id id ) const;
 		/**
 		 * find an instrument within the instruments
 		 * \param name the name of the instrument to find

--- a/src/core/Basics/Note.cpp
+++ b/src/core/Basics/Note.cpp
@@ -77,7 +77,7 @@ QString SelectedLayerInfo::toQString( const QString& sPrefix, bool bShort ) cons
 
 Note::Note( std::shared_ptr<Instrument> pInstrument, int nPosition,
 			float fVelocity, float fPan, int nLength, float fPitch )
-	: m_nInstrumentId( EMPTY_INSTR_ID ),
+	: m_instrumentId( Instrument::EmptyId ),
 	  m_sType( "" ),
 	  m_nPosition( nPosition ),
 	  m_fVelocity( fVelocity ),
@@ -101,7 +101,7 @@ Note::Note( std::shared_ptr<Instrument> pInstrument, int nPosition,
 {
 	if ( pInstrument != nullptr ) {
 		m_pAdsr = pInstrument->copyAdsr();
-		m_nInstrumentId = pInstrument->getId();
+		m_instrumentId = pInstrument->getId();
 		m_sType = pInstrument->getType();
 	}
 
@@ -109,7 +109,7 @@ Note::Note( std::shared_ptr<Instrument> pInstrument, int nPosition,
 }
 
 Note::Note( std::shared_ptr<Note> pOther )
-	: m_nInstrumentId( pOther->getInstrumentId() ),
+	: m_instrumentId( pOther->getInstrumentId() ),
 	  m_sType( pOther->getType() ),
 	  m_nPosition( pOther->getPosition() ),
 	  m_fVelocity( pOther->getVelocity() ),
@@ -134,7 +134,7 @@ Note::Note( std::shared_ptr<Note> pOther )
 {
 	if ( m_pInstrument != nullptr ) {
 		m_pAdsr = m_pInstrument->copyAdsr();
-		m_nInstrumentId = m_pInstrument->getId();
+		m_instrumentId = m_pInstrument->getId();
 
 		for ( const auto& [ ppOtherComponent, ppOtherSelectedLayerInfo ] :
 				  pOther->m_selectedLayerInfoMap ) {
@@ -461,7 +461,7 @@ void Note::mapToInstrument( std::shared_ptr<Instrument> pInstrument ) {
 	if ( pInstrument != nullptr ) {
 		m_pInstrument = pInstrument;
 		m_pAdsr = pInstrument->copyAdsr();
-		m_nInstrumentId = pInstrument->getId();
+		m_instrumentId = pInstrument->getId();
 	}
 	else {
 		m_pInstrument = nullptr;
@@ -538,7 +538,7 @@ void Note::saveTo( XMLNode& node ) const
 	node.write_string( "key", QString( "%1%2" )
 					   .arg( m_keyStr[m_key] ).arg( m_octave ) );
 	node.write_int( "length", m_nLength );
-	node.write_int( "instrument", m_nInstrumentId );
+	node.write_int( "instrument", static_cast<int>( m_instrumentId ) );
 	node.write_string( "type", m_sType );
 	node.write_bool( "note_off", m_bNoteOff );
 	node.write_float( "probability", m_fProbability );
@@ -577,10 +577,13 @@ std::shared_ptr<Note> Note::loadFrom( const XMLNode& node, bool bSilent )
 	pNote->setKeyOctave( node.read_string( "key", "C0", false, false, bSilent ) );
 	pNote->setNoteOff( node.read_bool( "note_off", pNote->getNoteOff(), false,
 									  false, bSilent ) );
-	pNote->setInstrumentId( node.read_int( "instrument", pNote->getInstrumentId(),
-										  false, false, bSilent ) );
-	pNote->setType( node.read_string( "type", pNote->getType(), true, true,
-									 bSilent ) );
+	pNote->setInstrumentId( static_cast<Instrument::Id>( node.read_int(
+		"instrument", static_cast<int>( pNote->getInstrumentId() ), false,
+		false, bSilent
+	) ) );
+	pNote->setType(
+		node.read_string( "type", pNote->getType(), true, true, bSilent )
+	);
 	pNote->setProbability( node.read_float( "probability", pNote->getProbability(),
 										   false, false, bSilent ));
 
@@ -606,7 +609,7 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 	if ( ! bShort ) {
 		sOutput = QString( "%1[Note]\n" ).arg( sPrefix )
 			.append( QString( "%1%2m_nInstrumentId: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_nInstrumentId ) )
+					 .arg( static_cast<int>(m_instrumentId) ) )
 			.append( QString( "%1%2m_sType: %3\n" ).arg( sPrefix ).arg( s )
 					 .arg( m_sType ) )
 			.append( QString( "%1%2m_nPosition: %3\n" ).arg( sPrefix ).arg( s )
@@ -674,7 +677,7 @@ QString Note::toQString( const QString& sPrefix, bool bShort ) const {
 	else {
 
 		sOutput = QString( "[Note]" )
-			.append( QString( ", m_nInstrumentId: %1" ).arg( m_nInstrumentId ) )
+			.append( QString( ", m_instrumentId: %1" ).arg( static_cast<int>(m_instrumentId) ) )
 			.append( QString( ", m_sType: %1" ).arg( m_sType ) )
 			.append( QString( ", m_nPosition: %1" ).arg( m_nPosition ) )
 			.append( QString( ", m_fVelocity: %1" ).arg( m_fVelocity ) )

--- a/src/core/Basics/Note.h
+++ b/src/core/Basics/Note.h
@@ -162,15 +162,15 @@ class Note : public H2Core::Object<Note>
 		/** #m_pInstrument accessor */
 		std::shared_ptr<Instrument> getInstrument() const;
 		/**
-		 * #m_nInstrumentId setter
+		 * #m_instrumentId setter
 		 * \param value the new value
 		 */
-		void setInstrumentId( int value );
-		/** #m_nInstrumentId accessor */
-		int getInstrumentId() const;
+		void setInstrumentId( Instrument::Id id );
+		/** #m_instrumentId accessor */
+		Instrument::Id getInstrumentId() const;
 
-		void setType( DrumkitMap::Type sType );
-		DrumkitMap::Type getType() const;
+		void setType( Instrument::Type sType );
+		Instrument::Type getType() const;
 
 		/**
 		 * #m_nPosition setter
@@ -309,12 +309,12 @@ class Note : public H2Core::Object<Note>
 		/** @returns true if instrument id and type as well as key and octave
 		 * matches with internal
 		 *
-		 * \param nInstrumentId the instrument ID to match with #m_nInstrumentId
-		 * \param sInstrumentType the instrument type to match with #m_sType
+		 * \param id the instrument ID to match with #m_instrumentId
+		 * \param sType the instrument type to match with #m_sType
 		 * \param key the key to match with #m_key
 		 * \param octave the octave to match with #m_octave
 		 */
-		bool match( int nInstrumentId, const QString& sType, Key key,
+		bool match( Instrument::Id id, const Instrument::Type& sType, Key key,
 					Octave octave ) const;
 
 		/** Return true if two notes match in instrument, key and octave. */
@@ -448,14 +448,14 @@ class Note : public H2Core::Object<Note>
 		 * Note that this number being set does not mean that the note is
 		 * actually associated with an instrument of the (current) drumkit. The
 		 * pointer #m_pInstrument will tell instead. */
-        int				m_nInstrumentId;
+        Instrument::Id m_instrumentId;
 		/** Drumkit-independent identifier used to relate a note/pattern to a
 		 * different kit.
 		 *
 		 * Note that this one being set does not mean that the note is actually
 		 * associated with an instrument of the (current) drumkit. The pointer
 		 * #m_pInstrument will tell instead. */
-		DrumkitMap::Type m_sType;
+		Instrument::Type m_sType;
 		int				m_nPosition;             ///< note position in
 												///ticks inside the pattern
 		float			m_fVelocity;           ///< velocity (intensity) of the note [0;1]
@@ -535,20 +535,20 @@ inline std::shared_ptr<Instrument> Note::getInstrument() const
 	return m_pInstrument;
 }
 
-inline void Note::setInstrumentId( int value )
+inline void Note::setInstrumentId( Instrument::Id id )
 {
-	m_nInstrumentId = value;
+	m_instrumentId = id;
 }
 
-inline int Note::getInstrumentId() const
+inline Instrument::Id Note::getInstrumentId() const
 {
-	return m_nInstrumentId;
+	return m_instrumentId;
 }
 
-inline void Note::setType( DrumkitMap::Type sType ) {
+inline void Note::setType( Instrument::Type sType ) {
 	m_sType = sType;
 }
-inline DrumkitMap::Type Note::getType() const {
+inline Instrument::Type Note::getType() const {
 	return m_sType;
 }
 
@@ -677,11 +677,15 @@ inline void Note::setMidiInfo( Key key, Octave octave, int msg )
 	m_nMidiMsg = msg;
 }
 
-inline bool Note::match( int nInstrumentId, const QString& sType, Key key,
-						 Octave octave ) const
+inline bool Note::match(
+	Instrument::Id id,
+	const Instrument::Type& sType,
+	Key key,
+	Octave octave
+) const
 {
-	return m_nInstrumentId == nInstrumentId && m_sType == sType &&
-		m_key == key && m_octave==octave;
+	return m_instrumentId == id && m_sType == sType && m_key == key &&
+		   m_octave == octave;
 }
 
 inline bool Note::matchPosition( const std::shared_ptr<Note> pNote ) const
@@ -689,7 +693,7 @@ inline bool Note::matchPosition( const std::shared_ptr<Note> pNote ) const
 	if ( pNote == nullptr ) {
 		return false;
 	}
-	return m_nInstrumentId == pNote->m_nInstrumentId &&
+	return m_instrumentId == pNote->m_instrumentId &&
 		m_sType == pNote->m_sType &&
 		m_nPosition == pNote->m_nPosition &&
 		m_key == pNote->m_key &&
@@ -701,7 +705,7 @@ inline bool Note::match( const std::shared_ptr<Note> pNote ) const
 	if ( pNote == nullptr ) {
 		return false;
 	}
-	return m_nInstrumentId == pNote->m_nInstrumentId &&
+	return m_instrumentId == pNote->m_instrumentId &&
 		m_sType == pNote->m_sType &&
 		m_nPosition == pNote->m_nPosition &&
 		m_fVelocity == pNote->m_fVelocity &&

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -23,20 +23,21 @@
 #ifndef H2C_PATTERN_H
 #define H2C_PATTERN_H
 
-#include <set>
 #include <memory>
-#include <core/License.h>
-#include <core/Object.h>
+#include <set>
+
 #include <core/Basics/DrumkitMap.h>
+#include <core/Basics/Instrument.h>
 #include <core/Basics/Note.h>
 #include <core/Helpers/Xml.h>
+#include <core/License.h>
+#include <core/Object.h>
 
 namespace H2Core
 {
 
 class Drumkit;
 class XMLNode;
-class Instrument;
 class InstrumentList;
 class PatternList;
 
@@ -118,16 +119,20 @@ class Pattern : public H2Core::Object<Pattern>
 		 * pNote.
 		 *
 		 * @param node the XMLNode to feed
-		 * @param nInstrumentId If set to a value other than #EMPTY_INSTR_ID, it
+		 * @param id If set to a value other than #Instrument::EmptyId, it
 		 *   is used to filter serialized notes by requiring a matching id.
 		 * @param sType If set to a non-empty value, it is used to filter
 		 *   serialized notess by requiring a matching type.
 		 * @param nPitch If a valid one is provided, one those notes matching
 		 *   this particular pitch will be stored.
 		 * @param bSilent whever to log info and debug messages. */
-		void saveTo( XMLNode& node, int nInstrumentId = EMPTY_INSTR_ID,
-					 const QString& sType = "", int nPitch = PITCH_INVALID,
-					 bool bSilent = false ) const;
+		void saveTo(
+			XMLNode& node,
+			Instrument::Id id = Instrument::EmptyId,
+			const Instrument::Type& sType = "",
+			int nPitch = PITCH_INVALID,
+			bool bSilent = false
+		) const;
 
 		void setVersion( int nVersion );
 		int getVersion() const;
@@ -179,33 +184,35 @@ class Pattern : public H2Core::Object<Pattern>
 		 * to the given arguments.
 		 *
 		 * \param nPosition the key of #m_notes to search in
-		 * \param nInstrumentId the instrument ID the note should be associated
-		 *   with
-		 * \param sInstrumentType the instrument type the note should be
-		 *   associated with
+		 * \param id the instrument ID the note should be associated with
+		 * \param sType the instrument type the note should be associated with
 		 * \return notes found or an empty vector.
 		 */
-		std::vector< std::shared_ptr<Note> > findNotes(
-			int nPosition, int nInstrumentId,
-			const QString& sInstrumentType ) const;
+		std::vector<std::shared_ptr<Note>> findNotes(
+			int nPosition,
+			Instrument::Id id,
+			const Instrument::Type& sType
+		) const;
 		/**
 		 * Search for a note at a given index within #m_notes which correspond
 		 * to the given arguments. With key and octave provided, the note must
 		 * be unique within the pattern. Hence, just a single note is returned.
 		 *
 		 * \param nPosition the key of #m_notes to search in
-		 * \param nInstrumentId the instrument ID the note should be associated
-		 *   with
-		 * \param sInstrumentType the instrument type the note should be
-		 *   associated with
+		 * \param id the instrument ID the note should be associated   with
+		 * \param sType the instrument type the note should be associated with
 		 * \param key the key that should be set to the note
 		 * \param octave the octave that should be set to the note
 		 *
 		 * \return the note if found, 0 otherwise
 		 */
-		std::shared_ptr<Note> findNote( int nPosition, int nInstrumentId,
-										const QString& sInstrumentType,
-										Note::Key key, Note::Octave octave ) const;
+		std::shared_ptr<Note> findNote(
+			int nPosition,
+			Instrument::Id id,
+			const Instrument::Type& sType,
+			Note::Key key,
+			Note::Octave octave
+		) const;
 		/**
 		 * removes a given note from m_notes, it's not deleted
 		 * \param pNote the note to be removed
@@ -275,9 +282,9 @@ class Pattern : public H2Core::Object<Pattern>
 						   std::shared_ptr<Drumkit> pOldDrumkit = nullptr );
 
 		/** Aggregates all types of the contained notes. */
-		std::set<DrumkitMap::Type> getAllTypes() const;
+		std::set<Instrument::Type> getAllTypes() const;
 		std::vector<std::shared_ptr<Note>> getAllNotesOfType(
-			const DrumkitMap::Type& sType ) const;
+			const Instrument::Type& sType ) const;
 
 		/** Formatted string version for debugging purposes.
 		 * \param sPrefix String prefix which will be added in front of

--- a/src/core/Basics/PatternList.cpp
+++ b/src/core/Basics/PatternList.cpp
@@ -79,17 +79,22 @@ std::shared_ptr<PatternList> PatternList::loadFrom( const XMLNode& node,
 	return pPatternList;
 }
 
-void PatternList::saveTo( XMLNode& node, int nInstrumentId,
-						   const QString& sType, int nPitch ) const {
+void PatternList::saveTo(
+	XMLNode& node,
+	Instrument::Id id,
+	const QString& sType,
+	int nPitch
+) const
+{
 	XMLNode patternListNode = node.createNode( "patternList" );
-	
+
 	for ( const auto& pPattern : m_pPatterns ) {
 		if ( pPattern != nullptr ) {
-			pPattern->saveTo( patternListNode, nInstrumentId, sType, nPitch );
+			pPattern->saveTo( patternListNode, id, sType, nPitch );
 		}
 	}
 }
-	
+
 void PatternList::add( std::shared_ptr<Pattern> pPattern, bool bAddVirtuals )
 {
 	ASSERT_AUDIO_ENGINE_LOCKED( toQString() );
@@ -359,8 +364,8 @@ QString PatternList::toQString( const QString& sPrefix, bool bShort ) const {
 	return sOutput;
 }
 
-std::set<DrumkitMap::Type> PatternList::getAllTypes() const {
-	std::set<DrumkitMap::Type> types;
+std::set<Instrument::Type> PatternList::getAllTypes() const {
+	std::set<Instrument::Type> types;
 
 	for ( const auto& ppPattern : m_pPatterns ) {
 		if ( ppPattern != nullptr ) {
@@ -372,7 +377,7 @@ std::set<DrumkitMap::Type> PatternList::getAllTypes() const {
 }
 
 std::vector<std::shared_ptr<Note>> PatternList::getAllNotesOfType(
-	const DrumkitMap::Type& sType ) const
+	const Instrument::Type& sType ) const
 {
 	std::vector<std::shared_ptr<Note>> notes;
 

--- a/src/core/Basics/PatternList.h
+++ b/src/core/Basics/PatternList.h
@@ -28,6 +28,7 @@
 
 #include <core/AudioEngine/AudioEngine.h>
 #include <core/Basics/DrumkitMap.h>
+#include <core/Basics/Instrument.h>
 #include <core/Object.h>
 
 namespace H2Core
@@ -70,34 +71,37 @@ class XMLNode;
 												  std::shared_ptr<Drumkit> pDrumkit = nullptr,
 												  bool bSilent = false );
 
-		/** Stores a serialized version of the instance to the XML note @a
-		 * pNote.
-		 *
-		 * @param pNode the XMLNode to feed
-		 * @param nInstrumentId If set to a value other than #EMPTY_INSTR_ID, it
-		 *   is used to filter serialized notes by requiring a matching id.
-		 * @param sType If set to a non-empty value, it is used to filter
-		 *   serialized notess by requiring a matching type.
-		 * @param nPitch If a valid one is provided, one those notes matching
-		 *   this particular pitch will be stored. */
-		void saveTo( XMLNode& pNode, int nInstrumentId = EMPTY_INSTR_ID,
-					  const QString& sType = "",
-					  int nPitch = PITCH_INVALID ) const;
+	/** Stores a serialized version of the instance to the XML note @a
+	 * pNote.
+	 *
+	 * @param pNode the XMLNode to feed
+	 * @param id If set to a value other than #Instrument::EmptyId, it
+	 *   is used to filter serialized notes by requiring a matching id.
+	 * @param sType If set to a non-empty value, it is used to filter
+	 *   serialized notess by requiring a matching type.
+	 * @param nPitch If a valid one is provided, one those notes matching
+	 *   this particular pitch will be stored. */
+	void saveTo(
+		XMLNode& pNode,
+		Instrument::Id id = Instrument::EmptyId,
+		const QString& sType = "",
+		int nPitch = PITCH_INVALID
+	) const;
 
-		/** returns the numbers of patterns */
-		int size() const;
+	/** returns the numbers of patterns */
+	int size() const;
 
-		/**
-		 * get a pattern from  the list
-		 * \param idx the index to get the pattern from
-		 */
-		std::shared_ptr<Pattern> operator[]( int idx ) const;
-		/**
-		 * add a pattern to the list
-		 * \param pattern a pointer to the pattern to add
-		 * \param bAddVirtuals Whether virtual patterns contained in
-		 * @a pattern should be added too.
-		 */
+	/**
+	 * get a pattern from  the list
+	 * \param idx the index to get the pattern from
+	 */
+	std::shared_ptr<Pattern> operator[]( int idx ) const;
+	/**
+	 * add a pattern to the list
+	 * \param pattern a pointer to the pattern to add
+	 * \param bAddVirtuals Whether virtual patterns contained in
+	 * @a pattern should be added too.
+	 */
 	void add( std::shared_ptr<Pattern> pPattern, bool bAddVirtuals = false );
 		/**
 		 * insert a pattern into the list
@@ -178,9 +182,9 @@ class XMLNode;
 
 		void mapToDrumkit( std::shared_ptr<Drumkit> pDrumkit,
 						   std::shared_ptr<Drumkit> pOldDrumkit = nullptr );
-		std::set<DrumkitMap::Type> getAllTypes() const;
+		std::set<Instrument::Type> getAllTypes() const;
 		std::vector<std::shared_ptr<Note>> getAllNotesOfType(
-			const DrumkitMap::Type& sType ) const;
+			const Instrument::Type& sType ) const;
 
 		friend bool operator==( const PatternList& lhs, const PatternList& rhs );
 		friend bool operator!=( const PatternList& lhs, const PatternList& rhs );

--- a/src/core/EventQueue.h
+++ b/src/core/EventQueue.h
@@ -24,6 +24,7 @@
 #define EVENT_QUEUE_H
 
 #include <core/Basics/Event.h>
+#include <core/Basics/Instrument.h>
 #include <core/Basics/Note.h>
 #include <core/Object.h>
 
@@ -114,7 +115,7 @@ public:
 
 	struct AddMidiNoteVector {
 		int m_column;       // position
-		int m_instrumentId; // specifies the instrument triggered
+		Instrument::Id m_id; // specifies the instrument triggered
 		int m_pattern;      // pattern number
 		int m_length;
 		float f_velocity;

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -369,7 +369,7 @@ bool Hydrogen::addRealtimeNote(	int		nInstrument,
       pAudioEngine->unlock();
       return false;
     }
-	const int nInstrumentId = pInstrument->getId();
+	const auto instrumentId = pInstrument->getId();
 
 	// Get current pattern and column
 	std::shared_ptr<Pattern> pCurrentPattern = nullptr;
@@ -489,7 +489,7 @@ bool Hydrogen::addRealtimeNote(	int		nInstrument,
 		else { // note on
 			EventQueue::AddMidiNoteVector noteAction;
 			noteAction.m_column = nTickInPattern;
-			noteAction.m_instrumentId = nInstrumentId;
+			noteAction.m_id = instrumentId;
 			noteAction.m_pattern = currentPatternNumber;
 			noteAction.f_velocity = fVelocity;
 			noteAction.f_pan = fPan;

--- a/src/core/IO/JackAudioDriver.cpp
+++ b/src/core/IO/JackAudioDriver.cpp
@@ -152,7 +152,8 @@ JackAudioDriver::JackAudioDriver( JackProcessCallback m_processCallback )
 	JackAudioDriver::pJackDriverInstance = this;
 	this->m_processCallback = m_processCallback;
 
-	m_pDummyPreviewInstrument = std::make_shared<Instrument>( EMPTY_INSTR_ID );
+	m_pDummyPreviewInstrument =
+		std::make_shared<Instrument>( Instrument::EmptyId );
 	m_pDummyPreviewInstrument->setName( "DummyPreviewInstrument" );
 	m_pDummyPreviewInstrument->setIsPreviewInstrument( true );
 
@@ -334,8 +335,8 @@ float* JackAudioDriver::getTrackBuffer( std::shared_ptr<Instrument> pInstrument,
 	}
 
 	InstrumentPorts ports;
-	if ( pInstrument->getId() == METRONOME_INSTR_ID ||
-		 pInstrument->getId() == PLAYBACK_INSTR_ID ) {
+	if ( pInstrument->getId() == Instrument::MetronomeId ||
+		 pInstrument->getId() == Instrument::PlaybackTrackId ) {
 		if ( m_portMapStatic.find( pInstrument ) == m_portMapStatic.end() ) {
 			ERRORLOG( QString( "No ports for instrument [%1]" )
 					  .arg( pInstrument->getName() ) );
@@ -609,7 +610,7 @@ void JackAudioDriver::makeTrackPorts( std::shared_ptr<Song> pSong,
 			}
 		}
 
-		DrumkitMap::Type sMappedName;
+		Instrument::Type sMappedName;
 		for ( const auto& [ ppInstrument, pports ] : newPorts ) {
 			m_portMap[ ppInstrument ] = pports;
 

--- a/src/core/Lilipond/Lilypond.h
+++ b/src/core/Lilipond/Lilypond.h
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 
+#include <core/Basics/Instrument.h>
 #include <core/Object.h>
 
 namespace H2Core {
@@ -64,7 +65,7 @@ private:
 	 * the list of notes at this moment. A note is represented by its instrument
 	 * and its velocity.
 	 */
-	typedef std::vector<std::vector<std::pair<int, float> > > notes_t;
+	typedef std::vector<std::vector<std::pair<Instrument::Id, float> > > notes_t;
 
 	/*
 	 * Retrieve the information in a PatternList
@@ -97,7 +98,7 @@ private:
 	 */
 	void writeVoice( QTextStream &stream,
 	                 unsigned nMeasure,
-	                 const std::vector<int> &whiteList ) const;
+	                 const std::vector<Instrument::Id> &whiteList ) const;
 
 	std::vector<notes_t>	m_Measures;		///< Representation of the song
 	QString					m_sName;		///< Name of the song

--- a/src/core/Midi/MidiInstrumentMap.h
+++ b/src/core/Midi/MidiInstrumentMap.h
@@ -27,13 +27,13 @@
 #include <map>
 #include <memory>
 
+#include <core/Basics/Instrument.h>
 #include <core/Midi/MidiMessage.h>
 #include <core/Object.h>
 
 namespace H2Core {
 
 class Drumkit;
-class Instrument;
 class Note;
 class XMLNode;
 
@@ -135,8 +135,9 @@ public:
 	int getGlobalOutputChannel() const;
 	void setGlobalOutputChannel( int nChannel );
 
-	const std::map<QString, NoteRef>& getCustomInputMappingsType() const;
-	const std::map<int, NoteRef>& getCustomInputMappingsId() const;
+	const std::map<Instrument::Type, NoteRef>& getCustomInputMappingsType(
+	) const;
+	const std::map<Instrument::Id, NoteRef>& getCustomInputMappingsId() const;
 
 	/** Note that the current design of MidiInstrumentMap does not feature a way to
      * delete a custom input mapping since there is no UX counterpart either.
@@ -160,10 +161,10 @@ private:
 
 	/** Instrument type-based note mapping. This one takes precedeence over the
      * id-based one. */
-	std::map<QString, NoteRef> m_customInputMappingsType;
+	std::map<Instrument::Type, NoteRef> m_customInputMappingsType;
 	/** Mapping for typeless instruments - new ones or those of custom legacy
      * kits. */
-	std::map<int, NoteRef> m_customInputMappingsId;
+	std::map<Instrument::Id, NoteRef> m_customInputMappingsId;
 
 };
 
@@ -197,12 +198,16 @@ inline void MidiInstrumentMap::setUseGlobalOutputChannel( bool bUse ){
 inline int MidiInstrumentMap::getGlobalOutputChannel() const {
 	return m_nGlobalOutputChannel;
 }
-inline const std::map<QString, MidiInstrumentMap::NoteRef>& MidiInstrumentMap::getCustomInputMappingsType() const {
+inline const std::map<Instrument::Type, MidiInstrumentMap::NoteRef>&
+MidiInstrumentMap::getCustomInputMappingsType() const
+{
 	return m_customInputMappingsType;
 }
-inline const std::map<int, MidiInstrumentMap::NoteRef>& MidiInstrumentMap::getCustomInputMappingsId() const {
+inline const std::map<Instrument::Id, MidiInstrumentMap::NoteRef>&
+MidiInstrumentMap::getCustomInputMappingsId() const
+{
 	return m_customInputMappingsId;
 }
-};
+};	// namespace H2Core
 
 #endif

--- a/src/core/Midi/SMF.cpp
+++ b/src/core/Midi/SMF.cpp
@@ -824,13 +824,13 @@ void SMF1WriterMulti::addEvent( std::shared_ptr<SMFEvent> pEvent,
 
 	if ( pEvent->m_type == SMFEvent::Type::NoteOn ||
 		 pEvent->m_type == SMFEvent::Type::NoteOff ) {
-		const int nIndex = pInstr->getId();
-		if ( m_eventLists.find( nIndex ) == m_eventLists.end() ) {
+		const auto id = pInstr->getId();
+		if ( m_eventLists.find( id ) == m_eventLists.end() ) {
 			ERRORLOG( QString( "EventList of index [%1] not found" ) );
 			return;
 		}
 
-		auto pEventList = m_eventLists[ nIndex ];
+		auto pEventList = m_eventLists[ id ];
 		if ( pEventList != nullptr ) {
 			pEventList->push_back( pEvent );
 		}
@@ -874,35 +874,45 @@ void SMF1WriterMulti::packEvents( std::shared_ptr<Song> pSong,
 	m_eventLists.clear();
 }
 
-QString SMF1WriterMulti::toQString( const QString& sPrefix, bool bShort ) const {
+QString SMF1WriterMulti::toQString( const QString& sPrefix, bool bShort ) const
+{
 	QString s = Base::sPrintIndention;
 	QString sOutput;
-	if ( ! bShort ) {
-		sOutput = QString( "%1[SMF1WriterMulti] m_eventLists: \n" ).arg( sPrefix );
-		for ( const auto& [ nnId, ppEventList ] : m_eventLists ) {
-			sOutput.append( QString( "%1%2[%3]:\n" ).arg( sPrefix )
-							.arg( s ).arg( nnId ) );
+	if ( !bShort ) {
+		sOutput =
+			QString( "%1[SMF1WriterMulti] m_eventLists: \n" ).arg( sPrefix );
+		for ( const auto& [iid, ppEventList] : m_eventLists ) {
+			sOutput.append( QString( "%1%2[%3]:\n" )
+								.arg( sPrefix )
+								.arg( s )
+								.arg( static_cast<int>( iid ) ) );
 			for ( const auto& ppEvent : *ppEventList ) {
-				sOutput.append( QString( "%1%2\n" ).arg( sPrefix + s + s )
-								.arg( ppEvent->toQString( "", true ) ) );
+				sOutput.append( QString( "%1%2\n" )
+									.arg( sPrefix + s + s )
+									.arg( ppEvent->toQString( "", true ) ) );
 			}
 		}
-		sOutput.append( QString( "%1%2m_bOmitCopyright: %3\n" ).arg( sPrefix )
-						.arg( s ).arg( m_bOmitCopyright ) );
-}
+		sOutput.append( QString( "%1%2m_bOmitCopyright: %3\n" )
+							.arg( sPrefix )
+							.arg( s )
+							.arg( m_bOmitCopyright ) );
+	}
 	else {
 		sOutput = QString( "[SMF1WriterMulti] m_eventLists: [" );
-		for ( const auto& [ nnId, ppEventList ] : m_eventLists ) {
-			sOutput.append( QString( "[[%1]: " ).arg( nnId ) );
+		for ( const auto& [iid, ppEventList] : m_eventLists ) {
+			sOutput.append( QString( "[[%1]: " ).arg( static_cast<int>( iid ) )
+			);
 			for ( const auto& ppEvent : *ppEventList ) {
-				sOutput.append( QString( "[%1] " )
-								.arg( ppEvent->toQString( s + s, true ) ) );
+				sOutput.append(
+					QString( "[%1] " ).arg( ppEvent->toQString( s + s, true ) )
+				);
 			}
 			sOutput.append( "] " );
 		}
-		sOutput.append( QString( "], m_bOmitCopyright: %1" )
-						.arg( m_bOmitCopyright ) );
-}
+		sOutput.append(
+			QString( "], m_bOmitCopyright: %1" ).arg( m_bOmitCopyright )
+		);
+	}
 
 	return sOutput;
 }

--- a/src/core/Midi/SMF.h
+++ b/src/core/Midi/SMF.h
@@ -23,6 +23,7 @@
 #ifndef SMF_H
 #define SMF_H
 
+#include <core/Basics/Instrument.h>
 #include <core/Object.h>
 
 #include <memory>
@@ -35,7 +36,6 @@
 namespace H2Core
 {
 
-class Instrument;
 class Pattern;
 class Song;
 
@@ -252,7 +252,7 @@ protected:
 private:
 	/** Contains events for each instrument in separate list using the
 	 * corresponding instrument ID as index. */
-	std::map<int, std::shared_ptr<EventList> > m_eventLists;
+	std::map<Instrument::Id, std::shared_ptr<EventList> > m_eventLists;
 };
 
 

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -56,15 +56,20 @@
 namespace H2Core
 {
 
-static std::shared_ptr<Instrument> createInstrument(int id, const QString& sFilePath, float volume )
+static std::shared_ptr<Instrument>
+createInstrument( Instrument::Id id, const QString& sFilePath, float volume )
 {
 	auto pInstrument = std::make_shared<Instrument>( id, sFilePath );
 	pInstrument->setVolume( volume );
-	auto pLayer = std::make_shared<InstrumentLayer>( Sample::load( sFilePath ) );
+	auto pLayer =
+		std::make_shared<InstrumentLayer>( Sample::load( sFilePath ) );
 	auto pComponent = pInstrument->getComponent( 0 );
 	if ( pComponent != nullptr ) {
-		pInstrument->addLayer( pComponent, pLayer, -1, Event::Trigger::Suppress );
-	} else {
+		pInstrument->addLayer(
+			pComponent, pLayer, -1, Event::Trigger::Suppress
+		);
+	}
+	else {
 		___ERRORLOG( "Invalid default component" );
 	}
 
@@ -72,29 +77,28 @@ static std::shared_ptr<Instrument> createInstrument(int id, const QString& sFile
 }
 
 Sampler::Sampler()
-		: m_pMainOut_L( nullptr )
-		, m_pMainOut_R( nullptr )
-		, m_pPreviewInstrument( nullptr )
-		, m_interpolateMode( Interpolation::InterpolateMode::Linear )
+	: m_pMainOut_L( nullptr ),
+	  m_pMainOut_R( nullptr ),
+	  m_pPreviewInstrument( nullptr ),
+	  m_interpolateMode( Interpolation::InterpolateMode::Linear )
 {
-	
-	
-	m_pMainOut_L = new float[ MAX_BUFFER_SIZE ];
-	m_pMainOut_R = new float[ MAX_BUFFER_SIZE ];
+	m_pMainOut_L = new float[MAX_BUFFER_SIZE];
+	m_pMainOut_R = new float[MAX_BUFFER_SIZE];
 
 	QString sEmptySampleFileName = Filesystem::empty_sample_path();
 
 	// instrument used in file preview
-	m_pDefaultPreviewInstrument = createInstrument(
-		EMPTY_INSTR_ID, sEmptySampleFileName, 0.8 );
+	m_pDefaultPreviewInstrument =
+		createInstrument( Instrument::EmptyId, sEmptySampleFileName, 0.8 );
 	m_pDefaultPreviewInstrument->setIsPreviewInstrument( true );
 	m_pPreviewInstrument = m_pDefaultPreviewInstrument;
 
 	// dummy instrument used for playback track
-	m_pPlaybackTrackInstrument = createInstrument( PLAYBACK_INSTR_ID, sEmptySampleFileName, 0.8 );
+	m_pPlaybackTrackInstrument = createInstrument(
+		Instrument::PlaybackTrackId, sEmptySampleFileName, 0.8
+	);
 	m_nPlayBackSamplePosition = 0;
 }
-
 
 Sampler::~Sampler()
 {
@@ -772,7 +776,7 @@ bool Sampler::renderNote( std::shared_ptr<Note> pNote, unsigned nBufferSize )
 
 		bool bIsMuted = false;
 		if ( pInstr->isPreviewInstrument() ||
-			 pInstr->getId() == METRONOME_INSTR_ID ) {
+			 pInstr->getId() == Instrument::MetronomeId ) {
 			// Metronome and preview is done for things not related to the what
 			// is happening in the song and pattern editors or drumkit. But,
 			// then again, it should still be possible to prevent all audio

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -359,8 +359,8 @@ QStringList SoundLibraryDatabase::getDrumkitFolders() const {
 	return drumkitFolders;
 }
 
-std::set<DrumkitMap::Type> SoundLibraryDatabase::getAllTypes() const {
-	std::set<DrumkitMap::Type> allTypes;
+std::set<Instrument::Type> SoundLibraryDatabase::getAllTypes() const {
+	std::set<Instrument::Type> allTypes;
 	for ( const auto& [ _, ppDrumkit ] : m_drumkitDatabase ) {
 		if ( ppDrumkit != nullptr ) {
 			allTypes.merge( ppDrumkit->getAllTypes() );

--- a/src/core/SoundLibrary/SoundLibraryDatabase.h
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.h
@@ -105,11 +105,11 @@ class SoundLibraryDatabase :    public H2Core::Object<SoundLibraryDatabase>
 
 		QStringList getDrumkitFolders() const;
 
-	/** Retrieves all #H2Core::DrumkitMap::Type found in the registered
+	/** Retrieves all #H2Core::Instrument::Type found in the registered
 	 * drumkits.
 	 *
 	 * @return The list of unique types sorted alphabetically.*/
-	 std::set<DrumkitMap::Type> getAllTypes() const;
+	 std::set<Instrument::Type> getAllTypes() const;
 	
 	void updatePatterns( bool bTriggerEvent = true );
 	void printPatterns() const;

--- a/src/gui/src/ExportSongDialog.cpp
+++ b/src/gui/src/ExportSongDialog.cpp
@@ -593,17 +593,17 @@ void ExportSongDialog::on_okBtn_clicked()
 
 }
 
-bool ExportSongDialog::instrumentHasNotes( int nInstrumentId )
+bool ExportSongDialog::instrumentHasNotes( int nInstrumentIndex )
 {
 	const auto pSong = Hydrogen::get_instance()->getSong();
 	if ( pSong == nullptr && pSong->getDrumkit() == nullptr ) {
 		return false;
 	}
 	const auto pInstrument =
-		pSong->getDrumkit()->getInstruments()->get( nInstrumentId );
+		pSong->getDrumkit()->getInstruments()->get( nInstrumentIndex );
 	if ( pInstrument == nullptr ) {
 		ERRORLOG( QString( "Could not retrieve instrument of id [%1]" )
-				  .arg( nInstrumentId ) );
+				  .arg( nInstrumentIndex ) );
 		return false;
 	}
 
@@ -612,7 +612,8 @@ bool ExportSongDialog::instrumentHasNotes( int nInstrumentId )
 	// do not have to check whether a pattern is actually played back over the
 	// course of a song.
 	for ( const auto& ppNote : pSong->getAllNotes() ) {
-		if ( ppNote != nullptr && ppNote->getInstrumentId() == nInstrumentId ) {
+		if ( ppNote != nullptr &&
+			 ppNote->getInstrumentId() == pInstrument->getId() ) {
 			return true;
 		}
 	}
@@ -636,13 +637,16 @@ QString ExportSongDialog::findUniqueExportFileNameForInstrument( std::shared_ptr
 			instrumentOccurence++;
 		}
 	}
-	
-	if(instrumentOccurence >= 2){
-		uniqueInstrumentName = pInstrument->getName() + QString("_") + QString::number( pInstrument->getId() );
-	} else {
+
+	if ( instrumentOccurence >= 2 ) {
+		uniqueInstrumentName =
+			pInstrument->getName() + QString( "_" ) +
+			QString::number( static_cast<int>( pInstrument->getId() ) );
+	}
+	else {
 		uniqueInstrumentName = pInstrument->getName();
 	}
-	
+
 	return uniqueInstrumentName;
 }
 

--- a/src/gui/src/ExportSongDialog.h
+++ b/src/gui/src/ExportSongDialog.h
@@ -71,7 +71,7 @@ private:
 	void		setResamplerMode(int index);
 	bool		checkUseOfRubberband();
 
-	bool		instrumentHasNotes( int nInstrumentId );
+	bool		instrumentHasNotes( int nInstrumentIndex );
 	QString		findUniqueExportFileNameForInstrument( std::shared_ptr<H2Core::Instrument> pInstrument );
 
 	void		exportTracks();

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -1210,8 +1210,7 @@ void HydrogenApp::onEventQueueTimer()
 		int nRow = 0;
 		DrumPatternRow row;
 		for ( const auto& rrow : m_pPatternEditorPanel->getDB() ) {
-			if ( rrow.nInstrumentID ==
-				 pQueue->m_addMidiNoteVector[0].m_instrumentId ) {
+			if ( rrow.id == pQueue->m_addMidiNoteVector[0].m_id ) {
 				row = rrow;
 				bFound = true;
 				break;
@@ -1219,17 +1218,20 @@ void HydrogenApp::onEventQueueTimer()
 			++nRow;
 		}
 
-		if ( ! bFound ) {
-			ERRORLOG( QString( "Could not find row in Pattern Editor corresponding to instrument ID [%1]" )
-					  .arg( pQueue->m_addMidiNoteVector[0].m_instrumentId ) );
+		if ( !bFound ) {
+			ERRORLOG( QString( "Could not find row in Pattern Editor "
+							   "corresponding to instrument ID [%1]" )
+						  .arg( static_cast<int>(
+							  pQueue->m_addMidiNoteVector[0].m_id
+						  ) ) );
 			return;
 		}
-		
+
 		// find if a (pitch matching) note is already present
 		const auto pOldNote = pSong->getPatternList()->
 			get( pQueue->m_addMidiNoteVector[0].m_pattern )->
 			findNote( pQueue->m_addMidiNoteVector[0].m_column,
-					  row.nInstrumentID, row.sType,
+					  row.id, row.sType,
 					  pQueue->m_addMidiNoteVector[0].nk_noteKeyVal,
 					  pQueue->m_addMidiNoteVector[0].no_octaveKeyVal );
 		
@@ -1256,7 +1258,7 @@ void HydrogenApp::onEventQueueTimer()
 		// add the new note
 		pushUndoCommand( new SE_addOrRemoveNoteAction(
 							 pQueue->m_addMidiNoteVector[0].m_column,
-							 row.nInstrumentID,
+							 row.id,
 							 row.sType,
 							 pQueue->m_addMidiNoteVector[0].m_pattern,
 							 pQueue->m_addMidiNoteVector[0].m_length,

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -1352,22 +1352,25 @@ void MainForm::action_drumkit_addInstrument(
 	// invalid ID and triggering the fallback in Drumkit::addInstrument which
 	// could end up using an ID of a note again).
 	if ( pInstrument->getType().isEmpty() &&
-		 pInstrument->getId() == EMPTY_INSTR_ID ) {
+		 pInstrument->getId() == Instrument::EmptyId ) {
 		std::set<int> presentIds;
-		for ( const auto& ppInstrument : *pSong->getDrumkit()->getInstruments() ) {
+		for ( const auto& ppInstrument :
+			  *pSong->getDrumkit()->getInstruments() ) {
 			if ( ppInstrument != nullptr ) {
-				presentIds.insert( ppInstrument->getId() );
+				presentIds.insert( static_cast<int>( ppInstrument->getId() ) );
 			}
 		}
 
 		for ( const auto& ppPattern : *pSong->getPatternList() ) {
-			for ( const auto& [ _, ppNote ] : *ppPattern->getNotes() ) {
+			for ( const auto& [_, ppNote] : *ppPattern->getNotes() ) {
 				// We only have to take those note not bearing a type into
 				// account. A type will always take precedence in mapping and
 				// even though the note could have the same ID as the empty,
 				// untyped instrument, it will never be associated with it.
 				if ( ppNote != nullptr && ppNote->getType().isEmpty() ) {
-					presentIds.insert( ppNote->getInstrumentId() );
+					presentIds.insert(
+						static_cast<int>( ppNote->getInstrumentId() )
+					);
 				}
 			}
 		}
@@ -1375,7 +1378,7 @@ void MainForm::action_drumkit_addInstrument(
 		// Pick an unique ID for the new instrument.
 		for ( int ii = 0; ii < presentIds.size() + 1; ++ii ) {
 			if ( presentIds.find( ii ) == presentIds.end() ) {
-				pInstrument->setId( ii );
+				pInstrument->setId( static_cast<Instrument::Id>( ii ) );
 				break;
 			}
 		}
@@ -2431,7 +2434,7 @@ void MainForm::action_drumkit_properties() {
 }
 
 void MainForm::editDrumkitProperties( bool bWriteToDisk, bool bSaveToNsmSession,
-									  int nInstrumentID )
+									  Instrument::Id id )
 {
 	const auto pHydrogen = Hydrogen::get_instance();
 	const auto pSong = pHydrogen->getSong();
@@ -2450,7 +2453,7 @@ void MainForm::editDrumkitProperties( bool bWriteToDisk, bool bSaveToNsmSession,
 	auto pNewDrumkit = std::make_shared<Drumkit>(pDrumkit);
 
 	DrumkitPropertiesDialog dialog( nullptr, pNewDrumkit, ! bWriteToDisk,
-									bSaveToNsmSession, nInstrumentID );
+									bSaveToNsmSession, id );
 	dialog.exec();
 }
 

--- a/src/gui/src/MainForm.h
+++ b/src/gui/src/MainForm.h
@@ -33,6 +33,7 @@
 #include "EventListener.h"
 #include "Widgets/WidgetWithScalableFont.h"
 
+#include <core/Basics/Instrument.h>
 #include <core/config.h>
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
@@ -97,14 +98,16 @@ class MainForm :  public QMainWindow,
 		static bool switchDrumkit( std::shared_ptr<H2Core::Drumkit> pTargetKit );
 
 		bool eventFilter( QObject *o, QEvent *e ) override;
-		/** @param nInstrumentID If set to a value different than
-		 *   #EMPTY_INSTR_ID, the corresponding line in the type tab will be
-		 *   selected on startup. */
-		static void editDrumkitProperties( bool bWriteToDisk,
-										   bool bSaveToNsmSession,
-										   int nInstrumentID = EMPTY_INSTR_ID );
+		/** @param id If set to a value different than
+		 *   #Instrument::EmptyId, the corresponding line in the type tab will
+		 * be selected on startup. */
+		static void editDrumkitProperties(
+			bool bWriteToDisk,
+			bool bSaveToNsmSession,
+			H2Core::Instrument::Id id = H2Core::Instrument::EmptyId
+		);
 
-public slots:
+	   public slots:
 		void showPreferencesDialog();
 		void showUserManual();
 

--- a/src/gui/src/MainToolBar/MidiControlDialog.h
+++ b/src/gui/src/MainToolBar/MidiControlDialog.h
@@ -26,16 +26,13 @@
 #include <QtGui>
 #include <QtWidgets>
 
+#include <core/Basics/Instrument.h>
 #include <core/Helpers/Time.h>
 #include <core/Object.h>
 #include <qevent.h>
 
 #include "../EventListener.h"
 #include "../Widgets/WidgetWithScalableFont.h"
-
-namespace H2Core {
-	class Instrument;
-}
 
 class LCDSpinBox;
 class MidiActionTable;
@@ -128,9 +125,10 @@ private:
          * of instrument type and id. This way we ensure no shared pointer to
          * any of these core data types gets stuck in a callback context and
          * e.g. causes sample data to not be freed. */
-		std::map< std::pair<QString, int>,
-				 std::shared_ptr<H2Core::Instrument> > m_instrumentMap;
+		std::map<
+			std::pair<H2Core::Instrument::Type, H2Core::Instrument::Id>,
+			std::shared_ptr<H2Core::Instrument> >
+			m_instrumentMap;
 };
-
 
 #endif

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -587,7 +587,7 @@ void NotePropertiesRuler::selectionMoveUpdateEvent( QMouseEvent* ev )
 	const auto selectedRow = m_pPatternEditorPanel->getRowDB(
 		m_pPatternEditorPanel->getSelectedRowDB()
 	);
-	if ( selectedRow.nInstrumentID == EMPTY_INSTR_ID &&
+	if ( selectedRow.id == Instrument::EmptyId &&
 		 selectedRow.sType.isEmpty() ) {
 		DEBUGLOG( "Empty row clicked" );
 		return;
@@ -1924,7 +1924,7 @@ NotePropertiesRuler::elementsIntersecting( const QRect& r )
 	const auto selectedRow = m_pPatternEditorPanel->getRowDB(
 		m_pPatternEditorPanel->getSelectedRowDB()
 	);
-	if ( selectedRow.nInstrumentID == EMPTY_INSTR_ID &&
+	if ( selectedRow.id == Instrument::EmptyId &&
 		 selectedRow.sType.isEmpty() ) {
 		return std::move( result );
 	}

--- a/src/gui/src/PatternEditor/PatternEditor.h
+++ b/src/gui/src/PatternEditor/PatternEditor.h
@@ -29,6 +29,7 @@
 #include "../Widgets/WidgetWithScalableFont.h"
 
 #include <core/Basics/GridPoint.h>
+#include <core/Basics/Instrument.h>
 #include <core/Basics/Note.h>
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
@@ -37,11 +38,6 @@
 
 #include <QtGui>
 #include <QtWidgets>
-
-namespace H2Core
-{
-	class Instrument;
-}
 
 class PatternEditorPanel;
 
@@ -93,21 +89,23 @@ public:
 		PatternEditor( QWidget *pParent );
 		~PatternEditor();
 
-		static void addOrRemoveNoteAction( int nPosition,
-										   int nInstrumentId,
-										   const QString& sType,
-										   int nPatternNumber,
-										   int nOldLength,
-										   float fOldVelocity,
-										   float fOldPan,
-										   float fOldLeadLag,
-										   int nOldKey,
-										   int nOldOctave,
-										   float fOldProbability,
-										   Editor::Action action,
-										   bool bIsNoteOff,
-										   bool bIsMappedToDrumkit,
-										   Editor::ActionModifier modifier );
+		static void addOrRemoveNoteAction(
+			int nPosition,
+			H2Core::Instrument::Id id,
+			const H2Core::Instrument::Type& sType,
+			int nPatternNumber,
+			int nOldLength,
+			float fOldVelocity,
+			float fOldPan,
+			float fOldLeadLag,
+			int nOldKey,
+			int nOldOctave,
+			float fOldProbability,
+			Editor::Action action,
+			bool bIsNoteOff,
+			bool bIsMappedToDrumkit,
+			Editor::ActionModifier modifier
+		);
 
 		//! Deselect some notes, and "overwrite" some others.
 		void deselectAndOverwriteNotes(
@@ -123,22 +121,24 @@ public:
 		 * used to find the actual #H2Core::Note to alter. In the latter
 		 * adjusting note/octave can be done too. This is covered using @a
 		 * nNewKey and @a nNewOctave. */
-		static void editNotePropertiesAction( const Property& property,
-											  int nPatternNumber,
-											  int nPosition,
-											  int nOldInstrumentId,
-											  int nNewInstrumentId,
-											  const QString& sOldType,
-											  const QString& sNewType,
-											  float fVelocity,
-											  float fPan,
-											  float fLeadLag,
-											  float fProbability,
-											  int nLength,
-											  int nNewKey,
-											  int nOldKey,
-											  int nNewOctave,
-											  int nOldOctave );
+		static void editNotePropertiesAction(
+			const Property& property,
+			int nPatternNumber,
+			int nPosition,
+			H2Core::Instrument::Id oldId,
+			H2Core::Instrument::Id newId,
+			const H2Core::Instrument::Type& sOldType,
+			const H2Core::Instrument::Type& sNewType,
+			float fVelocity,
+			float fPan,
+			float fLeadLag,
+			float fProbability,
+			int nLength,
+			int nNewKey,
+			int nOldKey,
+			int nNewOctave,
+			int nOldOctave
+		);
 
 		float getGridWidth() const;
 		void setGridWidth( float fGridWith );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include <core/Basics/Instrument.h>
 #include <core/Basics/Note.h>
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
@@ -66,15 +67,19 @@ class PianoRollEditor;
 struct DrumPatternRow {
 
 	explicit DrumPatternRow() noexcept;
-	explicit DrumPatternRow( int nId, const QString& sType,
-							 bool bAlternate, bool bMappedToDrumkit,
-							 bool bPlaysBackAudio ) noexcept;
+	explicit DrumPatternRow(
+		H2Core::Instrument::Id id,
+		const H2Core::Instrument::Type& sType,
+		bool bAlternate,
+		bool bMappedToDrumkit,
+		bool bPlaysBackAudio
+	) noexcept;
 
 	bool contains( std::shared_ptr<H2Core::Note> pNote ) const;
 
-	/** Associated #H2Core::Instrument::__id in the current #H2Core::Drumkit.
+	/** Associated #H2Core::Instrument::m_id in the current #H2Core::Drumkit.
 	 *
-	 * If set to #EMPTY_INSTR_ID, the row does not correspond to any. This
+	 * If set to #Instrument::EmptyId, the row does not correspond to any. This
 	 * happens in case #H2Core::Note were created with a different
 	 * #H2Core::Drumkit using an instrument type not present in the current one.
 	 * The note can not be played back with the current kit but can be
@@ -87,9 +92,9 @@ struct DrumPatternRow {
 	 * current instrument is important to the core itself when rendering
 	 * incoming MIDI notes.)
 	 *
-	 * Null element: #EMPTY_INSTR_ID */
-	int nInstrumentID;
-	/** Associated #H2Core::DrumkitMap::Type.
+	 * Null element: #Instrument::EmptyId */
+	H2Core::Instrument::Id id;
+	/** Associated #H2Core::Instrument::Type.
 	 *
 	 * If set to an empty string, the row does not correspond to any. This
 	 * happens in case #H2Core::Note were created for an #H2Core::Instrument not
@@ -101,7 +106,7 @@ struct DrumPatternRow {
 	 * #PatternEditorPanel::m_db.
 	 *
 	 * Null element: "" (empty string) */
-	QString sType;
+	H2Core::Instrument::Type sType;
 
 	/** Odd number rows will be painted in an alternate color to make the
 	 * visually distinct. */

--- a/src/gui/src/PatternEditor/PianoRollEditor.cpp
+++ b/src/gui/src/PatternEditor/PianoRollEditor.cpp
@@ -29,6 +29,7 @@
 #include "../Compatibility/MouseEvent.h"
 #include "../HydrogenApp.h"
 #include "../Skin.h"
+#include "core/Basics/Instrument.h"
 
 #include <core/AudioEngine/AudioEngine.h>
 #include <core/Basics/Note.h>
@@ -748,12 +749,12 @@ std::vector<PianoRollEditor::SelectionIndex> PianoRollEditor::elementsIntersecti
 
 	const auto selectedRow = m_pPatternEditorPanel->getRowDB(
 		m_pPatternEditorPanel->getSelectedRowDB() );
-	if ( selectedRow.nInstrumentID == EMPTY_INSTR_ID &&
+	if ( selectedRow.id == Instrument::EmptyId &&
 		 selectedRow.sType.isEmpty() ) {
 		DEBUGLOG( "Empty row" );
 		return std::move( result );
 	}
-	
+
 	int w = 8;
 	int h = m_nGridHeight - 2;
 

--- a/src/gui/src/Rack/ComponentEditor/ComponentEditor.cpp
+++ b/src/gui/src/Rack/ComponentEditor/ComponentEditor.cpp
@@ -175,7 +175,8 @@ void ComponentEditor::drumkitLoadedEvent() {
 void ComponentEditor::instrumentLayerChangedEvent( int nId )
 {
 	const auto pInstrument = Hydrogen::get_instance()->getSelectedInstrument();
-	if ( pInstrument != nullptr && pInstrument->getId() == nId ) {
+	if ( pInstrument != nullptr &&
+		 pInstrument->getId() == static_cast<Instrument::Id>( nId ) ) {
 		updateComponents();
 	}
 }

--- a/src/gui/src/Rack/InstrumentEditor.cpp
+++ b/src/gui/src/Rack/InstrumentEditor.cpp
@@ -86,15 +86,23 @@ font-size: 21px;" );
 	m_pMidiOutChannelLCD->move( 146, 257 );
 	m_pMidiOutChannelLCD->setToolTip(QString(tr("Midi out channel")));
 	connect(
-		m_pMidiOutChannelLCD, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-		[&](double fValue) {
+		m_pMidiOutChannelLCD,
+		QOverload<double>::of( &QDoubleSpinBox::valueChanged ),
+		[&]( double fValue ) {
 			auto pInstrument = Hydrogen::get_instance()->getSelectedInstrument();
 			if ( pInstrument == nullptr ) {
 				return;
 			}
+			auto pSong = Hydrogen::get_instance()->getSong();
+			if ( pSong == nullptr || pSong->getDrumkit() == nullptr ) {
+				return;
+			}
 			CoreActionController::setInstrumentMidiOutChannel(
-				pInstrument->getId(), static_cast<int>(fValue), nullptr );
-		});
+				pSong->getDrumkit()->getInstruments()->index( pInstrument ),
+				static_cast<int>( fValue ), nullptr
+			);
+		}
+	);
 	m_pMidiOutChannelLbl = new ClickableLabel(
 		m_pInstrumentProp, QSize( 61, 10 ),
 		pCommonStrings->getMidiOutChannelLabel() );
@@ -107,16 +115,25 @@ font-size: 21px;" );
 	m_pMidiOutNoteLCD->move( 210, 257 );
 	m_pMidiOutNoteLCD->setToolTip(QString(tr("Midi out note")));
 	connect(
-		m_pMidiOutNoteLCD, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
-		[&](double fValue) {
+		m_pMidiOutNoteLCD,
+		QOverload<double>::of( &QDoubleSpinBox::valueChanged ),
+		[&]( double fValue ) {
 			auto pInstrument = Hydrogen::get_instance()->getSelectedInstrument();
 			if ( pInstrument == nullptr ) {
 				return;
 			}
+			auto pSong = Hydrogen::get_instance()->getSong();
+			if ( pSong == nullptr || pSong->getDrumkit() == nullptr ) {
+				return;
+			}
 			CoreActionController::setInstrumentMidiOutNote(
-				pInstrument->getId(), static_cast<int>(fValue), nullptr );
-		});
-	m_pMidiOutNoteLbl = new ClickableLabel( m_pInstrumentProp, QSize( 61, 10 ) );
+				pSong->getDrumkit()->getInstruments()->index( pInstrument ),
+				static_cast<int>( fValue ), nullptr
+			);
+		}
+	);
+	m_pMidiOutNoteLbl =
+		new ClickableLabel( m_pInstrumentProp, QSize( 61, 10 ) );
 	m_pMidiOutNoteLbl->move( 208, 281 );
 
 	/////////////

--- a/src/gui/src/Rack/SoundLibrary/DrumkitPropertiesDialog.h
+++ b/src/gui/src/Rack/SoundLibrary/DrumkitPropertiesDialog.h
@@ -27,6 +27,7 @@
 #include "../../Widgets/WidgetWithLicenseProperty.h"
 
 #include <core/Basics/Drumkit.h>
+#include <core/Basics/Instrument.h>
 #include <core/Object.h>
 
 ///
@@ -44,13 +45,13 @@ class DrumkitPropertiesDialog :  public QDialog,
 	Q_OBJECT
 	public:
 		/** @param nInstrumentID If set to a value different than
-		 *   #EMPTY_INSTR_ID, the corresponding line in the type tab will be
+		 *   #Instrument::EmptyId, the corresponding line in the type tab will be
 		 *   selected on startup. */
 		DrumkitPropertiesDialog( QWidget* pParent,
 								 std::shared_ptr<Drumkit> pDrumkit,
 								 bool bEditingNotSaving,
 								 bool bSaveToNsmSession,
-								 int nInstrumentID = EMPTY_INSTR_ID );
+								 Instrument::Id id = Instrument::EmptyId );
 		~DrumkitPropertiesDialog();
 		void showEvent( QShowEvent *e ) override;
 
@@ -83,7 +84,7 @@ class DrumkitPropertiesDialog :  public QDialog,
 
 		/** used to selected a specific instrument type row on opening based on
 		 * the provided instrument ID. */
-		std::map<int, LCDCombo*> m_idToTypeMap;
+		std::map<Instrument::Id, LCDCombo*> m_idToTypeMap;
 };
 
 }

--- a/src/gui/src/Rack/SoundLibrary/SoundLibraryPanel.cpp
+++ b/src/gui/src/Rack/SoundLibrary/SoundLibraryPanel.cpp
@@ -242,17 +242,20 @@ void SoundLibraryPanel::updateTree()
 
 		m_drumkitLabels << sItemLabel;
 		m_drumkitRegister[ sItemLabel ] = ssPath;
-			
+
 		pDrumkitItem->setText( 0, sItemLabel );
 		pDrumkitItem->setToolTip( 0, ssPath );
-		if ( ! m_bInItsOwnDialog ) {
+		if ( !m_bInItsOwnDialog ) {
 			auto pInstrList = ppDrumkit->getInstruments();
 			for ( const auto& pInstrument : *ppDrumkit->getInstruments() ) {
 				if ( pInstrument != nullptr ) {
-					QTreeWidgetItem* pInstrumentItem = new QTreeWidgetItem( pDrumkitItem );
-					pInstrumentItem->setText( 0, QString( "[%1] %2" )
-											  .arg( pInstrument->getId() )
-											  .arg( pInstrument->getName() ) );
+					QTreeWidgetItem* pInstrumentItem =
+						new QTreeWidgetItem( pDrumkitItem );
+					pInstrumentItem->setText(
+						0, QString( "[%1] %2" )
+							   .arg( static_cast<int>( pInstrument->getId() ) )
+							   .arg( pInstrument->getName() )
+					);
 					pInstrumentItem->setToolTip( 0, pInstrument->getName() );
 				}
 			}

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -34,6 +34,7 @@
 #include <core/AudioEngine/TransportPosition.h>
 #include <core/Basics/AutomationPath.h>
 #include <core/Basics/Drumkit.h>
+#include <core/Basics/Instrument.h>
 #include <core/Basics/GridPoint.h>
 #include <core/Basics/Note.h>
 #include <core/Basics/Pattern.h>
@@ -429,8 +430,8 @@ class SE_addOrRemoveNoteAction : public QUndoCommand
 {
 public:
 	SE_addOrRemoveNoteAction( int nColumn,
-							  int nInstrumentId,
-							  const QString& sType,
+							  H2Core::Instrument::Id id,
+							  const H2Core::Instrument::Type& sType,
 							  int nPatternNumber,
 							  int nOldLength,
 							  float fOldVelocity,
@@ -445,18 +446,24 @@ public:
 							  Editor::ActionModifier modifier =
 							  Editor::ActionModifier::None
  ){
-
-		if ( action == Editor::Action::Delete ){
+		if ( action == Editor::Action::Delete ) {
 			setText( QString( "%1 [column: %2, id: %3, type: %4, pattern: %5]" )
-					 .arg( QObject::tr( "Delete note" ) ).arg( nColumn ).
-					 arg( nInstrumentId ).arg( sType ).arg( nPatternNumber ) );
-		} else {
+						 .arg( QObject::tr( "Delete note" ) )
+						 .arg( nColumn )
+						 .arg( static_cast<int>( id ) )
+						 .arg( sType )
+						 .arg( nPatternNumber ) );
+		}
+		else {
 			setText( QString( "%1 [column: %2, id: %3, type: %4, pattern: %5]" )
-					 .arg( QObject::tr( "Add note" ) ).arg( nColumn ).
-					 arg( nInstrumentId ).arg( sType ).arg( nPatternNumber ) );
+						 .arg( QObject::tr( "Add note" ) )
+						 .arg( nColumn )
+						 .arg( static_cast<int>( id ) )
+						 .arg( sType )
+						 .arg( nPatternNumber ) );
 		}
 		m_nColumn = nColumn;
-		m_nInstrumentId = nInstrumentId;
+		m_id = id;
 		m_sType = sType;
 		m_nPatternNumber = nPatternNumber;
 		m_nOldLength = nOldLength;
@@ -473,7 +480,7 @@ public:
 	}
 	virtual void undo() {
 		PatternEditor::addOrRemoveNoteAction( m_nColumn,
-											  m_nInstrumentId,
+											  m_id,
 											  m_sType,
 											  m_nPatternNumber,
 											  m_nOldLength,
@@ -490,7 +497,7 @@ public:
 	}
 	virtual void redo() {
 		PatternEditor::addOrRemoveNoteAction( m_nColumn,
-											  m_nInstrumentId,
+											  m_id,
 											  m_sType,
 											  m_nPatternNumber,
 											  m_nOldLength,
@@ -509,8 +516,8 @@ public:
 	}
 private:
 	int m_nColumn;
-	int m_nInstrumentId;
-	QString m_sType;
+	H2Core::Instrument::Id m_id;
+	H2Core::Instrument::Type m_sType;
 	int m_nPatternNumber;
 	int m_nOldLength;
 	float m_fOldVelocity;
@@ -608,10 +615,10 @@ public:
 	SE_editNotePropertiesAction( const PatternEditor::Property& property,
 								 int nPatternNumber,
 								 int nColumn,
-								 int nInstrumentId,
-								 int nOldInstrumentId,
-								 const QString& sType,
-								 const QString& sOldType,
+								 H2Core::Instrument::Id id,
+								 H2Core::Instrument::Id nOldId,
+								 const H2Core::Instrument::Type& sType,
+								 const H2Core::Instrument::Type& sOldType,
 								 float fVelocity,
 								 float fOldVelocity,
 								 float fPan,
@@ -629,8 +636,8 @@ public:
 		m_property( property ),
 		m_nPatternNumber( nPatternNumber ),
 		m_nColumn( nColumn ),
-		m_nInstrumentId( nInstrumentId ),
-		m_nOldInstrumentId( nOldInstrumentId ),
+		m_id( id ),
+		m_oldId( nOldId ),
 		m_sType( sType ),
 		m_sOldType( sOldType ),
 		m_fVelocity( fVelocity ),
@@ -655,8 +662,8 @@ public:
 		PatternEditor::editNotePropertiesAction( m_property,
 												 m_nPatternNumber,
 												 m_nColumn,
-												 m_nInstrumentId,
-												 m_nOldInstrumentId,
+												 m_id,
+												 m_oldId,
 												 m_sType,
 												 m_sOldType,
 												 m_fOldVelocity,
@@ -673,8 +680,8 @@ public:
 		PatternEditor::editNotePropertiesAction( m_property,
 												 m_nPatternNumber,
 												 m_nColumn,
-												 m_nOldInstrumentId,
-												 m_nInstrumentId,
+												 m_oldId,
+												 m_id,
 												 m_sOldType,
 												 m_sType,
 												 m_fVelocity,
@@ -694,10 +701,10 @@ private:
 		int m_nColumn;
 		/** Row selected in #DrumPatternEditor the moment the action was
 		 * created. */
-		int m_nInstrumentId;
-		int m_nOldInstrumentId;
-		QString m_sType;
-		QString m_sOldType;
+		H2Core::Instrument::Id m_id;
+		H2Core::Instrument::Id m_oldId;
+		H2Core::Instrument::Type m_sType;
+		H2Core::Instrument::Type m_sOldType;
 		float m_fVelocity;
 		float m_fOldVelocity;
 		float m_fPan;

--- a/src/tests/DrumkitTest.cpp
+++ b/src/tests/DrumkitTest.cpp
@@ -56,7 +56,7 @@ void DrumkitTest::testHasAllMidiNotesSame()
 	// One instrument
 	{
 		InstrumentList list;
-		auto pKick = std::make_shared<Instrument>( EMPTY_INSTR_ID, "Kick" );
+		auto pKick = std::make_shared<Instrument>( Instrument::EmptyId, "Kick" );
 		pKick->setMidiOutNote( 42 );
 		list.add( pKick );
 
@@ -67,15 +67,15 @@ void DrumkitTest::testHasAllMidiNotesSame()
 	{
 		InstrumentList list;
 
-		auto pKick = std::make_shared<Instrument>( EMPTY_INSTR_ID, "Kick" );
+		auto pKick = std::make_shared<Instrument>( Instrument::EmptyId, "Kick" );
 		pKick->setMidiOutNote( 10 );
 		list.add( pKick );
 
-		auto pSnare = std::make_shared<Instrument>( EMPTY_INSTR_ID, "Snare" );
+		auto pSnare = std::make_shared<Instrument>( Instrument::EmptyId, "Snare" );
 		pSnare->setMidiOutNote( 10 );
 		list.add( pSnare );
 
-		auto pHihat = std::make_shared<Instrument>( EMPTY_INSTR_ID, "HiHat" );
+		auto pHihat = std::make_shared<Instrument>( Instrument::EmptyId, "HiHat" );
 		pHihat->setMidiOutNote( 10 );
 		list.add( pHihat );
 
@@ -87,20 +87,20 @@ void DrumkitTest::testHasAllMidiNotesSame()
 	{
 		InstrumentList list;
 
-		auto pKick = std::make_shared<Instrument>( EMPTY_INSTR_ID, "Kick" );
+		auto pKick = std::make_shared<Instrument>( Instrument::EmptyId, "Kick" );
 		pKick->setMidiOutNote( 36 );
 		list.add( pKick );
 
-		auto pClap = std::make_shared<Instrument>( EMPTY_INSTR_ID, "Clap" );
+		auto pClap = std::make_shared<Instrument>( Instrument::EmptyId, "Clap" );
 		pClap->setMidiOutNote( 37 );
 		list.add( pClap );
 
-		auto pRide = std::make_shared<Instrument>( EMPTY_INSTR_ID, "Ride" );
+		auto pRide = std::make_shared<Instrument>( Instrument::EmptyId, "Ride" );
 		pRide->setMidiOutNote( 38 );
 		list.add( pRide );
 
 		auto pDummy =
-			std::make_shared<Instrument>( EMPTY_INSTR_ID, "Dummy Instrument" );
+			std::make_shared<Instrument>( Instrument::EmptyId, "Dummy Instrument" );
 		pDummy->setMidiOutNote( 36 );  // duplicate
 		list.add( pDummy );
 

--- a/src/tests/MemoryLeakageTest.cpp
+++ b/src/tests/MemoryLeakageTest.cpp
@@ -26,10 +26,10 @@
 #include <core/Basics/Adsr.h>
 #include <core/Basics/AutomationPath.h>
 #include <core/Basics/Drumkit.h>
+#include <core/Basics/Instrument.h>
+#include <core/Basics/InstrumentComponent.h>
 #include <core/Basics/InstrumentLayer.h>
 #include <core/Basics/InstrumentList.h>
-#include <core/Basics/InstrumentComponent.h>
-#include <core/Basics/Instrument.h>
 #include <core/Basics/Note.h>
 #include <core/Basics/Pattern.h>
 #include <core/Basics/PatternList.h>
@@ -39,15 +39,15 @@
 #include <core/CoreActionController.h>
 #include <core/License.h>
 
+#include <core/Helpers/Legacy.h>
+#include <core/Helpers/Xml.h>
 #include <core/Sampler/Sampler.h>
 #include <core/Sampler/Sampler.cpp>
-#include <core/Helpers/Xml.h>
-#include <core/Helpers/Legacy.h>
 
 #include "TestHelper.h"
 
-
-void MemoryLeakageTest::testConstructors() {
+void MemoryLeakageTest::testConstructors()
+{
 	___INFOLOG( "" );
 	auto mapSnapshot = H2Core::Base::getObjectMap();
 	int nAliveReference = H2Core::Base::getAliveObjectCount();
@@ -57,13 +57,17 @@ void MemoryLeakageTest::testConstructors() {
 		auto pADSR2 = std::make_shared<H2Core::ADSR>( pADSR );
 		pADSR = nullptr;
 		pADSR2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto AutomationPath = new H2Core::AutomationPath( 0, 1, 0.2 );
 		delete AutomationPath;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
@@ -71,104 +75,154 @@ void MemoryLeakageTest::testConstructors() {
 		auto pDrumkit2 = std::make_shared<H2Core::Drumkit>( pDrumkit );
 		pDrumkit = nullptr;
 		pDrumkit2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pADSR = std::make_shared<H2Core::ADSR>();
-		auto pInstrument = std::make_shared<H2Core::Instrument>( 0, "ladida", pADSR );
+		auto pInstrument = std::make_shared<H2Core::Instrument>(
+			static_cast<H2Core::Instrument::Id>( 0 ), "ladida", pADSR
+		);
 		auto pInstrument2 = std::make_shared<H2Core::Instrument>( pInstrument );
 		pInstrument = nullptr;
 		pInstrument2 = nullptr;
 		pADSR = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pSample = std::make_shared<H2Core::Sample>( H2TEST_FILE( "/drumkits/baseKit/kick.wav" ) );
-		auto pInstrumentLayer = std::make_shared<H2Core::InstrumentLayer>( pSample );
-		auto pInstrumentLayer2 = std::make_shared<H2Core::InstrumentLayer>( pInstrumentLayer );
+		auto pSample = std::make_shared<H2Core::Sample>(
+			H2TEST_FILE( "/drumkits/baseKit/kick.wav" )
+		);
+		auto pInstrumentLayer =
+			std::make_shared<H2Core::InstrumentLayer>( pSample );
+		auto pInstrumentLayer2 =
+			std::make_shared<H2Core::InstrumentLayer>( pInstrumentLayer );
 		pInstrumentLayer = nullptr;
 		pSample = nullptr;
 		pInstrumentLayer2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pInstrumentList = std::make_shared<H2Core::InstrumentList>();
-		auto pInstrumentList2 = std::make_shared<H2Core::InstrumentList>( pInstrumentList );
+		auto pInstrumentList2 =
+			std::make_shared<H2Core::InstrumentList>( pInstrumentList );
 		pInstrumentList = nullptr;
 		pInstrumentList2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pInstrumentComponent = std::make_shared<H2Core::InstrumentComponent>();
-		auto pInstrumentComponent2 = std::make_shared<H2Core::InstrumentComponent>( pInstrumentComponent );
+		auto pInstrumentComponent =
+			std::make_shared<H2Core::InstrumentComponent>();
+		auto pInstrumentComponent2 =
+			std::make_shared<H2Core::InstrumentComponent>( pInstrumentComponent
+			);
 		pInstrumentComponent = nullptr;
 		pInstrumentComponent2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pADSR = std::make_shared<H2Core::ADSR>();
-		auto pInstrument = std::make_shared<H2Core::Instrument>( 0, "ladida", pADSR );
-		auto pNote = std::make_shared<H2Core::Note>( pInstrument, 0, 0.f, 0.f, 1, 1.f );
+		auto pInstrument = std::make_shared<H2Core::Instrument>(
+			static_cast<H2Core::Instrument::Id>( 0 ), "ladida", pADSR
+		);
+		auto pNote =
+			std::make_shared<H2Core::Note>( pInstrument, 0, 0.f, 0.f, 1, 1.f );
 		auto pNote2 = std::make_shared<H2Core::Note>( pNote );
 		pNote = nullptr;
 		pNote2 = nullptr;
 		pInstrument = nullptr;
 		pADSR = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pPattern = std::make_shared<H2Core::Pattern>( "ladida", "ladida", "ladida" );
+		auto pPattern =
+			std::make_shared<H2Core::Pattern>( "ladida", "ladida", "ladida" );
 		auto pPattern2 = std::make_shared<H2Core::Pattern>( pPattern );
 		pPattern = nullptr;
 		pPattern2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pPatternList = std::make_shared<H2Core::PatternList>();
-		auto pPatternList2 = std::make_shared<H2Core::PatternList>( pPatternList );
+		auto pPatternList2 =
+			std::make_shared<H2Core::PatternList>( pPatternList );
 		pPatternList = nullptr;
 		pPatternList2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pSample = std::make_shared<H2Core::Sample>( H2TEST_FILE( "/drumkits/baseKit/kick.wav" ) );
+		auto pSample = std::make_shared<H2Core::Sample>(
+			H2TEST_FILE( "/drumkits/baseKit/kick.wav" )
+		);
 		auto pSample2 = std::make_shared<H2Core::Sample>( pSample );
 		pSample = nullptr;
 		pSample2 = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pSong = std::make_shared<H2Core::Song>( "ladida", "ladida", 120, 1 );
+		auto pSong =
+			std::make_shared<H2Core::Song>( "ladida", "ladida", 120, 1 );
 		pSong = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
-	
+
 	{
 		auto pSampler = new H2Core::Sampler();
 		delete pSampler;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	// Test copy constructors using real-live instead of new objects.
 	auto pDrumkitProper = H2Core::Drumkit::load(
 		H2Core::Filesystem::drumkit_path_search(
-			"GMRockKit", H2Core::Filesystem::Lookup::system, true ),
-		false, nullptr, true );
+			"GMRockKit", H2Core::Filesystem::Lookup::system, true
+		),
+		false, nullptr, true
+	);
 	CPPUNIT_ASSERT( pDrumkitProper != nullptr );
-	
+
 	pDrumkitProper->loadSamples();
-	
-	CPPUNIT_ASSERT( pDrumkitProper->getInstruments()->get( 0 )->getComponent( 0 )->getLayer( 0 )->getSample() != nullptr );
-	auto pSongProper = H2Core::Song::load( H2Core::Filesystem::demos_dir() + "GM_kit_Diddley.h2song" );
+
+	CPPUNIT_ASSERT(
+		pDrumkitProper->getInstruments()
+			->get( 0 )
+			->getComponent( 0 )
+			->getLayer( 0 )
+			->getSample() != nullptr
+	);
+	auto pSongProper = H2Core::Song::load(
+		H2Core::Filesystem::demos_dir() + "GM_kit_Diddley.h2song"
+	);
 	CPPUNIT_ASSERT( pSongProper != nullptr );
 
 	int nNewCount = H2Core::Base::getAliveObjectCount();
@@ -181,22 +235,27 @@ void MemoryLeakageTest::testConstructors() {
 	}
 
 	{
-		auto pInstrumentList = std::make_shared<H2Core::InstrumentList>( pSongProper->getDrumkit()->getInstruments() );
+		auto pInstrumentList = std::make_shared<H2Core::InstrumentList>(
+			pSongProper->getDrumkit()->getInstruments()
+		);
 		CPPUNIT_ASSERT( pInstrumentList != nullptr );
 		pInstrumentList = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
 
 	{
-		auto pPatternList = std::make_shared<H2Core::PatternList>(
-			pSongProper->getPatternList() );
+		auto pPatternList =
+			std::make_shared<H2Core::PatternList>( pSongProper->getPatternList()
+			);
 		CPPUNIT_ASSERT( pPatternList != nullptr );
 		pPatternList = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
-	
+
 	{
-		auto pPattern = std::make_shared<H2Core::Pattern>( pSongProper->getPatternList()->get( 0 ) );
+		auto pPattern = std::make_shared<H2Core::Pattern>(
+			pSongProper->getPatternList()->get( 0 )
+		);
 		CPPUNIT_ASSERT( pPattern != nullptr );
 		pPattern = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
@@ -211,111 +270,159 @@ void MemoryLeakageTest::testConstructors() {
 	}
 
 	{
-		auto pInstrument = std::make_shared<H2Core::Instrument>( pDrumkitProper->getInstruments()->get( 0 ) );
+		auto pInstrument = std::make_shared<H2Core::Instrument>(
+			pDrumkitProper->getInstruments()->get( 0 )
+		);
 		CPPUNIT_ASSERT( pInstrument != nullptr );
 		pInstrument = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
 
 	{
-		auto pADSR = std::make_shared<H2Core::ADSR>( pDrumkitProper->getInstruments()->get( 0 )->getAdsr() );
+		auto pADSR = std::make_shared<H2Core::ADSR>(
+			pDrumkitProper->getInstruments()->get( 0 )->getAdsr()
+		);
 		CPPUNIT_ASSERT( pADSR != nullptr );
 		pADSR = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
 
 	{
-		auto pInstrumentComponent = std::make_shared<H2Core::InstrumentComponent>( pDrumkitProper->getInstruments()->get( 0 )->getComponent( 0 ) );
+		auto pInstrumentComponent =
+			std::make_shared<H2Core::InstrumentComponent>(
+				pDrumkitProper->getInstruments()->get( 0 )->getComponent( 0 )
+			);
 		CPPUNIT_ASSERT( pInstrumentComponent != nullptr );
 		pInstrumentComponent = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
 
 	{
-		auto pInstrumentLayer = std::make_shared<H2Core::InstrumentLayer>( pDrumkitProper->getInstruments()->get( 0 )->getComponent( 0 )->getLayer( 0 ) );
+		auto pInstrumentLayer =
+			std::make_shared<H2Core::InstrumentLayer>( pDrumkitProper
+														   ->getInstruments()
+														   ->get( 0 )
+														   ->getComponent( 0 )
+														   ->getLayer( 0 ) );
 		CPPUNIT_ASSERT( pInstrumentLayer != nullptr );
 		pInstrumentLayer = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
 
 	{
-		auto pSample = std::make_shared<H2Core::Sample>( pDrumkitProper->getInstruments()->get( 0 )->getComponent( 0 )->getLayer( 0 )->getSample() );
+		auto pSample =
+			std::make_shared<H2Core::Sample>( pDrumkitProper->getInstruments()
+												  ->get( 0 )
+												  ->getComponent( 0 )
+												  ->getLayer( 0 )
+												  ->getSample() );
 		CPPUNIT_ASSERT( pSample != nullptr );
 		pSample = nullptr;
 		CPPUNIT_ASSERT( nNewCount == H2Core::Base::getAliveObjectCount() );
 	}
-	
+
 	pDrumkitProper = nullptr;
 	pSongProper = nullptr;
 	CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
 	___INFOLOG( "passed" );
 }
 
-void MemoryLeakageTest::testLoading() {
+void MemoryLeakageTest::testLoading()
+{
 	___INFOLOG( "" );
 	H2Core::XMLDoc doc;
 	H2Core::XMLNode node;
 
 	auto mapSnapshot = H2Core::Base::getObjectMap();
 	int nAliveReference = H2Core::Base::getAliveObjectCount();
-	
+
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 
-	QString sDrumkitPath =
-		H2Core::Filesystem::drumkit_path_search( "GMRockKit",
-												 H2Core::Filesystem::Lookup::system );
+	QString sDrumkitPath = H2Core::Filesystem::drumkit_path_search(
+		"GMRockKit", H2Core::Filesystem::Lookup::system
+	);
 
 	{
 		auto pDrumkit = H2Core::Drumkit::load(
-			H2TEST_FILE( "drumkits/baseKit/" ), false, nullptr, true );
+			H2TEST_FILE( "drumkits/baseKit/" ), false, nullptr, true
+		);
 		CPPUNIT_ASSERT( pDrumkit != nullptr );
 
 		pDrumkit->loadSamples();
-		
+
 		pDrumkit = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrumentComponent.xml" ) ) );
+		CPPUNIT_ASSERT(
+			doc.read( H2TEST_FILE( "/memoryLeakage/instrumentComponent.xml" ) )
+		);
 		node = doc.firstChildElement( "instrumentComponent" );
-		auto pInstrumentComponent = H2Core::InstrumentComponent::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ) );
+		auto pInstrumentComponent = H2Core::InstrumentComponent::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" )
+		);
 		CPPUNIT_ASSERT( pInstrumentComponent != nullptr );
 		pInstrumentComponent = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrument.xml" ) ) );
+		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrument.xml" )
+		) );
 		node = doc.firstChildElement( "instrument" );
-		auto pInstrument = H2Core::Instrument::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ) );
+		auto pInstrument = H2Core::Instrument::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" )
+		);
 		CPPUNIT_ASSERT( pInstrument != nullptr );
 		pInstrument = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrumentLayer.xml" ) ) );
+		CPPUNIT_ASSERT(
+			doc.read( H2TEST_FILE( "/memoryLeakage/instrumentLayer.xml" ) )
+		);
 		node = doc.firstChildElement( "instrumentLayer" );
-		auto pInstrumentLayer = H2Core::InstrumentLayer::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ) );
+		auto pInstrumentLayer = H2Core::InstrumentLayer::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" )
+		);
 		CPPUNIT_ASSERT( pInstrumentLayer != nullptr );
 		pInstrumentLayer = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrumentList.xml" ) ) );
+		CPPUNIT_ASSERT(
+			doc.read( H2TEST_FILE( "/memoryLeakage/instrumentList.xml" ) )
+		);
 		node = doc.firstChildElement( "song" );
-		auto pInstrumentList = H2Core::InstrumentList::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit" );
+		auto pInstrumentList = H2Core::InstrumentList::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit"
+		);
 		CPPUNIT_ASSERT( pInstrumentList != nullptr );
 		pInstrumentList = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrumentList.xml" ) ) );
+		CPPUNIT_ASSERT(
+			doc.read( H2TEST_FILE( "/memoryLeakage/instrumentList.xml" ) )
+		);
 		node = doc.firstChildElement( "song" );
-		auto pInstrumentList = H2Core::InstrumentList::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit" );
+		auto pInstrumentList = H2Core::InstrumentList::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit"
+		);
 		CPPUNIT_ASSERT( pInstrumentList != nullptr );
 		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/note.xml" ) ) );
 		node = doc.firstChildElement( "note" );
@@ -323,13 +430,19 @@ void MemoryLeakageTest::testLoading() {
 		CPPUNIT_ASSERT( pNote != nullptr );
 		pNote = nullptr;
 		pInstrumentList = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrumentListV2.xml" ) ) );
+		CPPUNIT_ASSERT(
+			doc.read( H2TEST_FILE( "/memoryLeakage/instrumentListV2.xml" ) )
+		);
 		node = doc.firstChildElement( "song" );
-		auto pInstrumentList = H2Core::InstrumentList::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit" );
+		auto pInstrumentList = H2Core::InstrumentList::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit"
+		);
 		CPPUNIT_ASSERT( pInstrumentList != nullptr );
 		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/note.xml" ) ) );
 		node = doc.firstChildElement( "note" );
@@ -337,83 +450,116 @@ void MemoryLeakageTest::testLoading() {
 		CPPUNIT_ASSERT( pNote != nullptr );
 		pNote = nullptr;
 		pInstrumentList = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrumentList.xml" ) ) );
+		CPPUNIT_ASSERT(
+			doc.read( H2TEST_FILE( "/memoryLeakage/instrumentList.xml" ) )
+		);
 		node = doc.firstChildElement( "song" );
-		auto pInstrumentList = H2Core::InstrumentList::loadFrom( node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit" );
+		auto pInstrumentList = H2Core::InstrumentList::loadFrom(
+			node, H2TEST_FILE( "/drumkits/baseKit" ), "baseKit"
+		);
 		CPPUNIT_ASSERT( pInstrumentList != nullptr );
-		auto pPattern = H2Core::Pattern::load(
-			H2TEST_FILE( "pattern/pattern.h2pattern" ) );
+		auto pPattern =
+			H2Core::Pattern::load( H2TEST_FILE( "pattern/pattern.h2pattern" ) );
 		CPPUNIT_ASSERT( pPattern != nullptr );
 		pPattern = nullptr;
 		pInstrumentList = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pPlaylist = H2Core::Playlist::load( H2TEST_FILE( "playlist/test.h2playlist" ) );
+		auto pPlaylist =
+			H2Core::Playlist::load( H2TEST_FILE( "playlist/test.h2playlist" ) );
 		CPPUNIT_ASSERT( pPlaylist != nullptr );
 		pPlaylist = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pSample = H2Core::Sample::load( H2TEST_FILE( "drumkits/baseKit/snare.wav" ) );
+		auto pSample =
+			H2Core::Sample::load( H2TEST_FILE( "drumkits/baseKit/snare.wav" ) );
 		CPPUNIT_ASSERT( pSample != nullptr );
 		pSample = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pSong = H2Core::Song::getEmptySong();
 		CPPUNIT_ASSERT( pSong != nullptr );
 		pSong = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pSong = H2Core::Song::load( H2TEST_FILE( "functional/test.h2song" ) );
+		auto pSong =
+			H2Core::Song::load( H2TEST_FILE( "functional/test.h2song" ) );
 		CPPUNIT_ASSERT( pSong != nullptr );
 		pSong = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pSampler = new H2Core::Sampler();
 		pSampler->reinitializePlaybackTrack();
 		delete pSampler;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		pHydrogen->getSong()->setPlaybackTrackFileName( H2TEST_FILE( "drumkits/baseKit/kick.wav" ) );
+		pHydrogen->getSong()->setPlaybackTrackFileName(
+			H2TEST_FILE( "drumkits/baseKit/kick.wav" )
+		);
 		auto pSampler = new H2Core::Sampler();
 		pSampler->reinitializePlaybackTrack();
 		delete pSampler;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
-		auto pInstrument = H2Core::createInstrument( 0, H2TEST_FILE( "drumkits/baseKit/kick.wav" ), 0.7 );
+		auto pInstrument = H2Core::createInstrument(
+			static_cast<H2Core::Instrument::Id>( 0 ),
+			H2TEST_FILE( "drumkits/baseKit/kick.wav" ), 0.7
+		);
 		pInstrument = nullptr;
-		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );
+		CPPUNIT_ASSERT(
+			nAliveReference == H2Core::Base::getAliveObjectCount()
+		);
 	}
 
 	{
 		auto pDrumkit = H2Core::Drumkit::load(
-			H2TEST_FILE( "drumkits/baseKit" ), false, nullptr, true );
+			H2TEST_FILE( "drumkits/baseKit" ), false, nullptr, true
+		);
 		CPPUNIT_ASSERT( pDrumkit != nullptr );
 		pDrumkit->loadSamples();
 		auto pDrumkit2 = H2Core::Drumkit::load(
 			H2Core::Filesystem::drumkit_path_search(
-				"GMRockKit", H2Core::Filesystem::Lookup::system, true ),
-			false, nullptr, true );
+				"GMRockKit", H2Core::Filesystem::Lookup::system, true
+			),
+			false, nullptr, true
+		);
 		CPPUNIT_ASSERT( pDrumkit2 != nullptr );
 		pDrumkit2->loadSamples();
-	
+
 		H2Core::CoreActionController::setDrumkit( pDrumkit );
 		int nLoaded = H2Core::Base::getAliveObjectCount();
 		H2Core::CoreActionController::setDrumkit( pDrumkit );
@@ -425,7 +571,8 @@ void MemoryLeakageTest::testLoading() {
 	___INFOLOG( "passed" );
 }
 
-void MemoryLeakageTest::tearDown() {
+void MemoryLeakageTest::tearDown()
+{
 	if ( H2Core::Filesystem::drumkit_exists( "testKitLadida" ) ) {
 		QString sPath = H2Core::Filesystem::drumkit_usr_path( "testKitLadida" );
 		CPPUNIT_ASSERT( H2Core::Filesystem::rm( sPath, true ) );

--- a/src/tests/NoteTest.cpp
+++ b/src/tests/NoteTest.cpp
@@ -453,7 +453,9 @@ void NoteTest::testSerializeProbability() {
 
 	auto pDrumkit = std::make_shared<Drumkit>();
 	auto pInstruments = std::make_shared<InstrumentList>();
-	auto pSnare = std::make_shared<Instrument>( 1, "Snare", nullptr );
+	auto pSnare = std::make_shared<Instrument>(
+		static_cast<Instrument::Id>( 1 ), "Snare", nullptr
+	);
 	pInstruments->add( pSnare );
 	pDrumkit->setInstruments( pInstruments );
 

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -922,7 +922,7 @@ void XmlTest::testSongLegacy() {
 		CPPUNIT_ASSERT( ppInstrument->hasSamples() );
 	}
 	CPPUNIT_ASSERT( ! pSongLegacy->hasMissingSamples() );
-	const auto pInstrumentGMRockKit = pSongLegacy->getDrumkit()->getInstruments()->find( 13 );
+	const auto pInstrumentGMRockKit = pSongLegacy->getDrumkit()->getInstruments()->get( 13 );
 	CPPUNIT_ASSERT( pInstrumentGMRockKit != nullptr );
 	CPPUNIT_ASSERT( pInstrumentGMRockKit->getComponents()->size() > 0 );
 	CPPUNIT_ASSERT( pInstrumentGMRockKit->getComponents()->front() != nullptr );
@@ -932,7 +932,7 @@ void XmlTest::testSongLegacy() {
 					->getLayer( 0 )->getSample() != nullptr );
 	const auto sFilePathGMRockKit = pInstrumentGMRockKit->getComponents()->front()
 		->getLayer( 0 )->getSample()->getFilePath();
-	const auto pInstrumentOld = pSongLegacy->getDrumkit()->getInstruments()->find( 12 );
+	const auto pInstrumentOld = pSongLegacy->getDrumkit()->getInstruments()->get( 12 );
 	CPPUNIT_ASSERT( pInstrumentOld != nullptr );
 	CPPUNIT_ASSERT( pInstrumentOld->getComponents()->size() > 0 );
 	CPPUNIT_ASSERT( pInstrumentOld->getComponents()->front() != nullptr );


### PR DESCRIPTION
there was, again, a bug because the ID of an instrument was confused
with its index in the instrument list during look up.

Since this is a quite common source of problems, I decided to refactor
the code base and use a strong typed `Instrument::Id` as an alias for
`int`. This way the compiler can help us to detect future mixups.

While at it, I also moved `DrumkitMap::Type` into `Instrument::Type` for
a more consistent design.

The mere refactoring did not just uncovered the initial bug but also
another one in `ExportSongDialog` which went unnoticed so far.