### PR TITLE
Preferences: write missing interface theme members

### DIFF
--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -347,6 +347,9 @@
   <SongEditor_pattern_color_48>67,96,131</SongEditor_pattern_color_48>
   <SongEditor_pattern_color_49>67,96,131</SongEditor_pattern_color_49>
   <SongEditor_visible_pattern_colors>18</SongEditor_visible_pattern_colors>
+  <iconColor>0</iconColor>
+  <indicateNotePlayback>true</indicateNotePlayback>
+  <indicateEffectiveNoteLength>true</indicateEffectiveNoteLength>
  </gui>
  <files>
   <lastSongFilename></lastSongFilename>

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -1266,6 +1266,25 @@ Preferences::load( const QString& sPath, const bool bSilent )
 			),
 			0, 50
 		);
+		const int nIconColor = guiNode.read_int(
+			"iconColor", static_cast<int>( pInterfaceTheme->m_iconColor ), true,
+			false, bSilent
+		);
+		pInterfaceTheme->m_iconColor =
+			nIconColor == static_cast<int>( InterfaceTheme::IconColor::White )
+				? InterfaceTheme::IconColor::White
+				: InterfaceTheme::IconColor::Black;
+
+		pInterfaceTheme->m_bIndicateNotePlayback = guiNode.read_bool(
+			"indicateNotePlayback", pInterfaceTheme->m_bIndicateNotePlayback,
+			true, false, bSilent
+		);
+
+		pInterfaceTheme->m_bIndicateEffectiveNoteLength = guiNode.read_bool(
+			"indicateEffectiveNoteLength",
+			pInterfaceTheme->m_bIndicateEffectiveNoteLength, true, false,
+			bSilent
+		);
 	}
 	else {
 		WARNINGLOG( "<gui> node not found" );
@@ -1842,6 +1861,17 @@ bool Preferences::saveTo( const QString& sPath, const bool bSilent ) const
 		guiNode.write_int(
 			"SongEditor_visible_pattern_colors",
 			pInterfaceTheme->m_nVisiblePatternColors
+		);
+
+		guiNode.write_int(
+			"iconColor", static_cast<int>( pInterfaceTheme->m_iconColor )
+		);
+		guiNode.write_bool(
+			"indicateNotePlayback", pInterfaceTheme->m_bIndicateNotePlayback
+		);
+		guiNode.write_bool(
+			"indicateEffectiveNoteLength",
+			pInterfaceTheme->m_bIndicateEffectiveNoteLength
 		);
 	}
 

--- a/src/tests/data/preferences/current.conf
+++ b/src/tests/data/preferences/current.conf
@@ -365,6 +365,9 @@
   <SongEditor_pattern_color_48>67,96,131</SongEditor_pattern_color_48>
   <SongEditor_pattern_color_49>67,96,131</SongEditor_pattern_color_49>
   <SongEditor_visible_pattern_colors>18</SongEditor_visible_pattern_colors>
+  <iconColor>0</iconColor>
+  <indicateNotePlayback>true</indicateNotePlayback>
+  <indicateEffectiveNoteLength>true</indicateEffectiveNoteLength>
  </gui>
  <files>
   <lastSongFilename>/home/phil/tmp/NewSong.h2song</lastSongFilename>


### PR DESCRIPTION
For backward compatibility reasons both `InterfaceTheme` and `FontTheme` are not stored using their dedicated `loadFrom()` and `saveTo()` routines but as part of the more general code to read/write `Preferences`. This code is then duplicated for exporting the theme into a `.h2theme` file.

It seems when introducing new members to `InterfaceTheme` recently I forgot to introduce them into the former read/write routines and setting them in `PreferencesDialog` was not persistent.

Fixes #2278.