### PR TITLE
Support arbitrary folders within the Sound Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,7 @@ All notable changes to this project will be documented in this file.
   - Multiple instruments and pattern can be added at once.
   - A detail view showing basic information about the selected item was added.
     It can be configured using a right-click context menu.
+  - Arbitrary folders can be added to the library.
 - JACK per-track output ports are now mapped on drumkit switch or manipulation
   on instrument with same type. Ports of instruments without type aren't mapped
   at all (same as for notes) (#1071).

--- a/data/hydrogen.default.conf
+++ b/data/hydrogen.default.conf
@@ -368,6 +368,7 @@
   <lastSongFilename></lastSongFilename>
   <lastPlaylistFilename></lastPlaylistFilename>
   <defaulteditor></defaulteditor>
+  <customSoundLibraryDirs/>
  </files>
  <midiEventMap/>
  <midiInstrumentMap>

--- a/data/i18n/hydrogen_ca.ts
+++ b/data/i18n/hydrogen_ca.ts
@@ -1381,11 +1381,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1603,6 +1598,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_cs.ts
+++ b/data/i18n/hydrogen_cs.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_de.ts
+++ b/data/i18n/hydrogen_de.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_el.ts
+++ b/data/i18n/hydrogen_el.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en.ts
+++ b/data/i18n/hydrogen_en.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_en_GB.ts
+++ b/data/i18n/hydrogen_en_GB.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_es.ts
+++ b/data/i18n/hydrogen_es.ts
@@ -1381,11 +1381,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1603,6 +1598,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_fr.ts
+++ b/data/i18n/hydrogen_fr.ts
@@ -1381,11 +1381,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1603,6 +1598,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_gl.ts
+++ b/data/i18n/hydrogen_gl.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hr.ts
+++ b/data/i18n/hydrogen_hr.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_hu_HU.ts
+++ b/data/i18n/hydrogen_hu_HU.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_it.ts
+++ b/data/i18n/hydrogen_it.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ja.ts
+++ b/data/i18n/hydrogen_ja.ts
@@ -1381,11 +1381,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1603,6 +1598,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_nl.ts
+++ b/data/i18n/hydrogen_nl.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pl.ts
+++ b/data/i18n/hydrogen_pl.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_pt_BR.ts
+++ b/data/i18n/hydrogen_pt_BR.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_ru.ts
+++ b/data/i18n/hydrogen_ru.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sr.ts
+++ b/data/i18n/hydrogen_sr.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_sv.ts
+++ b/data/i18n/hydrogen_sv.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_uk.ts
+++ b/data/i18n/hydrogen_uk.ts
@@ -1380,11 +1380,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1602,6 +1597,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/data/i18n/hydrogen_zh_CN.ts
+++ b/data/i18n/hydrogen_zh_CN.ts
@@ -1381,11 +1381,6 @@ Please set your system&apos;s locale to UTF-8!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save to Sound Library</source>
-        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Keep</source>
         <extracomment>Text displayed on a Keep button of a dialog. The character after the &apos;&amp;&apos; symbol can be used as a hotkey and the &apos;&amp;&apos; symbol itself will not be displayed.</extracomment>
         <translation type="unfinished"></translation>
@@ -1603,6 +1598,16 @@ Please set your system&apos;s locale to UTF-8!</source>
     <message>
         <source>&apos;Name&apos; must not be left empty</source>
         <extracomment>Text in warning dialog shown in case the line edit associated with the * translatable string m_sNameDialog within a properties dialog has no * content..</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add folder to Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove folder from Library</source>
+        <extracomment>Names an action in a drop down or pop up menu. (with no further text)</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/core/Basics/Pattern.cpp
+++ b/src/core/Basics/Pattern.cpp
@@ -550,6 +550,18 @@ void Pattern::applyMissingTypes(
 				}
 			}
 			if ( pDrumkitMap == nullptr ) {
+				// Kits in folders manually added by the user have a similar
+				// priority.
+				for ( const auto& [_, ppDrumkit] : pDB->getDrumkitDatabase() ) {
+					if ( ppDrumkit != nullptr &&
+						 ppDrumkit->getContext() == Filesystem::Context::Custom &&
+						 ppDrumkit->getName() == m_sDrumkitName ) {
+						pDrumkitMap = ppDrumkit->toDrumkitMap();
+						break;
+					}
+				}
+			}
+			if ( pDrumkitMap == nullptr ) {
 				// Kits in the user's drumkit folder are next.
 				for ( const auto& [_, ppDrumkit] : pDB->getDrumkitDatabase() ) {
 					if ( ppDrumkit != nullptr &&

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -34,6 +34,7 @@
 #include <core/config.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Hydrogen.h>
+#include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
 
 #ifdef H2CORE_HAVE_OSC
@@ -131,6 +132,12 @@ Filesystem::Context Filesystem::DetermineContext( const QString& sPath )
 			return Filesystem::Context::User;
 		}
 		else {
+			for ( const auto& ssPath :
+				  Preferences::get_instance()->getCustomSoundLibraryDirs() ) {
+				if ( sAbsolutePath.contains( ssPath ) ) {
+					return Filesystem::Context::Custom;
+				}
+			}
 			if ( Filesystem::dirWritable( sAbsolutePath, true ) ) {
 				return Filesystem::Context::SessionReadWrite;
 			}
@@ -157,6 +164,8 @@ QString Filesystem::ContextToQString( const Context& context )
 			return "SessionReadWrite";
 		case Filesystem::Context::Song:
 			return "Song";
+		case Filesystem::Context::Custom:
+			return "Custom";
 		default:
 			return QString( "Unknown context [%1]" )
 				.arg( static_cast<int>( context ) );
@@ -1488,9 +1497,13 @@ QStringList Filesystem::targetDirs( Artifact artifact, Context context )
 		return results;
 	}
 
+	if ( context == Context::Custom ) {
+		return Preferences::get_instance()->getCustomSoundLibraryDirs();
+	}
+
 	switch ( artifact ) {
 		case Artifact::DrumkitBundled: {
-			ERRORLOG( "There is no common folder for bundled drumkits." );
+			ERRORLOG( "Bunled drumkits have to be imported first." );
 			return results;
 		}
 		case Artifact::DrumkitExtracted: {

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -48,29 +48,31 @@ class Filesystem : public H2Core::Object<Filesystem> {
 
 	/** Indicates usage, storage, and access permissions of a kit.*/
 	enum class Context {
-		/** Kit is located in the system-level drumkit folder, loaded into the
+		/** Artifact is located in a system-level folder, loaded into the
 		 * #H2Core::SoundlibraryDatabase during startup, and is read-only.*/
 		System = 0,
-		/** Kit is located in the user-level drumkit folder, loaded into the
+		/** Artifact is located in the user-level folder, loaded into the
 		 * #H2Core::SoundlibraryDatabase during startup, and can be modified.*/
 		User = 1,
-		/** Kit is located at an arbitrary location of the host system and was
+		/** Artifact is located at an arbitrary location of the host system and was
 		 * loaded into Hydrogen during a session using e.g. OSC or its location
 		 * was provided during startup. It is transient and located in a place
 		 * the user only has read-only access and can not be modified.*/
 		SessionReadOnly = 2,
-		/** Kit is located at an arbitrary location of the host system and was
+		/** Artifact is located at an arbitrary location of the host system and was
 		 * loaded into Hydrogen during a session using e.g. OSC or its location
 		 * was provided during startup. It is transient and can be modified.*/
 		SessionReadWrite = 3,
-		/** In contrast to the other contexts this drumkit was not loaded from a
-		 * .h2drumkit or a drumkit.xml file within a drumkit folder. Instead, it
-		 * is part of a song and loaded with a .h2song or created with a new
-		 * song. It is stored with the song when saving the song and can be
-		 * converted into a regular kit by saving / exporting the drumkit. All
-		 * its metadata, like drumkit image, end up in a cache folder for
+		/** In contrast to the other contexts this artifact was not loaded from
+		 * a separate file. Instead, it is part of a song and loaded with a
+		 * .h2song or created with a new song. It is stored with the song when
+		 * saving the song and can be converted into a regular artifact by Save
+		 * As / Export. For drumkits image ends up in a cache folder for
 		 * Hydrogen.*/
-		Song = 4
+		Song = 4,
+		/** The artifact resides in one of the folders manually added to the
+		 * SoundLibrary by the user herself. */
+		Custom = 5,
 	};
 	static QString ContextToQString( const Context& context );
 	static Context DetermineContext( const QString& sPath );

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -135,6 +135,7 @@ Preferences::Preferences()
 	  m_bShowNoteOverwriteWarning( true ),
 	  m_sLastSongPath( "" ),
 	  m_sLastPlaylistPath( "" ),
+	  m_customSoundLibraryDirs( QStringList() ),
 	  m_bHearNewNotes( true ),
 	  m_bQuantizeEvents( true ),
 	  m_recentFiles( QStringList() ),
@@ -332,6 +333,7 @@ Preferences::Preferences( std::shared_ptr<Preferences> pOther )
 	  m_bShowNoteOverwriteWarning( pOther->m_bShowNoteOverwriteWarning ),
 	  m_sLastSongPath( pOther->m_sLastSongPath ),
 	  m_sLastPlaylistPath( pOther->m_sLastPlaylistPath ),
+	  m_customSoundLibraryDirs( pOther->m_customSoundLibraryDirs ),
 	  m_bHearNewNotes( pOther->m_bHearNewNotes ),
 	  m_nPunchInPos( pOther->m_nPunchInPos ),
 	  m_nPunchOutPos( pOther->m_nPunchOutPos ),
@@ -1316,6 +1318,16 @@ Preferences::load( const QString& sPath, const bool bSilent )
 		pPref->m_sDefaultEditor = filesNode.read_string(
 			"defaulteditor", pPref->m_sDefaultEditor, false, true, bSilent
 		);
+		const XMLNode customDirsNode =
+			filesNode.firstChildElement( "customSoundLibraryDirs" );
+		if ( !customDirsNode.isNull() ) {
+			auto customDirNode = customDirsNode.firstChildElement( "dir" );
+			while ( !customDirNode.isNull() && !customDirNode.text().isEmpty()
+			) {
+				pPref->m_customSoundLibraryDirs << customDirNode.text();
+				customDirNode = customDirNode.nextSiblingElement( "dir" );
+			}
+		}
 	}
 	else {
 		WARNINGLOG( "<files> node not found" );
@@ -1904,6 +1916,13 @@ bool Preferences::saveTo( const QString& sPath, const bool bSilent ) const
 			"lastPlaylistFilename", m_sLastPlaylistPath
 		);
 		filesNode.write_string( "defaulteditor", m_sDefaultEditor );
+
+		XMLNode customDirsNode = filesNode.createNode( "customSoundLibraryDirs" );
+		for ( const auto& sDir : m_customSoundLibraryDirs ) {
+			if ( !sDir.isEmpty() ) {
+				customDirsNode.write_string( "dir", sDir );
+			}
+		}
 	}
 
 	m_pMidiEventMap->saveTo( rootNode, bSilent );
@@ -2414,6 +2433,10 @@ QString Preferences::toQString( const QString& sPrefix, bool bShort ) const
 							 .arg( sPrefix )
 							 .arg( s )
 							 .arg( m_sLastPlaylistPath ) )
+				.append( QString( "%1%2m_customSoundLibraryDirs: [%3]\n" )
+							 .arg( sPrefix )
+							 .arg( s )
+							 .arg( m_customSoundLibraryDirs.join( ", " ) ) )
 				.append( QString( "%1%2m_bHearNewNotes: %3\n" )
 							 .arg( sPrefix )
 							 .arg( s )
@@ -2840,6 +2863,8 @@ QString Preferences::toQString( const QString& sPrefix, bool bShort ) const
 							 .arg( m_sLastSongPath ) )
 				.append( QString( ", m_sLastPlaylistPath: %1" )
 							 .arg( m_sLastPlaylistPath ) )
+				.append( QString( ", m_customSoundLibraryDirs: [%1]" )
+							 .arg( m_customSoundLibraryDirs.join( ", " ) ) )
 				.append(
 					QString( ", m_bHearNewNotes: %1" ).arg( m_bHearNewNotes )
 				)

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -394,6 +394,9 @@ class Preferences : public H2Core::Object<Preferences> {
 	const QString& getLastPlaylistPath() const;
 	void setLastPlaylistPath( const QString& sPath );
 
+	const QStringList& getCustomSoundLibraryDirs() const;
+	void setCustomSoundLibraryDirs( const QStringList& folders );
+
 	bool getHearNewNotes() const;
 	void setHearNewNotes( bool value );
 
@@ -616,6 +619,8 @@ class Preferences : public H2Core::Object<Preferences> {
 	///< Last song used
 	QString m_sLastSongPath;
 	QString m_sLastPlaylistPath;
+
+	QStringList m_customSoundLibraryDirs;
 
 	bool m_bHearNewNotes;
 	int m_nPunchInPos;
@@ -1090,6 +1095,15 @@ inline void Preferences::setLastPlaylistPath( const QString& sPath )
 inline const QString& Preferences::getLastPlaylistPath() const
 {
 	return m_sLastPlaylistPath;
+}
+
+inline void Preferences::setCustomSoundLibraryDirs( const QStringList& folders )
+{
+	m_customSoundLibraryDirs = folders;
+}
+inline const QStringList& Preferences::getCustomSoundLibraryDirs() const
+{
+	return m_customSoundLibraryDirs;
 }
 
 inline void Preferences::setHearNewNotes( bool value )

--- a/src/core/SoundLibrary/SoundLibraryDatabase.cpp
+++ b/src/core/SoundLibrary/SoundLibraryDatabase.cpp
@@ -63,6 +63,7 @@ QString SoundLibraryDatabase::findArtifact(
 
 	std::vector<Filesystem::Context> contexts;
 	if ( bStacked ) {
+		contexts.push_back( Filesystem::Context::Custom );
 		contexts.push_back( Filesystem::Context::SessionReadOnly );
 		contexts.push_back( Filesystem::Context::User );
 		contexts.push_back( Filesystem::Context::System );
@@ -199,6 +200,9 @@ void SoundLibraryDatabase::updateDrumkits( Event::Trigger trigger )
 	drumkitPaths << Filesystem::listContent(
 		Filesystem::Artifact::DrumkitExtracted,
 		Filesystem::Context::SessionReadOnly
+	);
+	drumkitPaths << Filesystem::listContent(
+		Filesystem::Artifact::DrumkitExtracted, Filesystem::Context::Custom
 	);
 
 	// custom drumkits added by the user
@@ -488,6 +492,9 @@ void SoundLibraryDatabase::updatePatterns( Event::Trigger trigger )
 	patternPaths << Filesystem::listContent(
 		Filesystem::Artifact::Pattern, Filesystem::Context::User
 	);
+	patternPaths << Filesystem::listContent(
+		Filesystem::Artifact::Pattern, Filesystem::Context::Custom
+	);
 
 	for ( const auto& ssPath : patternPaths ) {
 		auto pInfo = std::make_shared<PatternInfo>();
@@ -522,6 +529,9 @@ void SoundLibraryDatabase::updateSongs( Event::Trigger trigger )
 	);
 	songPaths << Filesystem::listContent(
 		Filesystem::Artifact::Song, Filesystem::Context::User
+	);
+	songPaths << Filesystem::listContent(
+		Filesystem::Artifact::Song, Filesystem::Context::Custom
 	);
 
 	for ( const auto& ssPath : songPaths ) {

--- a/src/gui/src/CommonStrings.cpp
+++ b/src/gui/src/CommonStrings.cpp
@@ -606,7 +606,9 @@ CommonStrings::CommonStrings(){
 	/*: Names an action in a drop down or pop up menu. (with no further text)*/
 	m_sMenuActionLoad = tr( "Load" );
 	/*: Names an action in a drop down or pop up menu. (with no further text)*/
-	m_sMenuActionSaveToSoundLibrary = tr( "Save to Sound Library" );
+	m_sMenuActionAddDirToSoundLibrary = tr( "Add folder to Library" );
+	/*: Names an action in a drop down or pop up menu. (with no further text)*/
+	m_sMenuActionRemoveDirFromSoundLibrary = tr( "Remove folder from Library" );
 	/*: Names an action in a drop down or pop up menu. (with no further text)*/
 	m_sMenuActionExport = tr( "Export" );
 	/*: Names an action in a drop down or pop up menu. (with no further text)*/

--- a/src/gui/src/CommonStrings.h
+++ b/src/gui/src/CommonStrings.h
@@ -430,9 +430,13 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	const QString& getMenuActionDelete() const { return m_sMenuActionDelete; }
 	const QString& getMenuActionRename() const { return m_sMenuActionRename; }
 	const QString& getMenuActionLoad() const { return m_sMenuActionLoad; }
-	const QString& getMenuActionSaveToSoundLibrary() const
+	const QString& getMenuActionAddDirToSoundLibrary() const
 	{
-		return m_sMenuActionSaveToSoundLibrary;
+		return m_sMenuActionAddDirToSoundLibrary;
+	}
+	const QString& getMenuActionRemoveDirFromSoundLibrary() const
+	{
+		return m_sMenuActionRemoveDirFromSoundLibrary;
 	}
 	const QString& getMenuActionExport() const { return m_sMenuActionExport; }
 	const QString& getMenuActionProperties() const
@@ -897,7 +901,8 @@ class CommonStrings : public H2Core::Object<CommonStrings> {
 	QString m_sMenuActionDelete;
 	QString m_sMenuActionRename;
 	QString m_sMenuActionLoad;
-	QString m_sMenuActionSaveToSoundLibrary;
+	QString m_sMenuActionAddDirToSoundLibrary;
+	QString m_sMenuActionRemoveDirFromSoundLibrary;
 	QString m_sMenuActionExport;
 	QString m_sMenuActionProperties;
 	QString m_sMenuActionDuplicate;

--- a/src/gui/src/DrumkitPropertiesDialog.cpp
+++ b/src/gui/src/DrumkitPropertiesDialog.cpp
@@ -388,6 +388,7 @@ DrumkitPropertiesDialog::DrumkitPropertiesDialog(
 		auto drumkitContext = pDrumkit->getContext();
 		if ( drumkitContext == Filesystem::Context::User ||
 			 drumkitContext == Filesystem::Context::SessionReadWrite ||
+			 drumkitContext == Filesystem::Context::Custom ||
 			 drumkitContext == Filesystem::Context::Song ) {
 			bWritable = true;
 		}

--- a/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.cpp
+++ b/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.cpp
@@ -51,6 +51,7 @@
 #include "../../Skin.h"
 #include "../../SongPropertiesDialog.h"
 #include "../../UndoActions.h"
+#include "../../Widgets/FileDialog.h"
 
 using namespace H2Core;
 
@@ -70,9 +71,10 @@ SoundLibraryTree::SoundLibraryTree(
 	setSelectionMode( QAbstractItemView::ExtendedSelection );
 	headerItem()->setHidden( true );
 
-	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
 
-	auto addDrumkitActions = [&]( QMenu* pMenu, bool bWritable, bool bAdd ) {
+	// Menus working on artifacts
+	auto addArtifactActions = [&]( QMenu* pMenu, bool bWritable, bool bAdd ) {
 		if ( m_bStandAlone ) {
 			return;
 		}
@@ -133,14 +135,36 @@ SoundLibraryTree::SoundLibraryTree(
 	};
 
 	m_pPopupMenu = new QMenu( this );
-	addDrumkitActions( m_pPopupMenu, true, false );
+	addArtifactActions( m_pPopupMenu, true, false );
 	m_pPopupMenuReadOnly = new QMenu( this );
-	addDrumkitActions( m_pPopupMenuReadOnly, false, false );
+	addArtifactActions( m_pPopupMenuReadOnly, false, false );
 
 	m_pPopupMenuAdd = new QMenu( this );
-	addDrumkitActions( m_pPopupMenuAdd, true, true );
+	addArtifactActions( m_pPopupMenuAdd, true, true );
 	m_pPopupMenuAddReadOnly = new QMenu( this );
-	addDrumkitActions( m_pPopupMenuAddReadOnly, false, true );
+	addArtifactActions( m_pPopupMenuAddReadOnly, false, true );
+
+	// Menus working on top-level folders
+	auto addDirActions = [&]( QMenu* pMenu, bool bWritable ) {
+		if ( m_bStandAlone ) {
+			return;
+		}
+		auto pDeleteAction = pMenu->addAction(
+			pCommonStrings->getMenuActionRemoveDirFromSoundLibrary(), this, SLOT( actionRemoveFolder() )
+		);
+		if ( !bWritable ) {
+			pDeleteAction->setEnabled( false );
+		}
+		pMenu->addAction(
+			pCommonStrings->getMenuActionAddDirToSoundLibrary(), this,
+			SLOT( actionAddFolder() )
+		);
+	};
+
+	m_pPopupMenuDir = new QMenu( this );
+	addDirActions( m_pPopupMenuDir, true );
+	m_pPopupMenuDirReadOnly = new QMenu( this );
+	addDirActions( m_pPopupMenuDirReadOnly, false );
 
 	// Select the expanded node (in case it is a drumkit). Else selecting an
 	// instrument would cause preview sounds of that instrument on each
@@ -237,6 +261,8 @@ void SoundLibraryTree::updateRegistry()
 {
 	clear();
 	m_registry.clear();
+	m_internalDirs.clear();
+	m_customDirs.clear();
 	m_pSessionItem = nullptr;
 	m_pSystemItem = nullptr;
 	m_pUserItem = nullptr;
@@ -272,7 +298,7 @@ void SoundLibraryTree::updateRegistry()
 	std::vector<std::shared_ptr<SoundLibraryInfo>> systemInfos;
 	std::vector<std::shared_ptr<SoundLibraryInfo>> userInfos;
 
-	// Separate patterns by context
+	// Separate artifacts by context
 	for ( const auto& ppInfo : infos ) {
 		if ( ppInfo == nullptr ) {
 			continue;
@@ -296,6 +322,7 @@ void SoundLibraryTree::updateRegistry()
 		m_pSessionItem->setFlags(
 			m_pSessionItem->flags() & ~Qt::ItemIsSelectable
 		);
+		m_internalDirs.push_back( m_pSessionItem );
 		addNodes( m_pSessionItem, sessionInfos, "" );
 	}
 	if ( userInfos.size() > 0 ) {
@@ -304,6 +331,7 @@ void SoundLibraryTree::updateRegistry()
 		m_pUserItem->setFont( 0, boldFont );
 		m_pUserItem->setExpanded( true );
 		m_pUserItem->setFlags( m_pUserItem->flags() & ~Qt::ItemIsSelectable );
+		m_internalDirs.push_back( m_pUserItem );
 		addNodes( m_pUserItem, userInfos, "" );
 	}
 	if ( systemInfos.size() > 0 ) {
@@ -314,6 +342,7 @@ void SoundLibraryTree::updateRegistry()
 		m_pSystemItem->setFlags(
 			m_pSystemItem->flags() & ~Qt::ItemIsSelectable
 		);
+		m_internalDirs.push_back( m_pSystemItem );
 		addNodes( m_pSystemItem, systemInfos, "" );
 	}
 }
@@ -772,6 +801,38 @@ void SoundLibraryTree::actionOnlineImport()
 	HydrogenApp::get_instance()->getMainForm()->action_drumkit_onlineImport();
 }
 
+void SoundLibraryTree::actionAddFolder()
+{
+	auto pPref = Preferences::get_instance();
+	const auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
+	FileDialog fd( this );
+
+	fd.setFileMode( QFileDialog::Directory );
+	fd.setDirectory( QDir::home() );
+	fd.setWindowTitle( pCommonStrings->getMenuActionAddDirToSoundLibrary() );
+	fd.setAcceptMode( QFileDialog::AcceptSave );
+	if ( fd.exec() != QDialog::Accepted ) {
+		return;
+	}
+
+	QString sDirPath = fd.selectedFiles().first();
+	if ( sDirPath.isEmpty() ) {
+		return;
+	}
+
+	auto customDirs = pPref->getCustomSoundLibraryDirs();
+	customDirs << sDirPath;
+	pPref->setCustomSoundLibraryDirs( customDirs );
+}
+void SoundLibraryTree::actionRemoveFolder()
+{
+	auto pHydrogen = Hydrogen::get_instance();
+	auto it = m_registry.find( currentItem() );
+	if ( it == m_registry.end() || it->second == nullptr ) {
+		return;
+	}
+}
+
 void SoundLibraryTree::recursivelyUpdateFont( QTreeWidgetItem* pItem )
 {
 	const auto pFontTheme = H2Core::Preferences::get_instance()->getFontTheme();
@@ -816,10 +877,10 @@ void SoundLibraryTree::mousePressEvent( QMouseEvent* event )
 
 	if ( event->button() == Qt::RightButton && !m_bStandAlone &&
 		 currentItem() != nullptr ) {
-		// Show popup menu
+		QMenu* pMenu = nullptr;
 		auto it = m_registry.find( currentItem() );
 		if ( it != m_registry.end() && it->second != nullptr ) {
-			QMenu* pMenu;
+			// Show popup menu for artifacts
 			if ( it->second->getContext() == Filesystem::Context::System ||
 				 it->second->getContext() ==
 					 Filesystem::Context::SessionReadOnly ) {
@@ -851,6 +912,18 @@ void SoundLibraryTree::mousePressEvent( QMouseEvent* event )
 				}
 			}
 
+		}
+		else {
+			// Popup menu for top-level folders
+			for ( const auto& ppItem : m_internalDirs ) {
+				if ( ppItem == currentItem() ) {
+					pMenu = m_pPopupMenuDirReadOnly;
+					break;
+				}
+			}
+		}
+
+		if ( pMenu != nullptr ) {
 			pMenu->popup( pEv->globalPosition().toPoint() );
 		}
 	}

--- a/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.cpp
+++ b/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.cpp
@@ -237,6 +237,14 @@ void SoundLibraryTree::updateFont()
 		m_pUserItem->setFont( 0, boldFont );
 		recursivelyUpdateFont( m_pUserItem );
 	}
+	if ( m_customDirs.size() > 0 ) {
+		for ( auto& ppItem : m_customDirs ) {
+			if ( ppItem != nullptr ) {
+				ppItem->setFont( 0, boldFont );
+				recursivelyUpdateFont( ppItem );
+			}
+		}
+	}
 }
 
 void SoundLibraryTree::updateInfo()
@@ -267,7 +275,8 @@ void SoundLibraryTree::updateRegistry()
 	m_pSystemItem = nullptr;
 	m_pUserItem = nullptr;
 
-	const auto pFontTheme = Preferences::get_instance()->getFontTheme();
+	const auto pPref = Preferences::get_instance();
+	const auto pFontTheme = pPref->getFontTheme();
 	auto pHydrogen = H2Core::Hydrogen::get_instance();
 	auto pSoundLibraryDatabase = pHydrogen->getSoundLibraryDatabase();
 	auto pCommonStrings = HydrogenApp::get_instance()->getCommonStrings();
@@ -297,8 +306,10 @@ void SoundLibraryTree::updateRegistry()
 	std::vector<std::shared_ptr<SoundLibraryInfo>> sessionInfos;
 	std::vector<std::shared_ptr<SoundLibraryInfo>> systemInfos;
 	std::vector<std::shared_ptr<SoundLibraryInfo>> userInfos;
+	std::map<QString, std::vector<std::shared_ptr<SoundLibraryInfo>>> customInfos;
 
 	// Separate artifacts by context
+	const auto customDirs = pPref->getCustomSoundLibraryDirs();
 	for ( const auto& ppInfo : infos ) {
 		if ( ppInfo == nullptr ) {
 			continue;
@@ -308,6 +319,20 @@ void SoundLibraryTree::updateRegistry()
 		}
 		else if ( ppInfo->getContext() == H2Core::Filesystem::Context::User ) {
 			userInfos.push_back( ppInfo );
+		}
+		else if ( ppInfo->getContext() == H2Core::Filesystem::Context::Custom ) {
+			for ( const auto& ssDir : customDirs ) {
+				if ( ppInfo->getPath().contains( ssDir ) ) {
+					if ( customInfos.find( ssDir ) != customInfos.end() ) {
+						customInfos[ ssDir ].push_back( ppInfo );
+					}
+					else {
+						std::vector<std::shared_ptr<SoundLibraryInfo>> infos;
+						infos.push_back( ppInfo );
+						customInfos[ ssDir ] = std::move( infos );
+					}
+				}
+			}
 		}
 		else {
 			sessionInfos.push_back( ppInfo );
@@ -324,6 +349,19 @@ void SoundLibraryTree::updateRegistry()
 		);
 		m_internalDirs.push_back( m_pSessionItem );
 		addNodes( m_pSessionItem, sessionInfos, "" );
+	}
+	if ( customInfos.size() > 0 ) {
+		for ( const auto& [ssLabel, iinfos] : customInfos ) {
+			auto pItem = new QTreeWidgetItem( this );
+			pItem->setText( 0, ssLabel );
+			pItem->setFont( 0, boldFont );
+			pItem->setExpanded( true );
+			pItem->setFlags(
+				pItem->flags() & ~Qt::ItemIsSelectable
+			);
+			m_customDirs.push_back( pItem );
+			addNodes( pItem, iinfos, ssLabel );
+		}
 	}
 	if ( userInfos.size() > 0 ) {
 		m_pUserItem = new QTreeWidgetItem( this );
@@ -823,14 +861,18 @@ void SoundLibraryTree::actionAddFolder()
 	auto customDirs = pPref->getCustomSoundLibraryDirs();
 	customDirs << sDirPath;
 	pPref->setCustomSoundLibraryDirs( customDirs );
+
+	Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
 }
 void SoundLibraryTree::actionRemoveFolder()
 {
-	auto pHydrogen = Hydrogen::get_instance();
-	auto it = m_registry.find( currentItem() );
-	if ( it == m_registry.end() || it->second == nullptr ) {
-		return;
-	}
+	auto pPref = Preferences::get_instance();
+
+	auto customDirs = pPref->getCustomSoundLibraryDirs();
+	customDirs.removeAll( currentItem()->text( 0 ) );
+	pPref->setCustomSoundLibraryDirs( customDirs );
+
+	Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
 }
 
 void SoundLibraryTree::recursivelyUpdateFont( QTreeWidgetItem* pItem )
@@ -918,6 +960,12 @@ void SoundLibraryTree::mousePressEvent( QMouseEvent* event )
 			for ( const auto& ppItem : m_internalDirs ) {
 				if ( ppItem == currentItem() ) {
 					pMenu = m_pPopupMenuDirReadOnly;
+					break;
+				}
+			}
+			for ( const auto& ppItem : m_customDirs ) {
+				if ( ppItem == currentItem() ) {
+					pMenu = m_pPopupMenuDir;
 					break;
 				}
 			}

--- a/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.cpp
+++ b/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.cpp
@@ -385,6 +385,33 @@ void SoundLibraryTree::updateRegistry()
 	}
 }
 
+void SoundLibraryTree::addDirToLibrary( const QString& sDirPath )
+{
+	if ( sDirPath.isEmpty() ) {
+		return;
+	}
+	auto pPref = Preferences::get_instance();
+
+	auto customDirs = pPref->getCustomSoundLibraryDirs();
+	customDirs << sDirPath;
+	pPref->setCustomSoundLibraryDirs( customDirs );
+
+	Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
+}
+void SoundLibraryTree::removeDirFromLibrary( const QString& sDirPath )
+{
+	if ( sDirPath.isEmpty() ) {
+		return;
+	}
+	auto pPref = Preferences::get_instance();
+
+	auto customDirs = pPref->getCustomSoundLibraryDirs();
+	customDirs.removeAll( sDirPath );
+	pPref->setCustomSoundLibraryDirs( customDirs );
+
+	Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
+}
+
 void SoundLibraryTree::actionAdd()
 {
 	auto pHydrogenApp = HydrogenApp::get_instance();
@@ -858,21 +885,20 @@ void SoundLibraryTree::actionAddFolder()
 		return;
 	}
 
-	auto customDirs = pPref->getCustomSoundLibraryDirs();
-	customDirs << sDirPath;
-	pPref->setCustomSoundLibraryDirs( customDirs );
-
-	Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
+	HydrogenApp::get_instance()->pushUndoCommand(
+		new SE_modifyCustomLibraryDirsAction(
+			sDirPath, SE_modifyCustomLibraryDirsAction::Action::Add
+		)
+	);
 }
 void SoundLibraryTree::actionRemoveFolder()
 {
-	auto pPref = Preferences::get_instance();
-
-	auto customDirs = pPref->getCustomSoundLibraryDirs();
-	customDirs.removeAll( currentItem()->text( 0 ) );
-	pPref->setCustomSoundLibraryDirs( customDirs );
-
-	Hydrogen::get_instance()->getSoundLibraryDatabase()->update();
+	HydrogenApp::get_instance()->pushUndoCommand(
+		new SE_modifyCustomLibraryDirsAction(
+			currentItem()->text( 0 ),
+			SE_modifyCustomLibraryDirsAction::Action::Remove
+		)
+	);
 }
 
 void SoundLibraryTree::recursivelyUpdateFont( QTreeWidgetItem* pItem )

--- a/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.h
+++ b/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.h
@@ -57,6 +57,9 @@ class SoundLibraryTree : public QTreeWidget,
 	void updateInfo();
 	void updateRegistry();
 
+	static void addDirToLibrary( const QString& sDirPath );
+	static void removeDirFromLibrary( const QString& sDirPath );
+
    public slots:
 	void actionAdd();
 	void actionLoad();

--- a/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.h
+++ b/src/gui/src/Rack/SoundLibrary/SoundLibraryTree.h
@@ -66,6 +66,8 @@ class SoundLibraryTree : public QTreeWidget,
 	void actionExport();
 	void actionImport();
 	void actionOnlineImport();
+	void actionAddFolder();
+	void actionRemoveFolder();
 
    signals:
 	void itemChanged( bool bSelected );
@@ -107,6 +109,9 @@ class SoundLibraryTree : public QTreeWidget,
 	QTreeWidgetItem* m_pSystemItem;
 	QTreeWidgetItem* m_pUserItem;
 
+	std::vector<QTreeWidgetItem*> m_internalDirs;
+	std::vector<QTreeWidgetItem*> m_customDirs;
+
 	QMenu* m_pPopupMenu;
 	QMenu* m_pPopupMenuReadOnly;
 	/** Second version of the menu backed by the same actions but with
@@ -115,6 +120,10 @@ class SoundLibraryTree : public QTreeWidget,
 	 * appended to the corresponding list of the current drumkit/song. */
 	QMenu* m_pPopupMenuAdd;
 	QMenu* m_pPopupMenuAddReadOnly;
+
+	/** Menu for the top-level nodes / folders. */
+	QMenu* m_pPopupMenuDir;
+	QMenu* m_pPopupMenuDirReadOnly;
 
 	/** Actions that remain available when multiple items are selected. All
 	 * other actions will be hidden in multi-select context. */

--- a/src/gui/src/UndoActions.h
+++ b/src/gui/src/UndoActions.h
@@ -57,6 +57,7 @@
 #include "PatternEditor/NotePropertiesRuler.h"
 #include "PatternEditor/DrumPatternEditor.h"
 #include "PatternEditor/PatternEditorPanel.h"
+#include "Rack/SoundLibrary/SoundLibraryTree.h"
 #include "SongEditor/PatternFillDialog.h"
 #include "SongEditor/SongEditor.h"
 #include "SongEditor/SongEditorPanel.h"
@@ -1780,6 +1781,48 @@ class SE_moveEnvelopePointAction : public QUndoCommand {
 	H2Core::EnvelopePoint m_oldPoint;
 	H2Core::EnvelopePoint m_newPoint;
 	SampleEditor::EnvelopeType m_envelopType;
+};
+
+class SE_modifyCustomLibraryDirsAction : public QUndoCommand {
+   public:
+	enum class Action { Add, Remove };
+	SE_modifyCustomLibraryDirsAction( const QString& sDirPath, Action action )
+		: m_sDirPath( sDirPath ), m_action( action )
+	{
+		const auto pCommonStrings =
+			HydrogenApp::get_instance()->getCommonStrings();
+		QString sText;
+		if ( action == Action::Add ) {
+			sText = pCommonStrings->getMenuActionAddDirToSoundLibrary();
+		}
+		else {
+			sText = pCommonStrings->getMenuActionRemoveDirFromSoundLibrary();
+		}
+		setText( QString( "%1: [%2]" ).arg( sText ).arg( sDirPath ) );
+	}
+
+	virtual void redo()
+	{
+		if ( m_action == Action::Add ) {
+			SoundLibraryTree::addDirToLibrary( m_sDirPath );
+		}
+		else {
+			SoundLibraryTree::removeDirFromLibrary( m_sDirPath );
+		}
+	}
+	virtual void undo()
+	{
+		if ( m_action == Action::Add ) {
+			SoundLibraryTree::removeDirFromLibrary( m_sDirPath );
+		}
+		else {
+			SoundLibraryTree::addDirToLibrary( m_sDirPath );
+		}
+	}
+
+   private:
+	QString m_sDirPath;
+	Action m_action;
 };
 
 #endif	// UNDOACTIONS_H

--- a/src/tests/data/preferences/current.conf
+++ b/src/tests/data/preferences/current.conf
@@ -384,6 +384,7 @@
   <lastSongFilename>/home/phil/tmp/NewSong.h2song</lastSongFilename>
   <lastPlaylistFilename></lastPlaylistFilename>
   <defaulteditor>/usr/local/bin/emacs</defaulteditor>
+  <customSoundLibraryDirs/>
  </files>
  <midiEventMap>
   <midiEvent>


### PR DESCRIPTION
Till now only the user-level and system-level data folders were scanned and included in the Sound Library. While this is a good starting point (downloaded assets are put in the user-level one), it most probably does not fit the specific needs of all users.

From now on, the user can add arbitrary folders to the library. This can be done by right-clicking one of the top-level nodes in the Sound Library widget. The action can be undone/redone as well.