### PR TITLE
LoopBackMidiDriver: fix compilation (#2326)

### DIFF
--- a/src/core/IO/LoopBackMidiDriver.cpp
+++ b/src/core/IO/LoopBackMidiDriver.cpp
@@ -118,7 +118,7 @@ QString LoopBackMidiDriver::toQString( const QString& sPrefix, bool bShort ) {
 	if ( ! bShort ) {
 		sOutput = QString( "%1[LoopBackMidiDriver]\n" ).arg( sPrefix )
 			.append( QString( "%1%2m_bActive: %3,\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_bActive ) )
+					 .arg( m_bActive.load() ) )
 			.append( QString( "%1%2m_messageQueue: [\n" ).arg( sPrefix ).arg( s ) );
 		for ( const auto& mmessage : m_messageQueue ) {
 			sOutput.append( QString( "%1%2%2%3\n" ).arg( sPrefix ).arg( s )
@@ -133,7 +133,7 @@ QString LoopBackMidiDriver::toQString( const QString& sPrefix, bool bShort ) {
 	}
 	else {
 		sOutput = QString( "[LoopBackMidiDriver]" )
-			.append( QString( ", m_bActive: %1" ).arg( m_bActive ) )
+			.append( QString( ", m_bActive: %1" ).arg( m_bActive.load() ) )
 			.append( ", m_messageQueue: [" );
 		for ( const auto& mmessage : m_messageQueue ) {
 			sOutput.append( QString( " %1 " ).arg( mmessage.toQString() ) );


### PR DESCRIPTION
it seems that Qt enforces stricter type requirements since Qt 6.9. The recent change of `MidiBaseDriver::m_bActive` from `bool` to `atomic<bool>` was compile fine both in the pipeline and on my local device since both featured an older version of Qt6. But in order for the code to compile with Qt >= 6.9 we have to explicitly dereference the atomic variable.

Fixes #2326