### PR TITLE
Fix FilesystemTest on BSD systems

### DIFF
--- a/src/tests/FilesystemTest.cpp
+++ b/src/tests/FilesystemTest.cpp
@@ -29,7 +29,7 @@ using namespace H2Core;
 void FilesystemTest::setUp() {
 #if !defined(WIN32) 
 	m_sNotExistingPath = QDir::homePath().append( "aFunnyNameYouWouldNotExpectInYourHomeFolder.h2song" );
-#ifdef Q_OS_MACX
+#ifdef Q_OS_BSD4
 	m_sNoAccessPath = "/etc/master.passwd";
 #else
 	m_sNoAccessPath = "/etc/shadow";


### PR DESCRIPTION
This makes this test pass on OpenBSD and should not break MACOS because `Q_OS_BSD4` is defined on MACOS and all BSDs. 