### PR TITLE
Introduce notion of patterns and drumkits being modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ All notable changes to this project will be documented in this file.
 - Patterns are now independent of Drumkits and the latter can switched without
   the need to adjust the patterns. Mapping between the two will be done using
   "instrument types".
+- Patterns and drumkits are now marked modified (*) in case they are loaded from
+  file.
 - `<instrumentComponent>` and `<instrumentLayer>` elements in drumkit XML
   definitions contain two new elements: `<isMuted>` and `<isSoloed>`.
 - Notes not rendered by the audio engine are now highlighted in the pattern

--- a/src/core/AudioEngine/AudioEngine.cpp
+++ b/src/core/AudioEngine/AudioEngine.cpp
@@ -117,10 +117,6 @@ AudioEngine::AudioEngine()
 	}
 
 	m_AudioProcessCallback = &audioEngine_process;
-
-#ifdef H2CORE_HAVE_LADSPA
-	Effects::create_instance();
-#endif
 }
 
 AudioEngine::~AudioEngine()
@@ -148,10 +144,6 @@ AudioEngine::~AudioEngine()
 	m_pMetronomeInstrument = nullptr;
 
 	this->unlock();
-	
-#ifdef H2CORE_HAVE_LADSPA
-	delete Effects::get_instance();
-#endif
 
 	delete m_pSampler;
 }
@@ -978,13 +970,13 @@ void AudioEngine::clearAudioBuffers( uint32_t nFrames )
 	m_MutexOutputPointer.unlock();
 
 #ifdef H2CORE_HAVE_LADSPA
