### PR TITLE
Allocate memory for Pm_GetHostErrorText

### DIFF
--- a/src/core/IO/PortMidiDriver.cpp
+++ b/src/core/IO/PortMidiDriver.cpp
@@ -565,7 +565,7 @@ QString PortMidiDriver::translatePmError( const PmError& err ) {
 	if ( err == pmHostError ) {
 		// Get OS-dependent part of the error messages, e.g. something
 		// went wrong in the underlying ALSA driver.
-		char *msg;
+		char msg[100];
 		Pm_GetHostErrorText( msg, 100 );
 		sRes.append( QString( ": [%1]" ).arg( msg ) );
 	}


### PR DESCRIPTION
This prevents a segfault when the driver is restarted and a host error occurs.

From the documentation of `Pm_GetHostErrorText`:
"These strings are computed at run time, so client has to allocate storage."