### PR TITLE
ForwardCompatibility: to new drumkit path format

### DIFF
--- a/src/core/Basics/Instrument.cpp
+++ b/src/core/Basics/Instrument.cpp
@@ -26,6 +26,7 @@
 
 #include <core/Hydrogen.h>
 
+#include <core/Helpers/Filesystem.h>
 #include <core/Helpers/Legacy.h>
 #include <core/Helpers/Xml.h>
 
@@ -264,6 +265,7 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode,
 												   const QString& sDrumkitName,
 												   const QString& sSongPath,
 												   const License& license,
+												   bool bFutureFormat,
 												   bool* pLegacyFormatEncountered,
 												   bool bSilent )
 {
@@ -298,6 +300,14 @@ std::shared_ptr<Instrument> Instrument::load_from( XMLNode* pNode,
 			// Current format
 			sInstrumentDrumkitPath = pNode->read_string( "drumkitPath", "",
 														 false, false, bSilent  );
+
+			// In version 2.0 the path to a drumkit will be handled as the
+			// absolute path to its describing `drumkit.xml` file. Not to the
+			// folder that file is contained in was in prior versions.
+			if ( bFutureFormat &&
+				 sInstrumentDrumkitPath.contains( Filesystem::drumkit_xml() ) ) {
+				sInstrumentDrumkitPath.remove( "/" + Filesystem::drumkit_xml() );
+			}
 
 #ifdef H2CORE_HAVE_APPIMAGE
 			sInstrumentDrumkitPath =

--- a/src/core/Basics/Instrument.h
+++ b/src/core/Basics/Instrument.h
@@ -152,7 +152,8 @@ class Instrument : public H2Core::Object<Instrument>
 			const QString& sDrumkitPath,
 			const QString& sDrumkitName,
 			const QString& sSongPath,
-			const License& license = License(),
+			const License& license,
+			bool bFutureFormat,
 			bool* pLegacyFormatEncountered = nullptr,
 			bool bSilent = false );
 

--- a/src/core/Basics/InstrumentList.cpp
+++ b/src/core/Basics/InstrumentList.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<InstrumentList> InstrumentList::load_from(
 
 		auto pInstrument = Instrument::load_from(
 			&instrumentNode, sDrumkitPath, sDrumkitName, sSongPath, license,
-			pLegacyFormatEncountered, bSilent );
+			false, pLegacyFormatEncountered, bSilent );
 		if ( pInstrument != nullptr ) {
 			( *pInstrumentList ) << pInstrument;
 		}

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -285,7 +285,7 @@ std::shared_ptr<Song> Song::loadFrom(
                 playbackTrackNode.firstChildElement( "instrument" );
             auto pPlaybackTrackInstrument = Instrument::load_from(
                 &playbackTrackInstrumentNode, "", "", sSongPath, pSong->getLicense(),
-                nullptr, bSilent
+                true, nullptr, bSilent
             );
             if ( pPlaybackTrackInstrument != nullptr ) {
                 auto pPlaybackTrackComponent =

--- a/src/core/Helpers/Future.cpp
+++ b/src/core/Helpers/Future.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<H2Core::Drumkit> Future::loadDrumkit(
 
 		auto pInstrument = Instrument::load_from(
 			&instrumentNode, sDrumkitPath, sDrumkitName, sSongPath, license,
-			nullptr, bSilent );
+			true, nullptr, bSilent );
 		if ( pInstrument != nullptr ) {
 			auto pInstrumentComponents = pInstrument->get_components();
 

--- a/src/tests/ForwardCompatibilityTest.cpp
+++ b/src/tests/ForwardCompatibilityTest.cpp
@@ -150,6 +150,10 @@ void ForwardCompatibilityTest::testSong()
 	CPPUNIT_ASSERT( pSong != nullptr );
 	CPPUNIT_ASSERT( pSong->getInstrumentList() != nullptr );
 	CPPUNIT_ASSERT( pSong->getInstrumentList()->size() == 21 );
+	for ( const auto& ppInstrument : *pSong->getInstrumentList() ) {
+		CPPUNIT_ASSERT( ppInstrument != nullptr );
+		CPPUNIT_ASSERT( ! ppInstrument->has_missing_samples() );
+	}
 	CPPUNIT_ASSERT( pSong->getComponents() != nullptr );
 	CPPUNIT_ASSERT( pSong->getComponents()->size() == 2 );
 	CPPUNIT_ASSERT( pSong->getAllNotes().size() != 0 );

--- a/src/tests/MemoryLeakageTest.cpp
+++ b/src/tests/MemoryLeakageTest.cpp
@@ -329,7 +329,8 @@ void MemoryLeakageTest::testLoading() {
 		CPPUNIT_ASSERT( doc.read( H2TEST_FILE( "/memoryLeakage/instrument.xml" ) ) );
 		node = doc.firstChildElement( "instrument" );
 		auto pInstrument = H2Core::Instrument::load_from(
-			&node, H2TEST_FILE( "/drumkits/baseKit" ), "", "" );
+			&node, H2TEST_FILE( "/drumkits/baseKit" ), "", "",
+			H2Core::License(), false );
 		CPPUNIT_ASSERT( pInstrument != nullptr );
 		pInstrument = nullptr;
 		CPPUNIT_ASSERT( nAliveReference == H2Core::Base::getAliveObjectCount() );

--- a/src/tests/data/forwardCompatibility/drumkits/GMRockKit-Future/drumkit.xml
+++ b/src/tests/data/forwardCompatibility/drumkits/GMRockKit-Future/drumkit.xml
@@ -66,6 +66,7 @@ p, li { white-space: pre-wrap; }
     <gain>1</gain>
     <isMuted>false</isMuted>
     <isSoloed>false</isSoloed>
+    <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
     <layer>
      <filename>emptySample.flac</filename>
      <min>0</min>

--- a/src/tests/data/forwardCompatibility/future.h2song
+++ b/src/tests/data/forwardCompatibility/future.h2song
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <song>
- <version>1.3.0-alpha-'8c60eb06f'</version>
+ <version>2.0.0-pre-alpha-'3336e7141'</version>
  <formatVersion>2</formatVersion>
  <bpm>120</bpm>
  <volume>0.5</volume>
@@ -97,7 +97,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;">A Sampled 5pc Pearl DX Series Drumkit.&lt;/p>&lt;/body>&lt;/html></info>
   <license>GPL</license>
   <tags>
-    <tag>GM compliant</tag>
+   <tag>GM compliant</tag>
   </tags>
   <image></image>
   <imageLicense>undefined license</imageLicense>
@@ -106,7 +106,7 @@ p, li { white-space: pre-wrap; }
     <id>0</id>
     <name>Kick</name>
     <type>Kick</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -261,6 +261,7 @@ p, li { white-space: pre-wrap; }
      <gain>1</gain>
      <isMuted>false</isMuted>
      <isSoloed>false</isSoloed>
+     <sampleSelectionAlgo>VELOCITY</sampleSelectionAlgo>
      <layer>
       <filename>../../../../data/drumkits/GMRockKit/Kick-Softest.wav</filename>
       <min>0</min>
@@ -286,7 +287,7 @@ p, li { white-space: pre-wrap; }
     <id>20</id>
     <name>New instrument</name>
     <type></type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -346,7 +347,7 @@ p, li { white-space: pre-wrap; }
     <id>18</id>
     <name>Kick Long</name>
     <type></type>
-    <drumkitPath>../../../../data/drumkits/TR808EmulationKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/TR808EmulationKit/drumkit.xml</drumkitPath>
     <drumkit>TR808EmulationKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -406,7 +407,7 @@ p, li { white-space: pre-wrap; }
     <id>19</id>
     <name>Snare 1</name>
     <type></type>
-    <drumkitPath>../../../../data/drumkits/TR808EmulationKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/TR808EmulationKit/drumkit.xml</drumkitPath>
     <drumkit>TR808EmulationKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -466,7 +467,7 @@ p, li { white-space: pre-wrap; }
     <id>1</id>
     <name>Stick</name>
     <type>Stick</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.99569</volume>
     <isMuted>false</isMuted>
@@ -602,7 +603,7 @@ p, li { white-space: pre-wrap; }
     <id>2</id>
     <name>Snare</name>
     <type>Snare</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1.02155</volume>
     <isMuted>false</isMuted>
@@ -754,7 +755,7 @@ p, li { white-space: pre-wrap; }
     <id>3</id>
     <name>Hand Clap</name>
     <type>Hand Clap</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1.02155</volume>
     <isMuted>false</isMuted>
@@ -814,7 +815,7 @@ p, li { white-space: pre-wrap; }
     <id>4</id>
     <name>Snare Rimshot</name>
     <type>Snare Rimshot</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -950,7 +951,7 @@ p, li { white-space: pre-wrap; }
     <id>5</id>
     <name>Floor Tom</name>
     <type>Tom Floor</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1.04741</volume>
     <isMuted>false</isMuted>
@@ -1086,7 +1087,7 @@ p, li { white-space: pre-wrap; }
     <id>6</id>
     <name>Hat Closed</name>
     <type>Hi-hat Closed</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.685345</volume>
     <isMuted>false</isMuted>
@@ -1222,7 +1223,7 @@ p, li { white-space: pre-wrap; }
     <id>7</id>
     <name>Tom 2</name>
     <type>Tom Low</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -1358,7 +1359,7 @@ p, li { white-space: pre-wrap; }
     <id>8</id>
     <name>Hat Pedal</name>
     <type>Hi-hat Pedal</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.685345</volume>
     <isMuted>false</isMuted>
@@ -1494,7 +1495,7 @@ p, li { white-space: pre-wrap; }
     <id>9</id>
     <name>Tom 1</name>
     <type>Tom High</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -1630,7 +1631,7 @@ p, li { white-space: pre-wrap; }
     <id>10</id>
     <name>Hat Open</name>
     <type>Hi-hat Open</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.698276</volume>
     <isMuted>false</isMuted>
@@ -1766,7 +1767,7 @@ p, li { white-space: pre-wrap; }
     <id>11</id>
     <name>Cowbell</name>
     <type>Cowbell</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.568965</volume>
     <isMuted>false</isMuted>
@@ -1902,7 +1903,7 @@ p, li { white-space: pre-wrap; }
     <id>12</id>
     <name>Ride</name>
     <type>Ride Bow</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.633621</volume>
     <isMuted>false</isMuted>
@@ -2038,7 +2039,7 @@ p, li { white-space: pre-wrap; }
     <id>13</id>
     <name>Crash</name>
     <type>Crash</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.517241</volume>
     <isMuted>false</isMuted>
@@ -2174,7 +2175,7 @@ p, li { white-space: pre-wrap; }
     <id>14</id>
     <name>Ride 2</name>
     <type>Ride Bow 2</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>1</volume>
     <isMuted>false</isMuted>
@@ -2310,7 +2311,7 @@ p, li { white-space: pre-wrap; }
     <id>15</id>
     <name>Splash</name>
     <type>Splash</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.543103</volume>
     <isMuted>false</isMuted>
@@ -2446,7 +2447,7 @@ p, li { white-space: pre-wrap; }
     <id>16</id>
     <name>Hat Semi-Open</name>
     <type>Hi-hat Semi-Open</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.69</volume>
     <isMuted>false</isMuted>
@@ -2582,7 +2583,7 @@ p, li { white-space: pre-wrap; }
     <id>17</id>
     <name>Bell</name>
     <type>Ride Bell</type>
-    <drumkitPath>../../../../data/drumkits/GMRockKit</drumkitPath>
+    <drumkitPath>../../../../data/drumkits/GMRockKit/drumkit.xml</drumkitPath>
     <drumkit>GMRockKit</drumkit>
     <volume>0.534828</volume>
     <isMuted>false</isMuted>
@@ -2924,6 +2925,18 @@ p, li { white-space: pre-wrap; }
    <noteList/>
   </pattern>
  </patternList>
+ <patternPaths>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+  <patternPath></patternPath>
+ </patternPaths>
  <virtualPatternList/>
  <patternSequence>
   <group>


### PR DESCRIPTION
starting with Hydrogen 2.0 (since https://github.com/hydrogen-music/hydrogen/pull/2330) all paths to drumkits are handled internally as absolute paths to the drumkit.xml file. Not the folder containing it as in previous versions.

This was done in an effort to streamline handling of drumkits, songs, and patterns in order to give users a more consistent UX.