### PR TITLE
Revert "AudioEngine: truncate custom note length on pattern end" (#2290)

### DIFF
--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -3231,16 +3231,6 @@ void AudioEngine::updateNoteQueue( unsigned nIntervalLengthInFrames )
 													   pAutomationPath->get_value( fPos ) );
 						}
 
-						// Ensure the custom length of the note does not exceed
-						// the length of the current pattern.
-						if ( pCopiedNote->getLength() != LENGTH_ENTIRE_SAMPLE ) {
-							pCopiedNote->setLength(
-								std::min(
-									static_cast<long>(pCopiedNote->getLength()),
-									static_cast<long>(pPattern->getLength()) -
-									m_pQueuingPosition->getPatternTickPosition() ) );
-						}
-
 #if AUDIO_ENGINE_DEBUG
 						AE_DEBUGLOG( QString( "m_pQueuingPosition: %1, new note: %2" )
 								  .arg( m_pQueuingPosition->toQString() )


### PR DESCRIPTION
This reverts commit 0aca450a888ebbb79a52553124927ea11ca40b81. As requested in #2290.

Fixes #2290