### PR TITLE
Fix FilesystemTest on OpenBSD

### DIFF
--- a/src/tests/FilesystemTest.cpp
+++ b/src/tests/FilesystemTest.cpp
@@ -34,7 +34,7 @@ void FilesystemTest::setUp() {
 #else
 	m_sNoAccessPath = "/etc/shadow";
 #endif
-	m_sReadOnlyPath = "/etc/profile";
+	m_sReadOnlyPath = "/etc/hosts";
 	m_sFullAccessPath = QString( Filesystem::usr_data_path() )
 		.append( "test.h2song"  );
 	m_sTmpPath = Filesystem::tmp_file_path( "test.h2song" );


### PR DESCRIPTION
The FilesystemTest is still failing on OpenBSD:
```

1) test: FilesystemTest::testPermissions (F) line: 56 /tmp/hydrogen/src/tests/FilesystemTest.cpp
assertion failed
- Expression: Filesystem::file_readable( m_sReadOnlyPath, true )
```

The reason for this is that there is no `/etc/profile` on OpenBSD (by default).
I'm not sure, but I think `/etc/hosts` should be present everywhere.