### PR TITLE
MidiTable: fix parameter persistence (#2328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Segfault on Port-MIDI host error by @rrrapha.
 - Fix linker error on OpenBSD by @rrrapha.
 - Fixed performance issue when using JACK audio with rubberband.
+- Parameter loss in the MIDI table within the preferences (#2328).
 
 ## [1.2.6] - 2025-07-29
 

--- a/src/gui/src/Widgets/MidiTable.cpp
+++ b/src/gui/src/Widgets/MidiTable.cpp
@@ -177,7 +177,6 @@ void MidiTable::insertNewRow(std::shared_ptr<Action> pAction, QString eventStrin
 	eventParameterSpinner->setSize( QSize( m_nColumn2Width, m_nRowHeight ) );
 	setCellWidget( oldRowCount , 2, eventParameterSpinner );
 	eventParameterSpinner->setMaximum( 999 );
-	eventParameterSpinner->setValue( eventParameter );
 	connect( eventParameterSpinner, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( sendChanged() ) );
 
@@ -196,7 +195,6 @@ void MidiTable::insertNewRow(std::shared_ptr<Action> pAction, QString eventStrin
 	actionParameterSpinner1->setSize( QSize( m_nColumn4Width, m_nRowHeight ) );
 	setCellWidget( oldRowCount , 4, actionParameterSpinner1 );
 	actionParameterSpinner1->setMaximum( 999 );
-	actionParameterSpinner1->setValue( pAction->getParameter1().toInt(&ok,10) );
 	actionParameterSpinner1->hide();
 	connect( actionParameterSpinner1, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( sendChanged() ) );
@@ -205,7 +203,6 @@ void MidiTable::insertNewRow(std::shared_ptr<Action> pAction, QString eventStrin
 	actionParameterSpinner2->setSize( QSize( m_nColumn5Width, m_nRowHeight ) );
 	setCellWidget( oldRowCount , 5, actionParameterSpinner2 );
 	actionParameterSpinner2->setMaximum( std::max(MAX_FX, MAX_COMPONENTS) );
-	actionParameterSpinner2->setValue( pAction->getParameter2().toInt(&ok,10) );
 	actionParameterSpinner2->hide();
 	connect( actionParameterSpinner2, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( sendChanged() ) );
@@ -214,10 +211,16 @@ void MidiTable::insertNewRow(std::shared_ptr<Action> pAction, QString eventStrin
 	actionParameterSpinner3->setSize( QSize( m_nColumn6Width, m_nRowHeight ) );
 	setCellWidget( oldRowCount , 6, actionParameterSpinner3 );
 	actionParameterSpinner3->setMaximum( H2Core::InstrumentComponent::getMaxLayers() );
-	actionParameterSpinner3->setValue( pAction->getParameter3().toInt(&ok,10) );
 	actionParameterSpinner3->hide();
 	connect( actionParameterSpinner3, SIGNAL( valueChanged( double ) ),
 			 this, SLOT( sendChanged() ) );
+
+	// Update the bounds of each widget before setting the actual value.
+	updateRow( oldRowCount );
+	eventParameterSpinner->setValue( eventParameter );
+	actionParameterSpinner1->setValue( pAction->getParameter1().toInt(&ok, 10) );
+	actionParameterSpinner2->setValue( pAction->getParameter2().toInt(&ok, 10) );
+	actionParameterSpinner3->setValue( pAction->getParameter3().toInt(&ok, 10) );
 }
 
 void MidiTable::setupMidiTable()


### PR DESCRIPTION
Previously, the proper value ranges for a parameter were only applied when manually altering a row. However, this lead to loss of certain parameters during initialization, e.g. a `SELECT_NEXT_PATTERN_RELATIVE` with `-1` as first parameter.