### PR TITLE
Link Backtrace_LIBRARIES to hydrogen-core

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -55,6 +55,16 @@ target_link_libraries(hydrogen-core-${VERSION}
 	Qt${QT_VERSION_MAJOR}::Gui # For QColor
 )
 
+if(Backtrace_FOUND)
+    target_include_directories(hydrogen-core-${VERSION}
+        PRIVATE
+        ${Backtrace_INCLUDE_DIRS}
+    )
+    target_link_libraries(hydrogen-core-${VERSION}
+        ${Backtrace_LIBRARIES}
+    )
+endif()
+
 #SET_TARGET_PROPERTIES(hydrogen-core-${VERSION} PROPERTIES PUBLIC_HEADER   "${hydrogen_INCLUDES}" )
 set_property(TARGET hydrogen-core-${VERSION} PROPERTY CXX_STANDARD 17)
 


### PR DESCRIPTION
On OpenBSD (and FreeBSD/NetBSD as well) `-lexecinfo` is needed for libhydrogen-core.
(`find_package(Backtrace)` defines `Backtrace_LIBRARIES` and `Backtrace_INCLUDE_DIRS`)

This is the linker error I get on OpenBSD:

```
ld: error: undefined reference: backtrace
>>> referenced by src/core/libhydrogen-core-1.2.6.so.2.0 (disallowed by --no-allow-shlib-undefined)

ld: error: undefined reference: backtrace_symbols
>>> referenced by src/core/libhydrogen-core-1.2.6.so.2.0 (disallowed by --no-allow-shlib-undefined)
c++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