-	if ( getState() == State::Ready ||
-		 getState() == State::CountIn ||
-		 getState() == State::Playing ||
-		 getState() == State::Testing ) {
-		Effects* pEffects = Effects::get_instance();
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( ( getState() == State::Ready || getState() == State::CountIn ||
+		   getState() == State::Playing || getState() == State::Testing ) &&
+		 pSong != nullptr ) {
+		const auto pEffects = pSong->getEffects();
 		for ( unsigned i = 0; i < MAX_FX; ++i ) {	// clear FX buffers
-			auto pFX = pEffects->getLadspaFX( i );
+			const auto pFX = pEffects->getLadspaFX( i );
 			if ( pFX != nullptr ) {
 				assert( pFX->m_pBuffer_L );
 				assert( pFX->m_pBuffer_R );
@@ -1547,7 +1539,7 @@ void AudioEngine::setupLadspaFX()
 
 #ifdef H2CORE_HAVE_LADSPA
 	for ( unsigned nFX = 0; nFX < MAX_FX; ++nFX ) {
-		auto pFX = Effects::get_instance()->getLadspaFX( nFX );
+		auto pFX = pSong->getEffects()->getLadspaFX( nFX );
 		if ( pFX == nullptr ) {
 			return;
 		}
@@ -2016,7 +2008,7 @@ void AudioEngine::processAudio( uint32_t nFrames ) {
 	const auto ladspaStartTimePoint = Clock::now();
 
 	for ( unsigned nFX = 0; nFX < MAX_FX; ++nFX ) {
-		auto pFX = Effects::get_instance()->getLadspaFX( nFX );
+		auto pFX = pSong->getEffects()->getLadspaFX( nFX );
 		if ( pFX != nullptr && pFX->isEnabled() ) {
 			pFX->processFX( nFrames );
 

--- a/src/core/Basics/AutomationPath.cpp
+++ b/src/core/Basics/AutomationPath.cpp
@@ -80,7 +80,7 @@ float AutomationPath::get_value(float x) const noexcept
 void AutomationPath::add_point(float x, float y)
 {
 	_points[x] = y;
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 
@@ -177,7 +177,7 @@ AutomationPath::iterator AutomationPath::move(iterator &in, float x, float y)
 {
 	_points.erase(in);
 	auto rv = _points.insert(std::make_pair(x,y));
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 	return rv.first;
 }
 
@@ -192,7 +192,7 @@ void AutomationPath::remove_point(float x)
 	if (it != _points.end()) {
 		_points.erase(it);
 	}
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 } //namespace H2Core

--- a/src/core/Basics/Drumkit.cpp
+++ b/src/core/Basics/Drumkit.cpp
@@ -63,6 +63,7 @@ Drumkit::Drumkit()
 	  m_tags( QStringList() ),
 	  m_sImage( "" ),
 	  m_imageLicense( License() ),
+	  m_bIsModified( false ),
 	  m_pInstruments( std::make_shared<InstrumentList>() )
 {
 }
@@ -78,6 +79,7 @@ Drumkit::Drumkit( std::shared_ptr<Drumkit> other )
 	  m_license( other->getLicense() ),
 	  m_tags( other->m_tags ),
 	  m_sImage( other->getImage() ),
+	  m_bIsModified( other->m_bIsModified ),
 	  m_imageLicense( other->getImageLicense() )
 {
 	m_pInstruments = std::make_shared<InstrumentList>( other->getInstruments() );
@@ -1450,6 +1452,7 @@ QString Drumkit::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( "%1%2m_tags: %3\n" ).arg( sPrefix ).arg( s ).arg( m_tags.join( ", " ) ) )
 			.append( QString( "%1%2image: %3\n" ).arg( sPrefix ).arg( s ).arg( m_sImage ) )
 			.append( QString( "%1%2imageLicense: %3\n" ).arg( sPrefix ).arg( s ).arg( m_imageLicense.toQString() ) )
+			.append( QString( "%1%2m_bIsModified: %3\n" ).arg( sPrefix ).arg( s ).arg( m_bIsModified ) )
 			.append( QString( "%1%2samples_loaded: %3\n" ).arg( sPrefix ).arg( s )
 					 .arg( m_pInstruments->isAnyInstrumentSampleLoaded() ) )
 			.append( QString( "%1" ).arg( m_pInstruments->toQString( sPrefix + s, bShort ) ) );
@@ -1469,6 +1472,7 @@ QString Drumkit::toQString( const QString& sPrefix, bool bShort ) const {
 			.append( QString( ", m_tags: %1" ).arg( m_tags.join( ", " ) ) )
 			.append( QString( ", image: %1" ).arg( m_sImage ) )
 			.append( QString( ", imageLicense: %1" ).arg( m_imageLicense.toQString() ) )
+			.append( QString( ", m_bIsModified: %1" ).arg( m_bIsModified ) )
 			.append( QString( ", samples_loaded: %1" )
 					 .arg( m_pInstruments->isAnyInstrumentSampleLoaded() ) )
 			.append( QString( ", [%1]" ).arg( m_pInstruments->toQString( sPrefix + s, bShort ) ) );

--- a/src/core/Basics/Drumkit.h
+++ b/src/core/Basics/Drumkit.h
@@ -273,6 +273,9 @@ class Drumkit : public H2Core::Object<Drumkit>
 		/** #m_imageLicense accessor */
 		const License& getImageLicense() const;
 
+	bool getIsModified() const;
+	void setIsModified( bool bIsModified );
+
 	/**
 	 * Returns vector of lists containing instrument name, component
 	 * name, file name, the license of all associated samples.
@@ -344,6 +347,13 @@ class Drumkit : public H2Core::Object<Drumkit>
 		QStringList m_tags;
 		QString m_sImage;				///< drumkit image filename
 		License m_imageLicense;			///< drumkit image license
+
+	/** Transient member not written to file stating whether a loaded drumkit
+	 * was modified and should be saved to prevent a loss of data.
+	 *
+	 * Note that drumkits not associated with files - new ones - will not be
+	 * marked modified. */
+	bool m_bIsModified;
 
 		std::shared_ptr<InstrumentList> m_pInstruments;  ///< the list of instruments
 
@@ -482,6 +492,16 @@ inline void Drumkit::setImageLicense( const License& imageLicense )
 inline const License& Drumkit::getImageLicense() const
 {
 	return m_imageLicense;
+}
+
+inline bool Drumkit::getIsModified() const {
+	return m_bIsModified;
+}
+
+inline void Drumkit::setIsModified( bool bIsModified ) {
+	if ( ! m_sPath.isEmpty() && bIsModified != m_bIsModified ) {
+		m_bIsModified = bIsModified;
+	}
 }
 
 };

--- a/src/core/Basics/Event.cpp
+++ b/src/core/Basics/Event.cpp
@@ -82,6 +82,8 @@ QString Event::TypeToQString( Event::Type type ) {
 		return "PatternChanged";
 	case Event::Type::PatternEditorLocked:
 		return "PatternEditorLocked";
+	case Event::Type::PatternIsModified:
+		return "PatternIsModified";
 	case Event::Type::PlaybackTrackChanged:
 		return "PlaybackTrackChanged";
 	case Event::Type::PlayingPatternsChanged:

--- a/src/core/Basics/Event.cpp
+++ b/src/core/Basics/Event.cpp
@@ -78,10 +78,10 @@ QString Event::TypeToQString( Event::Type type ) {
 		return "NextShot";
 	case Event::Type::NoteRender:
 		return "NoteRender";
+	case Event::Type::PatternChanged:
+		return "PatternChanged";
 	case Event::Type::PatternEditorLocked:
 		return "PatternEditorLocked";
-	case Event::Type::PatternModified:
-		return "PatternModified";
 	case Event::Type::PlaybackTrackChanged:
 		return "PlaybackTrackChanged";
 	case Event::Type::PlayingPatternsChanged:

--- a/src/core/Basics/Event.cpp
+++ b/src/core/Basics/Event.cpp
@@ -36,10 +36,10 @@ QString Event::TypeToQString( Event::Type type ) {
 		return "BbtChanged";
 	case Event::Type::BeatCounter:
 		return "BeatCounter";
+	case Event::Type::DrumkitIsModified:
+		return "DrumkitIsModified";
 	case Event::Type::DrumkitLoaded:
 		return "DrumkitLoaded";
-	case Event::Type::DrumkitModified:
-		return "DrumkitModified";
 	case Event::Type::EffectChanged:
 		return "EffectChanged";
 	case Event::Type::Error:

--- a/src/core/Basics/Event.cpp
+++ b/src/core/Basics/Event.cpp
@@ -38,6 +38,8 @@ QString Event::TypeToQString( Event::Type type ) {
 		return "BeatCounter";
 	case Event::Type::DrumkitLoaded:
 		return "DrumkitLoaded";
+	case Event::Type::DrumkitModified:
+		return "DrumkitModified";
 	case Event::Type::EffectChanged:
 		return "EffectChanged";
 	case Event::Type::Error:

--- a/src/core/Basics/Event.cpp
+++ b/src/core/Basics/Event.cpp
@@ -104,8 +104,8 @@ QString Event::TypeToQString( Event::Type type ) {
 		return "SelectedPatternChanged";
 	case Event::Type::SongModeActivation:
 		return "SongModeActivation";
-	case Event::Type::SongModified:
-		return "SongModified";
+	case Event::Type::SongIsModified:
+		return "SongIsModified";
 	case Event::Type::SongSizeChanged:
 		return "SongSizeChanged";
 	case Event::Type::SoundLibraryChanged:

--- a/src/core/Basics/Event.h
+++ b/src/core/Basics/Event.h
@@ -132,6 +132,8 @@ public:
 			PatternChanged,
 			/** Locks the PatternEditor on the pattern currently played back.*/
 			PatternEditorLocked,
+			/** Whether the modification state of a pattern changed. */
+			PatternIsModified,
 			PlaybackTrackChanged,
 			/**
 			 * Event triggered whenever part of or the whole current

--- a/src/core/Basics/Event.h
+++ b/src/core/Basics/Event.h
@@ -65,9 +65,9 @@ public:
 			 */
 			BbtChanged,
 			BeatCounter,
+			DrumkitIsModified,
 			/** A the current drumkit was replaced by a new one. */
 			DrumkitLoaded,
-			DrumkitModified,
 			EffectChanged,
 			Error,
 			GridCellToggled,

--- a/src/core/Basics/Event.h
+++ b/src/core/Basics/Event.h
@@ -67,6 +67,7 @@ public:
 			BeatCounter,
 			/** A the current drumkit was replaced by a new one. */
 			DrumkitLoaded,
+			DrumkitModified,
 			EffectChanged,
 			Error,
 			GridCellToggled,

--- a/src/core/Basics/Event.h
+++ b/src/core/Basics/Event.h
@@ -129,9 +129,9 @@ public:
 			NextShot,
 			/** Sampler does start to render a note. */
 			NoteRender,
+			PatternChanged,
 			/** Locks the PatternEditor on the pattern currently played back.*/
 			PatternEditorLocked,
-			PatternModified,
 			PlaybackTrackChanged,
 			/**
 			 * Event triggered whenever part of or the whole current

--- a/src/core/Basics/Event.h
+++ b/src/core/Basics/Event.h
@@ -191,7 +191,7 @@ public:
 			SelectedInstrumentChanged,
 			SelectedPatternChanged,
 			SongModeActivation,
-			SongModified,
+			SongIsModified,
 			SongSizeChanged,
 			SoundLibraryChanged,
 			/** Song::PatternMode::Stacked (0) or Song::PatternMode::Selected

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -47,7 +47,8 @@ Pattern::Pattern()
 	  m_nDenominator( 4 ),
 	  m_sName( "Pattern" ),
 	  m_sInfo( "" ),
-	  m_tags( QStringList() )
+	  m_tags( QStringList() ),
+	  m_bIsModified( false )
 {
 }
 
@@ -61,7 +62,8 @@ Pattern::Pattern( std::shared_ptr<Pattern> pOther )
 	  m_nDenominator( pOther->getDenominator() ),
 	  m_sName( pOther->getName() ),
 	  m_sInfo( pOther->getInfo() ),
-	  m_tags( QStringList() )
+	  m_tags( QStringList() ),
+	  m_bIsModified( pOther->m_bIsModified )
 {
 	FOREACH_NOTE_CST_IT_BEGIN_END( pOther->getNotes(), it )
 	{
@@ -789,6 +791,8 @@ QString Pattern::toQString( const QString& sPrefix, bool bShort ) const
 				) );
 			}
 		}
+		sOutput.append( QString( "%1%2m_bIsModified: %3\n" )
+						.arg( sPrefix ).arg( s ).arg( m_bIsModified ) );
 	}
 	else {
 		sOutput =
@@ -837,6 +841,7 @@ QString Pattern::toQString( const QString& sPrefix, bool bShort ) const
 		if ( m_flattenedVirtualPatterns.size() != 0 ) {
 			sOutput.append( "}" );
 		}
+		sOutput.append( QString( ", m_bIsModified: %1" ).arg( m_bIsModified ) );
 	}
 	return sOutput;
 }

--- a/src/core/Basics/Pattern.h
+++ b/src/core/Basics/Pattern.h
@@ -162,6 +162,9 @@ class Pattern : public H2Core::Object<Pattern> {
 	///< get the flattened virtual pattern set
 	const virtual_patterns_t* getFlattenedVirtualPatterns() const;
 
+	bool getIsModified() const;
+	void setIsModified( bool bIsModified );
+
 	/** Get the numerator of the time signature entered in
 	 * #PatternEditorPanel. Note that this quantity is a derived one based
 	 * and the denominator and the pattern length. */
@@ -357,6 +360,13 @@ class Pattern : public H2Core::Object<Pattern> {
 
 	/** Used to indicate changes in the underlying XSD file. */
 	static constexpr int nCurrentFormatVersion = 2;
+
+	/** Transient member not written to file stating whether a loaded pattern
+	 * was modified and should be saved to prevent a loss of data.
+	 *
+	 * Note that patterns not associated with files - a song's default or new
+	 * ones - will not be marked modified. */
+	bool m_bIsModified;
 };
 
 /** Iterate over all provided notes in an immutable way. */
@@ -518,6 +528,16 @@ inline const Pattern::virtual_patterns_t* Pattern::getFlattenedVirtualPatterns(
 ) const
 {
 	return &m_flattenedVirtualPatterns;
+}
+
+inline bool Pattern::getIsModified() const {
+	return m_bIsModified;
+}
+
+inline void Pattern::setIsModified( bool bIsModified ) {
+	if ( ! m_sPath.isEmpty() && bIsModified != m_bIsModified ) {
+		m_bIsModified = bIsModified;
+	}
 }
 
 inline void Pattern::insertNote( std::shared_ptr<Note> pNote )

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -492,6 +492,9 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 	pSong->setLastLoadedDrumkitPath(
 		Filesystem::sanitizeDrumkitPath( sLastLoadedDrumkitPath )
 	);
+	if ( pDrumkit != nullptr ) {
+		pDrumkit->setPath( pSong->getLastLoadedDrumkitPath() );
+	}
 
 	// Pattern list
 	auto pPatternList = PatternList::loadFrom(

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -97,6 +97,7 @@ Song::Song(
 	  m_sLastLoadedDrumkitPath( "" ),
 	  m_pDrumkit( std::make_shared<Drumkit>() ),
 	  m_pTimeline( std::make_shared<Timeline>() ),
+	  m_pEffects( std::make_shared<Effects>() ),
 	  m_bWasAskedAboutMissingSamples( false )
 {
 	if ( m_sName.isEmpty() ) {
@@ -692,13 +693,6 @@ Song::loadFrom( const XMLNode& rootNode, const QString& sPath, bool bSilent )
 		WARNINGLOG( "'patternSequence' node not found. Aborting." );
 	}
 
-#ifdef H2CORE_HAVE_LADSPA
-	// reset FX
-	for ( int fx = 0; fx < MAX_FX; ++fx ) {
-		Effects::get_instance()->setLadspaFX( nullptr, fx );
-	}
-#endif
-
 	// LADSPA FX
 	XMLNode ladspaNode = rootNode.firstChildElement( "ladspa" );
 	if ( !ladspaNode.isNull() ) {
@@ -709,14 +703,14 @@ Song::loadFrom( const XMLNode& rootNode, const QString& sPath, bool bSilent )
 				fxNode.read_string( "name", "", false, false, bSilent );
 
 			if ( sName != "no plugin" ) {
-				// FIXME: il caricamento va fatto fare all'engine, solo lui sa
-				// il samplerate esatto
 #ifdef H2CORE_HAVE_LADSPA
+				// TODO The upload must be handled by the engine, as only it
+				// knows the exact sample rate.
 				auto pFX = LadspaFX::load(
 					fxNode.read_string( "filename", "", false, false, bSilent ),
 					sName, 44100
 				);
-				Effects::get_instance()->setLadspaFX( pFX, nFX );
+				pSong->getEffects()->setLadspaFX( pFX, nFX );
 				if ( pFX != nullptr ) {
 					pFX->setEnabled( fxNode.read_bool(
 						"enabled", false, false, false, bSilent
@@ -1059,7 +1053,7 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples, bool bSilent )
 		XMLNode fxNode = ladspaFxNode.createNode( "fx" );
 
 #ifdef H2CORE_HAVE_LADSPA
-		auto pFX = Effects::get_instance()->getLadspaFX( nFX );
+		auto pFX = m_pEffects->getLadspaFX( nFX );
 		if ( pFX != nullptr ) {
 			fxNode.write_string( "name", pFX->getPluginLabel() );
 			fxNode.write_string( "filename", pFX->getLibraryPath() );

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -20,7 +20,6 @@
  *
  */
 
-
 #include <cassert>
 #include <memory>
 
@@ -35,9 +34,9 @@
 #include <core/Basics/InstrumentComponent.h>
 #include <core/Basics/InstrumentLayer.h>
 #include <core/Basics/InstrumentList.h>
+#include <core/Basics/Note.h>
 #include <core/Basics/Pattern.h>
 #include <core/Basics/PatternList.h>
-#include <core/Basics/Note.h>
 #include <core/Basics/Sample.h>
 #include <core/EventQueue.h>
 #include <core/FX/Effects.h>
@@ -51,57 +50,60 @@
 #include <core/Timeline.h>
 #include <core/Version.h>
 
-
 #include <QDir>
 
-namespace
-{
+namespace {
 
-}//anonymous namespace
-namespace H2Core
-{
+}  // anonymous namespace
+namespace H2Core {
 
 QString Song::sDefaultName = "Untitled Song";
 QString Song::sDefaultAuthor = "Unknown Author";
 
-Song::Song( const QString& sName, const QString& sAuthor, float fBpm, float fVolume )
-	: m_bIsTimelineActivated( false )
-	, m_bIsMuted( false )
-	, m_fBpm( fBpm )
-	, m_nVersion( 0 )
-	, m_sName( sName )
-	, m_sAuthor( sAuthor )
-	, m_fVolume( fVolume )
-	, m_fMetronomeVolume( 0.5 )
-	, m_sNotes( "..." )
-	, m_tags( QStringList() )
-	, m_pPatternList( std::make_shared<PatternList>() )
-	, m_pPatternGroupVector( std::make_shared< std::vector<
-							   std::shared_ptr<PatternList> > >() )
-	, m_sPath( "" )
-	, m_loopMode( LoopMode::Disabled )
-	, m_patternMode( PatternMode::Selected )
-	, m_fHumanizeTimeValue( 0.0 )
-	, m_fHumanizeVelocityValue( 0.0 )
-	, m_fSwingFactor( 0.0 )
-	, m_bIsModified( false )
-	, m_mode( Mode::Pattern )
-	, m_pVelocityAutomationPath( nullptr )
-	, m_license( License( "", sAuthor ) )
-	, m_actionMode( ActionMode::selectMode )
-	, m_bIsPatternEditorLocked( false )
-	, m_nPanLawType( Sampler::RATIO_STRAIGHT_POLYGONAL )
-	, m_fPanLawKNorm( Sampler::K_NORM_DEFAULT )
-	, m_sLastLoadedDrumkitPath( "" )
-	, m_pDrumkit( std::make_shared<Drumkit>() )
-	, m_pTimeline( std::make_shared<Timeline>() )
-	, m_bWasAskedAboutMissingSamples( false )
+Song::Song(
+	const QString& sName,
+	const QString& sAuthor,
+	float fBpm,
+	float fVolume
+)
+	: m_bIsTimelineActivated( false ),
+	  m_bIsMuted( false ),
+	  m_fBpm( fBpm ),
+	  m_nVersion( 0 ),
+	  m_sName( sName ),
+	  m_sAuthor( sAuthor ),
+	  m_fVolume( fVolume ),
+	  m_fMetronomeVolume( 0.5 ),
+	  m_sNotes( "..." ),
+	  m_tags( QStringList() ),
+	  m_pPatternList( std::make_shared<PatternList>() ),
+	  m_pPatternGroupVector(
+		  std::make_shared<std::vector<std::shared_ptr<PatternList>>>()
+	  ),
+	  m_sPath( "" ),
+	  m_loopMode( LoopMode::Disabled ),
+	  m_patternMode( PatternMode::Selected ),
+	  m_fHumanizeTimeValue( 0.0 ),
+	  m_fHumanizeVelocityValue( 0.0 ),
+	  m_fSwingFactor( 0.0 ),
+	  m_bIsModified( false ),
+	  m_mode( Mode::Pattern ),
+	  m_pVelocityAutomationPath( nullptr ),
+	  m_license( License( "", sAuthor ) ),
+	  m_actionMode( ActionMode::selectMode ),
+	  m_bIsPatternEditorLocked( false ),
+	  m_nPanLawType( Sampler::RATIO_STRAIGHT_POLYGONAL ),
+	  m_fPanLawKNorm( Sampler::K_NORM_DEFAULT ),
+	  m_sLastLoadedDrumkitPath( "" ),
+	  m_pDrumkit( std::make_shared<Drumkit>() ),
+	  m_pTimeline( std::make_shared<Timeline>() ),
+	  m_bWasAskedAboutMissingSamples( false )
 {
-	if ( m_sName.isEmpty() ){
+	if ( m_sName.isEmpty() ) {
 		m_sName = Song::sDefaultName;
 	}
 
-	m_pVelocityAutomationPath = new AutomationPath(0.0f, 1.5f,  1.0f);
+	m_pVelocityAutomationPath = new AutomationPath( 0.0f, 1.5f, 1.0f );
 }
 
 Song::~Song()
@@ -115,8 +117,7 @@ Song::~Song()
 	delete m_pVelocityAutomationPath;
 }
 
-std::shared_ptr<Song> Song::from( std::shared_ptr<SoundLibraryInfo> pInfo
-)
+std::shared_ptr<Song> Song::from( std::shared_ptr<SoundLibraryInfo> pInfo )
 {
 	if ( pInfo == nullptr ) {
 		return nullptr;
@@ -124,15 +125,17 @@ std::shared_ptr<Song> Song::from( std::shared_ptr<SoundLibraryInfo> pInfo
 
 	auto pSong = Song::load( pInfo->getPath() );
 	if ( pSong == nullptr ) {
-		ERRORLOG( QString( "Unable to load song from [%1]" )
-					  .arg( pInfo->toQString() ) );
+		ERRORLOG(
+			QString( "Unable to load song from [%1]" ).arg( pInfo->toQString() )
+		);
 		return nullptr;
 	}
 
 	return pSong;
 }
 
-void Song::setDrumkit( std::shared_ptr<Drumkit> pDrumkit ) {
+void Song::setDrumkit( std::shared_ptr<Drumkit> pDrumkit )
+{
 	m_pDrumkit = pDrumkit;
 
 	if ( m_pDrumkit->getContext() != Filesystem::Context::Song ) {
@@ -142,42 +145,60 @@ void Song::setDrumkit( std::shared_ptr<Drumkit> pDrumkit ) {
 	m_sLastLoadedDrumkitPath = pDrumkit->getPath();
 }
 
-void Song::setBpm( float fBpm ) {
+void Song::setBpm( float fBpm )
+{
 	if ( fBpm > MAX_BPM ) {
 		m_fBpm = MAX_BPM;
-		WARNINGLOG( QString( "Provided bpm %1 is too high. Assigning upper bound %2 instead" )
-					.arg( fBpm ).arg( MAX_BPM ) );
-	} else if ( fBpm < MIN_BPM ) {
+		WARNINGLOG(
+			QString(
+				"Provided bpm %1 is too high. Assigning upper bound %2 instead"
+			)
+				.arg( fBpm )
+				.arg( MAX_BPM )
+		);
+	}
+	else if ( fBpm < MIN_BPM ) {
 		m_fBpm = MIN_BPM;
-		WARNINGLOG( QString( "Provided bpm %1 is too low. Assigning lower bound %2 instead" )
-					.arg( fBpm ).arg( MIN_BPM ) );
-	} else {
+		WARNINGLOG(
+			QString(
+				"Provided bpm %1 is too low. Assigning lower bound %2 instead"
+			)
+				.arg( fBpm )
+				.arg( MIN_BPM )
+		);
+	}
+	else {
 		m_fBpm = fBpm;
 	}
 }
 
-void Song::setActionMode( const Song::ActionMode& actionMode ) {
+void Song::setActionMode( const Song::ActionMode& actionMode )
+{
 	m_actionMode = actionMode;
 }
 
-long Song::lengthInTicks() const {
+long Song::lengthInTicks() const
+{
 	long nSongLength = 0;
 	int nColumns = m_pPatternGroupVector->size();
 	// Sum the lengths of all pattern columns and use the macro four quarters in
 	// case some of them are of size zero.
 	for ( int i = 0; i < nColumns; i++ ) {
-		auto pColumn = ( *m_pPatternGroupVector )[ i ];
+		auto pColumn = ( *m_pPatternGroupVector )[i];
 		if ( pColumn->size() != 0 ) {
 			nSongLength += pColumn->longestPatternLength();
-		} else {
+		}
+		else {
 			nSongLength += 4 * H2Core::nTicksPerQuarter;
 		}
 	}
-    return nSongLength;
+	return nSongLength;
 }
 
-bool Song::isPatternActive( const GridPoint& gridPoint ) const {
-	if ( gridPoint.getRow() < 0 || gridPoint.getRow() > m_pPatternList->size() ) {
+bool Song::isPatternActive( const GridPoint& gridPoint ) const
+{
+	if ( gridPoint.getRow() < 0 ||
+		 gridPoint.getRow() > m_pPatternList->size() ) {
 		return false;
 	}
 
@@ -189,7 +210,7 @@ bool Song::isPatternActive( const GridPoint& gridPoint ) const {
 		 gridPoint.getColumn() >= m_pPatternGroupVector->size() ) {
 		return false;
 	}
-	auto pColumn = ( *m_pPatternGroupVector )[ gridPoint.getColumn() ];
+	auto pColumn = ( *m_pPatternGroupVector )[gridPoint.getColumn()];
 	if ( pColumn->index( pPattern ) == -1 ) {
 		return false;
 	}
@@ -197,7 +218,7 @@ bool Song::isPatternActive( const GridPoint& gridPoint ) const {
 	return true;
 }
 
-///Load a song from file
+/// Load a song from file
 std::shared_ptr<Song> Song::load( const QString& sInputPath, bool bSilent )
 {
 	QString sPath = Filesystem::absolutePath( sInputPath, bSilent );
@@ -205,14 +226,14 @@ std::shared_ptr<Song> Song::load( const QString& sInputPath, bool bSilent )
 		return nullptr;
 	}
 
-	if ( ! bSilent ) {
+	if ( !bSilent ) {
 		INFOLOG( "Reading " + sPath );
 	}
 
 	XMLDoc doc;
-	if ( ! doc.read( sPath ) && ! bSilent ) {
+	if ( !doc.read( sPath ) && !bSilent ) {
 		ERRORLOG( QString( "Something went wrong while loading song [%1]" )
-				  .arg( sPath ) );
+					  .arg( sPath ) );
 	}
 
 	XMLNode songNode = doc.firstChildElement( "song" );
@@ -222,13 +243,17 @@ std::shared_ptr<Song> Song::load( const QString& sInputPath, bool bSilent )
 		return nullptr;
 	}
 
-	if ( ! bSilent ) {
-		QString sSongVersion = songNode.read_string( "version", "Unknown version", false, false );
+	if ( !bSilent ) {
+		QString sSongVersion =
+			songNode.read_string( "version", "Unknown version", false, false );
 		if ( sSongVersion != QString( get_version().c_str() ) ) {
-			INFOLOG( QString( "Trying to load a song [%1] created with a different version [%2] of hydrogen. Current version: %3" )
-					 .arg( sPath )
-					 .arg( sSongVersion )
-					 .arg( get_version().c_str() ) );
+			INFOLOG(
+				QString( "Trying to load a song [%1] created with a different "
+						 "version [%2] of hydrogen. Current version: %3" )
+					.arg( sPath )
+					.arg( sSongVersion )
+					.arg( get_version().c_str() )
+			);
 		}
 	}
 
@@ -240,28 +265,36 @@ std::shared_ptr<Song> Song::load( const QString& sInputPath, bool bSilent )
 	return pSong;
 }
 
-std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sPath, bool bSilent )
+std::shared_ptr<Song>
+Song::loadFrom( const XMLNode& rootNode, const QString& sPath, bool bSilent )
 {
 	auto pPreferences = Preferences::get_instance();
 	auto pSong = std::make_shared<Song>();
 
-	pSong->setBpm( rootNode.read_float( "bpm", pSong->getBpm(), false, false,
-									   bSilent ) );
-	pSong->setVolume( rootNode.read_float( "volume", pSong->getVolume(), false,
-										  false, bSilent ) );
-	pSong->setName( rootNode.read_string( "name", pSong->getName(), false,
-										 false, bSilent ) );
-	pSong->setAuthor( rootNode.read_string( "author", pSong->getAuthor(), false,
-										   false, bSilent ) );
-	pSong->setVersion( rootNode.read_int( "userVersion", pSong->getVersion(),
-										 true, false, bSilent ) );
-	pSong->setIsMuted( rootNode.read_bool( "isMuted", pSong->getIsMuted(), true,
-										  false, bSilent ) );
-	pSong->setMetronomeVolume(
-		rootNode.read_float( "metronomeVolume", pSong->getMetronomeVolume(),
-							false, false, bSilent ) );
-	pSong->setNotes( rootNode.read_string( "notes", pSong->getNotes(), false,
-										  false, bSilent ) );
+	pSong->setBpm(
+		rootNode.read_float( "bpm", pSong->getBpm(), false, false, bSilent )
+	);
+	pSong->setVolume( rootNode.read_float(
+		"volume", pSong->getVolume(), false, false, bSilent
+	) );
+	pSong->setName(
+		rootNode.read_string( "name", pSong->getName(), false, false, bSilent )
+	);
+	pSong->setAuthor( rootNode.read_string(
+		"author", pSong->getAuthor(), false, false, bSilent
+	) );
+	pSong->setVersion( rootNode.read_int(
+		"userVersion", pSong->getVersion(), true, false, bSilent
+	) );
+	pSong->setIsMuted( rootNode.read_bool(
+		"isMuted", pSong->getIsMuted(), true, false, bSilent
+	) );
+	pSong->setMetronomeVolume( rootNode.read_float(
+		"metronomeVolume", pSong->getMetronomeVolume(), false, false, bSilent
+	) );
+	pSong->setNotes( rootNode.read_string(
+		"notes", pSong->getNotes(), false, false, bSilent
+	) );
 
 	const XMLNode tagsNode = rootNode.firstChildElement( "tags" );
 	if ( !tagsNode.isNull() ) {
@@ -274,31 +307,39 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 		pSong->setTags( tags );
 	}
 
-	pSong->setLicense(
-		License( rootNode.read_string( "license",
-									  pSong->getLicense().getLicenseString(),
-									   false, false, bSilent ),
-				pSong->getAuthor() ) );
-	if ( rootNode.read_bool( "loopEnabled", pSong->isLoopEnabled(), false,
-							false, bSilent ) ) {
+	pSong->setLicense( License(
+		rootNode.read_string(
+			"license", pSong->getLicense().getLicenseString(), false, false,
+			bSilent
+		),
+		pSong->getAuthor()
+	) );
+	if ( rootNode.read_bool(
+			 "loopEnabled", pSong->isLoopEnabled(), false, false, bSilent
+		 ) ) {
 		pSong->setLoopMode( Song::LoopMode::Enabled );
-	} else {
+	}
+	else {
 		pSong->setLoopMode( Song::LoopMode::Disabled );
 	}
 
-	if ( rootNode.read_bool( "patternModeMode",
-							   static_cast<bool>(pSong->getPatternMode()),
-							   false, false, bSilent ) ) {
+	if ( rootNode.read_bool(
+			 "patternModeMode", static_cast<bool>( pSong->getPatternMode() ),
+			 false, false, bSilent
+		 ) ) {
 		pSong->setPatternMode( Song::PatternMode::Selected );
-	} else {
+	}
+	else {
 		pSong->setPatternMode( Song::PatternMode::Stacked );
 	}
 
-	if ( rootNode.read_string( "mode",
-							  Song::ModeToQString( pSong->getMode() ).toLower(),
-							  false, false, bSilent ) == "song" ) {
+	if ( rootNode.read_string(
+			 "mode", Song::ModeToQString( pSong->getMode() ).toLower(), false,
+			 false, bSilent
+		 ) == "song" ) {
 		pSong->setMode( Song::Mode::Song );
-	} else {
+	}
+	else {
 		pSong->setMode( Song::Mode::Pattern );
 	}
 
@@ -312,8 +353,8 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 		const XMLNode playbackTrackInstrumentNode =
 			playbackTrackNode.firstChildElement( "instrument" );
 		if ( !playbackTrackInstrumentNode.isNull() ) {
-            // In case the node is null the user did not provide a playback
-            // track.
+			// In case the node is null the user did not provide a playback
+			// track.
 			pPlaybackTrackInstrument = Instrument::loadFrom(
 				playbackTrackInstrumentNode, "", "", sSongPath,
 				pSong->getLicense(), true, nullptr, bSilent
@@ -362,7 +403,7 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 	if ( pPlaybackTrackInstrument != nullptr ) {
 		pPlaybackTrackInstrument->setName( "PlaybackTrack" );
 		pPlaybackTrackInstrument->setId( Instrument::PlaybackTrackId );
-        pPlaybackTrackInstrument->loadSamples();
+		pPlaybackTrackInstrument->loadSamples();
 	}
 
 	pSong->setPlaybackTrackInstrument( pPlaybackTrackInstrument );
@@ -660,34 +701,49 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 
 	// LADSPA FX
 	XMLNode ladspaNode = rootNode.firstChildElement( "ladspa" );
-	if ( ! ladspaNode.isNull() ) {
+	if ( !ladspaNode.isNull() ) {
 		int nFX = 0;
 		XMLNode fxNode = ladspaNode.firstChildElement( "fx" );
-		while ( ! fxNode.isNull() ) {
-			QString sName = fxNode.read_string( "name", "", false, false, bSilent );
+		while ( !fxNode.isNull() ) {
+			QString sName =
+				fxNode.read_string( "name", "", false, false, bSilent );
 
 			if ( sName != "no plugin" ) {
-				// FIXME: il caricamento va fatto fare all'engine, solo lui sa il samplerate esatto
+				// FIXME: il caricamento va fatto fare all'engine, solo lui sa
+				// il samplerate esatto
 #ifdef H2CORE_HAVE_LADSPA
 				auto pFX = LadspaFX::load(
 					fxNode.read_string( "filename", "", false, false, bSilent ),
-					sName, 44100 );
+					sName, 44100
+				);
 				Effects::get_instance()->setLadspaFX( pFX, nFX );
 				if ( pFX != nullptr ) {
-					pFX->setEnabled( fxNode.read_bool( "enabled", false, false, false, bSilent ) );
-					pFX->setVolume( fxNode.read_float( "volume", 1.0, false, false, bSilent ) );
-					XMLNode inputControlNode = fxNode.firstChildElement( "inputControlPort" );
-					while ( ! inputControlNode.isNull() ) {
-						QString sName = inputControlNode.read_string( "name", "", false, false, bSilent );
-						float fValue = inputControlNode.read_float( "value", 0.0, false, false, bSilent );
+					pFX->setEnabled( fxNode.read_bool(
+						"enabled", false, false, false, bSilent
+					) );
+					pFX->setVolume( fxNode.read_float(
+						"volume", 1.0, false, false, bSilent
+					) );
+					XMLNode inputControlNode =
+						fxNode.firstChildElement( "inputControlPort" );
+					while ( !inputControlNode.isNull() ) {
+						QString sName = inputControlNode.read_string(
+							"name", "", false, false, bSilent
+						);
+						float fValue = inputControlNode.read_float(
+							"value", 0.0, false, false, bSilent
+						);
 
-						for ( unsigned nPort = 0; nPort < pFX->inputControlPorts.size(); nPort++ ) {
-							auto pPort = pFX->inputControlPorts[ nPort ];
+						for ( unsigned nPort = 0;
+							  nPort < pFX->inputControlPorts.size(); nPort++ ) {
+							auto pPort = pFX->inputControlPorts[nPort];
 							if ( QString( pPort->sName ) == sName ) {
 								pPort->fControlValue = fValue;
 							}
 						}
-						inputControlNode = inputControlNode.nextSiblingElement( "inputControlPort" );
+						inputControlNode = inputControlNode.nextSiblingElement(
+							"inputControlPort"
+						);
 					}
 				}
 #endif
@@ -695,22 +751,24 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 			nFX++;
 			fxNode = fxNode.nextSiblingElement( "fx" );
 		}
-	} else if ( ! bSilent ) {
+	}
+	else if ( !bSilent ) {
 		WARNINGLOG( "'ladspa' node not found" );
 	}
 
 	auto pTimeline = std::make_shared<Timeline>();
 	XMLNode bpmTimeLineNode = rootNode.firstChildElement( "BPMTimeLine" );
-	if ( ! bpmTimeLineNode.isNull() ) {
+	if ( !bpmTimeLineNode.isNull() ) {
 		XMLNode newBPMNode = bpmTimeLineNode.firstChildElement( "newBPM" );
 
 		// Use more efficient version to add TempoMarkers that will only
 		// sort and update them once.
 		std::vector<std::shared_ptr<Timeline::TempoMarker>> tempoMarkers;
-		while ( ! newBPMNode.isNull() ) {
+		while ( !newBPMNode.isNull() ) {
 			tempoMarkers.push_back( std::make_shared<Timeline::TempoMarker>(
 				newBPMNode.read_int( "BAR", 0, false, false, bSilent ),
-				newBPMNode.read_float( "BPM", 120.0, false, false, bSilent ) ) );
+				newBPMNode.read_float( "BPM", 120.0, false, false, bSilent )
+			) );
 			newBPMNode = newBPMNode.nextSiblingElement( "newBPM" );
 		}
 
@@ -719,43 +777,49 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 			// timeline associated with the _current_ song.
 			pTimeline->addTempoMarkers( tempoMarkers );
 		}
-	} else if ( ! bSilent ) {
+	}
+	else if ( !bSilent ) {
 		WARNINGLOG( "'BPMTimeLine' node not found" );
 	}
 
 	XMLNode timeLineTagNode = rootNode.firstChildElement( "timeLineTag" );
-	if ( ! timeLineTagNode.isNull() ) {
+	if ( !timeLineTagNode.isNull() ) {
 		XMLNode newTAGNode = timeLineTagNode.firstChildElement( "newTAG" );
 		// Use more efficient version to add TempoMarkers that will only sort
 		// once.
 		std::vector<std::shared_ptr<Timeline::Tag>> tags;
 
-		while ( ! newTAGNode.isNull() ) {
+		while ( !newTAGNode.isNull() ) {
 			tags.push_back( std::make_shared<Timeline::Tag>(
 				newTAGNode.read_int( "BAR", 0, false, false, bSilent ),
-				newTAGNode.read_string( "TAG", "", false, false, bSilent ) ) );
+				newTAGNode.read_string( "TAG", "", false, false, bSilent )
+			) );
 			newTAGNode = newTAGNode.nextSiblingElement( "newTAG" );
 		}
 
 		if ( tags.size() > 0 ) {
 			pTimeline->addTags( tags );
 		}
-	} else if ( ! bSilent ) {
+	}
+	else if ( !bSilent ) {
 		WARNINGLOG( "TagTimeLine node not found" );
 	}
 	pSong->setTimeline( pTimeline );
 
 	// Automation Paths
-	XMLNode automationPathsNode = rootNode.firstChildElement( "automationPaths" );
-	if ( ! automationPathsNode.isNull() ) {
+	XMLNode automationPathsNode =
+		rootNode.firstChildElement( "automationPaths" );
+	if ( !automationPathsNode.isNull() ) {
 		AutomationPathSerializer pathSerializer;
 
 		XMLNode pathNode = automationPathsNode.firstChildElement( "path" );
-		while ( ! pathNode.isNull()) {
-			QString sAdjust = pathNode.read_attribute( "adjust", "velocity", false, false, bSilent );
+		while ( !pathNode.isNull() ) {
+			QString sAdjust = pathNode.read_attribute(
+				"adjust", "velocity", false, false, bSilent
+			);
 
 			// Select automation path to be read based on "adjust" attribute
-			AutomationPath *pPath = nullptr;
+			AutomationPath* pPath = nullptr;
 			if ( sAdjust == "velocity" ) {
 				pPath = pSong->getVelocityAutomationPath();
 			}
@@ -769,12 +833,12 @@ std::shared_ptr<Song> Song::loadFrom( const XMLNode& rootNode, const QString& sP
 	}
 
 	return pSong;
-	}
+}
 
 /// Save a song to file
 bool Song::save( const QString& sPath, bool bKeepMissingSamples, bool bSilent )
 {
-	if ( ! bSilent ) {
+	if ( !bSilent ) {
 		INFOLOG( QString( "Saving song to [%1]" ).arg( sPath ) );
 	}
 
@@ -784,7 +848,9 @@ bool Song::save( const QString& sPath, bool bKeepMissingSamples, bool bSilent )
 	// In order to comply with the GPL license we have to add a
 	// license notice to the file.
 	if ( getLicense().getType() == License::GPL ) {
-		doc.appendChild( doc.createComment( License::getGPLLicenseNotice( getAuthor() ) ) );
+		doc.appendChild(
+			doc.createComment( License::getGPLLicenseNotice( getAuthor() ) )
+		);
 	}
 
 	saveTo( rootNode, bKeepMissingSamples, bSilent );
@@ -811,15 +877,16 @@ bool Song::save( const QString& sPath, bool bKeepMissingSamples, bool bSilent )
 		return false;
 	}
 
-	if ( ! bSilent ) {
-		INFOLOG("Save was successful.");
+	if ( !bSilent ) {
+		INFOLOG( "Save was successful." );
 	}
 
 	return true;
 }
 
-void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
-				  bool bSilent ) const {
+void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples, bool bSilent )
+	const
+{
 	rootNode.write_string( "version", QString( get_version().c_str() ) );
 	rootNode.write_int( "formatVersion", nCurrentFormatVersion );
 	rootNode.write_float( "bpm", m_fBpm );
@@ -841,9 +908,9 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 	rootNode.write_string( "license", m_license.getLicenseString() );
 	rootNode.write_bool( "loopEnabled", isLoopEnabled() );
 
-	bool bPatternMode = static_cast<bool>(Song::PatternMode::Selected);
+	bool bPatternMode = static_cast<bool>( Song::PatternMode::Selected );
 	if ( m_patternMode == Song::PatternMode::Stacked ) {
-		bPatternMode = static_cast<bool>(Song::PatternMode::Stacked);
+		bPatternMode = static_cast<bool>( Song::PatternMode::Stacked );
 	}
 	rootNode.write_bool( "patternModeMode", bPatternMode );
 
@@ -855,51 +922,67 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 	}
 
 	rootNode.write_int( "action_mode", static_cast<int>( m_actionMode ) );
-	rootNode.write_bool( "isPatternEditorLocked",
-						   m_bIsPatternEditorLocked );
+	rootNode.write_bool( "isPatternEditorLocked", m_bIsPatternEditorLocked );
 	rootNode.write_bool( "isTimelineActivated", m_bIsTimelineActivated );
 
 	if ( m_mode == Song::Mode::Song ) {
 		rootNode.write_string( "mode", QString( "song" ) );
-	} else {
+	}
+	else {
 		rootNode.write_string( "mode", QString( "pattern" ) );
 	}
 
-	QString sPanLawType; // prepare the pan law string to write
+	QString sPanLawType;  // prepare the pan law string to write
 	if ( m_nPanLawType == Sampler::RATIO_STRAIGHT_POLYGONAL ) {
 		sPanLawType = "RATIO_STRAIGHT_POLYGONAL";
-	} else if ( m_nPanLawType == Sampler::RATIO_CONST_POWER ) {
+	}
+	else if ( m_nPanLawType == Sampler::RATIO_CONST_POWER ) {
 		sPanLawType = "RATIO_CONST_POWER";
-	} else if ( m_nPanLawType == Sampler::RATIO_CONST_SUM ) {
+	}
+	else if ( m_nPanLawType == Sampler::RATIO_CONST_SUM ) {
 		sPanLawType = "RATIO_CONST_SUM";
-	} else if ( m_nPanLawType == Sampler::LINEAR_STRAIGHT_POLYGONAL ) {
+	}
+	else if ( m_nPanLawType == Sampler::LINEAR_STRAIGHT_POLYGONAL ) {
 		sPanLawType = "LINEAR_STRAIGHT_POLYGONAL";
-	} else if ( m_nPanLawType == Sampler::LINEAR_CONST_POWER ) {
+	}
+	else if ( m_nPanLawType == Sampler::LINEAR_CONST_POWER ) {
 		sPanLawType = "LINEAR_CONST_POWER";
-	} else if ( m_nPanLawType == Sampler::LINEAR_CONST_SUM ) {
+	}
+	else if ( m_nPanLawType == Sampler::LINEAR_CONST_SUM ) {
 		sPanLawType = "LINEAR_CONST_SUM";
-	} else if ( m_nPanLawType == Sampler::POLAR_STRAIGHT_POLYGONAL ) {
+	}
+	else if ( m_nPanLawType == Sampler::POLAR_STRAIGHT_POLYGONAL ) {
 		sPanLawType = "POLAR_STRAIGHT_POLYGONAL";
-	} else if ( m_nPanLawType == Sampler::POLAR_CONST_POWER ) {
+	}
+	else if ( m_nPanLawType == Sampler::POLAR_CONST_POWER ) {
 		sPanLawType = "POLAR_CONST_POWER";
-	} else if ( m_nPanLawType == Sampler::POLAR_CONST_SUM ) {
+	}
+	else if ( m_nPanLawType == Sampler::POLAR_CONST_SUM ) {
 		sPanLawType = "POLAR_CONST_SUM";
-	} else if ( m_nPanLawType == Sampler::QUADRATIC_STRAIGHT_POLYGONAL ) {
+	}
+	else if ( m_nPanLawType == Sampler::QUADRATIC_STRAIGHT_POLYGONAL ) {
 		sPanLawType = "QUADRATIC_STRAIGHT_POLYGONAL";
-	} else if ( m_nPanLawType == Sampler::QUADRATIC_CONST_POWER ) {
+	}
+	else if ( m_nPanLawType == Sampler::QUADRATIC_CONST_POWER ) {
 		sPanLawType = "QUADRATIC_CONST_POWER";
-	} else if ( m_nPanLawType == Sampler::QUADRATIC_CONST_SUM ) {
+	}
+	else if ( m_nPanLawType == Sampler::QUADRATIC_CONST_SUM ) {
 		sPanLawType = "QUADRATIC_CONST_SUM";
-	} else if ( m_nPanLawType == Sampler::LINEAR_CONST_K_NORM ) {
+	}
+	else if ( m_nPanLawType == Sampler::LINEAR_CONST_K_NORM ) {
 		sPanLawType = "LINEAR_CONST_K_NORM";
-	} else if ( m_nPanLawType == Sampler::POLAR_CONST_K_NORM ) {
+	}
+	else if ( m_nPanLawType == Sampler::POLAR_CONST_K_NORM ) {
 		sPanLawType = "POLAR_CONST_K_NORM";
-	} else if ( m_nPanLawType == Sampler::RATIO_CONST_K_NORM ) {
+	}
+	else if ( m_nPanLawType == Sampler::RATIO_CONST_K_NORM ) {
 		sPanLawType = "RATIO_CONST_K_NORM";
-	} else if ( m_nPanLawType == Sampler::QUADRATIC_CONST_K_NORM ) {
+	}
+	else if ( m_nPanLawType == Sampler::QUADRATIC_CONST_K_NORM ) {
 		sPanLawType = "QUADRATIC_CONST_K_NORM";
-	} else {
-		if ( ! bSilent ) {
+	}
+	else {
+		if ( !bSilent ) {
 			WARNINGLOG( "Unknown pan law in saving song. Saved default type." );
 		}
 		sPanLawType = "RATIO_STRAIGHT_POLYGONAL";
@@ -915,9 +998,11 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 	// "drumkit_info" instead of "drumkit" seem unintuitive but is dictated by a
 	// ancient design desicion and we will stick to it.
 	auto drumkitNode = rootNode.createNode( "drumkit_info" );
-	m_pDrumkit->saveTo( drumkitNode,
-					   true, // Enable per-instrument sample loading
-					   bKeepMissingSamples, bSilent );
+	m_pDrumkit->saveTo(
+		drumkitNode,
+		true,  // Enable per-instrument sample loading
+		bKeepMissingSamples, bSilent
+	);
 
 	rootNode.write_string( "lastLoadedDrumkitPath", m_sLastLoadedDrumkitPath );
 
@@ -981,17 +1066,25 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 			fxNode.write_bool( "enabled", pFX->isEnabled() );
 			fxNode.write_float( "volume", pFX->getVolume() );
 
-			for ( unsigned nControl = 0; nControl < pFX->inputControlPorts.size(); nControl++ ) {
-				auto pControlPort = pFX->inputControlPorts[ nControl ];
-				XMLNode controlPortNode = fxNode.createNode( "inputControlPort" );
+			for ( unsigned nControl = 0;
+				  nControl < pFX->inputControlPorts.size(); nControl++ ) {
+				auto pControlPort = pFX->inputControlPorts[nControl];
+				XMLNode controlPortNode =
+					fxNode.createNode( "inputControlPort" );
 				controlPortNode.write_string( "name", pControlPort->sName );
-				controlPortNode.write_string( "value", QString("%1").arg( pControlPort->fControlValue ) );
+				controlPortNode.write_string(
+					"value", QString( "%1" ).arg( pControlPort->fControlValue )
+				);
 			}
-			for ( unsigned nControl = 0; nControl < pFX->outputControlPorts.size(); nControl++ ) {
-				auto pControlPort = pFX->inputControlPorts[ nControl ];
-				XMLNode controlPortNode = fxNode.createNode( "outputControlPort" );
+			for ( unsigned nControl = 0;
+				  nControl < pFX->outputControlPorts.size(); nControl++ ) {
+				auto pControlPort = pFX->inputControlPorts[nControl];
+				XMLNode controlPortNode =
+					fxNode.createNode( "outputControlPort" );
 				controlPortNode.write_string( "name", pControlPort->sName );
-				controlPortNode.write_string( "value", QString("%1").arg( pControlPort->fControlValue ) );
+				controlPortNode.write_string(
+					"value", QString( "%1" ).arg( pControlPort->fControlValue )
+				);
 			}
 		}
 #else
@@ -1006,11 +1099,12 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 		}
 	}
 
-	//bpm time line
+	// bpm time line
 	auto tempoMarkerVector = m_pTimeline->getAllTempoMarkers();
 	XMLNode bpmTimeLineNode = rootNode.createNode( "BPMTimeLine" );
-	if ( tempoMarkerVector.size() >= 1 ){
-		for ( int tt = 0; tt < static_cast<int>(tempoMarkerVector.size()); tt++){
+	if ( tempoMarkerVector.size() >= 1 ) {
+		for ( int tt = 0; tt < static_cast<int>( tempoMarkerVector.size() );
+			  tt++ ) {
 			if ( tt == 0 && m_pTimeline->isFirstTempoMarkerSpecial() ) {
 				continue;
 			}
@@ -1020,11 +1114,11 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 		}
 	}
 
-	//time line tag
+	// time line tag
 	auto tagVector = m_pTimeline->getAllTags();
 	XMLNode timeLineTagNode = rootNode.createNode( "timeLineTag" );
-	if ( tagVector.size() >= 1 ){
-		for ( int t = 0; t < static_cast<int>(tagVector.size()); t++){
+	if ( tagVector.size() >= 1 ) {
+		for ( int t = 0; t < static_cast<int>( tagVector.size() ); t++ ) {
 			XMLNode newTAGNode = timeLineTagNode.createNode( "newTAG" );
 			newTAGNode.write_int( "BAR", tagVector[t]->nColumn );
 			newTAGNode.write_string( "TAG", tagVector[t]->sTag );
@@ -1033,21 +1127,23 @@ void Song::saveTo( XMLNode& rootNode, bool bKeepMissingSamples,
 
 	// Automation Paths
 	XMLNode automationPathsNode = rootNode.createNode( "automationPaths" );
-	AutomationPath *pPath = getVelocityAutomationPath();
+	AutomationPath* pPath = getVelocityAutomationPath();
 	if ( pPath != nullptr ) {
 		XMLNode pathNode = automationPathsNode.createNode( "path" );
-		pathNode.write_attribute("adjust", "velocity");
+		pathNode.write_attribute( "adjust", "velocity" );
 
 		AutomationPathSerializer serializer;
-		serializer.write_automation_path(pathNode, *pPath);
+		serializer.write_automation_path( pathNode, *pPath );
 	}
 }
 
-std::shared_ptr<Song> Song::getEmptySong( std::shared_ptr<SoundLibraryDatabase> pDB )
+std::shared_ptr<Song> Song::getEmptySong(
+	std::shared_ptr<SoundLibraryDatabase> pDB
+)
 {
-	std::shared_ptr<Song> pSong =
-		std::make_shared<Song>( Song::sDefaultName, Song::sDefaultAuthor,
-								120, 0.5 );
+	std::shared_ptr<Song> pSong = std::make_shared<Song>(
+		Song::sDefaultName, Song::sDefaultAuthor, 120, 0.5
+	);
 
 	pSong->setMetronomeVolume( 0.5 );
 	pSong->setNotes( "..." );
@@ -1076,7 +1172,7 @@ std::shared_ptr<Song> Song::getEmptySong( std::shared_ptr<SoundLibraryDatabase> 
 	pSong->setPatternList( pPatternList );
 
 	auto pPatternGroupVector =
-		std::make_shared< std::vector< std::shared_ptr<PatternList> > >();
+		std::make_shared<std::vector<std::shared_ptr<PatternList>>>();
 	pPatternGroupVector->push_back( patternSequence );
 	pSong->setPatternGroupVector( pPatternGroupVector );
 
@@ -1087,7 +1183,8 @@ std::shared_ptr<Song> Song::getEmptySong( std::shared_ptr<SoundLibraryDatabase> 
 	if ( pDB != nullptr ) {
 		// During startup
 		pSoundLibraryDatabase = pDB;
-	} else {
+	}
+	else {
 		pSoundLibraryDatabase =
 			Hydrogen::get_instance()->getSoundLibraryDatabase();
 	}
@@ -1124,7 +1221,6 @@ std::shared_ptr<Song> Song::getEmptySong( std::shared_ptr<SoundLibraryDatabase> 
 	pSong->setIsModified( false );
 
 	return pSong;
-
 }
 
 void Song::setIsModified( bool bIsModified )
@@ -1145,34 +1241,38 @@ bool Song::hasMissingSamples() const
 	return false;
 }
 
-void Song::setPanLawKNorm( float fKNorm ) {
+void Song::setPanLawKNorm( float fKNorm )
+{
 	if ( fKNorm >= 0. ) {
 		m_fPanLawKNorm = fKNorm;
-	} else {
-		WARNINGLOG("negative kNorm. Set default" );
+	}
+	else {
+		WARNINGLOG( "negative kNorm. Set default" );
 		m_fPanLawKNorm = Sampler::K_NORM_DEFAULT;
 	}
 }
 
-std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
+std::vector<std::shared_ptr<Note>> Song::getAllNotes() const
+{
+	std::vector<std::shared_ptr<Note>> notes;
+	std::set<std::shared_ptr<Pattern>> encounteredPattern;
 
-	std::vector< std::shared_ptr<Note> > notes;
-	std::set< std::shared_ptr<Pattern> > encounteredPattern;
+	auto addNotes =
+		[&notes]( std::shared_ptr<Note> pNote, int nColumnStartTick ) {
+			if ( pNote != nullptr ) {
+				// Use the copy constructor to not mess
+				// with the song itself.
+				auto pNoteCopied = std::make_shared<Note>( pNote );
 
-	auto addNotes = [&notes]( std::shared_ptr<Note> pNote,
-							  int nColumnStartTick ) {
-		if ( pNote != nullptr ) {
-			// Use the copy constructor to not mess
-			// with the song itself.
-			auto pNoteCopied = std::make_shared<Note>( pNote );
-
-			// The position property of the note specifies its position within
-			// the pattern. All we need to do is to add the pattern start tick.
-			pNoteCopied->setPosition( pNoteCopied->getPosition() +
-									  nColumnStartTick );
-			notes.push_back( pNoteCopied );
-		}
-	};
+				// The position property of the note specifies its position
+				// within the pattern. All we need to do is to add the pattern
+				// start tick.
+				pNoteCopied->setPosition(
+					pNoteCopied->getPosition() + nColumnStartTick
+				);
+				notes.push_back( pNoteCopied );
+			}
+		};
 
 	long nColumnStartTick = 0;
 	for ( const auto& ppColumn : *m_pPatternGroupVector ) {
@@ -1189,7 +1289,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 			}
 
 			// Add all notes of this pattern.
-			for ( const auto& [ _, ppNote ] : *ppPattern->getNotes() ) {
+			for ( const auto& [_, ppNote] : *ppPattern->getNotes() ) {
 				addNotes( ppNote, nColumnStartTick );
 			}
 			encounteredPattern.insert( ppPattern );
@@ -1197,7 +1297,7 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 			// Add notes of contained virtual patterns as well.
 			if ( ppPattern->isVirtual() ) {
 				for ( const auto& ppVirtualPattern :
-						  *ppPattern->getFlattenedVirtualPatterns() ) {
+					  *ppPattern->getFlattenedVirtualPatterns() ) {
 					// A pattern could be part of several patterns as well as
 					// activated directly. We only need to take it into account
 					// once.
@@ -1207,7 +1307,8 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 					}
 					encounteredPattern.insert( ppVirtualPattern );
 
-					for ( const auto& [ _, ppNote ] : *ppVirtualPattern->getNotes() ) {
+					for ( const auto& [_, ppNote] :
+						  *ppVirtualPattern->getNotes() ) {
 						addNotes( ppNote, nColumnStartTick );
 					}
 				}
@@ -1222,121 +1323,180 @@ std::vector<std::shared_ptr<Note>> Song::getAllNotes() const {
 	return notes;
 }
 
-QString Song::ModeToQString( const Mode& mode ) {
-	switch( mode ) {
-	case Mode::Pattern:
-		return "Pattern";
-	case Mode::Song:
-		return "Song";
-	case Mode::None:
-		return "None";
-	default:
-		return QString( "Unknown mode [%1]" )
-			.arg( static_cast<int>(mode) );
+QString Song::ModeToQString( const Mode& mode )
+{
+	switch ( mode ) {
+		case Mode::Pattern:
+			return "Pattern";
+		case Mode::Song:
+			return "Song";
+		case Mode::None:
+			return "None";
+		default:
+			return QString( "Unknown mode [%1]" )
+				.arg( static_cast<int>( mode ) );
 	}
 }
 
-QString Song::ActionModeToQString( const ActionMode& actionMode ) {
-	switch( actionMode ) {
-	case ActionMode::selectMode:
-		return "selectMode";
-	case ActionMode::drawMode:
-		return "drawMode";
-	case ActionMode::None:
-		return "None";
-	default:
-		return QString( "Unknown actionMode [%1]" )
-			.arg( static_cast<int>(actionMode) );
+QString Song::ActionModeToQString( const ActionMode& actionMode )
+{
+	switch ( actionMode ) {
+		case ActionMode::selectMode:
+			return "selectMode";
+		case ActionMode::drawMode:
+			return "drawMode";
+		case ActionMode::None:
+			return "None";
+		default:
+			return QString( "Unknown actionMode [%1]" )
+				.arg( static_cast<int>( actionMode ) );
 	}
 }
 
-QString Song::LoopModeToQString( const LoopMode& loopMode ) {
-	switch( loopMode ) {
-	case LoopMode::Disabled:
-		return "Disabled";
-	case LoopMode::Enabled:
-		return "Enabled";
-	case LoopMode::Finishing:
-		return "Finishing";
-	default:
-		return QString( "Unknown loopMode [%1]" )
-			.arg( static_cast<int>(loopMode) );
+QString Song::LoopModeToQString( const LoopMode& loopMode )
+{
+	switch ( loopMode ) {
+		case LoopMode::Disabled:
+			return "Disabled";
+		case LoopMode::Enabled:
+			return "Enabled";
+		case LoopMode::Finishing:
+			return "Finishing";
+		default:
+			return QString( "Unknown loopMode [%1]" )
+				.arg( static_cast<int>( loopMode ) );
 	}
 }
 
-QString Song::PatternModeToQString( const PatternMode& patternMode ) {
-	switch( patternMode ) {
-	case PatternMode::Stacked:
-		return "Stacked";
-	case PatternMode::Selected:
-		return "Selected";
-	case PatternMode::None:
-		return "None";
-	default:
-		return QString( "Unknown patternMode [%1]" )
-			.arg( static_cast<int>(patternMode) );
+QString Song::PatternModeToQString( const PatternMode& patternMode )
+{
+	switch ( patternMode ) {
+		case PatternMode::Stacked:
+			return "Stacked";
+		case PatternMode::Selected:
+			return "Selected";
+		case PatternMode::None:
+			return "None";
+		default:
+			return QString( "Unknown patternMode [%1]" )
+				.arg( static_cast<int>( patternMode ) );
 	}
 }
 
-QString Song::toQString( const QString& sPrefix, bool bShort ) const {
+QString Song::toQString( const QString& sPrefix, bool bShort ) const
+{
 	QString s = Base::sPrintIndention;
 	QString sOutput;
-	if ( ! bShort ) {
-		sOutput = QString( "%1[Song]\n" ).arg( sPrefix )
-			.append( QString( "%1%2m_bIsTimelineActivated: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_bIsTimelineActivated ) )
-			.append( QString( "%1%2m_bIsMuted: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_bIsMuted ) )
-			.append( QString( "%1%2m_fBpm: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fBpm ) )
-			.append( QString( "%1%2m_nVersion: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_nVersion ) )
-			.append( QString( "%1%2m_sName: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_sName ) )
-			.append( QString( "%1%2m_sAuthor: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_sAuthor ) )
-			.append( QString( "%1%2m_fVolume: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fVolume ) )
-			.append( QString( "%1%2m_fMetronomeVolume: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fMetronomeVolume ) )
-			.append( QString( "%1%2m_sNotes: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_sNotes ) )
-			.append( QString( "%1%2m_tags: %3\n" ).arg( sPrefix ).arg( s ).arg( m_tags.join( ", " ) ) )
-			.append( QString( "%1" ).arg( m_pPatternList->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( "%1%2m_pPatternGroupVector:\n" ).arg( sPrefix ).arg( s ) );
+	if ( !bShort ) {
+		sOutput = QString( "%1[Song]\n" )
+					  .arg( sPrefix )
+					  .append( QString( "%1%2m_bIsTimelineActivated: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_bIsTimelineActivated ) )
+					  .append( QString( "%1%2m_bIsMuted: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_bIsMuted ) )
+					  .append( QString( "%1%2m_fBpm: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_fBpm ) )
+					  .append( QString( "%1%2m_nVersion: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_nVersion ) )
+					  .append( QString( "%1%2m_sName: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_sName ) )
+					  .append( QString( "%1%2m_sAuthor: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_sAuthor ) )
+					  .append( QString( "%1%2m_fVolume: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_fVolume ) )
+					  .append( QString( "%1%2m_fMetronomeVolume: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_fMetronomeVolume ) )
+					  .append( QString( "%1%2m_sNotes: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_sNotes ) )
+					  .append( QString( "%1%2m_tags: %3\n" )
+								   .arg( sPrefix )
+								   .arg( s )
+								   .arg( m_tags.join( ", " ) ) )
+					  .append( QString( "%1" ).arg(
+						  m_pPatternList->toQString( sPrefix + s, bShort )
+					  ) )
+					  .append( QString( "%1%2m_pPatternGroupVector:\n" )
+								   .arg( sPrefix )
+								   .arg( s ) );
 		for ( const auto& pp : *m_pPatternGroupVector ) {
 			if ( pp != nullptr ) {
-				sOutput.append( QString( "%1" ).arg( pp->toQString( sPrefix + s + s, bShort ) ) );
+				sOutput.append( QString( "%1" ).arg(
+					pp->toQString( sPrefix + s + s, bShort )
+				) );
 			}
 		}
 		if ( m_pDrumkit != nullptr ) {
-			sOutput.append( QString( "%1" )
-							.arg( m_pDrumkit->toQString( sPrefix + s, bShort ) ) );
-		} else {
-			sOutput.append( QString( "%1%2m_pDrumkit: nullptr\n" ).arg( sPrefix )
-							.arg( s ) );
+			sOutput.append( QString( "%1" ).arg(
+				m_pDrumkit->toQString( sPrefix + s, bShort )
+			) );
 		}
-		sOutput.append( QString( "%1%2m_sPath: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_sPath ) )
-			.append( QString( "%1%2m_loopMode: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( LoopModeToQString( m_loopMode ) ) )
-			.append( QString( "%1%2m_patternMode: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( PatternModeToQString( m_patternMode ) ) )
-			.append( QString( "%1%2m_fHumanizeTimeValue: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fHumanizeTimeValue ) )
-			.append( QString( "%1%2m_fHumanizeVelocityValue: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fHumanizeVelocityValue ) )
-			.append( QString( "%1%2m_fSwingFactor: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fSwingFactor ) )
-			.append( QString( "%1%2m_bIsModified: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_bIsModified ) )
-			.append( QString( "%1%2m_latestRoundRobins\n" ).arg( sPrefix ).arg( s ) );
+		else {
+			sOutput.append(
+				QString( "%1%2m_pDrumkit: nullptr\n" ).arg( sPrefix ).arg( s )
+			);
+		}
+		sOutput
+			.append( QString( "%1%2m_sPath: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_sPath ) )
+			.append( QString( "%1%2m_loopMode: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( LoopModeToQString( m_loopMode ) ) )
+			.append( QString( "%1%2m_patternMode: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( PatternModeToQString( m_patternMode ) ) )
+			.append( QString( "%1%2m_fHumanizeTimeValue: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_fHumanizeTimeValue ) )
+			.append( QString( "%1%2m_fHumanizeVelocityValue: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_fHumanizeVelocityValue ) )
+			.append( QString( "%1%2m_fSwingFactor: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_fSwingFactor ) )
+			.append( QString( "%1%2m_bIsModified: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_bIsModified ) )
+			.append(
+				QString( "%1%2m_latestRoundRobins\n" ).arg( sPrefix ).arg( s )
+			);
 		for ( const auto& mm : m_latestRoundRobins ) {
-			sOutput.append( QString( "%1%2%3 : %4\n" ).arg( sPrefix ).arg( s )
-					 .arg( mm.first ).arg( mm.second ) );
+			sOutput.append( QString( "%1%2%3 : %4\n" )
+								.arg( sPrefix )
+								.arg( s )
+								.arg( mm.first )
+								.arg( mm.second ) );
 		}
-		sOutput.append( QString( "%1%2m_mode: %3\n" ).arg( sPrefix ).arg( s )
-						.arg( ModeToQString( m_mode ) ) )
+		sOutput
+			.append( QString( "%1%2m_mode: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( ModeToQString( m_mode ) ) )
 			.append( QString( "%1%2m_pPlaybackTrackInstrument: %3\n" )
 						 .arg( sPrefix )
 						 .arg( s )
@@ -1347,68 +1507,101 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 									   sPrefix + s, bShort
 								   )
 						 ) )
-			.append( QString( "%1" ).arg( m_pVelocityAutomationPath->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( "%1%2m_license: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_license.toQString( sPrefix + s, bShort ) ) )
-			.append( QString( "%1%2m_actionMode: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( ActionModeToQString( m_actionMode ) ) )
-			.append( QString( "%1%2m_bIsPatternEditorLocked: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_bIsPatternEditorLocked ) )
-			.append( QString( "%1%2m_nPanLawType: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_nPanLawType ) )
-			.append( QString( "%1%2m_fPanLawKNorm: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_fPanLawKNorm ) )
+			.append( QString( "%1" ).arg(
+				m_pVelocityAutomationPath->toQString( sPrefix + s, bShort )
+			) )
+			.append( QString( "%1%2m_license: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_license.toQString( sPrefix + s, bShort ) ) )
+			.append( QString( "%1%2m_actionMode: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( ActionModeToQString( m_actionMode ) ) )
+			.append( QString( "%1%2m_bIsPatternEditorLocked: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_bIsPatternEditorLocked ) )
+			.append( QString( "%1%2m_nPanLawType: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_nPanLawType ) )
+			.append( QString( "%1%2m_fPanLawKNorm: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_fPanLawKNorm ) )
 			.append( QString( "%1%2m_pTimeline:\n" ).arg( sPrefix ).arg( s ) );
 		if ( m_pTimeline != nullptr ) {
-			sOutput.append( QString( "%1" ).arg( m_pTimeline->toQString( sPrefix + s, bShort ) ) );
-		} else {
+			sOutput.append( QString( "%1" ).arg(
+				m_pTimeline->toQString( sPrefix + s, bShort )
+			) );
+		}
+		else {
 			sOutput.append( QString( "nullptr\n" ) );
 		}
-		sOutput.append( QString( "%1%2m_sLastLoadedDrumkitPath: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_sLastLoadedDrumkitPath ) )
-				.append( QString( "%1%2m_bWasAskedAboutMissingSamples: %3\n" ).arg( sPrefix ).arg( s )
-					 .arg( m_bWasAskedAboutMissingSamples ) );
-	} else {
-
-		sOutput = QString( "[Song]" )
-			.append( QString( ", m_bIsTimelineActivated: %1" ).arg( m_bIsTimelineActivated ) )
-			.append( QString( ", m_bIsMuted: %1" ).arg( m_bIsMuted ) )
-			.append( QString( ", m_fBpm: %1" ).arg( m_fBpm ) )
-			.append( QString( ", m_nVersion: %1" ).arg( m_nVersion ) )
-			.append( QString( ", m_sName: %1" ).arg( m_sName ) )
-			.append( QString( ", m_sAuthor: %1" ).arg( m_sAuthor ) )
-			.append( QString( ", m_fVolume: %1" ).arg( m_fVolume ) )
-			.append( QString( ", m_fMetronomeVolume: %1" ).arg( m_fMetronomeVolume ) )
-			.append( QString( ", m_sNotes: %1" ).arg( m_sNotes ) )
-			.append( QString( ", m_tags: %1" ).arg( m_tags.join( ", " ) ) )
-			.append( QString( "%1" ).arg( m_pPatternList->toQString( sPrefix + s, bShort ) ) )
-			.append( QString( ", m_pPatternGroupVector:" ) );
+		sOutput
+			.append( QString( "%1%2m_sLastLoadedDrumkitPath: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_sLastLoadedDrumkitPath ) )
+			.append( QString( "%1%2m_bWasAskedAboutMissingSamples: %3\n" )
+						 .arg( sPrefix )
+						 .arg( s )
+						 .arg( m_bWasAskedAboutMissingSamples ) );
+	}
+	else {
+		sOutput =
+			QString( "[Song]" )
+				.append( QString( ", m_bIsTimelineActivated: %1" )
+							 .arg( m_bIsTimelineActivated ) )
+				.append( QString( ", m_bIsMuted: %1" ).arg( m_bIsMuted ) )
+				.append( QString( ", m_fBpm: %1" ).arg( m_fBpm ) )
+				.append( QString( ", m_nVersion: %1" ).arg( m_nVersion ) )
+				.append( QString( ", m_sName: %1" ).arg( m_sName ) )
+				.append( QString( ", m_sAuthor: %1" ).arg( m_sAuthor ) )
+				.append( QString( ", m_fVolume: %1" ).arg( m_fVolume ) )
+				.append( QString( ", m_fMetronomeVolume: %1" )
+							 .arg( m_fMetronomeVolume ) )
+				.append( QString( ", m_sNotes: %1" ).arg( m_sNotes ) )
+				.append( QString( ", m_tags: %1" ).arg( m_tags.join( ", " ) ) )
+				.append( QString( "%1" ).arg(
+					m_pPatternList->toQString( sPrefix + s, bShort )
+				) )
+				.append( QString( ", m_pPatternGroupVector:" ) );
 		for ( const auto& pp : *m_pPatternGroupVector ) {
 			if ( pp != nullptr ) {
-				sOutput.append( QString( "%1" ).arg( pp->toQString( sPrefix + s + s, bShort ) ) );
+				sOutput.append( QString( "%1" ).arg(
+					pp->toQString( sPrefix + s + s, bShort )
+				) );
 			}
 		}
 		if ( m_pDrumkit != nullptr ) {
-			sOutput.append( QString( "%1" )
-							.arg( m_pDrumkit->toQString( sPrefix + s, bShort ) ) );
-		} else {
+			sOutput.append( QString( "%1" ).arg(
+				m_pDrumkit->toQString( sPrefix + s, bShort )
+			) );
+		}
+		else {
 			sOutput.append( ", m_pDrumkit: nullptr" );
 		}
 		sOutput.append( QString( ", m_sPath: %1" ).arg( m_sPath ) )
 			.append( QString( ", m_loopMode: %1" )
-					 .arg( LoopModeToQString( m_loopMode ) ) )
+						 .arg( LoopModeToQString( m_loopMode ) ) )
 			.append( QString( ", m_patternMode: %1" )
-					 .arg( PatternModeToQString( m_patternMode ) ) )
-			.append( QString( ", m_fHumanizeTimeValue: %1" ).arg( m_fHumanizeTimeValue ) )
-			.append( QString( ", m_fHumanizeVelocityValue: %1" ).arg( m_fHumanizeVelocityValue ) )
+						 .arg( PatternModeToQString( m_patternMode ) ) )
+			.append( QString( ", m_fHumanizeTimeValue: %1" )
+						 .arg( m_fHumanizeTimeValue ) )
+			.append( QString( ", m_fHumanizeVelocityValue: %1" )
+						 .arg( m_fHumanizeVelocityValue ) )
 			.append( QString( ", m_fSwingFactor: %1" ).arg( m_fSwingFactor ) )
 			.append( QString( ", m_bIsModified: %1" ).arg( m_bIsModified ) )
 			.append( QString( ", m_latestRoundRobins" ) );
 		for ( const auto& mm : m_latestRoundRobins ) {
-			sOutput.append( QString( ", %1 : %4" ).arg( mm.first ).arg( mm.second ) );
+			sOutput.append(
+				QString( ", %1 : %4" ).arg( mm.first ).arg( mm.second )
+			);
 		}
-		sOutput.append( QString( ", m_mode: %1" )
-						.arg( ModeToQString( m_mode ) ) )
+		sOutput
+			.append( QString( ", m_mode: %1" ).arg( ModeToQString( m_mode ) ) )
 			.append( QString( ", m_pPlaybackTrackInstrument: %1" )
 						 .arg(
 							 m_pPlaybackTrackInstrument == nullptr
@@ -1417,26 +1610,33 @@ QString Song::toQString( const QString& sPrefix, bool bShort ) const {
 									   "", bShort
 								   )
 						 ) )
-			.append( QString( ", m_pVelocityAutomationPath: %1" ).arg( m_pVelocityAutomationPath->toQString( sPrefix ) ) )
-			.append( QString( ", m_license: %1" ).arg( m_license.toQString( sPrefix, bShort ) ) )
-			.append( QString( ", m_actionMode: %1" ).
-					 arg( ActionModeToQString( m_actionMode ) ) )
+			.append( QString( ", m_pVelocityAutomationPath: %1" )
+						 .arg( m_pVelocityAutomationPath->toQString( sPrefix ) )
+			)
+			.append( QString( ", m_license: %1" )
+						 .arg( m_license.toQString( sPrefix, bShort ) ) )
+			.append( QString( ", m_actionMode: %1" )
+						 .arg( ActionModeToQString( m_actionMode ) ) )
 			.append( QString( ", m_bIsPatternEditorLocked: %1" )
-					 .arg( m_bIsPatternEditorLocked ) )
+						 .arg( m_bIsPatternEditorLocked ) )
 			.append( QString( ", m_nPanLawType: %1" ).arg( m_nPanLawType ) )
 			.append( QString( ", m_fPanLawKNorm: %1" ).arg( m_fPanLawKNorm ) )
 			.append( QString( ", m_pTimeline: " ) );
 		if ( m_pTimeline != nullptr ) {
-			sOutput.append( QString( "%1\n" ).arg( m_pTimeline->toQString( sPrefix, bShort ) ) );
-		} else {
+			sOutput.append( QString( "%1\n" ).arg(
+				m_pTimeline->toQString( sPrefix, bShort )
+			) );
+		}
+		else {
 			sOutput.append( QString( "nullptr\n" ) );
 		}
-		sOutput.append( QString( ", m_sLastLoadedDrumkitPath: %1" )
-							.arg( m_sLastLoadedDrumkitPath ) )
+		sOutput
+			.append( QString( ", m_sLastLoadedDrumkitPath: %1" )
+						 .arg( m_sLastLoadedDrumkitPath ) )
 			.append( QString( ", m_bWasAskedAboutMissingSamples: %1" )
-							.arg( m_bWasAskedAboutMissingSamples ) );
+						 .arg( m_bWasAskedAboutMissingSamples ) );
 	}
 
 	return sOutput;
 }
-};
+};	// namespace H2Core

--- a/src/core/Basics/Song.cpp
+++ b/src/core/Basics/Song.cpp
@@ -44,9 +44,6 @@
 #include <core/Globals.h>
 #include <core/Helpers/Legacy.h>
 #include <core/Hydrogen.h>
-#ifdef H2CORE_HAVE_OSC
-  #include <core/NsmClient.h>
-#endif
 #include <core/Preferences/Preferences.h>
 #include <core/Sampler/Sampler.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
@@ -1129,26 +1126,9 @@ std::shared_ptr<Song> Song::getEmptySong( std::shared_ptr<SoundLibraryDatabase> 
 
 void Song::setIsModified( bool bIsModified )
 {
-	bool Notify = false;
-
-	if( m_bIsModified != bIsModified ) {
-		Notify = true;
+	if ( m_bIsModified != bIsModified ) {
+		m_bIsModified = bIsModified;
 	}
-
-	m_bIsModified = bIsModified;
-
-	if( Notify ) {
-		EventQueue::get_instance()->pushEvent( Event::Type::SongModified, -1 );
-
-#ifdef H2CORE_HAVE_OSC
-		if ( Hydrogen::get_instance()->isUnderSessionManagement() ) {
-			// If Hydrogen is under session management (NSM), tell the
-			// NSM server that the Song was modified.
-			NsmClient::get_instance()->sendDirtyState( bIsModified );
-		}
-#endif
-	}
-
 }
 
 bool Song::hasMissingSamples() const

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -23,22 +23,20 @@
 #ifndef SONG_H
 #define SONG_H
 
-
-#include <QString>
 #include <QDomNode>
-#include <vector>
+#include <QString>
 #include <map>
 #include <memory>
+#include <vector>
 
-#include <core/License.h>
-#include <core/Object.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Helpers/Xml.h>
+#include <core/License.h>
+#include <core/Object.h>
 
 class TiXmlNode;
 
-namespace H2Core
-{
+namespace H2Core {
 
 class ADSR;
 class AutomationPath;
@@ -58,45 +56,45 @@ class Timeline;
 \brief	Song class
 */
 /** \ingroup docCore docDataStructure */
-class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<Song>
-{
-		H2_OBJECT(Song)
-	public:
-		enum class Mode {
-			Pattern = 0,
-			Song = 1,
-			/** Used in case no song is set and both pattern and song
-				editor are not ready to operate yet.*/
-			None = 2
-		};
-		static QString ModeToQString( const Mode& mode );
+class Song : public H2Core::Object<Song>,
+			 public std::enable_shared_from_this<Song> {
+	H2_OBJECT( Song )
+   public:
+	enum class Mode {
+		Pattern = 0,
+		Song = 1,
+		/** Used in case no song is set and both pattern and song
+			editor are not ready to operate yet.*/
+		None = 2
+	};
+	static QString ModeToQString( const Mode& mode );
 
-		/** Defines the type of user interaction experienced in the 
-			SongEditor.*/
-		enum class ActionMode {
-			/** Holding a pressed left mouse key will draw a rectangle to
-				select a group of Notes.*/
-			selectMode = 0,
-			/** Holding a pressed left mouse key will draw/delete patterns
-				in all grid cells encountered.*/
-			drawMode = 1,
-			/** Used in case no song is set and both pattern and song
-				editor are not ready to operate yet.*/
-			None = 2
-		};
-		static QString ActionModeToQString( const ActionMode& actionMode );
+	/** Defines the type of user interaction experienced in the
+		SongEditor.*/
+	enum class ActionMode {
+		/** Holding a pressed left mouse key will draw a rectangle to
+			select a group of Notes.*/
+		selectMode = 0,
+		/** Holding a pressed left mouse key will draw/delete patterns
+			in all grid cells encountered.*/
+		drawMode = 1,
+		/** Used in case no song is set and both pattern and song
+			editor are not ready to operate yet.*/
+		None = 2
+	};
+	static QString ActionModeToQString( const ActionMode& actionMode );
 
-		enum class LoopMode {
-			Disabled = 0,
-			Enabled = 1,
-			/**
-			 * Transport is still in loop mode (frames and ticks
-			 * larger than song size are allowed) but playback ends
-			 * the next time the end of the song is reached.
-			 */
-			Finishing = 2
-		};
-		static QString LoopModeToQString( const LoopMode& loopMode );
+	enum class LoopMode {
+		Disabled = 0,
+		Enabled = 1,
+		/**
+		 * Transport is still in loop mode (frames and ticks
+		 * larger than song size are allowed) but playback ends
+		 * the next time the end of the song is reached.
+		 */
+		Finishing = 2
+	};
+	static QString LoopModeToQString( const LoopMode& loopMode );
 
 	/** Determines how patterns will be added to
 	 * AudioEngine::m_pPlayingPatterns if transport is in
@@ -113,35 +111,38 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 		 */
 		None = 2
 	};
-		static QString PatternModeToQString( const PatternMode& patternMode );
+	static QString PatternModeToQString( const PatternMode& patternMode );
 
-		static QString sDefaultName;
-		static QString sDefaultAuthor;
+	static QString sDefaultName;
+	static QString sDefaultAuthor;
 
-		/** Please do not #H2Core::Hydrogen::setSong() a song created using this
-		 * constructor. It is just a minimal version with not all its members
-		 * properly initialized and can causes crashes (in the
-		 * #H2Core::AudioEngine) when used directly. Please use getEmptySong()
-		 * instead. */
-		Song( const QString& sName = Song::sDefaultName,
-			  const QString& sAuthor = Song::sDefaultAuthor,
-			  float fBpm = 120,
-			  float fVolume = 0.5 );
-		~Song();
+	/** Please do not #H2Core::Hydrogen::setSong() a song created using this
+	 * constructor. It is just a minimal version with not all its members
+	 * properly initialized and can causes crashes (in the
+	 * #H2Core::AudioEngine) when used directly. Please use getEmptySong()
+	 * instead. */
+	Song(
+		const QString& sName = Song::sDefaultName,
+		const QString& sAuthor = Song::sDefaultAuthor,
+		float fBpm = 120,
+		float fVolume = 0.5
+	);
+	~Song();
 
-		/** Creates the default / fallback song.
-		 *
-		 * @param pDB When creating an empty song during startup, the
-		 *   #H2Core::Hydrogen singleton might not be ready yet. This can be
-		 *   compensated by passing the created instance directly instead. */
-		static std::shared_ptr<Song> getEmptySong(
-			std::shared_ptr<SoundLibraryDatabase> pDB = nullptr );
-
-	static std::shared_ptr<Song> from(
-		std::shared_ptr<SoundLibraryInfo> pInfo
+	/** Creates the default / fallback song.
+	 *
+	 * @param pDB When creating an empty song during startup, the
+	 *   #H2Core::Hydrogen singleton might not be ready yet. This can be
+	 *   compensated by passing the created instance directly instead. */
+	static std::shared_ptr<Song> getEmptySong(
+		std::shared_ptr<SoundLibraryDatabase> pDB = nullptr
 	);
 
-	static std::shared_ptr<Song> 	load( const QString& sPath, bool bSilent = false );
+	static std::shared_ptr<Song> from( std::shared_ptr<SoundLibraryInfo> pInfo
+	);
+
+	static std::shared_ptr<Song>
+	load( const QString& sPath, bool bSilent = false );
 	/** Writes the song as .h2song to disk.
 	 *
 	 * @param sPath Absolute path to write the song to.
@@ -150,225 +151,238 @@ class Song : public H2Core::Object<Song>, public std::enable_shared_from_this<So
 	 * \param bSilent if set to true, all log messages except of errors and
 	 *   warnings are suppressed.
 	 */
-	bool 			save( const QString& sPath, bool bKeepMissingSamples,
-						 bool bSilent = false );
+	bool save(
+		const QString& sPath,
+		bool bKeepMissingSamples,
+		bool bSilent = false
+	);
 
 	bool getIsTimelineActivated() const;
 	void setIsTimelineActivated( bool bIsTimelineActivated );
-	
+
 	bool getIsPatternEditorLocked() const;
 	void setIsPatternEditorLocked( bool bIsPatternEditorLocked );
 
-		bool getIsMuted() const;
-		void setIsMuted( bool bIsMuted );
+	bool getIsMuted() const;
+	void setIsMuted( bool bIsMuted );
 
-		float getBpm() const;
-		void setBpm( float fBpm );
+	float getBpm() const;
+	void setBpm( float fBpm );
 
-		int getVersion() const;
-		void setVersion( int nVersion );
+	int getVersion() const;
+	void setVersion( int nVersion );
 
-		const QString& getName() const;
-		void setName( const QString& sName );
-		
-		void setVolume( float fVolume );
-		float getVolume() const;
+	const QString& getName() const;
+	void setName( const QString& sName );
 
-		void setMetronomeVolume( float fVolume );
-		float getMetronomeVolume() const;
+	void setVolume( float fVolume );
+	float getVolume() const;
 
-		std::shared_ptr<PatternList> getPatternList() const;
-		void setPatternList( std::shared_ptr<PatternList> pList );
+	void setMetronomeVolume( float fVolume );
+	float getMetronomeVolume() const;
 
-		std::shared_ptr<Drumkit> getDrumkit() const;
-		void setDrumkit( std::shared_ptr<Drumkit> pDrumkit );
+	std::shared_ptr<PatternList> getPatternList() const;
+	void setPatternList( std::shared_ptr<PatternList> pList );
 
-		/** Return a pointer to a vector storing all Pattern
-		 * present in the Song.
-		 * \return #m_pPatternGroupVector */
-		std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > getPatternGroupVector();
-		/** Return a pointer to a vector storing all Pattern
-		 * present in the Song.
-		 * \return #m_pPatternGroupVector */
-		const std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > getPatternGroupVector() const;
+	std::shared_ptr<Drumkit> getDrumkit() const;
+	void setDrumkit( std::shared_ptr<Drumkit> pDrumkit );
 
-		/** Sets the vector storing all Pattern present in the
-		 * Song #m_pPatternGroupVector.
-		 * \param pGroupVect Pointer to a vector containing all
-		 *   Pattern of the Song.*/
-		void setPatternGroupVector( std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > pGroupVect );
+	/** Return a pointer to a vector storing all Pattern
+	 * present in the Song.
+	 * \return #m_pPatternGroupVector */
+	std::shared_ptr<std::vector<std::shared_ptr<PatternList>>>
+	getPatternGroupVector();
+	/** Return a pointer to a vector storing all Pattern
+	 * present in the Song.
+	 * \return #m_pPatternGroupVector */
+	const std::shared_ptr<std::vector<std::shared_ptr<PatternList>>>
+	getPatternGroupVector() const;
 
-		/** get the length of the song, in tick units */
-		long lengthInTicks() const;
+	/** Sets the vector storing all Pattern present in the
+	 * Song #m_pPatternGroupVector.
+	 * \param pGroupVect Pointer to a vector containing all
+	 *   Pattern of the Song.*/
+	void setPatternGroupVector(
+		std::shared_ptr<std::vector<std::shared_ptr<PatternList>>> pGroupVect
+	);
 
-		void			setNotes( const QString& sNotes );
-		const QString&		getNotes() const;
-		void setTags( const QStringList& tags );
-		const QStringList& getTags() const;
+	/** get the length of the song, in tick units */
+	long lengthInTicks() const;
 
-		void			setLicense( const License& license );
-		const License&		getLicense() const;
+	void setNotes( const QString& sNotes );
+	const QString& getNotes() const;
+	void setTags( const QStringList& tags );
+	const QStringList& getTags() const;
 
-		void			setAuthor( const QString& sAuthor );
-		const QString&		getAuthor() const;
+	void setLicense( const License& license );
+	const License& getLicense() const;
 
-		const QString&		getPath() const;
-		void			setPath( const QString& sPath );
-							
-		const LoopMode&	getLoopMode() const;
-		void			setLoopMode( const LoopMode& loopMode );
-		bool			isLoopEnabled() const;
-							
-		const PatternMode& getPatternMode() const;
-		void			setPatternMode( const PatternMode& patternMode );
-							
-		float			getHumanizeTimeValue() const;
-		void			setHumanizeTimeValue( float fValue );
-							
-		float			getHumanizeVelocityValue() const;
-		void			setHumanizeVelocityValue( float fValue );
-							
-		float			getSwingFactor() const;
-		void			setSwingFactor( float fFactor );
+	void setAuthor( const QString& sAuthor );
+	const QString& getAuthor() const;
 
-		const Mode&		getMode() const;
-		void			setMode( const Mode& mode );
-							
-		bool			getIsModified() const;
-		void			setIsModified( bool bIsModified);
+	const QString& getPath() const;
+	void setPath( const QString& sPath );
 
-		AutomationPath*	getVelocityAutomationPath() const;
+	const LoopMode& getLoopMode() const;
+	void setLoopMode( const LoopMode& loopMode );
+	bool isLoopEnabled() const;
 
-		int			getLatestRoundRobin( float fStartVelocity ) const;
-		void			setLatestRoundRobin( float fStartVelocity, int nLatestRoundRobin );
+	const PatternMode& getPatternMode() const;
+	void setPatternMode( const PatternMode& patternMode );
 
-        std::shared_ptr<Instrument> getPlaybackTrackInstrument() const;
-        void setPlaybackTrackInstrument( std::shared_ptr<Instrument> pInstrument );
+	float getHumanizeTimeValue() const;
+	void setHumanizeTimeValue( float fValue );
 
-		const ActionMode& getActionMode() const;
-		void			setActionMode( const ActionMode& actionMode );
+	float getHumanizeVelocityValue() const;
+	void setHumanizeVelocityValue( float fValue );
 
-		/** Song was incompletely loaded from file (missing samples)
-		 */
-		bool hasMissingSamples() const;
+	float getSwingFactor() const;
+	void setSwingFactor( float fFactor );
 
-		void setPanLawType( int nPanLawType );
-		int getPanLawType() const;
-		void setPanLawKNorm( float fKNorm );
-		float getPanLawKNorm() const;
+	const Mode& getMode() const;
+	void setMode( const Mode& mode );
 
-		bool isPatternActive( const GridPoint& gridPoint ) const;
+	bool getIsModified() const;
+	void setIsModified( bool bIsModified );
+
+	AutomationPath* getVelocityAutomationPath() const;
+
+	int getLatestRoundRobin( float fStartVelocity ) const;
+	void setLatestRoundRobin( float fStartVelocity, int nLatestRoundRobin );
+
+	std::shared_ptr<Instrument> getPlaybackTrackInstrument() const;
+	void setPlaybackTrackInstrument( std::shared_ptr<Instrument> pInstrument );
+
+	const ActionMode& getActionMode() const;
+	void setActionMode( const ActionMode& actionMode );
+
+	/** Song was incompletely loaded from file (missing samples)
+	 */
+	bool hasMissingSamples() const;
+
+	void setPanLawType( int nPanLawType );
+	int getPanLawType() const;
+	void setPanLawKNorm( float fKNorm );
+	float getPanLawKNorm() const;
+
+	bool isPatternActive( const GridPoint& gridPoint ) const;
 
 	std::shared_ptr<Timeline> getTimeline() const;
 	void setTimeline( std::shared_ptr<Timeline> pTimeline );
 
 	std::vector<std::shared_ptr<Note>> getAllNotes() const;
 
-		const QString& getLastLoadedDrumkitPath() const;
-		void setLastLoadedDrumkitPath( const QString& sPath );
+	const QString& getLastLoadedDrumkitPath() const;
+	void setLastLoadedDrumkitPath( const QString& sPath );
 
 	bool getWasAskedAboutMissingSamples() const;
 	void setWasAskedAboutMissingSamples( bool bValue );
 
-		/** Formatted string version for debugging purposes.
-		 * \param sPrefix String prefix which will be added in front of
-		 * every new line
-		 * \param bShort Instead of the whole content of all classes
-		 * stored as members just a single unique identifier will be
-		 * displayed without line breaks.
-		 *
-		 * \return String presentation of current object.*/
-		QString toQString( const QString& sPrefix = "", bool bShort = true ) const override;
-	
-private:
+	/** Formatted string version for debugging purposes.
+	 * \param sPrefix String prefix which will be added in front of
+	 * every new line
+	 * \param bShort Instead of the whole content of all classes
+	 * stored as members just a single unique identifier will be
+	 * displayed without line breaks.
+	 *
+	 * \return String presentation of current object.*/
+	QString toQString( const QString& sPrefix = "", bool bShort = true )
+		const override;
 
-	static std::shared_ptr<Song> loadFrom( const XMLNode& pNode,
-										   const QString& sFileName,
-										   bool bSilent = false );
-	void saveTo( XMLNode& pNode, bool bKeepMissingSamples,
-				bool bSilent = false ) const;
+   private:
+	static std::shared_ptr<Song> loadFrom(
+		const XMLNode& pNode,
+		const QString& sFileName,
+		bool bSilent = false
+	);
+	void saveTo(
+		XMLNode& pNode,
+		bool bKeepMissingSamples,
+		bool bSilent = false
+	) const;
 
 	/** Whether the Timeline button was pressed in the GUI or it was
 		activated via an OSC command. */
 	bool m_bIsTimelineActivated;
-							
-		bool m_bIsMuted;
-		/**
-		 * Current speed in beats per minutes.
-		 *
-		 * See Transport::m_fBpm for how the handling of the
-		 * different tempo instances work.
-		 */
-		float m_fBpm;
 
-		int m_nVersion;
-		
-		///< song name
-		QString m_sName;
-		///< author of the song
-		QString m_sAuthor;
-		
-		///< volume of the song (0.0..1.0)
-		float	m_fVolume;
-		///< Metronome volume
-		float	m_fMetronomeVolume;
-		QString			m_sNotes;
-		QStringList m_tags;
+	bool m_bIsMuted;
+	/**
+	 * Current speed in beats per minutes.
+	 *
+	 * See Transport::m_fBpm for how the handling of the
+	 * different tempo instances work.
+	 */
+	float m_fBpm;
 
-		///< Pattern list
-		std::shared_ptr<PatternList>	m_pPatternList;
-		///< Sequence of pattern groups
-		std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > m_pPatternGroupVector;
+	int m_nVersion;
 
-		/** Current drumkit
-		 *
-		 * This one is either based on the last kit loaded from the
-		 * `SoundLibraryDatabase` or is a brand new kit. */
-		std::shared_ptr<Drumkit> m_pDrumkit;
+	///< song name
+	QString m_sName;
+	///< author of the song
+	QString m_sAuthor;
 
-		/** Absolute path to the underlying artifact serving as an unique
-		 * identifier of the artifact throughout Hydrogen.
-		 *
-		 * In case is no file backing the resource (yet), an path to an
-		 * non-existing file retrieved via #Filesystem::emptyPath will be used
-		 * instead. */
-		QString m_sPath;
+	///< volume of the song (0.0..1.0)
+	float m_fVolume;
+	///< Metronome volume
+	float m_fMetronomeVolume;
+	QString m_sNotes;
+	QStringList m_tags;
 
-		/**
-		 * The three states of this enum is just a way to handle the
-		 * playback within Hydrogen. Not its content but the output of
-		 * isLoopEnabled(), whether enabled or disabled, will be
-		 * written to disk.
-		 */
-		LoopMode		m_loopMode;
-		PatternMode		m_patternMode;
-		/**
-		 * Factor to scale the random contribution when humanizing
-		 * timing between 0 and #AudioEngine::fHumanizeTimingSD.
-		 *
-		 * Supported range [0,1].
-		 */
-		float			m_fHumanizeTimeValue;
-		/**
-		 * Factor to scale the random contribution when humanizing
-		 * velocity between 0 and #AudioEngine::fHumanizeVelocitySD.
-		 *
-		 * Supported range [0,1].
-		 */
-		float			m_fHumanizeVelocityValue;
-		float			m_fSwingFactor;
-		bool			m_bIsModified;
-		std::map< float, int> 	m_latestRoundRobins;
-		Mode			m_mode;
+	///< Pattern list
+	std::shared_ptr<PatternList> m_pPatternList;
+	///< Sequence of pattern groups
+	std::shared_ptr<std::vector<std::shared_ptr<PatternList>>>
+		m_pPatternGroupVector;
 
-        std::shared_ptr<Instrument> m_pPlaybackTrackInstrument;
+	/** Current drumkit
+	 *
+	 * This one is either based on the last kit loaded from the
+	 * `SoundLibraryDatabase` or is a brand new kit. */
+	std::shared_ptr<Drumkit> m_pDrumkit;
 
-		AutomationPath*		m_pVelocityAutomationPath;
-		///< license of the song
-		License			m_license;
+	/** Absolute path to the underlying artifact serving as an unique
+	 * identifier of the artifact throughout Hydrogen.
+	 *
+	 * In case is no file backing the resource (yet), an path to an
+	 * non-existing file retrieved via #Filesystem::emptyPath will be used
+	 * instead. */
+	QString m_sPath;
 
-		/** Stores the type of interaction with the SongEditor. */
-		ActionMode		m_actionMode;
+	/**
+	 * The three states of this enum is just a way to handle the
+	 * playback within Hydrogen. Not its content but the output of
+	 * isLoopEnabled(), whether enabled or disabled, will be
+	 * written to disk.
+	 */
+	LoopMode m_loopMode;
+	PatternMode m_patternMode;
+	/**
+	 * Factor to scale the random contribution when humanizing
+	 * timing between 0 and #AudioEngine::fHumanizeTimingSD.
+	 *
+	 * Supported range [0,1].
+	 */
+	float m_fHumanizeTimeValue;
+	/**
+	 * Factor to scale the random contribution when humanizing
+	 * velocity between 0 and #AudioEngine::fHumanizeVelocitySD.
+	 *
+	 * Supported range [0,1].
+	 */
+	float m_fHumanizeVelocityValue;
+	float m_fSwingFactor;
+	bool m_bIsModified;
+	std::map<float, int> m_latestRoundRobins;
+	Mode m_mode;
+
+	std::shared_ptr<Instrument> m_pPlaybackTrackInstrument;
+
+	AutomationPath* m_pVelocityAutomationPath;
+	///< license of the song
+	License m_license;
+
+	/** Stores the type of interaction with the SongEditor. */
+	ActionMode m_actionMode;
 
 	/**
 	 * If set to true, the user won't be able to select a pattern via
@@ -380,10 +394,10 @@ private:
 	 * This mode is only supported in Song mode.
 	 */
 	bool m_bIsPatternEditorLocked;
-		
-		int m_nPanLawType;
-		// k such that L^k+R^k = 1. Used in constant k-Norm pan law
-		float m_fPanLawKNorm;
+
+	int m_nPanLawType;
+	// k such that L^k+R^k = 1. Used in constant k-Norm pan law
+	float m_fPanLawKNorm;
 
 	std::shared_ptr<Timeline> m_pTimeline;
 
@@ -401,29 +415,35 @@ private:
 	QString m_sLastLoadedDrumkitPath;
 
 	/** In case the user opts for keeping missing samples, it would be quite
-         annoying if we ask about it every single time the song gets saved. */
+		 annoying if we ask about it every single time the song gets saved. */
 	bool m_bWasAskedAboutMissingSamples;
 
-		/** Used to indicate changes in the underlying XSD file. */
-		static constexpr int nCurrentFormatVersion = 2;
+	/** Used to indicate changes in the underlying XSD file. */
+	static constexpr int nCurrentFormatVersion = 2;
 };
 
-inline bool Song::getIsTimelineActivated() const {
+inline bool Song::getIsTimelineActivated() const
+{
 	return m_bIsTimelineActivated;
 }
-inline void Song::setIsTimelineActivated( bool bIsTimelineActivated ) {
+inline void Song::setIsTimelineActivated( bool bIsTimelineActivated )
+{
 	m_bIsTimelineActivated = bIsTimelineActivated;
 }
-inline bool Song::getIsPatternEditorLocked() const {
+inline bool Song::getIsPatternEditorLocked() const
+{
 	return m_bIsPatternEditorLocked;
 }
-inline void Song::setIsPatternEditorLocked( bool bIsPatternEditorLocked ) {
+inline void Song::setIsPatternEditorLocked( bool bIsPatternEditorLocked )
+{
 	m_bIsPatternEditorLocked = bIsPatternEditorLocked;
 }
-inline std::shared_ptr<Timeline> Song::getTimeline() const {
+inline std::shared_ptr<Timeline> Song::getTimeline() const
+{
 	return m_pTimeline;
 }
-inline void Song::setTimeline( std::shared_ptr<Timeline> pTimeline ) {
+inline void Song::setTimeline( std::shared_ptr<Timeline> pTimeline )
+{
 	m_pTimeline = pTimeline;
 }
 
@@ -442,13 +462,14 @@ inline float Song::getBpm() const
 	return m_fBpm;
 }
 
-inline void Song::setVersion( int nVersion ) {
+inline void Song::setVersion( int nVersion )
+{
 	m_nVersion = nVersion;
 }
-inline int Song::getVersion() const {
+inline int Song::getVersion() const
+{
 	return m_nVersion;
 }
-
 
 inline void Song::setName( const QString& sName )
 {
@@ -480,7 +501,7 @@ inline void Song::setMetronomeVolume( float fValue )
 	m_fMetronomeVolume = fValue;
 }
 
-inline bool Song::getIsModified() const 
+inline bool Song::getIsModified() const
 {
 	return m_bIsModified;
 }
@@ -500,16 +521,21 @@ inline void Song::setPatternList( std::shared_ptr<PatternList> pList )
 	m_pPatternList = pList;
 }
 
-inline std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > Song::getPatternGroupVector() {
-	return m_pPatternGroupVector;
-}
-
-inline const std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > Song::getPatternGroupVector() const
+inline std::shared_ptr<std::vector<std::shared_ptr<PatternList>>>
+Song::getPatternGroupVector()
 {
 	return m_pPatternGroupVector;
 }
 
-inline void Song::setPatternGroupVector( std::shared_ptr< std::vector< std::shared_ptr<PatternList> > > pGroupVector )
+inline const std::shared_ptr<std::vector<std::shared_ptr<PatternList>>>
+Song::getPatternGroupVector() const
+{
+	return m_pPatternGroupVector;
+}
+
+inline void Song::setPatternGroupVector(
+	std::shared_ptr<std::vector<std::shared_ptr<PatternList>>> pGroupVector
+)
 {
 	m_pPatternGroupVector = pGroupVector;
 }
@@ -565,8 +591,7 @@ inline void Song::setPath( const QString& sPath )
 
 inline bool Song::isLoopEnabled() const
 {
-	return m_loopMode == LoopMode::Enabled ||
-		m_loopMode == LoopMode::Finishing;
+	return m_loopMode == LoopMode::Enabled || m_loopMode == LoopMode::Finishing;
 }
 
 inline const Song::LoopMode& Song::getLoopMode() const
@@ -637,16 +662,19 @@ inline AutomationPath* Song::getVelocityAutomationPath() const
 
 inline int Song::getLatestRoundRobin( float fStartVelocity ) const
 {
-	if ( m_latestRoundRobins.find( fStartVelocity ) == m_latestRoundRobins.end() ) {
+	if ( m_latestRoundRobins.find( fStartVelocity ) ==
+		 m_latestRoundRobins.end() ) {
 		return 0;
-	} else {
+	}
+	else {
 		return m_latestRoundRobins.at( fStartVelocity );
 	}
 }
 
-inline void Song::setLatestRoundRobin( float fStartVelocity, int nLatestRoundRobin )
+inline void
+Song::setLatestRoundRobin( float fStartVelocity, int nLatestRoundRobin )
 {
-	m_latestRoundRobins[ fStartVelocity ] = nLatestRoundRobin;
+	m_latestRoundRobins[fStartVelocity] = nLatestRoundRobin;
 }
 
 inline std::shared_ptr<Instrument> Song::getPlaybackTrackInstrument() const
@@ -654,38 +682,48 @@ inline std::shared_ptr<Instrument> Song::getPlaybackTrackInstrument() const
 	return m_pPlaybackTrackInstrument;
 }
 
-inline void Song::setPlaybackTrackInstrument( std::shared_ptr<Instrument> pInstrument )
+inline void Song::setPlaybackTrackInstrument(
+	std::shared_ptr<Instrument> pInstrument
+)
 {
 	m_pPlaybackTrackInstrument = pInstrument;
 }
 
-inline const Song::ActionMode& Song::getActionMode() const {
+inline const Song::ActionMode& Song::getActionMode() const
+{
 	return m_actionMode;
 }
 
-inline void Song::setPanLawType( int nPanLawType ) {
+inline void Song::setPanLawType( int nPanLawType )
+{
 	m_nPanLawType = nPanLawType;
 }
 
-inline int Song::getPanLawType() const {
+inline int Song::getPanLawType() const
+{
 	return m_nPanLawType;
-} 
+}
 
-inline float Song::getPanLawKNorm() const {
+inline float Song::getPanLawKNorm() const
+{
 	return m_fPanLawKNorm;
 }
-inline void Song::setLastLoadedDrumkitPath( const QString& sPath ) {
+inline void Song::setLastLoadedDrumkitPath( const QString& sPath )
+{
 	m_sLastLoadedDrumkitPath = sPath;
 }
-inline const QString& Song::getLastLoadedDrumkitPath() const {
+inline const QString& Song::getLastLoadedDrumkitPath() const
+{
 	return m_sLastLoadedDrumkitPath;
 }
-inline bool Song::getWasAskedAboutMissingSamples() const {
+inline bool Song::getWasAskedAboutMissingSamples() const
+{
 	return m_bWasAskedAboutMissingSamples;
 }
-inline void Song::setWasAskedAboutMissingSamples( bool bValue ) {
+inline void Song::setWasAskedAboutMissingSamples( bool bValue )
+{
 	m_bWasAskedAboutMissingSamples = bValue;
 }
-};
+};	// namespace H2Core
 
 #endif

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -41,6 +41,7 @@ namespace H2Core {
 class ADSR;
 class AutomationPath;
 class Drumkit;
+class Effects;
 class GridPoint;
 class Instrument;
 class Note;
@@ -270,6 +271,9 @@ class Song : public H2Core::Object<Song>,
 	std::shared_ptr<Timeline> getTimeline() const;
 	void setTimeline( std::shared_ptr<Timeline> pTimeline );
 
+	std::shared_ptr<Effects> getEffects() const;
+	void setEffects( std::shared_ptr<Effects> pEffects );
+
 	std::vector<std::shared_ptr<Note>> getAllNotes() const;
 
 	const QString& getLastLoadedDrumkitPath() const;
@@ -401,6 +405,8 @@ class Song : public H2Core::Object<Song>,
 
 	std::shared_ptr<Timeline> m_pTimeline;
 
+	std::shared_ptr<Effects> m_pEffects;
+
 	/** Unique identifier of the drumkit last loaded.
 	 *
 	 * It is assigned to the song's current drumkit on load in order to properly
@@ -445,6 +451,14 @@ inline std::shared_ptr<Timeline> Song::getTimeline() const
 inline void Song::setTimeline( std::shared_ptr<Timeline> pTimeline )
 {
 	m_pTimeline = pTimeline;
+}
+inline std::shared_ptr<Effects> Song::getEffects() const
+{
+	return m_pEffects;
+}
+inline void Song::setEffects( std::shared_ptr<Effects> pEffects )
+{
+	m_pEffects = pEffects;
 }
 
 inline bool Song::getIsMuted() const

--- a/src/core/Basics/Song.h
+++ b/src/core/Basics/Song.h
@@ -389,8 +389,9 @@ private:
 
 	/** Unique identifier of the drumkit last loaded.
 	 *
-	 * This is a convenience variable allowing to cycle through the different
-	 * kits using MIDI and OSC commands (load next/previous kit).
+	 * It is assigned to the song's current drumkit on load in order to properly
+	 * link it with an artifact on disk. In addition, it allows to cycle through
+	 * the different kits using MIDI and OSC commands (load next/previous kit).
 	 *
 	 * Note: In older versions of Hydrogen (< 1.3.0) this variable was used to
 	 * determine the location of samples of the current song with relative file

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -2912,8 +2912,6 @@ bool CoreActionController::setSongProperties(
 
 	pHydrogen->setSongModified( true );
 
-	EventQueue::get_instance()->pushEvent( Event::Type::SongModified, 0 );
-
 	return true;
 }
 

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -2828,7 +2828,7 @@ bool CoreActionController::clearInstrumentInPattern(
 
 	pPattern->purgeInstrument( pInstrument, true );
 
-	EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, 0 );
+	EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, 0 );
 
 	return true;
 }
@@ -2874,7 +2874,7 @@ bool CoreActionController::setPatternProperties(
 
 	pHydrogen->setSongModified( true );
 
-	EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1 );
+	EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, -1 );
 
 	return true;
 }

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -2872,7 +2872,7 @@ bool CoreActionController::setPatternProperties(
 	}
 	pPattern->setTags( newTags );
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setPatternModified( true, nPatternIndex );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, -1 );
 

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -102,7 +102,7 @@ bool CoreActionController::setStripVolume(
 	if ( pInstr->getVolume() != fVolumeValue ) {
 		pInstr->setVolume( fVolumeValue );
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		return sendStripVolumeFeedback( nStrip );
 	}
@@ -251,7 +251,7 @@ bool CoreActionController::setMasterIsMuted( bool bIsMuted )
 	if ( pSong->getIsMuted() != bIsMuted ) {
 		pSong->setIsMuted( bIsMuted );
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		EventQueue::get_instance()->pushEvent(
 			Event::Type::MixerSettingsChanged, 0
@@ -281,7 +281,7 @@ bool CoreActionController::setHumanizeTime( float fValue )
 			Event::Type::MixerSettingsChanged, 0
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 	}
 
 	return true;
@@ -305,7 +305,7 @@ bool CoreActionController::setHumanizeVelocity( float fValue )
 			Event::Type::MixerSettingsChanged, 0
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 	}
 
 	return true;
@@ -329,7 +329,7 @@ bool CoreActionController::setSwing( float fValue )
 			Event::Type::MixerSettingsChanged, 0
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 	}
 
 	return true;
@@ -374,7 +374,7 @@ bool CoreActionController::setStripIsMuted(
 			Event::Type::InstrumentMuteSoloChanged, nStrip
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		return sendStripIsMutedFeedback( nStrip );
 	}
@@ -421,7 +421,7 @@ bool CoreActionController::setStripIsSoloed(
 			Event::Type::InstrumentMuteSoloChanged, nStrip
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		return sendStripIsSoloedFeedback( nStrip );
 	}
@@ -453,7 +453,7 @@ bool CoreActionController::setStripPan(
 			Event::Type::InstrumentParametersChanged, nStrip
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		return sendStripPanFeedback( nStrip );
 	}
@@ -485,7 +485,7 @@ bool CoreActionController::setStripPanSym(
 			Event::Type::InstrumentParametersChanged, nStrip
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		return sendStripPanFeedback( nStrip );
 	}
@@ -518,7 +518,7 @@ bool CoreActionController::setStripEffectLevel(
 			Event::Type::InstrumentParametersChanged, nStrip
 		);
 
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 	}
 
 	return true;
@@ -976,7 +976,7 @@ bool CoreActionController::setSong( std::shared_ptr<Song> pSong )
 	}
 
 	// As we just set a fresh song, we can mark it not modified
-	pHydrogen->setIsModified( false );
+	pHydrogen->setSongModified( false );
 
 	return true;
 }
@@ -1217,7 +1217,7 @@ bool CoreActionController::addTempoMarker( int nPosition, float fBpm )
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::UpdateTimeline, 0 );
 
@@ -1248,7 +1248,7 @@ bool CoreActionController::deleteTempoMarker( int nPosition )
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 	EventQueue::get_instance()->pushEvent( Event::Type::UpdateTimeline, 0 );
 
 	return true;
@@ -1268,7 +1268,7 @@ bool CoreActionController::addTag( int nPosition, const QString& sText )
 	pTimeline->deleteTag( nPosition );
 	pTimeline->addTag( nPosition, sText );
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::UpdateTimeline, 0 );
 
@@ -1288,7 +1288,7 @@ bool CoreActionController::deleteTag( int nPosition )
 
 	pHydrogen->getSong()->getTimeline()->deleteTag( nPosition );
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 	EventQueue::get_instance()->pushEvent( Event::Type::UpdateTimeline, 0 );
 
 	return true;
@@ -1628,7 +1628,7 @@ bool CoreActionController::setDrumkit( std::shared_ptr<Drumkit> pNewDrumkit )
 
 	initExternalControlInterfaces();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
 
@@ -2143,7 +2143,7 @@ bool CoreActionController::addInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	const auto nId =
 		EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
@@ -2224,7 +2224,7 @@ bool CoreActionController::removeInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	const auto nId =
 		EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
@@ -2324,7 +2324,7 @@ bool CoreActionController::replaceDrumkitInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
 
@@ -2372,7 +2372,7 @@ bool CoreActionController::replacePlaybackTrackInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent(
 		Event::Type::PlaybackTrackChanged, 0
@@ -2417,7 +2417,7 @@ bool CoreActionController::moveInstrument( int nSourceIndex, int nTargetIndex )
 
 	pHydrogen->getAudioEngine()->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
 
@@ -2447,7 +2447,7 @@ bool CoreActionController::renameComponent(
 
 	pComponent->setName( sNewName );
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent(
 		Event::Type::SelectedInstrumentChanged, 0
@@ -2644,7 +2644,7 @@ bool CoreActionController::setPattern(
 		pHydrogen->updateVirtualPatterns( Event::Trigger::Suppress );
 	}
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent(
 		Event::Type::SelectedPatternChanged, 0
@@ -2786,7 +2786,7 @@ bool CoreActionController::removePattern( int nPatternNumber )
 	}
 
 	pHydrogen->updateVirtualPatterns();
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	return true;
 }
@@ -2872,7 +2872,7 @@ bool CoreActionController::setPatternProperties(
 	}
 	pPattern->setTags( newTags );
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1 );
 
@@ -2910,7 +2910,7 @@ bool CoreActionController::setSongProperties(
 	}
 	pSong->setTags( newTags );
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::SongModified, 0 );
 
@@ -2995,7 +2995,7 @@ bool CoreActionController::toggleGridCell( const GridPoint& gridPoint )
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	// Update the SongEditor.
 	if ( pHydrogen->getGUIState() != Hydrogen::GUIState::headless ) {
@@ -3133,7 +3133,7 @@ bool CoreActionController::setBpm( float fBpm )
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	return true;
 }

--- a/src/core/CoreActionController.cpp
+++ b/src/core/CoreActionController.cpp
@@ -102,7 +102,7 @@ bool CoreActionController::setStripVolume(
 	if ( pInstr->getVolume() != fVolumeValue ) {
 		pInstr->setVolume( fVolumeValue );
 
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 
 		return sendStripVolumeFeedback( nStrip );
 	}
@@ -374,7 +374,7 @@ bool CoreActionController::setStripIsMuted(
 			Event::Type::InstrumentMuteSoloChanged, nStrip
 		);
 
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 
 		return sendStripIsMutedFeedback( nStrip );
 	}
@@ -421,7 +421,7 @@ bool CoreActionController::setStripIsSoloed(
 			Event::Type::InstrumentMuteSoloChanged, nStrip
 		);
 
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 
 		return sendStripIsSoloedFeedback( nStrip );
 	}
@@ -453,7 +453,7 @@ bool CoreActionController::setStripPan(
 			Event::Type::InstrumentParametersChanged, nStrip
 		);
 
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 
 		return sendStripPanFeedback( nStrip );
 	}
@@ -485,7 +485,7 @@ bool CoreActionController::setStripPanSym(
 			Event::Type::InstrumentParametersChanged, nStrip
 		);
 
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 
 		return sendStripPanFeedback( nStrip );
 	}
@@ -518,7 +518,7 @@ bool CoreActionController::setStripEffectLevel(
 			Event::Type::InstrumentParametersChanged, nStrip
 		);
 
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 	}
 
 	return true;
@@ -2143,7 +2143,7 @@ bool CoreActionController::addInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setDrumkitModified( true );
 
 	const auto nId =
 		EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
@@ -2224,7 +2224,7 @@ bool CoreActionController::removeInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setDrumkitModified( true );
 
 	const auto nId =
 		EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
@@ -2324,7 +2324,7 @@ bool CoreActionController::replaceDrumkitInstrument(
 
 	pAudioEngine->unlock();
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setDrumkitModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
 
@@ -2417,7 +2417,7 @@ bool CoreActionController::moveInstrument( int nSourceIndex, int nTargetIndex )
 
 	pHydrogen->getAudioEngine()->unlock();
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setDrumkitModified( true );
 
 	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitLoaded, 0 );
 
@@ -2447,7 +2447,7 @@ bool CoreActionController::renameComponent(
 
 	pComponent->setName( sNewName );
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setDrumkitModified( true );
 
 	EventQueue::get_instance()->pushEvent(
 		Event::Type::SelectedInstrumentChanged, 0

--- a/src/core/FX/Effects.cpp
+++ b/src/core/FX/Effects.cpp
@@ -72,7 +72,6 @@ void Effects::setLadspaFX( std::shared_ptr<LadspaFX> pFX, int nFX ) {
 
 	pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
 
-
 	if ( m_FXs[ nFX ] != nullptr ) {
 		m_FXs[ nFX ]->deactivate();
 	}
@@ -84,9 +83,7 @@ void Effects::setLadspaFX( std::shared_ptr<LadspaFX> pFX, int nFX ) {
 		updateRecentGroup();
 	}
 
-
 	pHydrogen->getAudioEngine()->unlock();
-	pHydrogen->setSongModified( true );
 }
 
 ///
@@ -194,7 +191,7 @@ std::vector< std::shared_ptr<LadspaFXInfo> > Effects::getPluginList()
 
 std::shared_ptr<LadspaFXGroup> Effects::getLadspaFXGroup()
 {
-	INFOLOG( "[getLadspaFXGroup]" );
+	INFOLOG( "" );
 
 	if ( m_pRootGroup ) {
 		return m_pRootGroup;
@@ -245,7 +242,6 @@ void Effects::updateRecentGroup()
 
 	m_pRecentGroup->clear();
 
-
 	QString sRecent; // The recent fx names sit in the preferences object
 	foreach ( sRecent, Preferences::get_instance()->getRecentFX() ) {
 		for ( std::vector< std::shared_ptr<LadspaFXInfo> >::iterator it =
@@ -257,7 +253,6 @@ void Effects::updateRecentGroup()
 			}
 		}
 	}
-	Hydrogen::get_instance()->setSongModified( true );
 }
 
 #ifdef H2CORE_HAVE_LRDF

--- a/src/core/FX/Effects.cpp
+++ b/src/core/FX/Effects.cpp
@@ -42,26 +42,13 @@
 namespace H2Core
 {
 
-// static data
-Effects* Effects::__instance = nullptr;
-
 Effects::Effects()
 		: m_pRootGroup( nullptr )
 		, m_pRecentGroup( nullptr )
 {
-	__instance = this;
-
 	m_FXs.resize( MAX_FX );
 
 	getPluginList();
-}
-
-
-void Effects::create_instance()
-{
-	if ( __instance == nullptr ) {
-		__instance = new Effects;
-	}
 }
 
 Effects::~Effects() {

--- a/src/core/FX/Effects.cpp
+++ b/src/core/FX/Effects.cpp
@@ -99,10 +99,7 @@ void Effects::setLadspaFX( std::shared_ptr<LadspaFX> pFX, int nFX ) {
 
 
 	pHydrogen->getAudioEngine()->unlock();
-
-	if ( pHydrogen->getSong() != nullptr ) {
-		pHydrogen->setIsModified( true );
-	}
+	pHydrogen->setSongModified( true );
 }
 
 ///
@@ -273,7 +270,7 @@ void Effects::updateRecentGroup()
 			}
 		}
 	}
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 #ifdef H2CORE_HAVE_LRDF

--- a/src/core/FX/Effects.h
+++ b/src/core/FX/Effects.h
@@ -24,71 +24,71 @@
 #define EFFECTS_H
 
 #include <core/config.h>
+#include <core/Object.h>
+
 #if defined(H2CORE_HAVE_LADSPA) || _DOXYGEN_
 
-#include <core/Globals.h>
-#include <core/Object.h>
 #include <core/FX/LadspaFX.h>
+#include <core/Globals.h>
 
+#include <cassert>
 #include <memory>
 #include <vector>
-#include <cassert>
 
-namespace H2Core
-{
+namespace H2Core {
 /** \ingroup docCore docAudioEngine */
-class Effects : public H2Core::Object<Effects>
-{
-	H2_OBJECT(Effects)
-public:
-	/**
-	 * If #__instance equals 0, a new Effects
-	 * singleton will be created and stored in it.
-	 *
-	 * It is called in Hydrogen::audioEngine_init().
-	 */
-	static void create_instance();
-	/**
-	 * Returns a pointer to the current Effects singleton
-	 * stored in #__instance.
-	 */
-	static Effects* get_instance() { assert(__instance); return __instance; }
+class Effects : public H2Core::Object<Effects> {
+	H2_OBJECT( Effects )
+   public:
+	Effects();
 	~Effects();
 
 	std::shared_ptr<LadspaFX> getLadspaFX( int nFX ) const;
-	void  setLadspaFX( std::shared_ptr<LadspaFX> pFX, int nFX );
+	void setLadspaFX( std::shared_ptr<LadspaFX> pFX, int nFX );
 
-	std::vector< std::shared_ptr<LadspaFXInfo> > getPluginList();
+	std::vector<std::shared_ptr<LadspaFXInfo> > getPluginList();
 	std::shared_ptr<LadspaFXGroup> getLadspaFXGroup();
 
-
-private:
-	/**
-	 * Object holding the current Effects singleton. It is
-	 * initialized with NULL, set with create_instance(), and
-	 * accessed with get_instance().
-	 */
-	static Effects* __instance;
-	std::vector< std::shared_ptr<LadspaFXInfo> > m_pluginList;
-	std::shared_ptr<LadspaFXGroup> m_pRootGroup;
-	std::shared_ptr<LadspaFXGroup> m_pRecentGroup;
-
+   private:
+	void getRDF(
+		std::shared_ptr<LadspaFXGroup> pGroup,
+		std::vector<std::shared_ptr<LadspaFXInfo> > pluginList
+	);
+	void RDFDescend(
+		const QString& sBase,
+		std::shared_ptr<LadspaFXGroup> pGroup,
+		std::vector<std::shared_ptr<LadspaFXInfo> > pluginList
+	);
 	void updateRecentGroup();
 
-	std::vector< std::shared_ptr<LadspaFX> > m_FXs;
-
-	Effects();
-
-	void RDFDescend( const QString& sBase, std::shared_ptr<LadspaFXGroup> pGroup,
-					 std::vector< std::shared_ptr<LadspaFXInfo> > pluginList );
-	void getRDF( std::shared_ptr<LadspaFXGroup> pGroup,
-				 std::vector< std::shared_ptr<LadspaFXInfo> > pluginList );
-
+	std::vector<std::shared_ptr<LadspaFXInfo> > m_pluginList;
+	std::shared_ptr<LadspaFXGroup> m_pRootGroup;
+	std::shared_ptr<LadspaFXGroup> m_pRecentGroup;
+	std::vector<std::shared_ptr<LadspaFX> > m_FXs;
 };
 
+};	// namespace H2Core
+
+#else  // H2CORE_HAVE_LADSPA
+// LADSPA is disabled
+
+namespace H2Core {
+/** \ingroup docCore */
+class Effects : public H2Core::Object<Effects> {
+	H2_OBJECT( Effects )
+   public:
+	/**
+	 * Fallback version of the Effects in case
+	 * #H2CORE_HAVE_LADSPA was not defined during the configuration
+	 * and the usage of LADSPA plugins is not intended by
+	 * the user.
+	 */
+	Effects() {}
+	~Effects(){};
 };
 
-#endif
+};	// namespace H2Core
 
+#endif	// H2CORE_HAVE_LADSPA
 
 #endif

--- a/src/core/FX/LadspaFX.cpp
+++ b/src/core/FX/LadspaFX.cpp
@@ -47,18 +47,18 @@ LadspaFXGroup::~LadspaFXGroup() {
 void LadspaFXGroup::clear() {
 	m_childGroups.clear();
 	m_ladspaList.clear();
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 void LadspaFXGroup::addLadspaInfo( std::shared_ptr<LadspaFXInfo> pInfo ) {
 	m_ladspaList.push_back( pInfo );
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 
 void LadspaFXGroup::addChild( std::shared_ptr<LadspaFXGroup> pChild ) {
 	m_childGroups.push_back( pChild );
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 bool LadspaFXGroup::alphabeticOrder( std::shared_ptr<LadspaFXGroup> a,
@@ -71,7 +71,7 @@ void LadspaFXGroup::sort() {
 			   LadspaFXInfo::alphabeticOrder );
 	std::sort( m_childGroups.begin(), m_childGroups.end(),
 			   LadspaFXGroup::alphabeticOrder );
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 }
 
 ////////////////
@@ -151,14 +151,14 @@ void LadspaFX::setPluginName( const QString& sName ) {
 	m_sName = sName;
 	
 	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 void LadspaFX::setEnabled( bool value, Event::Trigger trigger ) {
 	m_bEnabled = value;
 	
 	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	}
 
 	if ( trigger != Event::Trigger::Suppress ) {
@@ -354,7 +354,7 @@ std::shared_ptr<LadspaFX> LadspaFX::load( const QString& sLibraryPath,
 	}
 	
 	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	}
 	return pFX;
 }
@@ -417,7 +417,7 @@ void LadspaFX::activate( Event::Trigger trigger ) {
 		m_bActivated = true;
 		Logger::CrashContext cc( &m_sLibraryPath );
 		m_d->activate( m_handle );
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 
 		if ( trigger != Event::Trigger::Suppress ) {
 			EventQueue::get_instance()->pushEvent( Event::Type::EffectChanged, 0 );
@@ -431,7 +431,7 @@ void LadspaFX::deactivate( Event::Trigger trigger ) {
 		m_bActivated = false;
 		Logger::CrashContext cc( &m_sLibraryPath );
 		m_d->deactivate( m_handle );
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 
 		if ( trigger != Event::Trigger::Suppress ) {
 			EventQueue::get_instance()->pushEvent( Event::Type::EffectChanged, 0 );
@@ -449,7 +449,7 @@ void LadspaFX::setVolume( float fValue ) {
 	m_fVolume = fValue;
 
 	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 };

--- a/src/core/FX/LadspaFX.cpp
+++ b/src/core/FX/LadspaFX.cpp
@@ -47,18 +47,15 @@ LadspaFXGroup::~LadspaFXGroup() {
 void LadspaFXGroup::clear() {
 	m_childGroups.clear();
 	m_ladspaList.clear();
-	Hydrogen::get_instance()->setSongModified( true );
 }
 
 void LadspaFXGroup::addLadspaInfo( std::shared_ptr<LadspaFXInfo> pInfo ) {
 	m_ladspaList.push_back( pInfo );
-	Hydrogen::get_instance()->setSongModified( true );
 }
 
 
 void LadspaFXGroup::addChild( std::shared_ptr<LadspaFXGroup> pChild ) {
 	m_childGroups.push_back( pChild );
-	Hydrogen::get_instance()->setSongModified( true );
 }
 
 bool LadspaFXGroup::alphabeticOrder( std::shared_ptr<LadspaFXGroup> a,
@@ -71,7 +68,6 @@ void LadspaFXGroup::sort() {
 			   LadspaFXInfo::alphabeticOrder );
 	std::sort( m_childGroups.begin(), m_childGroups.end(),
 			   LadspaFXGroup::alphabeticOrder );
-	Hydrogen::get_instance()->setSongModified( true );
 }
 
 ////////////////
@@ -149,17 +145,12 @@ LadspaFX::~LadspaFX() {
 
 void LadspaFX::setPluginName( const QString& sName ) {
 	m_sName = sName;
-	
-	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setSongModified( true );
-	}
 }
 void LadspaFX::setEnabled( bool value, Event::Trigger trigger ) {
-	m_bEnabled = value;
-	
-	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setSongModified( true );
+	if ( m_bEnabled == value ) {
+		return;
 	}
+	m_bEnabled = value;
 
 	if ( trigger != Event::Trigger::Suppress ) {
 		EventQueue::get_instance()->pushEvent( Event::Type::EffectChanged, 0 );
@@ -352,10 +343,6 @@ std::shared_ptr<LadspaFX> LadspaFX::load( const QString& sLibraryPath,
 			_ERRORLOG( "unknown port" );
 		}
 	}
-	
-	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setSongModified( true );
-	}
 	return pFX;
 }
 
@@ -417,7 +404,6 @@ void LadspaFX::activate( Event::Trigger trigger ) {
 		m_bActivated = true;
 		Logger::CrashContext cc( &m_sLibraryPath );
 		m_d->activate( m_handle );
-		Hydrogen::get_instance()->setSongModified( true );
 
 		if ( trigger != Event::Trigger::Suppress ) {
 			EventQueue::get_instance()->pushEvent( Event::Type::EffectChanged, 0 );
@@ -431,7 +417,6 @@ void LadspaFX::deactivate( Event::Trigger trigger ) {
 		m_bActivated = false;
 		Logger::CrashContext cc( &m_sLibraryPath );
 		m_d->deactivate( m_handle );
-		Hydrogen::get_instance()->setSongModified( true );
 
 		if ( trigger != Event::Trigger::Suppress ) {
 			EventQueue::get_instance()->pushEvent( Event::Type::EffectChanged, 0 );
@@ -447,10 +432,6 @@ void LadspaFX::setVolume( float fValue ) {
 		fValue = 0.0;
 	}
 	m_fVolume = fValue;
-
-	if ( Hydrogen::get_instance()->getSong() != nullptr ) {
-		Hydrogen::get_instance()->setSongModified( true );
-	}
 }
 };
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -321,7 +321,7 @@ bool Hydrogen::addRealtimeNote(
 	const bool bPlaySelectedInstrument = pPref->getMidiInstrumentMap()->getInput() ==
 		MidiInstrumentMap::Input::SelectedInstrument;
 	int scalar = ( 4 * 4 * H2Core::nTicksPerQuarter ) / ( res * nBase );
-	int currentPatternNumber;
+	int nCurrentPatternNumber;
 
 	std::shared_ptr<Song> pSong = getSong();
 
@@ -374,12 +374,12 @@ bool Hydrogen::addRealtimeNote(
 
 		// Capture new notes in the bottom-most pattern (if not already done above)
 		auto pColumn = ( *pColumns )[ nColumn ];
-		currentPatternNumber = -1;
+		nCurrentPatternNumber = -1;
 		for ( int n = 0; n < pColumn->size(); n++ ) {
 			auto pPattern = pColumn->get( n );
 			int nIndex = pPatternList->index( pPattern );
-			if ( nIndex > currentPatternNumber ) {
-				currentPatternNumber = nIndex;
+			if ( nIndex > nCurrentPatternNumber ) {
+				nCurrentPatternNumber = nIndex;
 				pCurrentPattern = pPattern;
 			}
 		}
@@ -395,7 +395,7 @@ bool Hydrogen::addRealtimeNote(
 			 && ( m_nSelectedPatternNumber < ( int )pPatternList->size() ) )
 		{
 			pCurrentPattern = pPatternList->get( m_nSelectedPatternNumber );
-			currentPatternNumber = m_nSelectedPatternNumber;
+			nCurrentPatternNumber = m_nSelectedPatternNumber;
 		}
 
 		if ( ! pCurrentPattern ) {
@@ -427,10 +427,8 @@ bool Hydrogen::addRealtimeNote(
 
 		INFOLOG( QString( "Recording [%1] to pattern: %2 (%3), tick: [%4/%5]." )
 				 .arg( bNoteOff ? "NoteOff" : "NoteOn")
-				 .arg( currentPatternNumber ).arg( pCurrentPattern->getName() )
+				 .arg( nCurrentPatternNumber ).arg( pCurrentPattern->getName() )
 				 .arg( nTickInPattern ).arg( pCurrentPattern->getLength() ) );
-
-		bool bSongModified = false;
 
 		if ( bNoteOff ) {
             // Handle the Note-Off event corresponding to the previous Note-On.
@@ -459,6 +457,7 @@ bool Hydrogen::addRealtimeNote(
 					m_nLastRecordedMIDINoteTick;
 			}
 
+			bool bPatternModified = false;
 			for ( unsigned nnNote = 0; nnNote < nPatternSize; nnNote++ ) {
 				const Pattern::notes_t* notes = pCurrentPattern->getNotes();
 				FOREACH_NOTE_CST_IT_BOUND_LENGTH(
@@ -476,16 +475,23 @@ bool Hydrogen::addRealtimeNote(
 								nPatternSize - m_nLastRecordedMIDINoteTick;
 						}
 						pNote->setLength( nNewNoteLength );
-						bSongModified = true;
+						bPatternModified = true;
 					}
 				}
+			}
+
+			if ( bPatternModified && ! pCurrentPattern->getIsModified() ) {
+				EventQueue::get_instance()->pushEvent(
+					Event::Type::PatternChanged, -1
+				);
+				setPatternModified( true, nCurrentPatternNumber );
 			}
 		}
 		else { // note on
 			EventQueue::AddMidiNoteVector noteAction;
 			noteAction.nColumn = nTickInPattern;
 			noteAction.id = instrumentId;
-			noteAction.nPattern = currentPatternNumber;
+			noteAction.nPattern = nCurrentPatternNumber;
 			noteAction.fVelocity = fVelocity;
 			noteAction.fPan = fPan;
 			noteAction.nLength = -1;
@@ -502,13 +508,6 @@ bool Hydrogen::addRealtimeNote(
 			EventQueue::get_instance()->m_addMidiNoteVector.push_back(noteAction);
 
 			m_nLastRecordedMIDINoteTick = nTickInPattern;
-			
-			bSongModified = true;
-		}
-		
-		if ( bSongModified ) {
-			EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, -1 );
-			setSongModified( true );
 		}
 	}
 

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1405,7 +1405,7 @@ void Hydrogen::setSongModified( bool bIsModified )
 
 	m_pSong->setIsModified( bIsModified );
 
-	EventQueue::get_instance()->pushEvent( Event::Type::SongModified, -1 );
+	EventQueue::get_instance()->pushEvent( Event::Type::SongIsModified, -1 );
 
 #ifdef H2CORE_HAVE_OSC
 	if ( isUnderSessionManagement() ) {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1369,7 +1369,7 @@ void Hydrogen::setDrumkitModified( bool bIsModified )
 
 	m_pSong->getDrumkit()->setIsModified( bIsModified );
 
-	//EventQueue::get_instance()->pushEvent( Event::Type::DrumkitModified, -1 );
+	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitModified, -1 );
 }
 
 void Hydrogen::setPatternModified( bool bIsModified, int nIndex )

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1353,6 +1353,25 @@ void Hydrogen::recreateOscServer() {
 #endif
 }
 
+void Hydrogen::setDrumkitModified( bool bIsModified )
+{
+	if ( m_pSong == nullptr || m_pSong->getDrumkit() == nullptr ) {
+		return;
+	}
+
+	if ( bIsModified && ! m_pSong->getIsModified() ) {
+		m_pSong->setIsModified( true );
+	}
+
+	if ( m_pSong->getDrumkit()->getIsModified() == bIsModified ) {
+		return;
+	}
+
+	m_pSong->getDrumkit()->setIsModified( bIsModified );
+
+	//EventQueue::get_instance()->pushEvent( Event::Type::DrumkitModified, -1 );
+}
+
 void Hydrogen::setPatternModified( bool bIsModified, int nIndex )
 {
 	if ( m_pSong == nullptr ) {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -507,7 +507,7 @@ bool Hydrogen::addRealtimeNote(
 		}
 		
 		if ( bSongModified ) {
-			EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1 );
+			EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, -1 );
 			setSongModified( true );
 		}
 	}
@@ -1623,7 +1623,7 @@ void Hydrogen::updateVirtualPatterns( Event::Trigger trigger ) {
 
 	if ( trigger != Event::Trigger::Suppress ) {
 		EventQueue::get_instance()->pushEvent(
-			Event::Type::PatternModified, 0
+			Event::Type::PatternChanged, 0
 		);
 	}
 }

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1393,8 +1393,9 @@ void Hydrogen::setPatternModified( bool bIsModified, int nIndex )
 
 	pPattern->setIsModified( bIsModified );
 
-	// EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1
-	// );
+	EventQueue::get_instance()->pushEvent(
+		Event::Type::PatternIsModified, nIndex
+	);
 }
 
 void Hydrogen::setSongModified( bool bIsModified )

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1353,6 +1353,31 @@ void Hydrogen::recreateOscServer() {
 #endif
 }
 
+void Hydrogen::setPatternModified( bool bIsModified, int nIndex )
+{
+	if ( m_pSong == nullptr ) {
+		return;
+	}
+
+	auto pPattern = m_pSong->getPatternList()->get( nIndex );
+	if ( pPattern == nullptr ) {
+		return;
+	}
+
+	if ( bIsModified && ! m_pSong->getIsModified() ) {
+		m_pSong->setIsModified( true );
+	}
+
+	if ( pPattern->getIsModified() == bIsModified ) {
+		return;
+	}
+
+	pPattern->setIsModified( bIsModified );
+
+	// EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1
+	// );
+}
+
 void Hydrogen::setSongModified( bool bIsModified )
 {
 	if ( m_pSong == nullptr || m_pSong->getIsModified() == bIsModified ) {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1359,7 +1359,7 @@ void Hydrogen::setDrumkitModified( bool bIsModified )
 	}
 
 	if ( bIsModified && ! m_pSong->getIsModified() ) {
-		m_pSong->setIsModified( true );
+		setSongModified( true );
 	}
 
 	if ( m_pSong->getDrumkit()->getIsModified() == bIsModified ) {
@@ -1383,7 +1383,7 @@ void Hydrogen::setPatternModified( bool bIsModified, int nIndex )
 	}
 
 	if ( bIsModified && ! m_pSong->getIsModified() ) {
-		m_pSong->setIsModified( true );
+		setSongModified( true );
 	}
 
 	if ( pPattern->getIsModified() == bIsModified ) {

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -1369,7 +1369,7 @@ void Hydrogen::setDrumkitModified( bool bIsModified )
 
 	m_pSong->getDrumkit()->setIsModified( bIsModified );
 
-	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitModified, -1 );
+	EventQueue::get_instance()->pushEvent( Event::Type::DrumkitIsModified, -1 );
 }
 
 void Hydrogen::setPatternModified( bool bIsModified, int nIndex )

--- a/src/core/Hydrogen.cpp
+++ b/src/core/Hydrogen.cpp
@@ -430,7 +430,7 @@ bool Hydrogen::addRealtimeNote(
 				 .arg( currentPatternNumber ).arg( pCurrentPattern->getName() )
 				 .arg( nTickInPattern ).arg( pCurrentPattern->getLength() ) );
 
-		bool bIsModified = false;
+		bool bSongModified = false;
 
 		if ( bNoteOff ) {
             // Handle the Note-Off event corresponding to the previous Note-On.
@@ -476,7 +476,7 @@ bool Hydrogen::addRealtimeNote(
 								nPatternSize - m_nLastRecordedMIDINoteTick;
 						}
 						pNote->setLength( nNewNoteLength );
-						bIsModified = true;
+						bSongModified = true;
 					}
 				}
 			}
@@ -503,12 +503,12 @@ bool Hydrogen::addRealtimeNote(
 
 			m_nLastRecordedMIDINoteTick = nTickInPattern;
 			
-			bIsModified = true;
+			bSongModified = true;
 		}
 		
-		if ( bIsModified ) {
+		if ( bSongModified ) {
 			EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1 );
-			setIsModified( true );
+			setSongModified( true );
 		}
 	}
 
@@ -1228,7 +1228,7 @@ void Hydrogen::setIsPatternEditorLocked( bool bValue ) {
 	if ( m_pSong != nullptr &&
 		 bValue != m_pSong->getIsPatternEditorLocked() ) {
 		m_pSong->setIsPatternEditorLocked( bValue );
-		m_pSong->setIsModified( true );
+		setSongModified( true );
 
 		updateSelectedPattern();
 			
@@ -1289,7 +1289,7 @@ void Hydrogen::setPatternMode( const Song::PatternMode& mode )
 		m_pAudioEngine->lock( RIGHT_HERE );
 
 		m_pSong->setPatternMode( mode );
-		setIsModified( true );
+		setSongModified( true );
 		
 		if ( m_pAudioEngine->getState() != AudioEngine::State::Playing ||
 			 mode == Song::PatternMode::Selected ) {
@@ -1353,16 +1353,28 @@ void Hydrogen::recreateOscServer() {
 #endif
 }
 
-void Hydrogen::setIsModified( bool bIsModified ) {
-	if ( getSong() != nullptr ) {
-		if ( getSong()->getIsModified() != bIsModified ) {
-			getSong()->setIsModified( bIsModified );
-		}
+void Hydrogen::setSongModified( bool bIsModified )
+{
+	if ( m_pSong == nullptr || m_pSong->getIsModified() == bIsModified ) {
+		return;
 	}
+
+	m_pSong->setIsModified( bIsModified );
+
+	EventQueue::get_instance()->pushEvent( Event::Type::SongModified, -1 );
+
+#ifdef H2CORE_HAVE_OSC
+	if ( isUnderSessionManagement() ) {
+		// If Hydrogen is under session management (NSM), tell the
+		// NSM server that the Song was modified.
+		NsmClient::get_instance()->sendDirtyState( bIsModified );
+	}
+#endif
 }
-bool Hydrogen::getIsModified() const {
-	if ( getSong() != nullptr ) {
-		return getSong()->getIsModified();
+
+bool Hydrogen::getSongModified() const {
+	if ( m_pSong != nullptr ) {
+		return m_pSong->getIsModified();
 	}
 	return false;
 }

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -256,6 +256,11 @@ public:
 	std::shared_ptr<AudioDriver> getAudioDriver() const;
 	std::shared_ptr<MidiBaseDriver> getMidiDriver() const;
 
+	/** Sets the state of a pattern contained in #m_pSong to @a bIsModified.
+	 *
+	 * Use this wrapper function instead of Pattern::setIsModified() since it
+	 * ensures the modification state of the enclosing song is set as well. */
+	void setPatternModified( bool bIsModified, int nIndex );
 	/** Wrapper around Song::setIsModified() that checks whether a
 		song is set.*/
 	void setSongModified( bool bIsModified );

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -256,6 +256,12 @@ public:
 	std::shared_ptr<AudioDriver> getAudioDriver() const;
 	std::shared_ptr<MidiBaseDriver> getMidiDriver() const;
 
+	/** Sets the state of the current drumkit - the one contained in #m_pSong -
+	 * to @a bIsModified.
+	 *
+	 * Use this wrapper function instead of Drumkit::setIsModified() since it
+	 * ensures the modification state of the enclosing song is set as well. */
+	void setDrumkitModified( bool bIsModified );
 	/** Sets the state of a pattern contained in #m_pSong to @a bIsModified.
 	 *
 	 * Use this wrapper function instead of Pattern::setIsModified() since it

--- a/src/core/Hydrogen.h
+++ b/src/core/Hydrogen.h
@@ -258,10 +258,10 @@ public:
 
 	/** Wrapper around Song::setIsModified() that checks whether a
 		song is set.*/
-	void setIsModified( bool bIsModified );
+	void setSongModified( bool bIsModified );
 	/** Wrapper around Song::getIsModified() that checks whether a
 		song is set.*/
-	bool getIsModified() const;
+	bool getSongModified() const;
 
 	void			onTapTempoAccelEvent( TimePoint start = TimePoint() );
 

--- a/src/core/Logger.cpp
+++ b/src/core/Logger.cpp
@@ -386,6 +386,15 @@ Logger::CrashContext::~CrashContext() {
 	}
 }
 
-};
+void Logger::setCrashContext( QString* pContext )
+{
+	Logger::pCrashContext = pContext;
+}
+QString* Logger::getCrashContext()
+{
+	return Logger::pCrashContext;
+}
+
+};	// namespace H2Core
 
 /* vim: set softtabstop=4 noexpandtab: */

--- a/src/core/Logger.h
+++ b/src/core/Logger.h
@@ -141,8 +141,8 @@ class Logger {
 		 * unlocking of a shared crash context structure.
 		 * @{
 		 */
-		static void setCrashContext( QString *pContext ) { Logger::pCrashContext = pContext; }
-		static QString *getCrashContext() { return Logger::pCrashContext; }
+		static void setCrashContext( QString *pContext );
+		static QString *getCrashContext();
 		/** @} */
 
 		bool getLogColors() const;

--- a/src/core/Midi/MidiActionManager.cpp
+++ b/src/core/Midi/MidiActionManager.cpp
@@ -1702,7 +1702,7 @@ bool MidiActionManager::clearPattern( std::shared_ptr<MidiAction> pAction ) {
 
 	pPattern->clear( true );
 
-	EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, 0 );
+	EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, 0 );
 
 	return true;
 }

--- a/src/core/NsmClient.cpp
+++ b/src/core/NsmClient.cpp
@@ -146,7 +146,7 @@ int NsmClient::OpenCallback( const char *name,
 		// Mark empty song modified in order to emphasis that an
 		// initial song save is required to generate the song file and
 		// link the associated drumkit in the session folder.
-		pSong->setIsModified( true );
+		pHydrogen->setSongModified( true );
 		pNsmClient->setIsNewSession( true );
 	}
 

--- a/src/core/NsmClient.h
+++ b/src/core/NsmClient.h
@@ -90,9 +90,6 @@ class NsmClient : public H2Core::Object<NsmClient>
 		 * Informs the NSM server whether the current H2Core::Song is
 		 * modified or not.
 		 *
-		 * This function is triggered within
-		 * H2Core::Song::setIsModified().
-		 *
 		 * \param isDirty true, if the current H2Core::Song was
 		 * modified, and false if it wasn't
 		 */

--- a/src/core/Sampler/Sampler.cpp
+++ b/src/core/Sampler/Sampler.cpp
@@ -1829,7 +1829,7 @@ bool Sampler::renderNote(
 	if ( !bIsMuted ) {
 		float masterVol = pSong->getVolume();
 		for ( unsigned nFX = 0; nFX < MAX_FX; ++nFX ) {
-			auto pFX = Effects::get_instance()->getLadspaFX( nFX );
+			auto pFX = pSong->getEffects()->getLadspaFX( nFX );
 			float fLevel = pInstrument->getFxLevel( nFX );
 			if ( pFX != nullptr && fLevel != 0.0 ) {
 				fLevel = fLevel * pFX->getVolume();

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -36,7 +36,7 @@ class EventListener
 		virtual void bbtChangedEvent(){}
 		virtual void beatCounterEvent() {}
 		virtual void drumkitLoadedEvent(){}
-		virtual void drumkitModifiedEvent(){}
+		virtual void drumkitIsModifiedEvent(){}
 		virtual void effectChangedEvent(){}
 		virtual void errorEvent( int nErrorCode ) { UNUSED( nErrorCode ); }
     	virtual void gridCellToggledEvent(){}

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -63,7 +63,7 @@ class EventListener
 		virtual void nextShotEvent(){}
 		virtual void noteRenderEvent( int nInstrument ) { UNUSED( nInstrument ); }
 		virtual void patternEditorLockedEvent(){}
-		virtual void patternModifiedEvent() {}
+		virtual void patternChangedEvent() {}
 		virtual void playbackTrackChangedEvent(){}
 		virtual void playingPatternsChangedEvent() {}
 		virtual void playlistChangedEvent( int nValue ){ UNUSED( nValue ); }

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -62,8 +62,9 @@ class EventListener
 		virtual void nextPatternsChangedEvent(){}
 		virtual void nextShotEvent(){}
 		virtual void noteRenderEvent( int nInstrument ) { UNUSED( nInstrument ); }
-		virtual void patternEditorLockedEvent(){}
 		virtual void patternChangedEvent() {}
+		virtual void patternEditorLockedEvent(){}
+		virtual void patternIsModifiedEvent() {}
 		virtual void playbackTrackChangedEvent(){}
 		virtual void playingPatternsChangedEvent() {}
 		virtual void playlistChangedEvent( int nValue ){ UNUSED( nValue ); }

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -75,7 +75,7 @@ class EventListener
 		virtual void selectedPatternChangedEvent() {}
 		virtual void selectedInstrumentChangedEvent() {}
 		virtual void songModeActivationEvent(){}
-		virtual void songModifiedEvent() {}
+		virtual void songIsModifiedEvent() {}
 		virtual void songSizeChangedEvent(){}
 		virtual void soundLibraryChangedEvent(){}
 		virtual void stackedModeActivationEvent( int nValue ){ UNUSED( nValue ); }

--- a/src/gui/src/EventListener.h
+++ b/src/gui/src/EventListener.h
@@ -36,6 +36,7 @@ class EventListener
 		virtual void bbtChangedEvent(){}
 		virtual void beatCounterEvent() {}
 		virtual void drumkitLoadedEvent(){}
+		virtual void drumkitModifiedEvent(){}
 		virtual void effectChangedEvent(){}
 		virtual void errorEvent( int nErrorCode ) { UNUSED( nErrorCode ); }
     	virtual void gridCellToggledEvent(){}

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -1109,8 +1109,8 @@ void HydrogenApp::onEventQueueTimer()
 				ppEventListener->patternEditorLockedEvent();
 				break;
 
-			case Event::Type::PatternModified:
-				ppEventListener->patternModifiedEvent();
+			case Event::Type::PatternChanged:
+				ppEventListener->patternChangedEvent();
 				break;
 
 			case Event::Type::PlaybackTrackChanged:

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -953,7 +953,7 @@ SoundLibraryPanel* HydrogenApp::getSoundLibraryPanel() const
 	return m_pRack->getSoundLibraryPanel();
 }
 
-void HydrogenApp::songModifiedEvent()
+void HydrogenApp::songIsModifiedEvent()
 {
 	updateWindowTitle();
 }
@@ -1153,8 +1153,8 @@ void HydrogenApp::onEventQueueTimer()
 				ppEventListener->songModeActivationEvent();
 				break;
 
-			case Event::Type::SongModified:
-				ppEventListener->songModifiedEvent();
+			case Event::Type::SongIsModified:
+				ppEventListener->songIsModifiedEvent();
 				break;
 
 			case Event::Type::SongSizeChanged:

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -1105,12 +1105,16 @@ void HydrogenApp::onEventQueueTimer()
 				ppEventListener->quitEvent( pEvent->getValue() );
 				break;
 
+			case Event::Type::PatternChanged:
+				ppEventListener->patternChangedEvent();
+				break;
+
 			case Event::Type::PatternEditorLocked:
 				ppEventListener->patternEditorLockedEvent();
 				break;
 
-			case Event::Type::PatternChanged:
-				ppEventListener->patternChangedEvent();
+			case Event::Type::PatternIsModified:
+				ppEventListener->patternIsModifiedEvent();
 				break;
 
 			case Event::Type::PlaybackTrackChanged:

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -1016,8 +1016,8 @@ void HydrogenApp::onEventQueueTimer()
 				ppEventListener->beatCounterEvent();
 				break;
 
-			case Event::Type::DrumkitModified:
-				ppEventListener->drumkitModifiedEvent();
+			case Event::Type::DrumkitIsModified:
+				ppEventListener->drumkitIsModifiedEvent();
 				break;
 
 			case Event::Type::DrumkitLoaded:

--- a/src/gui/src/HydrogenApp.cpp
+++ b/src/gui/src/HydrogenApp.cpp
@@ -1016,6 +1016,10 @@ void HydrogenApp::onEventQueueTimer()
 				ppEventListener->beatCounterEvent();
 				break;
 
+			case Event::Type::DrumkitModified:
+				ppEventListener->drumkitModifiedEvent();
+				break;
+
 			case Event::Type::DrumkitLoaded:
 				ppEventListener->drumkitLoadedEvent();
 				break;

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -107,8 +107,8 @@ class HydrogenApp :  public QObject, public EventListener,  public H2Core::Objec
 										 const QString& sBaseFile );
 
 		/** Checks whether there are unsaved changes in the current song (for
-		* H2Core::Filesystem::FileType::Song) or playlist (for
-		* H2Core::Filesystem::FileType::Playlist).
+		* H2Core::Filesystem::Artifact::Song) or playlist (for
+		* H2Core::Filesystem::Artifact::Playlist).
 		*
 		* @return `true` if handled, `false` if aborted. */
 		static bool handleUnsavedChanges( const H2Core::Filesystem::Artifact& type );

--- a/src/gui/src/HydrogenApp.h
+++ b/src/gui/src/HydrogenApp.h
@@ -269,7 +269,7 @@ signals:
 		void engineError(uint nErrorCode);
 
 		void setupSinglePanedInterface();
-		virtual void songModifiedEvent() override;
+		virtual void songIsModifiedEvent() override;
 		virtual void XRunEvent() override;
 
 		/** Handles the loading and saving of the H2Core::Preferences

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -123,7 +123,11 @@ void LadspaFXProperties::faderChanged( WidgetWithInput * pRef )
 	pFader->setPeak_R( pFader->getValue() );
 
 #ifdef H2CORE_HAVE_LADSPA
-	auto pFX = Effects::get_instance()->getLadspaFX( m_nLadspaFX );
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+	auto pFX = pSong->getEffects()->getLadspaFX( m_nLadspaFX );
 
 	for ( uint i = 0; i < m_pInputControlFaders.size(); i++ ) {
 		if (pFader == m_pInputControlFaders[ i ] ) {
@@ -156,7 +160,11 @@ void LadspaFXProperties::updateControls()
 	INFOLOG( "*** [updateControls] ***" );
 	m_pTimer->stop();
 
-	auto pFX = Effects::get_instance()->getLadspaFX( m_nLadspaFX );
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+	auto pFX = pSong->getEffects()->getLadspaFX( m_nLadspaFX );
 
 	// svuoto i vettori..
 	if ( m_pInputControlNames.size() != 0 ) {
@@ -332,6 +340,10 @@ void LadspaFXProperties::selectFXBtnClicked()
 		ERRORLOG( "AudioDriver is not ready!" );
 		return;
 	}
+	auto pSong = pHydrogen->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
 
 	LadspaFXSelector fxSelector(m_nLadspaFX);
 	if (fxSelector.exec() == QDialog::Accepted) {
@@ -339,7 +351,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 		if ( ! sSelectedFX.isEmpty() ) {
 			std::shared_ptr<LadspaFX> pFX = nullptr;
 
-			auto pluginList = Effects::get_instance()->getPluginList();
+			auto pluginList = pSong->getEffects()->getPluginList();
 			for ( const auto& ppFXInfo : pluginList ) {
 				if ( ppFXInfo->m_sName == sSelectedFX ) {
 					int nSampleRate = pAudioDriver->getSampleRate();
@@ -349,7 +361,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 					break;
 				}
 			}
-			Effects::get_instance()->setLadspaFX( pFX, m_nLadspaFX );
+			pSong->getEffects()->setLadspaFX( pFX, m_nLadspaFX );
 
 			pHydrogen->restartLadspaFX();
 			updateControls();
@@ -363,16 +375,25 @@ void LadspaFXProperties::selectFXBtnClicked()
 
 void LadspaFXProperties::removeFXBtnClicked() {
 #ifdef H2CORE_HAVE_LADSPA
-	Hydrogen::get_instance()->setSongModified( true );
-	Effects::get_instance()->setLadspaFX( nullptr, m_nLadspaFX );
-	Hydrogen::get_instance()->restartLadspaFX();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+	pHydrogen->setSongModified( true );
+	pSong->getEffects()->setLadspaFX( nullptr, m_nLadspaFX );
+	pHydrogen->restartLadspaFX();
 	updateControls();	
 #endif
 }
 
 void LadspaFXProperties::updateOutputControls() {
 #ifdef H2CORE_HAVE_LADSPA
-	auto pFX = Effects::get_instance()->getLadspaFX(m_nLadspaFX);
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+	auto pFX = pSong->getEffects()->getLadspaFX(m_nLadspaFX);
 	if ( pFX != nullptr ) {
 		m_pActivateBtn->setEnabled(true);
 		if (pFX->isEnabled()) {
@@ -414,7 +435,11 @@ void LadspaFXProperties::updateOutputControls() {
 
 void LadspaFXProperties::activateBtnClicked() {
 #ifdef H2CORE_HAVE_LADSPA
-	auto pFX = Effects::get_instance()->getLadspaFX(m_nLadspaFX);
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+	auto pFX = pSong->getEffects()->getLadspaFX(m_nLadspaFX);
 	if ( pFX != nullptr) {
 		Hydrogen::get_instance()->getAudioEngine()->lock( RIGHT_HERE );
 		pFX->setEnabled( !pFX->isEnabled() );

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -268,6 +268,7 @@ void LadspaFXProperties::updateControls()
 				tr( "Input control param. value" ), pControlPort->m_bIsInteger,
 				false, pControlPort->fLowerBound, pControlPort->fUpperBound
 			);
+			pFader->setModifierTarget( Modifier::Song );
 			connect(
 				pFader, SIGNAL( valueChanged( WidgetWithInput* ) ), this,
 				SLOT( faderChanged( WidgetWithInput* ) )
@@ -306,7 +307,8 @@ void LadspaFXProperties::updateControls()
 				m_pFrame, QSize( 23, 117 ), Fader::Type::Vertical,
 				tr( "Output control param. value" ), pControl->m_bIsInteger,
 				true, pControl->fLowerBound, pControl->fUpperBound
-			);
+									);
+			pFader->setModifierTarget( Modifier::Song );
 			pFader->move( xPos + 20, 60 );
 			pFader->show();
 			pFader->setMaxPeak( pControl->fUpperBound );

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -364,7 +364,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 				}
 			}
 			pSong->getEffects()->setLadspaFX( pFX, m_nLadspaFX );
-			pHydrogen->getSongModified( true );
+			pHydrogen->setSongModified( true );
 
 			pHydrogen->restartLadspaFX();
 			updateControls();

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -146,7 +146,7 @@ void LadspaFXProperties::faderChanged( WidgetWithInput * pRef )
 			m_pInputControlLabel[ i ]->setText( sValue );
 		}
 	}
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 #endif
 }
 
@@ -363,7 +363,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 
 void LadspaFXProperties::removeFXBtnClicked() {
 #ifdef H2CORE_HAVE_LADSPA
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 	Effects::get_instance()->setLadspaFX( nullptr, m_nLadspaFX );
 	Hydrogen::get_instance()->restartLadspaFX();
 	updateControls();	

--- a/src/gui/src/LadspaFXProperties.cpp
+++ b/src/gui/src/LadspaFXProperties.cpp
@@ -362,6 +362,7 @@ void LadspaFXProperties::selectFXBtnClicked()
 				}
 			}
 			pSong->getEffects()->setLadspaFX( pFX, m_nLadspaFX );
+			pHydrogen->getSongModified( true );
 
 			pHydrogen->restartLadspaFX();
 			updateControls();
@@ -380,8 +381,8 @@ void LadspaFXProperties::removeFXBtnClicked() {
 	if ( pSong == nullptr ) {
 		return;
 	}
-	pHydrogen->setSongModified( true );
 	pSong->getEffects()->setLadspaFX( nullptr, m_nLadspaFX );
+	pHydrogen->setSongModified( true );
 	pHydrogen->restartLadspaFX();
 	updateControls();	
 #endif
@@ -435,15 +436,20 @@ void LadspaFXProperties::updateOutputControls() {
 
 void LadspaFXProperties::activateBtnClicked() {
 #ifdef H2CORE_HAVE_LADSPA
-	auto pSong = Hydrogen::get_instance()->getSong();
+	auto pHydrogen = Hydrogen::get_instance();
+	auto pSong = pHydrogen->getSong();
 	if ( pSong == nullptr ) {
 		return;
 	}
 	auto pFX = pSong->getEffects()->getLadspaFX(m_nLadspaFX);
 	if ( pFX != nullptr) {
-		Hydrogen::get_instance()->getAudioEngine()->lock( RIGHT_HERE );
+		pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
+
 		pFX->setEnabled( !pFX->isEnabled() );
-		Hydrogen::get_instance()->getAudioEngine()->unlock();
+
+		pHydrogen->getAudioEngine()->unlock();
+
+		pHydrogen->setSongModified( true );
 	}
 #endif
 }

--- a/src/gui/src/LadspaFXSelector.cpp
+++ b/src/gui/src/LadspaFXSelector.cpp
@@ -55,9 +55,12 @@ LadspaFXSelector::LadspaFXSelector(int nLadspaFX)
 	m_pGroupsListView->setHeaderLabels( QStringList( tr( "Groups" ) ) );
 
 #ifdef H2CORE_HAVE_LADSPA
-	auto pFX = Effects::get_instance()->getLadspaFX(nLadspaFX);
-	if ( pFX != nullptr ) {
-		m_sSelectedPluginName = pFX->getPluginName();
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong != nullptr ) {
+		auto pFX = pSong->getEffects()->getLadspaFX( nLadspaFX );
+		if ( pFX != nullptr ) {
+			m_sSelectedPluginName = pFX->getPluginName();
+		}
 	}
 	buildLadspaGroups();
 
@@ -75,8 +78,13 @@ LadspaFXSelector::~LadspaFXSelector() {
 void LadspaFXSelector::buildLadspaGroups() {
 #ifdef H2CORE_HAVE_LADSPA
 	m_pGroupsListView->clear();
+
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
 	
-	auto pFXGroup = Effects::get_instance()->getLadspaFXGroup();
+	auto pFXGroup = pSong->getEffects()->getLadspaFXGroup();
 
 	if ( pFXGroup != nullptr ) {
 		for ( const auto& ppNewGroup : pFXGroup->getChildList() ) {
@@ -142,10 +150,15 @@ void LadspaFXSelector::pluginSelected() {
 		return;
 	}
 
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
+
 	QString sSelected = m_pPluginsListBox->currentItem()->text();
 	m_sSelectedPluginName = sSelected;
 
-	auto pluginList = Effects::get_instance()->getPluginList();
+	auto pluginList = pSong->getEffects()->getPluginList();
 	for ( const auto& ppFXInfo : pluginList ) {
 		if ( ppFXInfo->m_sName == m_sSelectedPluginName ) {
 
@@ -192,6 +205,11 @@ void LadspaFXSelector::on_m_pGroupsListView_currentItemChanged( QTreeWidgetItem*
 	if ( currentItem == nullptr ) {
 		return;
 	}
+
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr ) {
+		return;
+	}
 	
 	if ( currentItem->childCount() ) {
 		currentItem->setExpanded( true );
@@ -201,7 +219,7 @@ void LadspaFXSelector::on_m_pGroupsListView_currentItemChanged( QTreeWidgetItem*
 
 	m_pPluginsListBox->clear(); // ... Why not anyway ? Jakob Lund
 
-	auto pFXGroup = Effects::get_instance()->getLadspaFXGroup();
+	auto pFXGroup = pSong->getEffects()->getLadspaFXGroup();
 
 	auto pluginList = findPluginsInGroup( itemText, pFXGroup );
 	

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2378,7 +2378,7 @@ void MainForm::onFixMidiSetup()
 	auto pSong = pHydrogen->getSong();
 	if ( pSong != nullptr ) {
 		pSong->getDrumkit()->getInstruments()->setDefaultMidiOutNotes();
-		pHydrogen->setSongModified( true );
+		pHydrogen->setDrumkitModified( true );
 
 		m_pMidiSetupInfoBar->hide();
 	}

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -33,6 +33,7 @@
 #include <core/Basics/Pattern.h>
 #include <core/Basics/PatternList.h>
 #include <core/Basics/Playlist.h>
+#include <core/EventQueue.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/H2Exception.h>
 #include <core/Hydrogen.h>
@@ -1313,6 +1314,12 @@ void MainForm::action_pattern_save( int nPatternRow )
 		);
 	}
 	else {
+		// Done in the GUI instead of Pattern::save() itself because this only
+		// concerns patterns of the current song.
+		pPattern->setIsModified( false );
+		EventQueue::get_instance()->pushEvent(
+			Event::Type::PatternIsModified, nPatternRow
+		);
 		pHydrogenApp->showStatusBarMessage(
 			pCommonStrings->getStatusPatternLoaded()
 		);
@@ -1393,6 +1400,14 @@ void MainForm::action_pattern_save_as( int nPatternRow )
 	}
 
 	if ( pPattern->save( pPattern->getPath() ) ) {
+		// Done in the GUI instead of Pattern::save() itself because this only
+		// concerns patterns of the current song. We have to change the is
+		// modified state on the original pattern and not the copy we did in
+		// order to not leak any information in case saving did fail.
+		pSong->getPatternList()->get( nPatternRow )->setIsModified( false );
+		EventQueue::get_instance()->pushEvent(
+			Event::Type::PatternIsModified, nPatternRow
+		);
 		pPref->setLastExportPatternAsDirectory(
 			QFileInfo( pPattern->getPath() ).absoluteDir().absolutePath()
 		);
@@ -2003,6 +2018,10 @@ void MainForm::action_drumkit_save()
 
 	}
 	else {
+		pDrumkit->setIsModified( false );
+		EventQueue::get_instance()->pushEvent(
+			Event::Type::DrumkitIsModified, -1
+		);
 		pHydrogenApp->showStatusBarMessage(
 			QString( "%1 [%2]" )
 				.arg( pCommonStrings->getStatusPatternLoaded() )
@@ -2047,6 +2066,14 @@ void MainForm::action_drumkit_save_as()
 		sPath
 	);
 	if ( dialog.exec() == QDialog::Accepted ) {
+		// We have to change the is modified state on the original pattern and
+		// not the copy we did in order to not leak any information in case
+		// saving did fail.
+		pSong->getDrumkit()->setIsModified( false );
+		EventQueue::get_instance()->pushEvent(
+			Event::Type::DrumkitIsModified, -1
+		);
+
 		pPref->setLastSaveDrumkitAsDirectory(
 			Filesystem::drumkitDirFromPath( pDrumkit->getPath() )
 		);

--- a/src/gui/src/MainForm.cpp
+++ b/src/gui/src/MainForm.cpp
@@ -2351,7 +2351,7 @@ void MainForm::onFixMidiSetup()
 	auto pSong = pHydrogen->getSong();
 	if ( pSong != nullptr ) {
 		pSong->getDrumkit()->getInstruments()->setDefaultMidiOutNotes();
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 
 		m_pMidiSetupInfoBar->hide();
 	}
@@ -2619,7 +2619,7 @@ void MainForm::onAutoSaveTimer()
 					/* bSilent */ true );
 
 		pSong->setPath( sOldPath );
-		pSong->setIsModified( true );
+		pHydrogen->setSongModified( true );
 	}
 
 	if ( pPlaylist != nullptr && pPlaylist->getIsModified() ) {

--- a/src/gui/src/MainToolBar/MidiControlDialog.cpp
+++ b/src/gui/src/MainToolBar/MidiControlDialog.cpp
@@ -976,9 +976,9 @@ void MidiControlDialog::addInstrumentTableRow() {
 			MidiControlDialog::nMappingBoxHeight
 		),
 		LCDSpinBox::Type::Int, static_cast<int>( Midi::NoteMinimum ),
-		static_cast<int>( Midi::NoteMaximum ),
-		LCDSpinBox::Flag::ModifyOnChange | LCDSpinBox::Flag::ShowMidiNote
+		static_cast<int>( Midi::NoteMaximum ), LCDSpinBox::Flag::ShowMidiNote
 	);
+	pOutputNoteSpinBox->setModifierTarget( Modifier::Song );
 
 	auto pOutputChannelSpinBox = new LCDSpinBox(
 		m_pInstrumentTable,
@@ -987,9 +987,9 @@ void MidiControlDialog::addInstrumentTableRow() {
 			MidiControlDialog::nMappingBoxHeight
 		),
 		LCDSpinBox::Type::Int, static_cast<int>( Midi::ChannelOff ),
-		static_cast<int>( Midi::ChannelMaximum ),
-		LCDSpinBox::Flag::ModifyOnChange | LCDSpinBox::Flag::ZeroAsOff
+		static_cast<int>( Midi::ChannelMaximum ), LCDSpinBox::Flag::ZeroAsOff
 	);
+	pOutputChannelSpinBox->setModifierTarget( Modifier::Song );
 	pOutputChannelSpinBox->setSizePolicy(
 		QSizePolicy::Expanding, QSizePolicy::Fixed
 	);

--- a/src/gui/src/Mixer/LadspaFXLine.cpp
+++ b/src/gui/src/Mixer/LadspaFXLine.cpp
@@ -61,7 +61,7 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 		if ( m_pFX != nullptr ) {
 			m_pFX->setEnabled( ! m_pBypassBtn->isChecked() );
 
-			Hydrogen::get_instance()->setIsModified( true );
+			Hydrogen::get_instance()->setSongModified( true );
 		}
 	});
 #endif
@@ -104,7 +104,7 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 			QString( "%1:rotaryChanged:%2" )
 			.arg( class_name() ).arg( pFX->getPluginName() ) );
 
-			Hydrogen::get_instance()->setIsModified( true );
+			Hydrogen::get_instance()->setSongModified( true );
 		}
 	});
 #endif

--- a/src/gui/src/Mixer/LadspaFXLine.cpp
+++ b/src/gui/src/Mixer/LadspaFXLine.cpp
@@ -91,6 +91,7 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 	// m_pRotary
 	m_pVolumeRotary = new Rotary(
 		this, Rotary::Type::Normal, tr( "Effect return" ), false );
+	m_pVolumeRotary->setModifierTarget( Modifier::Song );
 	m_pVolumeRotary->setDefaultValue( m_pVolumeRotary->getMax() );
 	m_pVolumeRotary->move( 124, 4 );
 	m_pVolumeRotary->setIsActive( false );
@@ -103,8 +104,6 @@ LadspaFXLine::LadspaFXLine( QWidget* pParent, std::shared_ptr<LadspaFX> pFX,
 					.arg( m_pVolumeRotary->getValue(), 0, 'f', 2 ),
 			QString( "%1:rotaryChanged:%2" )
 			.arg( class_name() ).arg( pFX->getPluginName() ) );
-
-			Hydrogen::get_instance()->setSongModified( true );
 		}
 	});
 #endif

--- a/src/gui/src/Mixer/MasterLine.cpp
+++ b/src/gui/src/Mixer/MasterLine.cpp
@@ -65,6 +65,7 @@ MasterLine::MasterLine( QWidget* pParent )
 		this, QSize( 34, 189 ), Fader::Type::Master, tr( "Master volume" ),
 		false, false, 0.0, 1.5
 	);
+	m_pFader->setModifierTarget( Modifier::Song );
 	m_pFader->move( 24, 75 );
 	connect( m_pFader, &Fader::valueChanged, [&]() {
 		CoreActionController::setMasterVolume( m_pFader->getValue() );
@@ -88,6 +89,7 @@ MasterLine::MasterLine( QWidget* pParent )
 	m_pHumanizeVelocityRotary = new Rotary(
 		this, Rotary::Type::Normal, tr( "Humanize velocity" ), false
 	);
+	m_pHumanizeVelocityRotary->setModifierTarget( Modifier::Song );
 	m_pHumanizeVelocityRotary->setMidiAction( std::make_shared<MidiAction>(
 		MidiAction::Type::HumanizationVelocityAbsolute
 	) );
@@ -103,6 +105,7 @@ MasterLine::MasterLine( QWidget* pParent )
 
 	m_pHumanizeTimeRotary =
 		new Rotary( this, Rotary::Type::Normal, tr( "Humanize time" ), false );
+	m_pHumanizeTimeRotary->setModifierTarget( Modifier::Song );
 	m_pHumanizeTimeRotary->setMidiAction( std::make_shared<MidiAction>(
 		MidiAction::Type::HumanizationTimingAbsolute
 	) );
@@ -119,6 +122,7 @@ MasterLine::MasterLine( QWidget* pParent )
 	m_pSwingRotary = new Rotary(
 		this, Rotary::Type::Normal, tr( "16th-note Swing" ), false
 	);
+	m_pSwingRotary->setModifierTarget( Modifier::Song );
 	m_pSwingRotary->setMidiAction( std::make_shared<MidiAction>(
 		MidiAction::Type::HumanizationSwingAbsolute
 	) );

--- a/src/gui/src/Mixer/Mixer.cpp
+++ b/src/gui/src/Mixer/Mixer.cpp
@@ -87,7 +87,11 @@ Mixer::Mixer( QWidget* pParent )
 
 // fX frame
 #ifdef H2CORE_HAVE_LADSPA
-	auto pEffects = Effects::get_instance();
+	std::shared_ptr<Effects> pEffects;
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong != nullptr ) {
+		pEffects = pSong->getEffects();
+	}
 #endif
 	m_pFXFrame = new PixmapWidget( nullptr );
 	m_pFXFrame->setObjectName( "MixerFXRack" );
@@ -95,7 +99,8 @@ Mixer::Mixer( QWidget* pParent )
 	m_pFXFrame->setPixmap( "/mixerPanel/background_FX.png" );
 	for ( int nnFX = 0; nnFX < MAX_FX; nnFX++ ) {
 #ifdef H2CORE_HAVE_LADSPA
-		auto pFX = pEffects->getLadspaFX( nnFX );
+		auto pFX =
+			pEffects != nullptr ? pEffects->getLadspaFX( nnFX ) : nullptr;
 		auto ppLine = new LadspaFXLine( m_pFXFrame, pFX, nnFX );
 #else
 		auto ppLine = new LadspaFXLine( m_pFXFrame, nullptr, nnFX );
@@ -253,7 +258,7 @@ void Mixer::updateMixer()
 #ifdef H2CORE_HAVE_LADSPA
 	// LADSPA
 	for ( int nnFX = 0; nnFX < MAX_FX; nnFX++ ) {
-		auto pFX = Effects::get_instance()->getLadspaFX( nnFX );
+		auto pFX = pSong->getEffects()->getLadspaFX( nnFX );
 		auto pFxLine = m_ladspaFXLines[ nnFX ];
 		if ( pFxLine->getFX() != pFX ) {
 			pFxLine->setFX( pFX );

--- a/src/gui/src/Mixer/MixerLine.cpp
+++ b/src/gui/src/Mixer/MixerLine.cpp
@@ -143,6 +143,7 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 	m_pPanRotary = new Rotary(
 		this, Rotary::Type::Center, pCommonStrings->getNotePropertyPan(), false,
 		PAN_MIN, PAN_MAX );
+	m_pPanRotary->setModifierTarget( Modifier::Drumkit );
 	m_pPanRotary->setObjectName( "PanRotary" );
 	m_pPanRotary->move( 6, 32 );
 	connect( m_pPanRotary, &Rotary::valueChanged, [&]() {
@@ -158,6 +159,7 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 	for ( int ii = 0; ii < MAX_FX; ii++ ) {
 		auto pRotary = new Rotary(
 			this, Rotary::Type::Small, tr( "FX %1 send" ).arg( ii + 1 ), false );
+		pRotary->setModifierTarget( Modifier::Song );
 		pRotary->setObjectName( "FXRotary" );
 		if ( (ii % 2) == 0 ) {
 			pRotary->move( 9, 63 + (20 * nnRow) );
@@ -191,6 +193,7 @@ MixerLine::MixerLine(QWidget* pParent, std::shared_ptr<Instrument> pInstrument )
 		this, QSize( 23, 117 ), Fader::Type::Vertical, tr( "Volume" ), false,
 		false, 0.0, 1.5
 	);
+	m_pFader->setModifierTarget( Modifier::Drumkit );
 	m_pFader->move( 23, 128 );
 	connect( m_pFader, &Fader::valueChanged, [&]() {
 		const int nLine = retrieveLineNumber();

--- a/src/gui/src/Mixer/MixerSettingsDialog.cpp
+++ b/src/gui/src/Mixer/MixerSettingsDialog.cpp
@@ -147,7 +147,7 @@ void MixerSettingsDialog::on_okBtn_clicked() {
 	*/
 	pSong->setPanLawKNorm( - 6.0206 / fdBCenterCompensation );
 
-	Hydrogen::get_instance()->setIsModified( true );
+	Hydrogen::get_instance()->setSongModified( true );
 
 	accept();
 }

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -995,7 +995,7 @@ void NotePropertiesRuler::mouseDrawUpdate( QMouseEvent* ev )
 	}
 
 	if ( bValueChanged ) {
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 		if ( m_property == PatternEditor::Property::Velocity ) {
 			// A note's velocity determines its color in the other pattern
 			// editors as well.
@@ -1132,7 +1132,7 @@ bool NotePropertiesRuler::adjustNotePropertyDelta(
 	}
 
 	if ( bValueChanged ) {
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	}
 
 	return bValueChanged;
@@ -1210,7 +1210,7 @@ void NotePropertiesRuler::applyCursorDelta( float fDelta, bool bKey )
 			updateEditor( Editor::Update::Content );
 		}
 
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 

--- a/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
+++ b/src/gui/src/PatternEditor/NotePropertiesRuler.cpp
@@ -995,7 +995,9 @@ void NotePropertiesRuler::mouseDrawUpdate( QMouseEvent* ev )
 	}
 
 	if ( bValueChanged ) {
-		Hydrogen::get_instance()->setSongModified( true );
+		Hydrogen::get_instance()->setPatternModified(
+			true, m_pPatternEditorPanel->getPatternNumber()
+		);
 		if ( m_property == PatternEditor::Property::Velocity ) {
 			// A note's velocity determines its color in the other pattern
 			// editors as well.
@@ -1132,7 +1134,9 @@ bool NotePropertiesRuler::adjustNotePropertyDelta(
 	}
 
 	if ( bValueChanged ) {
-		Hydrogen::get_instance()->setSongModified( true );
+		Hydrogen::get_instance()->setPatternModified(
+			true, m_pPatternEditorPanel->getPatternNumber()
+		);
 	}
 
 	return bValueChanged;
@@ -1210,7 +1214,9 @@ void NotePropertiesRuler::applyCursorDelta( float fDelta, bool bKey )
 			updateEditor( Editor::Update::Content );
 		}
 
-		Hydrogen::get_instance()->setSongModified( true );
+		Hydrogen::get_instance()->setPatternModified(
+			true, m_pPatternEditorPanel->getPatternNumber()
+		);
 	}
 }
 

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -277,7 +277,7 @@ void PatternEditor::addOrRemoveNoteAction( int nPosition,
 		}
 	}
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setPatternModified( true, nPatternNumber );
 
 	pVisibleEditor->updateMouseHoveredElements( nullptr );
 	pVisibleEditor->updateKeyboardHoveredElements();
@@ -297,6 +297,9 @@ void PatternEditor::deselectAndOverwriteNotes(
 	// Iterate over all the notes in 'selected' and 'overwrite' by erasing any *other* notes occupying the
 	// same position.
 	auto pHydrogen = Hydrogen::get_instance();
+
+	bool bPatternModified = false;
+
 	pHydrogen->getAudioEngine()->lock( RIGHT_HERE );
 	Pattern::notes_t *pNotes = const_cast< Pattern::notes_t *>( pPattern->getNotes() );
 	for ( auto pSelectedNote : selected ) {
@@ -317,6 +320,7 @@ void PatternEditor::deselectAndOverwriteNotes(
 					  pNote->getPosition() == pSelectedNote->getPosition() ) {
 				// Something else occupying the same position (which may or may not be an exact duplicate)
 				it = pNotes->erase( it );
+				bPatternModified = true;
 			}
 			else {
 				// Any other note
@@ -325,7 +329,12 @@ void PatternEditor::deselectAndOverwriteNotes(
 		}
 	}
 	pHydrogen->getAudioEngine()->unlock();
-	pHydrogen->setSongModified( true );
+
+	if ( bPatternModified ) {
+		pHydrogen->setPatternModified(
+			true, m_pPatternEditorPanel->getPatternNumber()
+		);
+	}
 }
 
 void PatternEditor::undoDeselectAndOverwriteNotes(
@@ -355,7 +364,12 @@ void PatternEditor::undoDeselectAndOverwriteNotes(
 		}
 	}
 	pHydrogen->getAudioEngine()->unlock();
-	pHydrogen->setSongModified( true );
+
+	if ( overwritten.size() > 0 ) {
+		pHydrogen->setPatternModified(
+			true, m_pPatternEditorPanel->getPatternNumber()
+		);
+	}
 	updateVisibleComponents( Editor::Update::Content );
 }
 
@@ -504,7 +518,7 @@ void PatternEditor::editNotePropertiesAction( const Property& property,
 	pHydrogen->getAudioEngine()->unlock();
 
 	if ( bValueChanged ) {
-		pHydrogen->setSongModified( true );
+		pHydrogen->setPatternModified( true, nPatternNumber );
 		std::vector< std::shared_ptr<Note > > notes{ pNote };
 
 		if ( property == Property::Type || property == Property::InstrumentId ) {
@@ -2382,7 +2396,9 @@ void PatternEditor::mouseEditUpdate( QMouseEvent *ev ) {
 	m_dragUpdate = pEv->position().toPoint();
 
 	pHydrogen->getAudioEngine()->unlock(); // unlock the audio engine
-	pHydrogen->setSongModified( true );
+	pHydrogen->setPatternModified(
+		true, m_pPatternEditorPanel->getPatternNumber()
+	);
 
 	updateVisibleComponents( Editor::Update::Content );
 }

--- a/src/gui/src/PatternEditor/PatternEditor.cpp
+++ b/src/gui/src/PatternEditor/PatternEditor.cpp
@@ -277,7 +277,7 @@ void PatternEditor::addOrRemoveNoteAction( int nPosition,
 		}
 	}
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	pVisibleEditor->updateMouseHoveredElements( nullptr );
 	pVisibleEditor->updateKeyboardHoveredElements();
@@ -325,7 +325,7 @@ void PatternEditor::deselectAndOverwriteNotes(
 		}
 	}
 	pHydrogen->getAudioEngine()->unlock();
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 }
 
 void PatternEditor::undoDeselectAndOverwriteNotes(
@@ -355,7 +355,7 @@ void PatternEditor::undoDeselectAndOverwriteNotes(
 		}
 	}
 	pHydrogen->getAudioEngine()->unlock();
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 	updateVisibleComponents( Editor::Update::Content );
 }
 
@@ -504,7 +504,7 @@ void PatternEditor::editNotePropertiesAction( const Property& property,
 	pHydrogen->getAudioEngine()->unlock();
 
 	if ( bValueChanged ) {
-		pHydrogen->setIsModified( true );
+		pHydrogen->setSongModified( true );
 		std::vector< std::shared_ptr<Note > > notes{ pNote };
 
 		if ( property == Property::Type || property == Property::InstrumentId ) {
@@ -2382,7 +2382,7 @@ void PatternEditor::mouseEditUpdate( QMouseEvent *ev ) {
 	m_dragUpdate = pEv->position().toPoint();
 
 	pHydrogen->getAudioEngine()->unlock(); // unlock the audio engine
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	updateVisibleComponents( Editor::Update::Content );
 }

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1371,6 +1371,14 @@ void PatternEditorPanel::updatePatternInfo()
 		}
 	}
 
+	auto labelFromName = [&]( std::shared_ptr<Pattern> pPattern ) {
+		QString sText( pPattern->getName() );
+		if ( pPattern->getIsModified() ) {
+			sText.append( "*" );
+		}
+		return sText;
+	};
+
 	if ( m_pPattern == nullptr ) {
 		this->setWindowTitle( tr( "Pattern editor - No pattern selected" ) );
 
@@ -1402,7 +1410,7 @@ void PatternEditorPanel::updatePatternInfo()
 		updatePatternsToShow();
 
 		// Update pattern tabs
-		m_pTabBar->addTab( m_pPattern->getName() );
+		m_pTabBar->addTab( labelFromName( m_pPattern ) );
 		m_tabPatternMap[0] = pSong->getPatternList()->index( m_pPattern );
 
 		auto patterns = getPatternsToShow();
@@ -1416,7 +1424,7 @@ void PatternEditorPanel::updatePatternInfo()
 			if ( ppPattern != nullptr && ppPattern != m_pPattern ) {
 				m_tabPatternMap[nnCount] =
 					pSong->getPatternList()->index( ppPattern );
-				m_pTabBar->addTab( ppPattern->getName() );
+				m_pTabBar->addTab( labelFromName( ppPattern ) );
 				m_pTabBar->setTabEnabled( nnCount, bTabsEnabled );
 				++nnCount;
 			}
@@ -1434,7 +1442,7 @@ void PatternEditorPanel::updatePatternInfo()
 			const auto ppPattern = pPatternList->get( nnPattern );
 			if ( ppPattern != nullptr &&
 				 ppPattern->getName() != m_pTabBar->tabText( nnTab ) ) {
-				m_pTabBar->setTabText( nnTab, ppPattern->getName() );
+				m_pTabBar->setTabText( nnTab, labelFromName( ppPattern ) );
 			}
 
 			if ( nnPattern == nPatternIndex ) {
@@ -1552,6 +1560,10 @@ void PatternEditorPanel::patternChangedEvent()
 	updatePatternInfo();
 	updateEditors( Editor::Update::Background );
 	resizeEvent( nullptr );
+}
+
+void PatternEditorPanel::patternIsModifiedEvent() {
+	updatePatternInfo();
 }
 
 void PatternEditorPanel::playingPatternsChangedEvent()

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -851,7 +851,12 @@ void PatternEditorPanel::createEditors()
 
 void PatternEditorPanel::updateDrumkitLabel()
 {
-	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
+	auto pSong = Hydrogen::get_instance()->getSong();
+	if ( pSong == nullptr || pSong->getDrumkit() == nullptr ) {
+		return;
+	}
+
+	const auto pFontTheme = Preferences::get_instance()->getFontTheme();
 
 	QFont font(
 		pFontTheme->m_sApplicationFontFamily,
@@ -860,10 +865,11 @@ void PatternEditorPanel::updateDrumkitLabel()
 	font.setBold( true );
 	m_pDrumkitLabel->setFont( font );
 
-	auto pSong = Hydrogen::get_instance()->getSong();
-	if ( pSong != nullptr && pSong->getDrumkit() != nullptr ) {
-		m_pDrumkitLabel->setText( pSong->getDrumkit()->getName() );
+	QString sName( pSong->getDrumkit()->getName() );
+	if ( pSong->getDrumkit()->getIsModified() ) {
+		sName.append( "*" );
 	}
+	m_pDrumkitLabel->setText( sName );
 }
 
 void PatternEditorPanel::drumkitLoadedEvent()
@@ -879,6 +885,11 @@ void PatternEditorPanel::drumkitLoadedEvent()
 	if ( nPreviousRows != m_db.size() ) {
 		resizeEvent( nullptr );
 	}
+}
+
+void PatternEditorPanel::drumkitModifiedEvent()
+{
+	updateDrumkitLabel();
 }
 
 void PatternEditorPanel::syncToExternalHorizontalScrollbar( int )

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1723,7 +1723,7 @@ void PatternEditorPanel::patternSizeChangedAction(
 	pHydrogen->updateSongSize();
 	pAudioEngine->unlock();
 
-	pHydrogen->setSongModified( true );
+	pHydrogen->setPatternModified( true, nSelectedPatternNumber );
 
 	// Ensure the cursor stays within the accessible region of the current
 	// pattern.

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -379,7 +379,8 @@ PatternEditorPanel::PatternEditorPanel( QWidget* pParent )
 	m_pToolBar->addSeparator();
 
 	// GRID resolution
-	m_pResolutionCombo = new LCDCombo( m_pToolBar, QSize( 0, 0 ), true );
+	m_pResolutionCombo = new LCDCombo( m_pToolBar, QSize( 0, 0 ) );
+	m_pResolutionCombo->setModifierTarget( Modifier::Song );
 	m_pResolutionCombo->setFocusPolicy( Qt::ClickFocus );
 	m_pResolutionCombo->setMinimumSize( QSize( 24, nWidgetHeight ) );
 	m_pResolutionCombo->setMaximumSize( QSize( 500, nWidgetHeight ) );
@@ -788,7 +789,7 @@ void PatternEditorPanel::createEditors()
 	pPropertiesVBox->setSpacing( 0 );
 	pPropertiesVBox->setContentsMargins( 0, 0, 0, 0 );
 
-	m_pPropertiesCombo = new LCDCombo( nullptr, QSize( 0, 0 ), false );
+	m_pPropertiesCombo = new LCDCombo( nullptr, QSize( 0, 0 ) );
 	m_pPropertiesCombo->setFixedHeight( 18 );
 	m_pPropertiesCombo->setMaximumWidth( PatternEditorSidebar::m_nWidth );
 	m_pPropertiesCombo->setFocusPolicy( Qt::ClickFocus );

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -331,8 +331,9 @@ PatternEditorPanel::PatternEditorPanel( QWidget* pParent )
 
 	m_pLCDSpinBoxNumerator = new LCDSpinBox(
 		m_pToolBar, QSize( 62, nWidgetHeight ), LCDSpinBox::Type::Double, 0.1,
-		16.0, LCDSpinBox::Flag::ModifyOnChange
+		16.0
 	);
+	m_pLCDSpinBoxNumerator->setModifierTarget( Modifier::Pattern );
 	m_pLCDSpinBoxNumerator->setKind( LCDSpinBox::Kind::PatternSizeNumerator );
 	connect(
 		m_pLCDSpinBoxNumerator, &LCDSpinBox::slashKeyPressed, this,
@@ -359,9 +360,9 @@ PatternEditorPanel::PatternEditorPanel( QWidget* pParent )
 	m_pToolBar->addWidget( m_pPatternSizeSeparatorLabel );
 
 	m_pLCDSpinBoxDenominator = new LCDSpinBox(
-		m_pToolBar, QSize( 48, nWidgetHeight ), LCDSpinBox::Type::Int, 1, 192,
-		LCDSpinBox::Flag::ModifyOnChange
+		m_pToolBar, QSize( 48, nWidgetHeight ), LCDSpinBox::Type::Int, 1, 192
 	);
+	m_pLCDSpinBoxDenominator->setModifierTarget( Modifier::Pattern );
 	m_pLCDSpinBoxDenominator->setKind( LCDSpinBox::Kind::PatternSizeDenominator
 	);
 	connect(

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -887,7 +887,7 @@ void PatternEditorPanel::drumkitLoadedEvent()
 	}
 }
 
-void PatternEditorPanel::drumkitModifiedEvent()
+void PatternEditorPanel::drumkitIsModifiedEvent()
 {
 	updateDrumkitLabel();
 }

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1700,7 +1700,7 @@ void PatternEditorPanel::patternSizeChangedAction(
 	pHydrogen->updateSongSize();
 	pAudioEngine->unlock();
 
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 
 	// Ensure the cursor stays within the accessible region of the current
 	// pattern.

--- a/src/gui/src/PatternEditor/PatternEditorPanel.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.cpp
@@ -1547,7 +1547,7 @@ void PatternEditorPanel::updateEditors( Editor::Update update )
 	updateTypeLabelVisibility();
 }
 
-void PatternEditorPanel::patternModifiedEvent()
+void PatternEditorPanel::patternChangedEvent()
 {
 	updatePatternInfo();
 	updateEditors( Editor::Update::Background );
@@ -1725,7 +1725,7 @@ void PatternEditorPanel::patternSizeChangedAction(
 		setCursorColumn( nNewColumn );
 	}
 
-	EventQueue::get_instance()->pushEvent( Event::Type::PatternModified, -1 );
+	EventQueue::get_instance()->pushEvent( Event::Type::PatternChanged, -1 );
 }
 
 void PatternEditorPanel::addInstrument(

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -223,6 +223,7 @@ class PatternEditorPanel : public QWidget,
 	virtual void instrumentMuteSoloChangedEvent( int ) override;
 	virtual void patternEditorLockedEvent() override;
 	virtual void patternChangedEvent() override;
+	virtual void patternIsModifiedEvent() override;
 	virtual void playingPatternsChangedEvent() override;
 	virtual void relocationEvent() override;
 	virtual void selectedInstrumentChangedEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -222,7 +222,7 @@ class PatternEditorPanel : public QWidget,
 	virtual void instrumentLayerChangedEvent( int ) override;
 	virtual void instrumentMuteSoloChangedEvent( int ) override;
 	virtual void patternEditorLockedEvent() override;
-	virtual void patternModifiedEvent() override;
+	virtual void patternChangedEvent() override;
 	virtual void playingPatternsChangedEvent() override;
 	virtual void relocationEvent() override;
 	virtual void selectedInstrumentChangedEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -218,6 +218,7 @@ class PatternEditorPanel : public QWidget,
 
 	// Implements EventListener interface
 	virtual void drumkitLoadedEvent() override;
+	virtual void drumkitModifiedEvent() override;
 	virtual void instrumentLayerChangedEvent( int ) override;
 	virtual void instrumentMuteSoloChangedEvent( int ) override;
 	virtual void patternEditorLockedEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorPanel.h
+++ b/src/gui/src/PatternEditor/PatternEditorPanel.h
@@ -218,7 +218,7 @@ class PatternEditorPanel : public QWidget,
 
 	// Implements EventListener interface
 	virtual void drumkitLoadedEvent() override;
-	virtual void drumkitModifiedEvent() override;
+	virtual void drumkitIsModifiedEvent() override;
 	virtual void instrumentLayerChangedEvent( int ) override;
 	virtual void instrumentMuteSoloChangedEvent( int ) override;
 	virtual void patternEditorLockedEvent() override;

--- a/src/gui/src/PatternEditor/PatternEditorRuler.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorRuler.cpp
@@ -217,7 +217,7 @@ void PatternEditorRuler::mousePressEvent( QMouseEvent* ev ) {
 
 		if ( pHydrogen->getMode() != Song::Mode::Pattern ) {
 			H2Core::CoreActionController::activateSongMode( false );
-			pHydrogen->setIsModified( true );
+			pHydrogen->setSongModified( true );
 		}
 
 		H2Core::CoreActionController::locateToTick( nNewTick );

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -583,7 +583,7 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 
 	m_pSampleWarning = new Button(
 		this, QSize( 15, 13 ), Button::Type::Icon, "warning.svg", "", QSize(),
-		tr( "Some samples for this instrument failed to load." ), true
+		tr( "Some samples for this instrument failed to load." )
 	);
 	m_pSampleWarning->hide();
 	m_pInnerLayout->addWidget( m_pSampleWarning );

--- a/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
+++ b/src/gui/src/PatternEditor/PatternEditorSidebar.cpp
@@ -601,8 +601,9 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 
 	m_pMuteBtn = new MuteButton(
 		pButtonContainer, QSize( SidebarRow::m_nButtonWidth, height() ),
-		tr( "Mute instrument" ), ColoredButton::Flag::ModifyOnChange
+		tr( "Mute instrument" ), ColoredButton::Flag::None
 	);
+	m_pMuteBtn->setModifierTarget( Modifier::Drumkit );
 	m_pMuteBtn->setChecked( false );
 	m_pMuteBtn->setBorderless( true );
 	m_pMuteBtn->setObjectName( "SidebarRowMuteButton" );
@@ -611,8 +612,9 @@ SidebarRow::SidebarRow( QWidget* pParent, const DrumPatternRow& row )
 
 	m_pSoloBtn = new SoloButton(
 		pButtonContainer, QSize( SidebarRow::m_nButtonWidth, height() ),
-		pCommonStrings->getBigSoloButton(), ColoredButton::Flag::ModifyOnChange
+		pCommonStrings->getBigSoloButton(), ColoredButton::Flag::None
 	);
+	m_pSoloBtn->setModifierTarget( Modifier::Drumkit );
 	m_pSoloBtn->setChecked( false );
 	m_pSoloBtn->setBorderless( true );
 	m_pSoloBtn->setObjectName( "SidebarRowSoloButton" );

--- a/src/gui/src/Rack/ComponentEditor/ComponentView.cpp
+++ b/src/gui/src/Rack/ComponentEditor/ComponentView.cpp
@@ -300,6 +300,7 @@ ComponentView::ComponentView( QWidget* pParent,
 	m_pComponentGainRotary = new Rotary(
 		m_pToolBarComponent, Rotary::Type::Normal, tr( "Component volume" ), false,
 		0.0, 5.0 );
+	m_pComponentGainRotary->setModifierTarget( Modifier::Drumkit );
 	m_pComponentGainRotary->setDefaultValue( 1.0 );
 	connect( m_pComponentGainRotary, &Rotary::valueChanged, [&]() {
 		if ( m_pComponent != nullptr ) {
@@ -455,6 +456,7 @@ ComponentView::ComponentView( QWidget* pParent,
 	m_pLayerGainRotary = new Rotary(
 		m_pToolBarLayer, Rotary::Type::Normal, tr( "Layer gain" ), false,
 		0.0, 5.0 );
+	m_pLayerGainRotary->setModifierTarget( Modifier::Drumkit );
 	m_pLayerGainRotary->setDefaultValue( 1.0 );
 	connect( m_pLayerGainRotary, &Rotary::valueChanged, [&]() {
 		if ( m_pComponent != nullptr ) {
@@ -565,6 +567,7 @@ ComponentView::ComponentView( QWidget* pParent,
 		Instrument::fPitchOffsetMinimum + InstrumentEditor::nPitchFineControl,
 		Instrument::fPitchOffsetMaximum - InstrumentEditor::nPitchFineControl
 	);
+	m_pLayerPitchCoarseRotary->setModifierTarget( Modifier::Drumkit );
 	connect( m_pLayerPitchCoarseRotary, &Rotary::valueChanged, [&]() {
 		const float fNewPitch = round( m_pLayerPitchCoarseRotary->getValue() ) +
 								m_pLayerPitchFineRotary->getValue() / 100.0;
@@ -595,6 +598,7 @@ ComponentView::ComponentView( QWidget* pParent,
 		pLayerPropFineWidget, Rotary::Type::Center, tr( "Layer pitch (Fine)" ),
 		true, -50.0, 50.0
 	);
+	m_pLayerPitchFineRotary->setModifierTarget( Modifier::Drumkit );
 	connect( m_pLayerPitchFineRotary, &Rotary::valueChanged, [&]() {
 		const float fNewPitch = round( m_pLayerPitchCoarseRotary->getValue() ) +
 								m_pLayerPitchFineRotary->getValue() / 100.0;

--- a/src/gui/src/Rack/ComponentEditor/ComponentView.cpp
+++ b/src/gui/src/Rack/ComponentEditor/ComponentView.cpp
@@ -488,7 +488,8 @@ ComponentView::ComponentView( QWidget* pParent,
 	pHBoxSampleSelectionLayout->addWidget( m_pSampleSelectionLbl );
 
 	m_pSampleSelectionCombo = new LCDCombo(
-		pSampleSelectionWidget, QSize( 0, 0 ), true );
+		pSampleSelectionWidget, QSize( 0, 0 ) );
+	m_pSampleSelectionCombo->setModifierTarget( Modifier::Drumkit );
 	m_pSampleSelectionCombo->setFixedHeight(
 		ComponentView::nSampleSelectionHeight );
 	m_pSampleSelectionCombo->setToolTip( tr( "Select selection algorithm" ) );

--- a/src/gui/src/Rack/ComponentEditor/ComponentView.cpp
+++ b/src/gui/src/Rack/ComponentEditor/ComponentView.cpp
@@ -266,27 +266,27 @@ ComponentView::ComponentView( QWidget* pParent,
 	m_pComponentMuteBtn = new MuteButton(
 		pComponentButtonContainer,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
-		tr( "Mute component" ),
-		ColoredButton::Flag::ModifyOnChange
+		tr( "Mute component" ), ColoredButton::Flag::None
 	);
+	m_pComponentMuteBtn->setModifierTarget( Modifier::Drumkit );
 	m_pComponentMuteBtn->setChecked( pComponent->getIsMuted() );
 	m_pComponentMuteBtn->setBorderless( true );
 	m_pComponentMuteBtn->setObjectName( "ComponentMuteButton" );
-	connect( m_pComponentMuteBtn, &QPushButton::clicked, [&](){
+	connect( m_pComponentMuteBtn, &QPushButton::clicked, [&]() {
 		if ( m_pComponent != nullptr ) {
 			m_pComponent->setIsMuted( m_pComponentMuteBtn->isChecked() );
 			// Repaint since we indicate mute for all layers.
 			m_pLayerPreview->update();
 		}
-	});
+	} );
 	pComponentButtonContainerLayout->addWidget( m_pComponentMuteBtn );
 
 	m_pComponentSoloBtn = new SoloButton(
 		pComponentButtonContainer,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
-		tr( "Solo component" ),
-		ColoredButton::Flag::ModifyOnChange
+		tr( "Solo component" ), ColoredButton::Flag::None
 	);
+	m_pComponentSoloBtn->setModifierTarget( Modifier::Drumkit );
 	m_pComponentSoloBtn->setChecked( pComponent->getIsSoloed() );
 	m_pComponentSoloBtn->setBorderless( true );
 	m_pComponentSoloBtn->setObjectName( "ComponentSoloButton" );
@@ -416,8 +416,9 @@ ComponentView::ComponentView( QWidget* pParent,
 		pLayerButtonContainer,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
 		tr( "Mute layer" ),
-		ColoredButton::Flag::ModifyOnChange
+		ColoredButton::Flag::None
 	);
+	m_pLayerMuteBtn->setModifierTarget( Modifier::Drumkit );
 	m_pLayerMuteBtn->setObjectName( "LayerMuteButton" );
 	m_pLayerMuteBtn->setBorderless( true );
 	connect( m_pLayerMuteBtn, &QPushButton::clicked, [&]() {
@@ -435,8 +436,9 @@ ComponentView::ComponentView( QWidget* pParent,
 		m_pToolBarLayer,
 		QSize( ComponentView::nButtonWidth, ComponentView::nButtonHeight ),
 		tr( "Solo layer" ),
-		ColoredButton::Flag::ModifyOnChange
+		ColoredButton::Flag::None
 	);
+	m_pLayerSoloBtn->setModifierTarget( Modifier::Drumkit );
 	m_pLayerSoloBtn->setObjectName( "LayerSoloButton" );
 	m_pLayerSoloBtn->setBorderless( true );
 	connect( m_pLayerSoloBtn, &QPushButton::clicked, [&]() {

--- a/src/gui/src/Rack/ComponentEditor/LayerPreview.cpp
+++ b/src/gui/src/Rack/ComponentEditor/LayerPreview.cpp
@@ -850,7 +850,7 @@ void LayerPreview::mouseMoveEvent( QMouseEvent* ev )
 
 			if ( bChanged ) {
 				update();
-				Hydrogen::get_instance()->setIsModified( true );
+				Hydrogen::get_instance()->setSongModified( true );
 			}
 			break;
 		}

--- a/src/gui/src/Rack/ComponentEditor/LayerPreview.cpp
+++ b/src/gui/src/Rack/ComponentEditor/LayerPreview.cpp
@@ -850,7 +850,7 @@ void LayerPreview::mouseMoveEvent( QMouseEvent* ev )
 
 			if ( bChanged ) {
 				update();
-				Hydrogen::get_instance()->setSongModified( true );
+				Hydrogen::get_instance()->setDrumkitModified( true );
 			}
 			break;
 		}

--- a/src/gui/src/Rack/InstrumentEditor.cpp
+++ b/src/gui/src/Rack/InstrumentEditor.cpp
@@ -376,7 +376,7 @@ font-size: 21px;" );
 	connect( m_pIsStopNoteCheckBox, &QCheckBox::clicked, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setStopNotes(
 			static_cast<int>(m_pIsStopNoteCheckBox->isChecked()) );
-		Hydrogen::get_instance()->setSongModified( true );
+		Hydrogen::get_instance()->setDrumkitModified( true );
 	});
 	m_pIsStopNoteLbl = new ClickableLabel( m_pInstrumentProp, QSize( 87, 10 ),
 										   pCommonStrings->getIsStopNoteLabel() );
@@ -391,7 +391,7 @@ font-size: 21px;" );
 	connect( m_pApplyVelocity, &QCheckBox::clicked, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setApplyVelocity(
 			static_cast<int>(m_pApplyVelocity->isChecked()) );
-		Hydrogen::get_instance()->setSongModified( true );
+		Hydrogen::get_instance()->setDrumkitModified( true );
 	});
 	m_pApplyVelocityLbl = new ClickableLabel( m_pInstrumentProp, QSize( 87, 10 ),
 											  pCommonStrings->getApplyVelocityLabel() );

--- a/src/gui/src/Rack/InstrumentEditor.cpp
+++ b/src/gui/src/Rack/InstrumentEditor.cpp
@@ -84,8 +84,9 @@ font-size: 21px;" );
 		m_pInstrumentProp, QSize( 59, 24 ), LCDSpinBox::Type::Int,
 		static_cast<int>( Midi::ChannelOff ),
 		static_cast<int>( Midi::ChannelMaximum ),
-		LCDSpinBox::Flag::ModifyOnChange | LCDSpinBox::Flag::ZeroAsOff
+		LCDSpinBox::Flag::ZeroAsOff
 	);
+	m_pMidiOutChannelLCD->setModifierTarget( Modifier::Drumkit );
 	m_pMidiOutChannelLCD->move( 111, 257 );
 	m_pMidiOutChannelLCD->setToolTip( QString( tr( "Midi out channel" ) ) );
 	connect(
@@ -117,9 +118,9 @@ font-size: 21px;" );
 	m_pMidiOutNoteLCD = new LCDSpinBox(
 		m_pInstrumentProp, QSize( 94, 24 ), LCDSpinBox::Type::Int,
 		static_cast<int>( Midi::NoteMinimum ),
-		static_cast<int>( Midi::NoteMaximum ),
-		LCDSpinBox::Flag::ModifyOnChange | LCDSpinBox::Flag::ShowMidiNote
+		static_cast<int>( Midi::NoteMaximum ), LCDSpinBox::Flag::ShowMidiNote
 	);
+	m_pMidiOutNoteLCD->setModifierTarget( Modifier::Drumkit );
 	m_pMidiOutNoteLCD->move( 175, 257 );
 	m_pMidiOutNoteLCD->setToolTip( QString( tr( "Midi out note" ) ) );
 	connect(
@@ -352,10 +353,11 @@ font-size: 21px;" );
 									 pCommonStrings->getGainLabel() );
 	m_pGainLbl->move( 120, 125 );
 
-
 	m_pMuteGroupLCD = new LCDSpinBox(
 		m_pInstrumentProp, QSize( 59, 24 ), LCDSpinBox::Type::Int, -1, 100,
-		LCDSpinBox::Flag::ModifyOnChange | LCDSpinBox::Flag::MinusOneAsOff );
+		LCDSpinBox::Flag::MinusOneAsOff
+	);
+	m_pMuteGroupLCD->setModifierTarget( Modifier::Drumkit );
 	m_pMuteGroupLCD->move( 210, 101 );
 	connect( m_pMuteGroupLCD, &LCDSpinBox::valueAdjusted, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setMuteGroup(
@@ -400,22 +402,26 @@ font-size: 21px;" );
 
 	m_pHihatGroupLCD = new LCDSpinBox(
 		m_pInstrumentProp, QSize( 59, 24 ), LCDSpinBox::Type::Int, -1, 32,
-		LCDSpinBox::Flag::ModifyOnChange | LCDSpinBox::Flag::MinusOneAsOff );
+		LCDSpinBox::Flag::MinusOneAsOff
+	);
+	m_pHihatGroupLCD->setModifierTarget( Modifier::Drumkit );
 	m_pHihatGroupLCD->move( 33, 303 );
 	connect( m_pHihatGroupLCD, &LCDSpinBox::valueAdjusted, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setHihatGrp(
-			static_cast<int>(m_pHihatGroupLCD->value()) );
-	});
-	m_pHihatGroupLbl = new ClickableLabel( m_pInstrumentProp, QSize( 69, 10 ),
-										   pCommonStrings->getHihatGroupLabel() );
+			static_cast<int>( m_pHihatGroupLCD->value() )
+		);
+	} );
+	m_pHihatGroupLbl = new ClickableLabel(
+		m_pInstrumentProp, QSize( 69, 10 ), pCommonStrings->getHihatGroupLabel()
+	);
 	m_pHihatGroupLbl->move( 28, 327 );
 
 	m_pHihatMinRangeLCD = new LCDSpinBox(
 		m_pInstrumentProp, QSize( 59, 24 ), LCDSpinBox::Type::Int,
 		static_cast<int>( Midi::ParameterMinimum ),
-		static_cast<int>( Midi::ParameterMaximum ),
-		LCDSpinBox::Flag::ModifyOnChange
+		static_cast<int>( Midi::ParameterMaximum )
 	);
+	m_pHihatMinRangeLCD->setModifierTarget( Modifier::Drumkit );
 	m_pHihatMinRangeLCD->move( 146, 303 );
 	connect( m_pHihatMinRangeLCD, &LCDSpinBox::valueAdjusted, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setLowerCc(
@@ -436,10 +442,10 @@ font-size: 21px;" );
 	m_pHihatMaxRangeLCD = new LCDSpinBox(
 		m_pInstrumentProp, QSize( 59, 24 ), LCDSpinBox::Type::Int,
 		static_cast<int>( Midi::ParameterMinimum ),
-		static_cast<int>( Midi::ParameterMaximum ),
-		LCDSpinBox::Flag::ModifyOnChange
+		static_cast<int>( Midi::ParameterMaximum )
 	);
 	m_pHihatMaxRangeLCD->move( 210, 303 );
+	m_pHihatMaxRangeLCD->setModifierTarget( Modifier::Drumkit );
 	connect( m_pHihatMaxRangeLCD, &LCDSpinBox::valueAdjusted, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setHigherCc(
 			Midi::parameterFromIntClamp(

--- a/src/gui/src/Rack/InstrumentEditor.cpp
+++ b/src/gui/src/Rack/InstrumentEditor.cpp
@@ -238,7 +238,7 @@ font-size: 21px;" );
 		auto pInstrument = pHydrogen->getSelectedInstrument();
 		if ( pInstrument != nullptr ) {
 			pInstrument->setFilterActive( !pInstrument->isFilterActive() );
-			pHydrogen->setSongModified( true );
+			pHydrogen->setDrumkitModified( true );
             updateActivation();
 			updateIcons();
 		}

--- a/src/gui/src/Rack/InstrumentEditor.cpp
+++ b/src/gui/src/Rack/InstrumentEditor.cpp
@@ -186,6 +186,7 @@ font-size: 21px;" );
 		m_pInstrumentProp, Rotary::Type::Center, tr( "Pitch offset (Coarse)" ),
 		true, Instrument::fPitchOffsetMinimum + InstrumentEditor::nPitchFineControl,
 		Instrument::fPitchOffsetMaximum - InstrumentEditor::nPitchFineControl );
+	m_pPitchCoarseRotary->setModifierTarget( Modifier::Drumkit );
 	m_pPitchCoarseRotary->move( 94, 210 );
 	connect( m_pPitchCoarseRotary, &Rotary::valueChanged, [&]() {
 		//round fVal, since Coarse is the integer number of half steps
@@ -203,6 +204,7 @@ font-size: 21px;" );
 		false, -InstrumentEditor::nPitchFineControl,
 		InstrumentEditor::nPitchFineControl );
 	//it will have resolution of 100 steps between Min and Max => quantum delta = 0.01
+	m_pPitchFineRotary->setModifierTarget( Modifier::Drumkit );
 	m_pPitchFineRotary->move( 151, 210 );
 	connect( m_pPitchFineRotary, &Rotary::valueChanged, [&]() {
 		//round fVal, since Coarse is the integer number of half steps
@@ -218,6 +220,7 @@ font-size: 21px;" );
 	m_pRandomPitchRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal, tr( "Random pitch factor" ),
 		false );
+	m_pRandomPitchRotary->setModifierTarget( Modifier::Drumkit );
 	m_pRandomPitchRotary->move( 208, 210 );
 	connect( m_pRandomPitchRotary, &Rotary::valueChanged, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setRandomPitchFactor(
@@ -247,6 +250,7 @@ font-size: 21px;" );
 
 	m_pCutoffRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal, tr( "Filter Cutoff" ), false );
+	m_pCutoffRotary->setModifierTarget( Modifier::Drumkit );
 	m_pCutoffRotary->setDefaultValue( m_pCutoffRotary->getMax() );
 	m_pCutoffRotary->move( 124, 164 );
 	connect( m_pCutoffRotary, &Rotary::valueChanged, [&]() {
@@ -259,6 +263,7 @@ font-size: 21px;" );
 
 	m_pResonanceRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal, tr( "Filter resonance" ), false );
+	m_pResonanceRotary->setModifierTarget( Modifier::Drumkit );
 	connect( m_pResonanceRotary, &Rotary::valueChanged, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setFilterResonance(
 			std::min( 0.95f, m_pResonanceRotary->getValue() ) );
@@ -274,6 +279,7 @@ font-size: 21px;" );
 	m_pAttackRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal,
 		tr( "Length of Attack phase" ), false );
+	m_pAttackRotary->setModifierTarget( Modifier::Drumkit );
 	m_pAttackRotary->move( 45, 52 );
 	connect( m_pAttackRotary, &Rotary::valueChanged, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->getAdsr()->setAttack(
@@ -286,6 +292,7 @@ font-size: 21px;" );
 	m_pDecayRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal,
 		tr( "Length of Decay phase" ), false );
+	m_pDecayRotary->setModifierTarget( Modifier::Drumkit );
 	m_pDecayRotary->move( 101, 52 );
 	connect( m_pDecayRotary, &Rotary::valueChanged, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->getAdsr()->setDecay(
@@ -298,6 +305,7 @@ font-size: 21px;" );
 	m_pSustainRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal,
 		tr( "Sample volume in Sustain phase" ), false );
+	m_pSustainRotary->setModifierTarget( Modifier::Drumkit );
 	m_pSustainRotary->setDefaultValue( m_pSustainRotary->getMax() );
 	m_pSustainRotary->move( 157, 52 );
 	connect( m_pSustainRotary, &Rotary::valueChanged, [&]() {
@@ -311,6 +319,7 @@ font-size: 21px;" );
 	m_pReleaseRotary = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal,
 		tr( "Length of Release phase" ), false );
+	m_pReleaseRotary->setModifierTarget( Modifier::Drumkit );
 	m_pReleaseRotary->setDefaultValue( 0.09 );
 	m_pReleaseRotary->move( 213, 52 );
 	connect( m_pReleaseRotary, &Rotary::valueChanged, [&]() {
@@ -331,6 +340,7 @@ font-size: 21px;" );
 	m_pInstrumentGain = new Rotary(
 		m_pInstrumentProp, Rotary::Type::Normal, tr( "Instrument gain" ), false,
 		0.0, 5.0 );
+	m_pInstrumentGain->setModifierTarget( Modifier::Drumkit );
 	m_pInstrumentGain->setDefaultValue( 1.0 );
 	m_pInstrumentGain->move( 122, 100 );
 	connect( m_pInstrumentGain, &Rotary::valueChanged, [&]() {

--- a/src/gui/src/Rack/InstrumentEditor.cpp
+++ b/src/gui/src/Rack/InstrumentEditor.cpp
@@ -238,7 +238,7 @@ font-size: 21px;" );
 		auto pInstrument = pHydrogen->getSelectedInstrument();
 		if ( pInstrument != nullptr ) {
 			pInstrument->setFilterActive( !pInstrument->isFilterActive() );
-			pHydrogen->setIsModified( true );
+			pHydrogen->setSongModified( true );
             updateActivation();
 			updateIcons();
 		}
@@ -364,7 +364,7 @@ font-size: 21px;" );
 	connect( m_pIsStopNoteCheckBox, &QCheckBox::clicked, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setStopNotes(
 			static_cast<int>(m_pIsStopNoteCheckBox->isChecked()) );
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	});
 	m_pIsStopNoteLbl = new ClickableLabel( m_pInstrumentProp, QSize( 87, 10 ),
 										   pCommonStrings->getIsStopNoteLabel() );
@@ -379,7 +379,7 @@ font-size: 21px;" );
 	connect( m_pApplyVelocity, &QCheckBox::clicked, [&]() {
 		Hydrogen::get_instance()->getSelectedInstrument()->setApplyVelocity(
 			static_cast<int>(m_pApplyVelocity->isChecked()) );
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	});
 	m_pApplyVelocityLbl = new ClickableLabel( m_pInstrumentProp, QSize( 87, 10 ),
 											  pCommonStrings->getApplyVelocityLabel() );

--- a/src/gui/src/ShotList.cpp
+++ b/src/gui/src/ShotList.cpp
@@ -105,7 +105,7 @@ void ShotList::shoot( const QString& s ) {
 		// Since the shot lists do also toggle some buttons that mark
 		// the overall song modified, we need to discard the flag in
 		// order to avoid a popup dialog.
-		H2Core::Hydrogen::get_instance()->setIsModified( false );
+		H2Core::Hydrogen::get_instance()->setSongModified( false );
 		
 		QTimer::singleShot( 1, QApplication::instance(), &QApplication::closeAllWindows );
 	} else if ( sCmd.compare( "dump", Qt::CaseInsensitive) == 0 ) {

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -974,6 +974,10 @@ void SongEditorPanel::patternChangedEvent() {
 	updateEditors( Editor::Update::Content );
 }
 
+void SongEditorPanel::patternIsModifiedEvent() {
+	m_pPatternList->updateEditor();
+}
+
 void SongEditorPanel::playbackTrackChangedEvent() {
 	updatePlaybackTrack();
 }

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -250,12 +250,13 @@ SongEditorPanel::SongEditorPanel( QWidget *pParent ) : QWidget( pParent ) {
 	// mute playback track toggle button
 	m_pMutePlaybackTrackButton = new MuteButton(
 		m_pPlaybackTrackToolBar,
-		QSize( SongEditorPanel::nButtonWidth, SongEditorPanel::nButtonToolHeight ),
+		QSize(
+			SongEditorPanel::nButtonWidth, SongEditorPanel::nButtonToolHeight
+		),
 		tr( "Mute playback track" ),
-		ColoredButton::Flag::ModifyOnChange |
-			ColoredButton::Flag::CustomRendering |
-			ColoredButton::Flag::AsToolButton
+		ColoredButton::Flag::CustomRendering | ColoredButton::Flag::AsToolButton
 	);
+	m_pMutePlaybackTrackButton->setModifierTarget( Modifier::Song );
 	m_pMutePlaybackTrackButton->setBorderless( true );
 	m_pMutePlaybackTrackButton->setObjectName(
 		"SongEditorPlaybackTrackMuteButton"

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -110,6 +110,7 @@ SongEditorPanel::SongEditorPanel( QWidget *pParent ) : QWidget( pParent ) {
 		Fader::Type::Horizonal, tr( "Playback track volume" ), false, false,
 		0.0, 1.5
 	);
+	m_pPlaybackTrackFader->setModifierTarget( Modifier::Song );
 	m_pPlaybackTrackFader->setObjectName( "SongEditorPlaybackTrackFader" );
 	if ( pPlaybackTrackInstrument != nullptr ) {
 		m_pPlaybackTrackFader->setValue( pPlaybackTrackInstrument->getVolume()

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -573,7 +573,8 @@ SongEditorPanel::SongEditorPanel( QWidget *pParent ) : QWidget( pParent ) {
 	connect( m_pAutomationPathView, SIGNAL( pointRemoved(float, float) ), this, SLOT( automationPathPointRemoved(float,float) ) );
 	connect( m_pAutomationPathView, SIGNAL( pointMoved(float, float, float, float) ), this, SLOT( automationPathPointMoved(float,float, float, float) ) );
 
-	m_pAutomationCombo = new LCDCombo( nullptr, QSize( m_nPatternListWidth, 18 ), true );
+	m_pAutomationCombo = new LCDCombo( nullptr, QSize( m_nPatternListWidth, 18 ) );
+	m_pAutomationCombo->setModifierTarget( Modifier::Song );
 	m_pAutomationCombo->setToolTip( tr("Adjust parameter values in time") );
 	m_pAutomationCombo->addItem( pCommonStrings->getNotePropertyVelocity() );
 	m_pAutomationCombo->setCurrentIndex( 0 );

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -970,7 +970,7 @@ void SongEditorPanel::patternEditorLockedEvent() {
 	}
 }
 
-void SongEditorPanel::patternModifiedEvent() {
+void SongEditorPanel::patternChangedEvent() {
 	updateEditors( Editor::Update::Content );
 }
 

--- a/src/gui/src/SongEditor/SongEditorPanel.cpp
+++ b/src/gui/src/SongEditor/SongEditorPanel.cpp
@@ -348,7 +348,7 @@ SongEditorPanel::SongEditorPanel( QWidget *pParent ) : QWidget( pParent ) {
 						: pCommonStrings->getStatusOff()
 				);
 		HydrogenApp::get_instance()->showStatusBarMessage( sMessage );
-		Hydrogen::get_instance()->setIsModified( true );
+		Hydrogen::get_instance()->setSongModified( true );
 	} );
 
     m_pTimelineToolBar->addSeparator();

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -102,7 +102,7 @@ class SongEditorPanel : public QWidget,
 		virtual void midiClockActivationEvent() override;
 		virtual void nextPatternsChangedEvent() override;
 		virtual void patternEditorLockedEvent() override;
-		virtual void patternModifiedEvent() override;
+		virtual void patternChangedEvent() override;
 		virtual void playbackTrackChangedEvent() override;
 		virtual void playingPatternsChangedEvent() override;
 		virtual void relocationEvent() override;

--- a/src/gui/src/SongEditor/SongEditorPanel.h
+++ b/src/gui/src/SongEditor/SongEditorPanel.h
@@ -103,6 +103,7 @@ class SongEditorPanel : public QWidget,
 		virtual void nextPatternsChangedEvent() override;
 		virtual void patternEditorLockedEvent() override;
 		virtual void patternChangedEvent() override;
+		virtual void patternIsModifiedEvent() override;
 		virtual void playbackTrackChangedEvent() override;
 		virtual void playingPatternsChangedEvent() override;
 		virtual void relocationEvent() override;

--- a/src/gui/src/SongEditor/SongEditorPatternList.cpp
+++ b/src/gui/src/SongEditor/SongEditorPatternList.cpp
@@ -541,7 +541,7 @@ void SongEditorPatternList::movePatternLine(
 	HydrogenApp::get_instance()->getSongEditorPanel()->updateEditors(
 		Editor::Update::Content
 	);
-	pHydrogen->setIsModified( true );
+	pHydrogen->setSongModified( true );
 }
 
 int SongEditorPatternList::yToRow( int nY ) const

--- a/src/gui/src/SongEditor/SongEditorPatternList.cpp
+++ b/src/gui/src/SongEditor/SongEditorPatternList.cpp
@@ -984,7 +984,11 @@ void SongEditorPatternList::createBackground()
 			PatternArray[i].bNext = false;
 		}
 
-		PatternArray[i].sPatternName = pPattern->getName();
+		QString sText( pPattern->getName() );
+		if ( pPattern->getIsModified() ) {
+			sText.append( "*" );
+		}
+		PatternArray[i].sPatternName = sText;
 	}
 	pAudioEngine->unlock();
 

--- a/src/gui/src/SongEditor/SongEditorPositionRuler.cpp
+++ b/src/gui/src/SongEditor/SongEditorPositionRuler.cpp
@@ -402,7 +402,7 @@ void SongEditorPositionRuler::mousePressEvent( QMouseEvent *ev )
 
 			if ( pHydrogen->getMode() == Song::Mode::Pattern ) {
 				CoreActionController::activateSongMode( true );
-				pHydrogen->setIsModified( true );
+				pHydrogen->setSongModified( true );
 			}
 
 			CoreActionController::locateToColumn( nColumn );

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -609,9 +609,5 @@ void SongPropertiesDialog::on_okBtn_clicked()
 
 	pHydrogen->setSongModified( bIsModified && !( m_action & Action::SaveAs ) );
 
-	// We do not need to send an Event::SongModified in here. This is only
-	// required for the currently active song, which must always be altered
-	// using Action::ModifyViaUndo.
-
 	accept();
 }

--- a/src/gui/src/SongPropertiesDialog.cpp
+++ b/src/gui/src/SongPropertiesDialog.cpp
@@ -607,7 +607,7 @@ void SongPropertiesDialog::on_okBtn_clicked()
 		bIsModified = true;
 	}
 
-	pHydrogen->setIsModified( bIsModified && !( m_action & Action::SaveAs ) );
+	pHydrogen->setSongModified( bIsModified && !( m_action & Action::SaveAs ) );
 
 	// We do not need to send an Event::SongModified in here. This is only
 	// required for the currently active song, which must always be altered

--- a/src/gui/src/Widgets/AutomationPathView.cpp
+++ b/src/gui/src/Widgets/AutomationPathView.cpp
@@ -326,7 +326,7 @@ void AutomationPathView::mousePressEvent(QMouseEvent *event)
 		m_fOriginY = y;
 		m_bPointAdded = false;
 	}
-	H2Core::Hydrogen::get_instance()->setIsModified( true );
+	H2Core::Hydrogen::get_instance()->setSongModified( true );
 
 	createBackground();
 	update();
@@ -382,7 +382,7 @@ void AutomationPathView::mouseMoveEvent(QMouseEvent *event)
 
 	if ( m_bIsHolding && _path && _selectedPoint != _path->end() ) {
 		_selectedPoint = _path->move(_selectedPoint, x, y);
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 
 	createBackground();
@@ -405,7 +405,7 @@ void AutomationPathView::keyPressEvent(QKeyEvent *event)
 			_path->remove_point(_selectedPoint->first);
 			_selectedPoint = _path->end();
 			
-			H2Core::Hydrogen::get_instance()->setIsModified( true );
+			H2Core::Hydrogen::get_instance()->setSongModified( true );
 
 			emit pointRemoved( x, y );
 			createBackground();

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -36,8 +36,7 @@
 
 Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 				const QString& sIcon, const QString& sText, const QSize& iconSize,
-				const QString& sBaseToolTip, bool bModifyOnChange,
-				int nBorderRadius )
+				const QString& sBaseToolTip, int nBorderRadius )
 	: QPushButton( pParent )
 	, m_size( size )
 	, m_type( type )
@@ -46,7 +45,6 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 	, m_sIcon( sIcon )
 	, m_bIsActive( true )
 	, m_nFixedFontSize( -1 )
-	, m_bModifyOnChange( bModifyOnChange )
 	, m_nBorderRadius( nBorderRadius )
 	, m_bUseCustomBackgroundColors( false )
 {
@@ -78,8 +76,6 @@ Button::Button( QWidget *pParent, const QSize& size, const Type& type,
 	
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,
 			 this, &Button::onPreferencesChanged );
-
-	connect( this, SIGNAL(clicked()), this, SLOT(onClick()));
 }
 
 Button::~Button() {
@@ -373,11 +369,6 @@ void Button::onPreferencesChanged( const H2Core::Preferences::Changes& changes )
 	}
 }
 
-void Button::onClick() {
-	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
-	}
-}
 
 void Button::setBorderRadius( int nBorderRadius ) {
 	m_nBorderRadius = nBorderRadius;

--- a/src/gui/src/Widgets/Button.cpp
+++ b/src/gui/src/Widgets/Button.cpp
@@ -375,7 +375,7 @@ void Button::onPreferencesChanged( const H2Core::Preferences::Changes& changes )
 
 void Button::onClick() {
 	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -87,7 +87,7 @@ public:
 	 * \param sText
 	 * \param iconSize
 	 * \param sBaseTooltip
-	 * \param bModifyOnChange Whether Hydrogen::setIsModified() is
+	 * \param bModifyOnChange Whether Hydrogen::setSongModified() is
 	 * invoked with `true` as soon as the value of the widget does
 	 * change.
 	 * \param nBorderRadius Radius of the button in pixel, which will
@@ -161,7 +161,7 @@ private:
 
 	bool m_bIsActive;
 	
-	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+	/** Whether Hydrogen::setSongModified() is invoked with `true` as
 		soon as the value of the widget does change.*/
 	bool m_bModifyOnChange;
 

--- a/src/gui/src/Widgets/Button.h
+++ b/src/gui/src/Widgets/Button.h
@@ -55,9 +55,11 @@
  * in the tooltip.
  */
 /** \ingroup docGUI docWidgets*/
-class Button : public QPushButton, protected WidgetWithScalableFont<6, 8, 10>,  public H2Core::Object<Button>, public MidiLearnable
-{
-    H2_OBJECT(Button)
+class Button : public QPushButton,
+			   protected WidgetWithScalableFont<6, 8, 10>,
+			   public H2Core::Object<Button>,
+			   public MidiLearnable {
+	H2_OBJECT(Button)
 	Q_OBJECT
 
 public:
@@ -87,9 +89,6 @@ public:
 	 * \param sText
 	 * \param iconSize
 	 * \param sBaseTooltip
-	 * \param bModifyOnChange Whether Hydrogen::setSongModified() is
-	 * invoked with `true` as soon as the value of the widget does
-	 * change.
 	 * \param nBorderRadius Radius of the button in pixel, which will
 	 * be passed to the style sheet.
 	 */
@@ -101,7 +100,6 @@ public:
 		   const QString& sText = "",
 		   const QSize& iconSize = QSize( 0, 0 ),
 		   const QString& sBaseToolTip = "",
-		   bool bModifyOnChange = false,
 		   int nBorderRadius = -1
 		   );
 	~Button();
@@ -134,9 +132,6 @@ public:
 public slots:
 	virtual void onPreferencesChanged( const H2Core::Preferences::Changes& changes );
 
-private slots:
-	void onClick();
-
 signals:
 	void rightClicked();
 
@@ -160,10 +155,6 @@ private:
 	bool m_bLastCheckedState;
 
 	bool m_bIsActive;
-	
-	/** Whether Hydrogen::setSongModified() is invoked with `true` as
-		soon as the value of the widget does change.*/
-	bool m_bModifyOnChange;
 
 		/** We will change the checked background color along with theme changes
 		 * until we receive an explicit user action to customize the background
@@ -171,7 +162,6 @@ private:
 		bool m_bUseCustomBackgroundColors;
 		QColor m_checkedBackgroundColor;
 		QColor m_checkedBackgroundTextColor;
-
 };
 inline bool Button::getIsActive() const {
 	return m_bIsActive;

--- a/src/gui/src/Widgets/ColoredButton.cpp
+++ b/src/gui/src/Widgets/ColoredButton.cpp
@@ -43,12 +43,13 @@ ColoredButton::ColoredButton(
 		  "",
 		  QSize( 0, 0 ),
 		  sBaseToolTip,
-		  flag & Flag::ModifyOnChange,
 		  -1
 	  ),
       m_bBorderless( false ),
       m_flag( static_cast<Flag>(flag) )
 {
+	m_nModifierTarget = Modifier::None;
+
 	const auto pColorTheme =
 		H2Core::Preferences::get_instance()->getColorTheme();
 	m_defaultBackgroundColor = pColorTheme->m_widgetColor;
@@ -58,6 +59,8 @@ ColoredButton::ColoredButton(
 	);
 
 	setFlat( true );
+
+	connect( this, SIGNAL( clicked() ), this, SLOT( onClick() ) );
 }
 
 ColoredButton::~ColoredButton()
@@ -70,6 +73,10 @@ void ColoredButton::setBorderless( bool bBorderless )
 		m_bBorderless = bBorderless;
         updateStyleSheet();
 	}
+}
+
+void ColoredButton::onClick() {
+	modify();
 }
 
 void ColoredButton::paintEvent( QPaintEvent* pEvent )

--- a/src/gui/src/Widgets/ColoredButton.h
+++ b/src/gui/src/Widgets/ColoredButton.h
@@ -24,11 +24,14 @@
 #define COLORED_BUTTON_H
 
 #include "Button.h"
+#include "Modifier.h"
 
 /** Common basis for #MuteButton and #SoloButton.
  *
  * \ingroup docGUI docWidgets*/
-class ColoredButton : public Button, public H2Core::Object<ColoredButton> {
+class ColoredButton : public Button,
+					  public Modifier,
+					  public H2Core::Object<ColoredButton> {
 	H2_OBJECT( ColoredButton )
 	Q_OBJECT
 
@@ -38,7 +41,6 @@ class ColoredButton : public Button, public H2Core::Object<ColoredButton> {
 
 	enum Flag {
 		None = 0x000,
-		ModifyOnChange = 0x001,
 		/** Depending on the background color of the widget the colored button
 		 * is residing in - and given that it adopts the same color in unchecked
 		 * state - the default text color might be illegible. To circumvent
@@ -49,11 +51,11 @@ class ColoredButton : public Button, public H2Core::Object<ColoredButton> {
 		 * option should be used with care. We also do not provide the "M" or
 		 * "S" for mute or solo button as SVG icons because we want to support
 		 * internationalization. */
-		CustomRendering = 0x002,
+		CustomRendering = 0x001,
 		/** Display borders during hovering and pressing as well as in checked
 		 * state on borderless buttons. This yields the same UI/UX as for tool
 		 * buttons in a tool bar. */
-		AsToolButton = 0x004
+		AsToolButton = 0x002
 	};
 
 	ColoredButton(
@@ -71,6 +73,9 @@ class ColoredButton : public Button, public H2Core::Object<ColoredButton> {
 	void setDefaultBackgroundColor( const QColor& color );
 
 	void updateStyleSheet() override;
+
+   private slots:
+	void onClick();
 
    protected:
 	void paintEvent( QPaintEvent* pEvent ) override;

--- a/src/gui/src/Widgets/Fader.cpp
+++ b/src/gui/src/Widgets/Fader.cpp
@@ -43,8 +43,7 @@ Fader::Fader(
 	bool bUseIntSteps,
 	bool bWithoutKnob,
 	float fMin,
-	float fMax,
-	bool bModifyOnChange
+	float fMax
 )
 	: WidgetWithInput(
 		  pParent,
@@ -53,8 +52,7 @@ Fader::Fader(
 		  1,  // nScrollSpeed
 		  5,  // nScrollSpeedFast
 		  fMin,
-		  fMax,
-		  bModifyOnChange
+		  fMax
 	  ),
 	  m_type( type ),
 	  m_bWithoutKnob( bWithoutKnob ),

--- a/src/gui/src/Widgets/Fader.h
+++ b/src/gui/src/Widgets/Fader.h
@@ -41,11 +41,10 @@
  *
  */
 /** \ingroup docGUI docWidgets*/
-class Fader : public WidgetWithInput, public H2Core::Object<Fader>
-{
-    H2_OBJECT(Fader)
-	
-public:
+class Fader : public WidgetWithInput, public H2Core::Object<Fader> {
+	H2_OBJECT( Fader )
+
+   public:
 	enum class Type {
 		Vertical,
 		/** Only used for the playback track in the SongEditorPanel*/
@@ -55,8 +54,7 @@ public:
 	
 	Fader( QWidget *pParent, const QSize& size, const Type& type,
 		   const QString& sBaseToolTip, bool bUseIntSteps = false,
-		   bool bWithoutKnob = false, float fMin = 0.0, float fMax = 1.0,
-		   bool bModifyOnChange = true );
+		   bool bWithoutKnob = false, float fMin = 0.0, float fMax = 1.0 );
 	~Fader();
 
 	void setMaxPeak( float fMax );

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -50,7 +50,7 @@ LCDCombo::LCDCombo( QWidget *pParent, const QSize& size )
 		HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this,
 		&LCDCombo::onPreferencesChanged
 	);
-	connect( this, &QComboBox::activated, [&]() {
+	connect( this, QOverload<int>::of(&QComboBox::activated), [&]( int ) {
 		if ( m_nModifierTarget != Modifier::None ) {
 			modify();
 		}

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -28,14 +28,15 @@
 #include <core/Globals.h>
 
 
-LCDCombo::LCDCombo( QWidget *pParent, const QSize& size, bool bModifyOnChange )
+LCDCombo::LCDCombo( QWidget *pParent, const QSize& size )
 	: QComboBox( pParent )
 	, m_size( size )
 	, m_bEntered( false )
-	, m_bModifyOnChange( bModifyOnChange )
 	, m_nMaxWidth( 0 )
 	, m_bIsActive( true )
 {
+	m_nModifierTarget = Modifier::None;
+
 	setFocusPolicy( Qt::NoFocus );
 
 	if ( ! size.isNull() ) {
@@ -45,19 +46,18 @@ LCDCombo::LCDCombo( QWidget *pParent, const QSize& size, bool bModifyOnChange )
 
 	updateStyleSheet();
 
-	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this, &LCDCombo::onPreferencesChanged );
-	// Mark the current song modified if there was an user interaction
-	// with the widget.
-	connect( this, SIGNAL( activated(int) ), this, SLOT( handleIsModified(int) ) );
+	connect(
+		HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged, this,
+		&LCDCombo::onPreferencesChanged
+	);
+	connect( this, &QComboBox::activated, [&]() {
+		if ( m_nModifierTarget != Modifier::None ) {
+			modify();
+		}
+	} );
 }
 
 LCDCombo::~LCDCombo() {
-}
-
-void LCDCombo::handleIsModified( int ) {
-	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
-	}
 }
 
 void LCDCombo::addItem( const QString& sText, const QVariant& userData ) {

--- a/src/gui/src/Widgets/LCDCombo.cpp
+++ b/src/gui/src/Widgets/LCDCombo.cpp
@@ -56,7 +56,7 @@ LCDCombo::~LCDCombo() {
 
 void LCDCombo::handleIsModified( int ) {
 	if ( m_bModifyOnChange ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -62,7 +62,7 @@ private:
 	bool m_bEntered;
 	bool m_bIsActive;
 
-	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+	/** Whether Hydrogen::setSongModified() is invoked with `true` as
 		soon as the value of the widget does change.*/
 	bool m_bModifyOnChange;
 

--- a/src/gui/src/Widgets/LCDCombo.h
+++ b/src/gui/src/Widgets/LCDCombo.h
@@ -26,25 +26,27 @@
 
 #include <QtGui>
 #include <QComboBox>
+
+#include "Modifier.h"
 #include "WidgetWithScalableFont.h"
 
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
 
 /** \ingroup docGUI docWidgets*/
-class LCDCombo : public QComboBox, protected WidgetWithScalableFont<6, 8, 9>, public H2Core::Object<LCDCombo>
-{
+class LCDCombo : public QComboBox,
+				 public Modifier,
+				 protected WidgetWithScalableFont<6, 8, 9>,
+				 public H2Core::Object<LCDCombo> {
 	H2_OBJECT(LCDCombo)
 	Q_OBJECT
 
 public:
-	explicit LCDCombo( QWidget *pParent, const QSize& size = QSize( 0, 0 ),
-					   bool bModifyOnChange = false );
+	explicit LCDCombo( QWidget *pParent, const QSize& size = QSize( 0, 0 ) );
 	~LCDCombo();
 
 	void setSize( const QSize& size );
-	void setModifyOnChange( bool bModifyOnChange );
-	
+
 	virtual void showPopup() override;
 	void addItem(const QString& sText, const QVariant& userData = QVariant());
 	
@@ -53,7 +55,6 @@ public:
 
 public slots:
 	void onPreferencesChanged( const H2Core::Preferences::Changes& changes );
-	void handleIsModified( int );
 
 private:
 	void updateStyleSheet();
@@ -61,10 +62,6 @@ private:
 
 	bool m_bEntered;
 	bool m_bIsActive;
-
-	/** Whether Hydrogen::setSongModified() is invoked with `true` as
-		soon as the value of the widget does change.*/
-	bool m_bModifyOnChange;
 
 	/** Keep track of the text width of the items added. It is used to
 		determine the size of the popup in order to ensure all content
@@ -79,9 +76,6 @@ private:
 #endif
 	virtual void leaveEvent( QEvent *ev ) override;
 };
-inline void LCDCombo::setModifyOnChange( bool bModifyOnChange ) {
-	m_bModifyOnChange = bModifyOnChange;
-}
 inline bool LCDCombo::getIsActive() const {
 	return m_bIsActive;
 }

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -134,7 +134,7 @@ void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 
 	if ( fOldValue != value() &&
 		 ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 
@@ -190,7 +190,7 @@ void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 	}
 	
 	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 
@@ -362,7 +362,7 @@ void LCDSpinBox::mousePressEvent( QMouseEvent* ev ) {
 	QDoubleSpinBox::mousePressEvent( ev );
 	
 	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 
@@ -372,7 +372,7 @@ void LCDSpinBox::mouseMoveEvent( QMouseEvent* ev ) {
 	QDoubleSpinBox::mouseMoveEvent( ev );
 	
 	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 
@@ -382,7 +382,7 @@ void LCDSpinBox::mouseReleaseEvent( QMouseEvent* ev ) {
 	QDoubleSpinBox::mouseReleaseEvent( ev );
 	
 	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setIsModified( true );
+		H2Core::Hydrogen::get_instance()->setSongModified( true );
 	}
 }
 

--- a/src/gui/src/Widgets/LCDSpinBox.cpp
+++ b/src/gui/src/Widgets/LCDSpinBox.cpp
@@ -26,8 +26,8 @@
 #include "../CommonStrings.h"
 #include "../HydrogenApp.h"
 #include "../Skin.h"
-#include "core/Basics/Note.h"
 
+#include <core/Basics/Note.h>
 #include <core/Globals.h>
 #include <core/Preferences/Preferences.h>
 
@@ -43,6 +43,8 @@ LCDSpinBox::LCDSpinBox( QWidget *pParent, QSize size, Type type, double fMin,
 {
 	setFocusPolicy( Qt::ClickFocus );
 	setLocale( QLocale( QLocale::C, QLocale::AnyCountry ) );
+
+	m_nModifierTarget = Modifier::None;
 	
 	if ( size.isNull() || size.isEmpty() ) {
 		m_size = sizeHint();
@@ -132,9 +134,8 @@ void LCDSpinBox::wheelEvent( QWheelEvent *ev ) {
 
 	}
 
-	if ( fOldValue != value() &&
-		 ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
+	if ( fOldValue != value() && m_nModifierTarget != Modifier::None ) {
+		modify();
 	}
 }
 
@@ -189,8 +190,8 @@ void LCDSpinBox::keyPressEvent( QKeyEvent *ev ) {
 		 QDoubleSpinBox::keyPressEvent( ev );
 	}
 	
-	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
+	if ( fOldValue != value() && m_nModifierTarget != Modifier::None ) {
+		modify();
 	}
 }
 
@@ -361,8 +362,8 @@ void LCDSpinBox::mousePressEvent( QMouseEvent* ev ) {
 
 	QDoubleSpinBox::mousePressEvent( ev );
 	
-	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
+	if ( fOldValue != value() && m_nModifierTarget != Modifier::None ) {
+		modify();
 	}
 }
 
@@ -371,8 +372,8 @@ void LCDSpinBox::mouseMoveEvent( QMouseEvent* ev ) {
 
 	QDoubleSpinBox::mouseMoveEvent( ev );
 	
-	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
+	if ( fOldValue != value() && m_nModifierTarget != Modifier::None ) {
+		modify();
 	}
 }
 
@@ -381,8 +382,8 @@ void LCDSpinBox::mouseReleaseEvent( QMouseEvent* ev ) {
 
 	QDoubleSpinBox::mouseReleaseEvent( ev );
 	
-	if ( fOldValue != value() && ( m_flag & Flag::ModifyOnChange ) ) {
-		H2Core::Hydrogen::get_instance()->setSongModified( true );
+	if ( fOldValue != value() && m_nModifierTarget != Modifier::None ) {
+		modify();
 	}
 }
 

--- a/src/gui/src/Widgets/LCDSpinBox.h
+++ b/src/gui/src/Widgets/LCDSpinBox.h
@@ -27,6 +27,8 @@
 #include <QtGui>
 #include <QDoubleSpinBox>
 
+#include "Modifier.h"
+
 #include <core/Basics/Event.h>
 #include <core/Object.h>
 #include <core/Preferences/Preferences.h>
@@ -47,9 +49,10 @@
  * results.
  */
 /** \ingroup docGUI docWidgets*/
-class LCDSpinBox : public QDoubleSpinBox, public H2Core::Object<LCDSpinBox>
-{
-    H2_OBJECT(LCDSpinBox)
+class LCDSpinBox : public QDoubleSpinBox,
+				   public Modifier,
+				   public H2Core::Object<LCDSpinBox> {
+	H2_OBJECT(LCDSpinBox)
 	Q_OBJECT
 
 public:
@@ -73,23 +76,22 @@ public:
 
 	enum Flag {
 		None = 0x000,
-		ModifyOnChange = 0x001,
 		/** Used for MIDI channel spin boxes to indicate no MIDI in/output once
 		 * the value is equal to #Midi::ChannelOff */
-		ZeroAsOff = 0x002,
+		ZeroAsOff = 0x001,
 		/** Used for other properties which can be disabled by setting their
 		 * value to `-1` */
-		MinusOneAsOff = 0x004,
+		MinusOneAsOff = 0x002,
 		/** Used for MIDI channel spin boxes to indicate MIDI input from all
 		 * channels will be accepted once the value is equal to
 		 * #Midi::ChannelAll */
-		MinusOneAsAll = 0x008,
+		MinusOneAsAll = 0x004,
 		/** Assume the provided integer represents a MIDI note and display the
 		 * cooresponding name next to it. */
-		ShowMidiNote = 0x010,
+		ShowMidiNote = 0x008,
 		/** Used to indicate that the selected value is associated to the
 		 * currently selected instrument. */
-		MinusOneAsCurrentlySelected = 0x020
+		MinusOneAsCurrentlySelected = 0x010
 	};
 
 	LCDSpinBox( QWidget *pParent, QSize size = QSize(), Type type = Type::Int,

--- a/src/gui/src/Widgets/Modifier.cpp
+++ b/src/gui/src/Widgets/Modifier.cpp
@@ -1,0 +1,72 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#include "Modifier.h"
+
+#include <QString>
+
+#include <core/Hydrogen.h>
+#include <core/Object.h>
+
+#include "../HydrogenApp.h"
+#include "../PatternEditor/PatternEditorPanel.h"
+
+void Modifier::setModifierTarget( int nModifierTarget )
+{
+	if ( nModifierTarget != Drumkit && nModifierTarget != Pattern &&
+		 nModifierTarget != Song ) {
+		___ERRORLOG( QString( "Invalid artifact [%1]" ).arg( nModifierTarget )
+		);
+		m_nModifierTarget = None;
+	}
+	else {
+		m_nModifierTarget = nModifierTarget;
+	}
+}
+
+void Modifier::modify()
+{
+	if ( m_nModifierTarget == Modifier::None ) {
+		return;
+	}
+
+	auto pHydrogen = H2Core::Hydrogen::get_instance();
+	switch ( m_nModifierTarget ) {
+		case Drumkit:
+			pHydrogen->setDrumkitModified( true );
+			break;
+		case Pattern:
+			pHydrogen->setPatternModified(
+				true, HydrogenApp::get_instance()
+						  ->getPatternEditorPanel()
+						  ->getPatternNumber()
+			);
+			break;
+		case Song:
+			pHydrogen->setSongModified( true );
+			break;
+		default:
+			___ERRORLOG(
+				QString( "Invalid artifact [%1]" ).arg( m_nModifierTarget )
+			);
+	}
+}

--- a/src/gui/src/Widgets/Modifier.h
+++ b/src/gui/src/Widgets/Modifier.h
@@ -1,0 +1,88 @@
+/*
+ * Hydrogen
+ * Copyright(c) 2008-2025 The hydrogen development team [hydrogen-devel@lists.sourceforge.net]
+ *
+ * http://www.hydrogen-music.org
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY, without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ */
+
+#ifndef MODIFIER_H
+#define MODIFIER_H
+
+#include <QString>
+
+#include <core/Hydrogen.h>
+#include <core/Object.h>
+
+#include "../HydrogenApp.h"
+#include "../PatternEditor/PatternEditorPanel.h"
+
+/** Derived classes will have the capability to mark a corresponding artifact as
+ * changed. */
+class Modifier {
+   public:
+	// Not an enum class as we use in so many other spaces because of the
+	// more concise calling.
+	enum { None, Drumkit, Pattern, Song };
+
+	void setModifierTarget( int nModifierTarget )
+	{
+		if ( nModifierTarget != Drumkit && nModifierTarget != Pattern &&
+			 nModifierTarget != Song ) {
+			___ERRORLOG(
+				QString( "Invalid artifact [%1]" ).arg( nModifierTarget )
+			);
+			m_nModifierTarget = None;
+		}
+		else {
+			m_nModifierTarget = nModifierTarget;
+		}
+	};
+
+	void modify()
+	{
+		if ( m_nModifierTarget == Modifier::None ) {
+			return;
+		}
+
+		auto pHydrogen = H2Core::Hydrogen::get_instance();
+		switch ( m_nModifierTarget ) {
+			case Drumkit:
+				pHydrogen->setDrumkitModified( true );
+				break;
+			case Pattern:
+				pHydrogen->setPatternModified(
+					true, HydrogenApp::get_instance()
+							  ->getPatternEditorPanel()
+							  ->getPatternNumber()
+				);
+				break;
+			case Song:
+				pHydrogen->setSongModified( true );
+				break;
+			default:
+				___ERRORLOG(
+					QString( "Invalid artifact [%1]" ).arg( m_nModifierTarget )
+				);
+		}
+	};
+
+   protected:
+	int m_nModifierTarget;
+};
+
+#endif

--- a/src/gui/src/Widgets/Modifier.h
+++ b/src/gui/src/Widgets/Modifier.h
@@ -25,12 +25,6 @@
 
 #include <QString>
 
-#include <core/Hydrogen.h>
-#include <core/Object.h>
-
-#include "../HydrogenApp.h"
-#include "../PatternEditor/PatternEditorPanel.h"
-
 /** Derived classes will have the capability to mark a corresponding artifact as
  * changed. */
 class Modifier {
@@ -39,47 +33,8 @@ class Modifier {
 	// more concise calling.
 	enum { None, Drumkit, Pattern, Song };
 
-	void setModifierTarget( int nModifierTarget )
-	{
-		if ( nModifierTarget != Drumkit && nModifierTarget != Pattern &&
-			 nModifierTarget != Song ) {
-			___ERRORLOG(
-				QString( "Invalid artifact [%1]" ).arg( nModifierTarget )
-			);
-			m_nModifierTarget = None;
-		}
-		else {
-			m_nModifierTarget = nModifierTarget;
-		}
-	};
-
-	void modify()
-	{
-		if ( m_nModifierTarget == Modifier::None ) {
-			return;
-		}
-
-		auto pHydrogen = H2Core::Hydrogen::get_instance();
-		switch ( m_nModifierTarget ) {
-			case Drumkit:
-				pHydrogen->setDrumkitModified( true );
-				break;
-			case Pattern:
-				pHydrogen->setPatternModified(
-					true, HydrogenApp::get_instance()
-							  ->getPatternEditorPanel()
-							  ->getPatternNumber()
-				);
-				break;
-			case Song:
-				pHydrogen->setSongModified( true );
-				break;
-			default:
-				___ERRORLOG(
-					QString( "Invalid artifact [%1]" ).arg( m_nModifierTarget )
-				);
-		}
-	};
+	void setModifierTarget( int nModifierTarget );
+	void modify();
 
    protected:
 	int m_nModifierTarget;

--- a/src/gui/src/Widgets/Rotary.cpp
+++ b/src/gui/src/Widgets/Rotary.cpp
@@ -32,15 +32,14 @@
 #include <core/Globals.h>
 
 Rotary::Rotary( QWidget* parent, const Type& type, const QString& sBaseTooltip,
-				bool bUseIntSteps, float fMin, float fMax, bool bModifyOnChange )
+				bool bUseIntSteps, float fMin, float fMax )
 	: WidgetWithInput( parent,
 					   bUseIntSteps,
 					   sBaseTooltip,
 					   1, //nScrollSpeed,
 					   5, // nScrollSpeedFast,
 					   fMin,
-					   fMax,
-					   bModifyOnChange )
+					   fMax )
 	, m_type( type ) {
 
 	connect( HydrogenApp::get_instance(), &HydrogenApp::preferencesChanged,

--- a/src/gui/src/Widgets/Rotary.h
+++ b/src/gui/src/Widgets/Rotary.h
@@ -66,8 +66,7 @@ public:
 	Rotary& operator=( const Rotary& rhs ) = delete;
 	
 	Rotary( QWidget* parent, const Type& type, const QString& sBaseTooltip,
-			bool bUseIntSteps, float fMin = 0.0, float fMax = 1.0,
-			bool bModifyOnChange = true );
+			bool bUseIntSteps, float fMin = 0.0, float fMax = 1.0 );
 	~Rotary();
 
 public slots:

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -126,7 +126,7 @@ void WidgetWithInput::setValue( float fValue, bool bTriggeredByUserInteraction,
 		update();
 
 		if ( m_bModifyOnChange && bTriggeredByUserInteraction ) {
-			H2Core::Hydrogen::get_instance()->setIsModified( true );
+			H2Core::Hydrogen::get_instance()->setSongModified( true );
 		}
 	}
 }

--- a/src/gui/src/Widgets/WidgetWithInput.cpp
+++ b/src/gui/src/Widgets/WidgetWithInput.cpp
@@ -30,28 +30,34 @@
 
 #include <core/Hydrogen.h>
 
-WidgetWithInput::WidgetWithInput( QWidget* parent, bool bUseIntSteps,
-								  const QString& sBaseToolTip, int nScrollSpeed,
-								  int nScrollSpeedFast, float fMin, float fMax,
-								  bool bModifyOnChange )
-	: QWidget( parent )
-	, m_bUseIntSteps( bUseIntSteps )
-	, m_nScrollSpeed( nScrollSpeed )
-	, m_nScrollSpeedFast( nScrollSpeedFast )
-	, m_fMin( fMin )
-	, m_fMax( fMax )
-	, m_fDefaultValue( fMin )
-	, m_fValue( fMin )
-	, m_fMousePressValue( 0.0 )
-	, m_fMousePressY( 0.0 )
-	, m_bIgnoreMouseMove( false )
-	, m_bEntered( false )
-	, m_bIsActive( true )
-	, m_nWidgetHeight( 20 )
-	, m_nWidgetWidth( 20 )
-	, m_sInputBuffer( "" )
-	, m_bModifyOnChange( bModifyOnChange ) {
-	
+WidgetWithInput::WidgetWithInput(
+	QWidget* parent,
+	bool bUseIntSteps,
+	const QString& sBaseToolTip,
+	int nScrollSpeed,
+	int nScrollSpeedFast,
+	float fMin,
+	float fMax
+)
+	: QWidget( parent ),
+	  m_bUseIntSteps( bUseIntSteps ),
+	  m_nScrollSpeed( nScrollSpeed ),
+	  m_nScrollSpeedFast( nScrollSpeedFast ),
+	  m_fMin( fMin ),
+	  m_fMax( fMax ),
+	  m_fDefaultValue( fMin ),
+	  m_fValue( fMin ),
+	  m_fMousePressValue( 0.0 ),
+	  m_fMousePressY( 0.0 ),
+	  m_bIgnoreMouseMove( false ),
+	  m_bEntered( false ),
+	  m_bIsActive( true ),
+	  m_nWidgetHeight( 20 ),
+	  m_nWidgetWidth( 20 ),
+	  m_sInputBuffer( "" )
+{
+	m_nModifierTarget = Modifier::None;
+
 	setAttribute( Qt::WA_Hover );
 	setFocusPolicy( Qt::ClickFocus );
 	setBaseToolTip( sBaseToolTip );
@@ -125,8 +131,9 @@ void WidgetWithInput::setValue( float fValue, bool bTriggeredByUserInteraction,
 		updateToolTip();
 		update();
 
-		if ( m_bModifyOnChange && bTriggeredByUserInteraction ) {
-			H2Core::Hydrogen::get_instance()->setSongModified( true );
+		if ( m_nModifierTarget != Modifier::None &&
+			 bTriggeredByUserInteraction ) {
+			modify();
 		}
 	}
 }

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -143,7 +143,7 @@ protected:
 	QString m_sInputBuffer;
 		TimePoint m_lastInputEvent;
 
-	/** Whether Hydrogen::setIsModified() is invoked with `true` as
+	/** Whether Hydrogen::setSongModified() is invoked with `true` as
 		soon as the value of the widget does change.*/
 	bool m_bModifyOnChange;
 };

--- a/src/gui/src/Widgets/WidgetWithInput.h
+++ b/src/gui/src/Widgets/WidgetWithInput.h
@@ -30,6 +30,7 @@
 #include <QtWidgets>
 
 #include "MidiLearnable.h"
+#include "Modifier.h"
 
 #include <core/Basics/Event.h>
 #include <core/Helpers/Time.h>
@@ -58,19 +59,18 @@
  * key press will fill a fresh buffer. Alternatively, the user can use
  * the ESC key to immediately flush the input buffer.
  */
-class WidgetWithInput : public QWidget, public MidiLearnable {
+class WidgetWithInput : public QWidget, public Modifier, public MidiLearnable {
 	Q_OBJECT
 
-public:
-		/** Number of seconds before #m_sInputBuffer will be flushed (happens
-			asynchronically whenever the next key input occurs.)*/
-		static constexpr std::chrono::duration<float> nInputTimeout =
-			std::chrono::duration<float>(2);
+   public:
+	/** Number of seconds before #m_sInputBuffer will be flushed (happens
+		asynchronically whenever the next key input occurs.)*/
+	static constexpr std::chrono::duration<float> nInputTimeout =
+		std::chrono::duration<float>( 2 );
 
 	WidgetWithInput( QWidget* parent, bool bUseIntSteps,
 					 const QString& sBaseToolTip, int nScrollSpeed,
-					 int nScrollSpeedFast, float fMin, float fMax,
-					 bool bModifyOnChange );
+					 int nScrollSpeedFast, float fMin, float fMax );
 	~WidgetWithInput();
 	void setMin( float fMin );
 	float getMin() const;
@@ -142,10 +142,6 @@ protected:
 	/** All key input will be appended to this string.*/
 	QString m_sInputBuffer;
 		TimePoint m_lastInputEvent;
-
-	/** Whether Hydrogen::setSongModified() is invoked with `true` as
-		soon as the value of the widget does change.*/
-	bool m_bModifyOnChange;
 };
 
 inline float WidgetWithInput::getValue() const {

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -503,14 +503,14 @@ int main(int argc, char *argv[])
 				 NsmClient::get_instance()->getIsNewSession() ) {
 				
 				NsmClient::get_instance()->sendDirtyState( true );
-				pHydrogen->setIsModified( true );
+				pHydrogen->setSongModified( true );
 			}
 			else {
 				NsmClient::get_instance()->sendDirtyState( false );
-				pHydrogen->setIsModified( false );
+				pHydrogen->setSongModified( false );
 			}
 #else
-			pHydrogen->setIsModified( false );
+			pHydrogen->setSongModified( false );
 #endif
 		}
 

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -1256,7 +1256,7 @@ void XmlTest::testWriteToNonExistingDir() {
 	const QString sTmpDir =
 		H2Core::Filesystem::tmpDir() + "non-existing-xml-test";
 	const QString sTmpPath =
-		QString( "%1/non/existing/sub/folder/test.h2pattern" );
+		QString( "%1/non/existing/sub/folder/test.h2pattern" ).arg( sTmpDir );
 
 	auto pPattern = std::make_shared<Pattern>();
 	CPPUNIT_ASSERT( pPattern->save( sTmpPath ) );

--- a/src/tests/XmlTest.cpp
+++ b/src/tests/XmlTest.cpp
@@ -41,6 +41,7 @@
 #include <core/Helpers/Xml.h>
 #include <core/Preferences/Preferences.h>
 #include <core/License.h>
+#include <core/SoundLibrary/SongInfo.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
 #include <QDir>
@@ -989,6 +990,25 @@ void XmlTest::testSongLegacy() {
 	CPPUNIT_ASSERT( Filesystem::rm( sKitDirUser, true /* recursive */,
 									false /* bSilent */ ) );
 
+	___INFOLOG( "passed" );
+}
+
+void XmlTest::testSongLoadFromInfo() {
+	___INFOLOG( "" );
+
+	auto pCurrentSong = Hydrogen::get_instance()->getSong();
+	CPPUNIT_ASSERT( pCurrentSong );
+
+	auto pInfo = std::make_shared<SongInfo>();
+	CPPUNIT_ASSERT( pInfo->load( H2TEST_FILE( "song/current.h2song" ) ) );
+
+	if ( pCurrentSong->getIsModified() ) {
+		pCurrentSong->setIsModified( false );
+	}
+
+	auto pAnotherSong = Song::from( pInfo );
+
+	CPPUNIT_ASSERT( ! pCurrentSong->getIsModified() );
 	___INFOLOG( "passed" );
 }
 

--- a/src/tests/XmlTest.h
+++ b/src/tests/XmlTest.h
@@ -51,9 +51,10 @@ class XmlTest : public CppUnit::TestCase {
 	CPPUNIT_TEST(testPlaylistFormatIntegrity);
 	CPPUNIT_TEST(testPlaylist);
 	CPPUNIT_TEST(checkTestPatterns);
-	CPPUNIT_TEST(testSongFormatIntegrity);
 	CPPUNIT_TEST(testSong);
+	CPPUNIT_TEST(testSongFormatIntegrity);
 	CPPUNIT_TEST(testSongLegacy);
+	CPPUNIT_TEST(testSongLoadFromInfo);
 	CPPUNIT_TEST(testPreferencesFormatIntegrity);
 	CPPUNIT_TEST(testShippedPreferences);
 	CPPUNIT_TEST(testShippedThemes);
@@ -98,17 +99,21 @@ class XmlTest : public CppUnit::TestCase {
 		void testPlaylistFormatIntegrity();
 		void testPlaylist();
 
+		void testSong();
 		/** Checks whether the format of `.h2song` files did change. */
 		void testSongFormatIntegrity();
-		void testSong();
-		// In the beginning of the 1.X.X series we had a lot of changes
-		// regarding how instruments are stored in a song and how the associated
-		// samples are looked up. Unfortunately, shortcomings of the individual
-		// approaches manifested only one at a time.
-		//
-		// This test loads song of various versions and checks whether all
-		// samples could be loaded.
+		/** In the beginning of the 1.X.X series we had a lot of changes
+		 * regarding how instruments are stored in a song and how the associated
+		 * samples are looked up. Unfortunately, shortcomings of the individual
+		 * approaches manifested only one at a time.
+		 *
+		 * This test loads song of various versions and checks whether all
+		 * samples could be loaded. */
 		void testSongLegacy();
+		/** When loading an entire song from a #SongInfo - as done for property
+		 * editing or duplication in the sound library - the current song must
+		 * not be marked modified. */
+		void testSongLoadFromInfo();
 
 		/** Checks whether the format of our preferences file `hydrogen.conf`
 		 * did change. */


### PR DESCRIPTION
Previously we marked

- the overall song
- samples
- playlists

as modified by appending an `*`. However, two of our main artifacts - patterns and drumkits - were not handled.

This patch introduces `*` for those artifacts as well. But only for those artifacts already backed by a file. It is intended to indicate the need to write back information to the file the artifact was loaded from to avoid a loss of information.