### PR TITLE
Comply with XDG paths on Linux (#643)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -110,7 +110,7 @@ for:
 
       echo $DISPLAY_VERSION
 
-      cache_tag=usr_cache_jack # this can be modified to rebuild deps
+      cache_tag=usr_cache_online # this can be modified to rebuild deps
 
       cdir=$HOME/cache_dir
       cache_tar=$cdir/$cache_tag.tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- On Linux user-level files are now stored in XDG paths
+  (`$XDG_CONFIG_HOME/hydrogen/hydrogen.conf`, `$XDG_CACHE_HOME/hydrogen/`,
+  `$XDG_DATA_HOME/hydrogen/ `) in case no `~/.hydrogen` folder is present.
+  (#643).
 - Drumkit handling was reworked. Each song will now hold a proper drumkit.
   Tweaking its name, instruments etc. does not affect the kits in the Sound
   Library (user and system drumkit folder) unless it is explicitly saved to it.

--- a/linux/h2cli.1
+++ b/linux/h2cli.1
@@ -132,6 +132,6 @@ A player Hydrogen-based songs on the command line
 .SH COPYRIGHT AND LICENSE
 \fBCopyright (C)\fR 2002\-2008 Alessandro Cominu
 .br
-\fBCopyright (C)\fR 2008\-2025 The hydrogen development team
+\fBCopyright (C)\fR 2008\-2026 The hydrogen development team
 .PP
 \fBHydrogen\fR is free software; you can redistribute it and/or modify it under the terms of the GPL version 2 or later.

--- a/linux/h2player.1
+++ b/linux/h2player.1
@@ -57,6 +57,6 @@ A CLI tool for exporting songs and batch processing drumkits
 .SH COPYRIGHT AND LICENSE
 \fBCopyright (C)\fR 2002\-2008 Alessandro Cominu
 .br
-\fBCopyright (C)\fR 2008\-2025 The hydrogen development team
+\fBCopyright (C)\fR 2008\-2026 The hydrogen development team
 .PP
 \fBHydrogen\fR is free software; you can redistribute it and/or modify it under the terms of the GPL version 2 or later.

--- a/linux/hydrogen.1
+++ b/linux/hydrogen.1
@@ -53,13 +53,9 @@ Use an alternate system data path.
 .TP
 \fB\-\-user\-data\fR=\fIPATH\fR
 Use an alternate user data path.
-.IP
-The default one is \fB$HOME\fR/.hydrogen.
 .TP
 \fB\-\-config\fR=\fIPATH\fR
-Use an alternate config path.
-.IP
-The default one is \fB$HOME\fR/.hydrogen/hydrogen.conf.
+Use an alternate path to the \fIhydrogen.conf\fR file.
 .TP
 \fB\-\-layout\fR=\fILAYOUT\fR
 UI layout. Either \fItabbed\fR or \fIsingle\fR (default).
@@ -91,38 +87,62 @@ Show version info.
 Show this help message.
 .SH FILES
 .TP
-\fB$HOME\fR/.hydrogen/data/drumkits
-User-level drumkit folder. All drumkits you download via the online import as well as those you created manually will end up here. A portable version of a drumkit - the \fI.h2drumkit\fR tar archive file - can included into this folder using the \-\-install option. Only those kits residing either in this folder or in the system drumkit folder (for those kits you received via your package manager) will show up in the Sound Library.
+New installations of Hydrogen will follow XDG paths and create folders called \fIhydrogen\fR within the locations defined by the environmental variables:
+.RS
+.PP
+\(bu $XDG_CONFIG_HOME (defaults to \fI~/.config/\fR)
+.PP
+\(bu $XDG_CACHE_HOME  (defaults to \fI~/.cache/\fR)
+.PP
+\(bu $XDG_DATA_HOME   (defaults to \fI~/.local/share/\fR)
+.RE
+.PP
+Previous versions created a folder within the home directory called
+\fI~/.hydrogen\fR (note that this location could have been altered by a
+compilation option). If the old folder is found, it takes precedence over the
+XDG paths.
+.PP
+\fB$XDG_DATA_HOME/hydrogen/\fR (new)
+.br
+\fB$HOME/.hydrogen/data/\fR (old; takes precedence)
+.RS
 .TP
-\fB$HOME\fR/.hydrogen/data/patterns
-If you save a pattern, it will be exported as \fI.h2pattern\fR XML file into this folder. Only the patterns residing in here will show up in the Sound Library.
+\fBdrumkits/\fR
+User-level drumkit folder. All drumkits you download via the online import as well as those you created manually will end up here. A portable version of a drumkit - the \fI.h2drumkit\fR tar archive file - can included into this folder using the \-\-install option. Drumkits residing in this folder will be shown in the Sound Library by default.
 .TP
-\fB$HOME\fR/.hydrogen/data/playlists
+\fBpatterns/\fR
+Patterns - \fI.h2pattern\fR XML files - residing in this folder will be shown in the Sound Library by default.
+.TP
+\fBplaylists/\fR
 This folder may have been original designed for holding \fI.h2playlist\fR XML files. But it does not serve any special purpose anymore and you can put them where ever you want.
 .TP
-\fB$HOME\fR/.hydrogen/data/plugins
+\fBplugins/\fR
 In here you can put \fBLADSPA\fR plugins to be used by Hydrogen, which are not within \fBLADSPA_PATH\fR.
 .TP
-\fB$HOME\fR/.hydrogen/data/scripts
+\fBscripts/\fR
 Playlists in Hydrogen can be configured to run a \fBBASH\fR script before loading a particular song. This folder may have been original designed for holding those script but you can put them where ever you want.
 .TP
-\fB$HOME\fR/.hydrogen/data/songs
-If you want a \fI.h2song\fR XML file to show up in the Sound Library, you have to store it in here.
-.SH CONFIGURATION
+\fBsongs/\fR
+Songs - \fI.h2song\fR XML files - residing in this folder will be shown in the Sound Library by default.
 .TP
-\fB$HOME\fR/.hydrogen/hydrogen.conf
-XML file containing all configurations for Hydrogen.
-.TP
-\fB$HOME\fR/.hydrogen/data/emptySong.h2song
-Whenever you create a new song, it will be derived from this template.
-.TP
-\fB$HOME\fR/.hydrogen/data/themes/
+\fBthemes/\fR
 You can change colors, fonts, and many more in Hydrogen. These custom settings can be stored as \fI.h2theme\fR XML files in here by exporting the current theme in the Preferences dialog.
-.SH ENVIRONMENT
+.SH CONFIGURATION
 .PP
-.B LADSPA_PATH
-.HP 
+In new installations of Hydrogen the configuration file will be located at \fI$XDG_CONFIG_HOME/hydrogen/hydrogen.conf\fR. In case an old one at \fI~/.hydrogen/hydrogen.conf\fR is present, it takes precedence.
+.SH ENVIRONMENT
+.TP
+\fBLADSPA_PATH\fR
 Path to \fBLADSPA\fR plugins.
+.TP
+\fBXDG_CONFIG_HOME\fR
+Defines the folder that contains the configuration in \fIhydrogen/hydrogen.conf\fR.
+.TP
+\fBXDG_CACHE_HOME\fR
+Will be used to store session data.
+.TP
+\fBXDG_DATA_HOME\fR
+Will contain most user-level data within the subfolder \fIhydrogen\fR.
 .SH BUGS & FEATURES REQUEST
 .PP
 If you find any bug or if you would like to propose a new feature, please report it to https://github.com/hydrogen-music/hydrogen/issues
@@ -146,6 +166,6 @@ A player Hydrogen-based songs on the command line
 .SH COPYRIGHT AND LICENSE
 \fBCopyright (C)\fR 2002\-2008 Alessandro Cominu
 .br
-\fBCopyright (C)\fR 2008\-2025 The hydrogen development team
+\fBCopyright (C)\fR 2008\-2026 The hydrogen development team
 .PP
 \fBHydrogen\fR is free software; you can redistribute it and/or modify it under the terms of the GPL version 2 or later.

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -36,6 +36,10 @@
 #include <core/Hydrogen.h>
 #include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
+#if defined(Q_OS_MACX) || defined(WIN32)
+#else
+#include <QStandardPaths>
+#endif
 
 #ifdef H2CORE_HAVE_OSC
 #include <core/NsmClient.h>
@@ -102,8 +106,9 @@ const QString Filesystem::sPatternFilter = "Hydrogen Patterns (*.h2pattern)";
 const QString Filesystem::sPlaylistFilter = "Hydrogen Playlists (*.h2playlist)";
 
 QString Filesystem::m_sSystemDataPath;
-QString Filesystem::m_sUserDataPath;
+QString Filesystem::m_sUserCachePath;
 QString Filesystem::m_sUserConfigPath;
+QString Filesystem::m_sUserDataPath;
 
 #ifdef Q_OS_MACX
 QString Filesystem::m_sUserLogPath =
@@ -115,6 +120,7 @@ QString Filesystem::m_sUserLogPath =
 #else
 QString Filesystem::m_sUserLogPath =
 	QDir::homePath().append( "/" H2_USR_PATH "/" LOG_FILE );
+bool m_bLogPathInitialized = false;
 #endif
 
 QStringList Filesystem::m_ladspaPaths;
@@ -311,9 +317,27 @@ bool Filesystem::bootstrap(
 #else
 	m_sSystemDataPath = H2_SYS_PATH "/data/";
 #endif
-	m_sUserDataPath = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
-	m_sUserConfigPath =
-		QDir::homePath().append( "/" H2_USR_PATH "/" USR_CONFIG );
+	// If the old path exists (e.g. ~/.hydrogen), old path is used; else uses
+	// QStandardPaths to get XDG Paths on Linux.
+	if ( !QFileInfo::exists( QFileInfo( m_sUserConfigPath ).absolutePath() ) ) {
+		m_sUserConfigPath =
+			QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation
+			)
+				.append( "/" USR_CONFIG );
+		m_sUserDataPath = QStandardPaths::writableLocation(
+							  QStandardPaths::AppLocalDataLocation
+		)
+							  .append( "/" );
+		m_sUserCachePath =
+			QStandardPaths::writableLocation( QStandardPaths::CacheLocation )
+				.append( "/" );
+	}
+	else {
+		m_sUserCachePath = m_sUserDataPath + CACHE;
+		m_sUserDataPath = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
+		m_sUserConfigPath =
+			QDir::homePath().append( "/" H2_USR_PATH "/" USR_CONFIG );
+	}
 #endif
 	if ( !sSysDataPath.isEmpty() ) {
 		INFOLOG( QString( "Using custom system data folder [%1]" )
@@ -801,6 +825,21 @@ QString Filesystem::clickFilePath()
 }
 const QString& Filesystem::logFilePath()
 {
+	// Called within the Reporter prior to the bootstrap of Filesystem itself.
+	// Therefore we need some special treatments.
+#if defined( Q_OS_MACX ) || defined( WIN32 )
+#else
+	if ( !m_bLogPathInitialized ) {
+		if ( !QFileInfo::exists( QDir::homePath().append( "/" H2_USR_PATH )
+			 ) ) {
+			m_sUserLogPath = QStandardPaths::writableLocation(
+								 QStandardPaths::AppLocalDataLocation
+			)
+								 .append( "/" LOG_FILE );
+		}
+		m_bLogPathInitialized = true;
+	}
+#endif
 	return m_sUserLogPath;
 }
 
@@ -867,11 +906,19 @@ QString Filesystem::userPlaylistsDir()
 }
 QString Filesystem::cacheDir()
 {
+#if defined(Q_OS_MACX) || defined(WIN32)
 	return m_sUserDataPath + CACHE;
+#else
+	return m_sUserCachePath;
+#endif
 }
 QString Filesystem::repositoriesCacheDir()
 {
+#if defined(Q_OS_MACX) || defined(WIN32)
 	return m_sUserDataPath + CACHE + REPOSITORIES;
+#else
+	return m_sUserCachePath + REPOSITORIES;
+#endif
 }
 QString Filesystem::demosDir()
 {

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -578,7 +578,7 @@ bool Filesystem::pathUsable( const QString& sPath, bool bCreate, bool bSilent )
 {
 	if ( !QDir( sPath ).exists() ) {
 		if ( !bSilent ) {
-			INFOLOG( QString( "bCreate user directory : %1" ).arg( sPath ) );
+			INFOLOG( QString( "Create user directory : %1" ).arg( sPath ) );
 		}
 		if ( bCreate && !QDir( "/" ).mkpath( sPath ) ) {
 			ERRORLOG(

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -30,13 +30,18 @@
 #include <QDateTime>
 #include <QRegularExpression>
 
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
+#include <QtEnvironmentVariables>
+#else
+#include <QtGlobal>
+#endif
+
 #include <core/Basics/Drumkit.h>
 #include <core/config.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Hydrogen.h>
 #include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
-#include <QtEnvironmentVariables>
 
 #ifdef H2CORE_HAVE_OSC
 #include <core/NsmClient.h>
@@ -134,6 +139,25 @@ bool Filesystem::m_bLogPathInitialized = false;
 QStringList Filesystem::m_ladspaPaths;
 
 QString Filesystem::m_sPreferencesOverwritePath = "";
+
+static QString getEnvironmentVariable( const QString& sEnvironmentVariable )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
+	return qEnvironmentVariable( sEnvironmentVariable.toLocal8Bit().data() );
+#else
+	return QString( qgetenv( sEnvironmentVariable.toLocal8Bit().data() ) );
+#endif
+};
+
+static bool isEnvironmentVariableSet( const QString& sEnvironmentVariable )
+{
+#if QT_VERSION >= QT_VERSION_CHECK( 6, 8, 0 )
+	return qEnvironmentVariableIsSet( sEnvironmentVariable.toLocal8Bit().data()
+	);
+#else
+	return !qgetenv( sEnvironmentVariable.toLocal8Bit().data() ).isEmpty();
+#endif
+};
 
 Filesystem::Context Filesystem::DetermineContext( const QString& sPath )
 {
@@ -330,8 +354,8 @@ bool Filesystem::bootstrap(
 	// same location amongst all our binaries (bearing different application
 	// names). But we still allow the user to overwrite the default paths.
 	if ( !QFileInfo::exists( QDir::homePath().append( "/" H2_USR_PATH ) ) ) {
-		if ( qEnvironmentVariableIsSet( "XDG_CONFIG_HOME" ) ) {
-			m_sUserConfigPath = qEnvironmentVariable( "XDG_CONFIG_HOME" ) +
+		if ( isEnvironmentVariableSet( "XDG_CONFIG_HOME" ) ) {
+			m_sUserConfigPath = getEnvironmentVariable( "XDG_CONFIG_HOME" ) +
 								"/" + APPLICATION_NAME + "/" + USR_CONFIG;
 		}
 		else {
@@ -339,8 +363,8 @@ bool Filesystem::bootstrap(
 				QDir::homePath().append( "/" XDG_LINUX_CONFIG APPLICATION_NAME
 										 "/" USR_CONFIG );
 		}
-		if ( qEnvironmentVariableIsSet( "XDG_DATA_HOME" ) ) {
-			m_sUserDataPath = qEnvironmentVariable( "XDG_DATA_HOME" ) + "/" +
+		if ( isEnvironmentVariableSet( "XDG_DATA_HOME" ) ) {
+			m_sUserDataPath = getEnvironmentVariable( "XDG_DATA_HOME" ) + "/" +
 							  APPLICATION_NAME + "/";
 		}
 		else {
@@ -348,9 +372,9 @@ bool Filesystem::bootstrap(
 				QDir::homePath().append( "/" XDG_LINUX_DATA APPLICATION_NAME "/"
 				);
 		}
-		if ( qEnvironmentVariableIsSet( "XDG_CACHE_HOME" ) ) {
-			m_sUserCachePath = qEnvironmentVariable( "XDG_CACHE_HOME" ) + "/" +
-							   APPLICATION_NAME + "/";
+		if ( isEnvironmentVariableSet( "XDG_CACHE_HOME" ) ) {
+			m_sUserCachePath = getEnvironmentVariable( "XDG_CACHE_HOME" ) +
+							   "/" + APPLICATION_NAME + "/";
 		}
 		else {
 			m_sUserCachePath =
@@ -858,8 +882,8 @@ const QString& Filesystem::logFilePath()
 	if ( !m_bLogPathInitialized ) {
 		if ( !QFileInfo::exists( QDir::homePath().append( "/" H2_USR_PATH )
 			 ) ) {
-			if ( qEnvironmentVariableIsSet( "XDG_DATA_HOME" ) ) {
-				m_sUserLogPath = qEnvironmentVariable( "XDG_DATA_HOME" ) + "/" +
+			if ( isEnvironmentVariableSet( "XDG_DATA_HOME" ) ) {
+				m_sUserLogPath = getEnvironmentVariable( "XDG_DATA_HOME" ) + "/" +
 								 APPLICATION_NAME + "/" + LOG_FILE;
 			}
 			else {

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -36,10 +36,7 @@
 #include <core/Hydrogen.h>
 #include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
-#if defined(Q_OS_MACX) || defined(WIN32)
-#else
-#include <QStandardPaths>
-#endif
+#include <qtenvironmentvariables.h>
 
 #ifdef H2CORE_HAVE_OSC
 #include <core/NsmClient.h>
@@ -62,6 +59,16 @@
 #define SONGS "songs/"
 #define THEMES "themes/"
 #define TMP "hydrogen/"
+
+// XDG-compliant paths for Linux systems. Note that we do not use QStandardPaths
+// because `hydrogen`, `h2cli`, and `h2player` must use the same folders while
+// not sharing the same application name. Just temporarily setting their
+// application name to "hydrogen" would be an even dirtier solution than
+// hard-coding paths.
+#define XDG_LINUX_CACHE ".cache/"
+#define XDG_LINUX_CONFIG ".config/"
+#define XDG_LINUX_DATA ".local/share/"
+#define APPLICATION_NAME "hydrogen"
 
 // files
 /** Sound of metronome beat */
@@ -319,19 +326,37 @@ bool Filesystem::bootstrap(
 	m_sSystemDataPath = H2_SYS_PATH "/data/";
 #endif
 	// If the old path exists (e.g. ~/.hydrogen), old path is used; else uses
-	// QStandardPaths to get XDG Paths on Linux.
+	// XDG Paths on Linux. We do not use QStandardPaths in order to share the
+	// same location amongst all our binaries (bearing different application
+	// names). But we still allow the user to overwrite the default paths.
 	if ( !QFileInfo::exists( QDir::homePath().append( "/" H2_USR_PATH ) ) ) {
-		m_sUserConfigPath =
-			QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation
-			)
-				.append( "/" USR_CONFIG );
-		m_sUserDataPath = QStandardPaths::writableLocation(
-							  QStandardPaths::AppLocalDataLocation
-		)
-							  .append( "/" );
-		m_sUserCachePath =
-			QStandardPaths::writableLocation( QStandardPaths::CacheLocation )
-				.append( "/" );
+		if ( qEnvironmentVariableIsSet( "XDG_CONFIG_HOME" ) ) {
+			m_sUserConfigPath = qEnvironmentVariable( "XDG_CONFIG_HOME" ) +
+								"/" + APPLICATION_NAME + "/" + USR_CONFIG;
+		}
+		else {
+			m_sUserConfigPath =
+				QDir::homePath().append( "/" XDG_LINUX_CONFIG APPLICATION_NAME
+										 "/" USR_CONFIG );
+		}
+		if ( qEnvironmentVariableIsSet( "XDG_DATA_HOME" ) ) {
+			m_sUserDataPath = qEnvironmentVariable( "XDG_DATA_HOME" ) + "/" +
+							  APPLICATION_NAME + "/";
+		}
+		else {
+			m_sUserDataPath =
+				QDir::homePath().append( "/" XDG_LINUX_DATA APPLICATION_NAME "/"
+				);
+		}
+		if ( qEnvironmentVariableIsSet( "XDG_CACHE_HOME" ) ) {
+			m_sUserCachePath = qEnvironmentVariable( "XDG_CACHE_HOME" ) + "/" +
+							   APPLICATION_NAME + "/";
+		}
+		else {
+			m_sUserCachePath =
+				QDir::homePath().append( "/" XDG_LINUX_CACHE APPLICATION_NAME
+										 "/" );
+		}
 	}
 	else {
 		m_sUserDataPath = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
@@ -833,10 +858,15 @@ const QString& Filesystem::logFilePath()
 	if ( !m_bLogPathInitialized ) {
 		if ( !QFileInfo::exists( QDir::homePath().append( "/" H2_USR_PATH )
 			 ) ) {
-			m_sUserLogPath = QStandardPaths::writableLocation(
-								 QStandardPaths::AppLocalDataLocation
-			)
-								 .append( "/" LOG_FILE );
+			if ( qEnvironmentVariableIsSet( "XDG_DATA_HOME" ) ) {
+				m_sUserLogPath = qEnvironmentVariable( "XDG_DATA_HOME" ) + "/" +
+								 APPLICATION_NAME + "/" + LOG_FILE;
+			}
+			else {
+				m_sUserLogPath =
+					QDir::homePath().append( "/" XDG_LINUX_DATA APPLICATION_NAME
+											 "/" LOG_FILE );
+			}
 		}
 		m_bLogPathInitialized = true;
 	}

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -120,8 +120,9 @@ QString Filesystem::m_sUserLogPath =
 #else
 QString Filesystem::m_sUserLogPath =
 	QDir::homePath().append( "/" H2_USR_PATH "/" LOG_FILE );
-bool m_bLogPathInitialized = false;
 #endif
+
+bool Filesystem::m_bLogPathInitialized = false;
 
 QStringList Filesystem::m_ladspaPaths;
 
@@ -319,7 +320,7 @@ bool Filesystem::bootstrap(
 #endif
 	// If the old path exists (e.g. ~/.hydrogen), old path is used; else uses
 	// QStandardPaths to get XDG Paths on Linux.
-	if ( !QFileInfo::exists( QFileInfo( m_sUserConfigPath ).absolutePath() ) ) {
+	if ( !QFileInfo::exists( QDir::homePath().append( "/" H2_USR_PATH ) ) ) {
 		m_sUserConfigPath =
 			QStandardPaths::writableLocation( QStandardPaths::AppConfigLocation
 			)
@@ -333,8 +334,8 @@ bool Filesystem::bootstrap(
 				.append( "/" );
 	}
 	else {
-		m_sUserCachePath = m_sUserDataPath + CACHE;
 		m_sUserDataPath = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
+		m_sUserCachePath = m_sUserDataPath + CACHE;
 		m_sUserConfigPath =
 			QDir::homePath().append( "/" H2_USR_PATH "/" USR_CONFIG );
 	}

--- a/src/core/Helpers/Filesystem.cpp
+++ b/src/core/Helpers/Filesystem.cpp
@@ -36,7 +36,7 @@
 #include <core/Hydrogen.h>
 #include <core/Preferences/Preferences.h>
 #include <core/SoundLibrary/SoundLibraryDatabase.h>
-#include <qtenvironmentvariables.h>
+#include <QtEnvironmentVariables>
 
 #ifdef H2CORE_HAVE_OSC
 #include <core/NsmClient.h>

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -545,11 +545,13 @@ class Filesystem : public H2Core::Object<Filesystem> {
 	 * LOCAL_DATA_PATH.
 	 */
 	static QString m_sSystemDataPath;  ///< the path to the system files
-	static QString m_sUserDataPath;	   ///< the path to the user files
+	static QString m_sUserCachePath;  ///< the path to the user config file
 	static QString m_sUserConfigPath;  ///< the path to the user config file
+	static QString m_sUserDataPath;	   ///< the path to the user files
 	static QString m_sUserLogPath;	   ///< the path to the log file
 	static QStringList m_ladspaPaths;  ///< paths to laspa plugins
 	static std::vector<AudioFormat> m_supportedAudioFormats;
+	static bool m_bLogPathInitialized;
 };
 
 inline const QString& Filesystem::getPreferencesOverwritePath()

--- a/src/core/Helpers/Filesystem.h
+++ b/src/core/Helpers/Filesystem.h
@@ -545,7 +545,7 @@ class Filesystem : public H2Core::Object<Filesystem> {
 	 * LOCAL_DATA_PATH.
 	 */
 	static QString m_sSystemDataPath;  ///< the path to the system files
-	static QString m_sUserCachePath;  ///< the path to the user config file
+	static QString m_sUserCachePath;  ///< the path to the user cache folder
 	static QString m_sUserConfigPath;  ///< the path to the user config file
 	static QString m_sUserDataPath;	   ///< the path to the user files
 	static QString m_sUserLogPath;	   ///< the path to the log file

--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -213,6 +213,7 @@ int main(int argc, char *argv[])
 #endif
 		// Create bootstrap QApplication to get H2 Core set up with correct Filesystem paths before starting GUI application.
 		QCoreApplication *pBootStrApp = new QCoreApplication( argc, argv );
+		pBootStrApp->setApplicationName( "hydrogen" );
 
 		Parser parser;
 		if ( ! parser.parse( argc, argv ) ) {

--- a/src/tests/CliTest.cpp
+++ b/src/tests/CliTest.cpp
@@ -31,6 +31,9 @@
 #include <core/Basics/Drumkit.h>
 #include <core/Helpers/Filesystem.h>
 #include <core/Helpers/Xml.h>
+#include <qprocess.h>
+
+using namespace H2Core;
 
 void CliTest::setUp() {
 	___INFOLOG( "" );
@@ -48,20 +51,20 @@ void CliTest::testKitToDrumkitMap() {
 	// Check whether things work for a kit without any kits too.
 	const QString sNoTypesFolder = H2TEST_FILE( "drumkits/baseKit" );
 	// We load the kits to ensure they are clean and can be loaded.
-	const auto pDrumkitRef = H2Core::Drumkit::load(
-		H2Core::Filesystem::drumkitPathFromDir( sRefFolder ), false, nullptr,
+	const auto pDrumkitRef = Drumkit::load(
+		Filesystem::drumkitPathFromDir( sRefFolder ), false, nullptr,
 		true
 	);
 	CPPUNIT_ASSERT( pDrumkitRef != nullptr );
-	const auto pDrumkitNoTypes = H2Core::Drumkit::load(
-		H2Core::Filesystem::drumkitPathFromDir( sNoTypesFolder ), false,
+	const auto pDrumkitNoTypes = Drumkit::load(
+		Filesystem::drumkitPathFromDir( sNoTypesFolder ), false,
 		nullptr, true
 	);
 	CPPUNIT_ASSERT( pDrumkitNoTypes != nullptr );
 
 	// Now, we also write the output and compare it with reference files.
 	const QString sTmpRefFile =
-		H2Core::Filesystem::tmpDir() + "sample-cli.h2map";
+		Filesystem::tmpDir() + "sample-cli.h2map";
 	QStringList argsRefFile;
 	argsRefFile << "--kitToDrumkitMap" << sRefFolder
 		<< "-o" << sTmpRefFile;
@@ -73,12 +76,12 @@ void CliTest::testKitToDrumkitMap() {
 	H2TEST_ASSERT_XML_FILES_EQUAL(
 		sTmpRefFile, H2TEST_FILE( "drumkit_map/sample.h2map" ) );
 
-	H2Core::Filesystem::rm( sTmpRefFile, true );
+	Filesystem::rm( sTmpRefFile, true );
 
 	// And now for the empty one.
 
 	const QString sTmpNoTypesFile =
-		H2Core::Filesystem::tmpDir() + "empty-cli.h2map";
+		Filesystem::tmpDir() + "empty-cli.h2map";
 	QStringList argsNoTypesFile;
 	argsNoTypesFile << "--kitToDrumkitMap" << sNoTypesFolder
 		<< "-o" << sTmpNoTypesFile;
@@ -90,10 +93,166 @@ void CliTest::testKitToDrumkitMap() {
 	H2TEST_ASSERT_XML_FILES_EQUAL(
 		sTmpNoTypesFile, H2TEST_FILE( "drumkit_map/empty.h2map" ) );
 
-	H2Core::XMLDoc docNoTypes;
+	XMLDoc docNoTypes;
 	CPPUNIT_ASSERT( docNoTypes.read( sTmpNoTypesFile ) );
 
-	H2Core::Filesystem::rm( sTmpNoTypesFile, true );
+	Filesystem::rm( sTmpNoTypesFile, true );
 
 	___INFOLOG( "passed" );
 }
+
+#if defined(Q_OS_MACX) || defined(WIN32)
+#else
+void CliTest::testXdgPaths() {
+	___INFOLOG( "" );
+
+	auto rm = []( const QString& sDir ) {
+		if ( Filesystem::dirExists( sDir, true ) ) {
+			return Filesystem::rm( sDir, true, true );
+		}
+		return true;
+	};
+
+	const QString sKitPath = H2TEST_FILE( "drumkits/testKit.h2drumkit" );
+	CPPUNIT_ASSERT( Filesystem::fileExists( sKitPath ) );
+
+	const QString sOldUserData = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
+	const bool bOldUserDataPresent = Filesystem::dirExists( sOldUserData, true );
+	bool bTestKitOldBackedUp = false;
+	const QString sTestKitOldPath = sOldUserData + "/drumkits/testKit";
+	const QString sTestKitOldBackupPath = Filesystem::tmpDir() + "/oldTestKit";
+	rm( sTestKitOldBackupPath );
+	if ( bOldUserDataPresent && Filesystem::dirExists( sTestKitOldPath, true ) ) {
+		QDir dir;
+		// Move the whole folder
+		CPPUNIT_ASSERT( dir.rename( sTestKitOldPath, sTestKitOldBackupPath ) );
+		bTestKitOldBackedUp = true;
+	}
+
+	// We back up the user-level data folder as well.
+	bool bOldUserDirBackedUp = false;
+	const QString sOldUserDataBackupPath = Filesystem::tmpDir() + "/oldUserData";
+	rm( sOldUserDataBackupPath );
+	if ( bOldUserDataPresent ) {
+		QDir dir;
+		// Move the whole folder
+		if ( ! dir.rename( sOldUserData, sOldUserDataBackupPath ) ) {
+			// Cleanup
+			if ( bTestKitOldBackedUp ) {
+				dir.rename( sTestKitOldBackupPath, sTestKitOldPath );
+			}
+			CPPUNIT_FAIL( "Unable to back up old user home folder" );
+		}
+		bOldUserDirBackedUp = true;
+	}
+
+	auto tearDown = [&]( const QString& sMsg ) {
+		if ( bOldUserDirBackedUp ) {
+			QDir dir;
+			// Move the whole folder
+			dir.rename( sOldUserDataBackupPath, sOldUserData );
+		}
+		if ( bTestKitOldBackedUp ) {
+			QDir dir;
+			dir.rename( sTestKitOldBackupPath, sTestKitOldPath );
+		}
+		CPPUNIT_FAIL( sMsg.toStdString() );
+	};
+
+	// First, we check whether the old data folder is honored.
+	if ( Filesystem::dirExists( sOldUserData, true ) ) {
+		tearDown( "Old data dir must not be present prior to test" );
+	}
+	if ( ! Filesystem::mkdir( sOldUserData ) ) {
+		tearDown( "Unable to create old data dir" );
+	}
+
+	QStringList argsRefFile;
+	argsRefFile << "-i" << sKitPath << "-VDebug";
+	{
+		auto pProcessRefFile = new QProcess();
+		// Connect signals to slots or lambdas to read output as it arrives
+		QObject::connect(
+			pProcessRefFile, &QProcess::readyReadStandardOutput,
+			[pProcessRefFile]() {
+				QString output =
+					QString::fromUtf8( pProcessRefFile->readAllStandardOutput()
+					);
+				___DEBUGLOG( QString( "Stdout: %1" ).arg( output ) );
+			}
+		);
+
+		QObject::connect(
+			pProcessRefFile, &QProcess::readyReadStandardError,
+			[pProcessRefFile]() {
+				QString error =
+					QString::fromUtf8( pProcessRefFile->readAllStandardError()
+					);
+				___DEBUGLOG( QString( "Stderr: %1" ).arg( error ) );
+			}
+		);
+		pProcessRefFile->start( m_sCliPath, argsRefFile );
+		if ( !pProcessRefFile->waitForFinished() ) {
+			tearDown( "h2cli on old data dir did not return" );
+		}
+		if ( pProcessRefFile->exitCode() != 0 ) {
+			tearDown( QString( "h2cli on old data dir existed with %1" )
+						  .arg( pProcessRefFile->exitCode() ) );
+		}
+	}
+	if ( ! Filesystem::dirExists( sTestKitOldPath, true ) ) {
+		tearDown( "Test kit was not installed to old data dir as expected." );
+	}
+
+	if ( ! Filesystem::rm( sOldUserData, true ) ) {
+		tearDown( "Unable to remove old data dir." );
+	}
+
+	// Now we test the same thing with the XDG counter part.
+	const QString sXdgTmpData = Filesystem::tmpDir() + "/tmpXdgData";
+	const QString sXdgTmpCache = Filesystem::tmpDir() + "/tmpXdgCache";
+	const QString sXdgTmpConfig = Filesystem::tmpDir() + "/tmpXdgConfig";
+	rm( sXdgTmpCache );
+	rm( sXdgTmpConfig );
+	rm( sXdgTmpData );
+	const QString sTestKitXdgPath = sXdgTmpData + "drumkits/testKit";
+	{
+		auto pProcessRefFile = new QProcess();
+		auto env = QProcessEnvironment::systemEnvironment();
+		env.insert( "XDG_CONFIG_HOME", sXdgTmpConfig );
+		env.insert( "XDG_CACHE_HOME", sXdgTmpCache );
+		env.insert( "XDG_DATA_HOME", sXdgTmpData );
+		pProcessRefFile->setProcessEnvironment( env );
+		pProcessRefFile->start( m_sCliPath, argsRefFile );
+		if ( ! pProcessRefFile->waitForFinished() ) {
+			tearDown( "h2cli on XDG data dir did not return" );
+		}
+		if ( pProcessRefFile->exitCode() != 0 ) {
+			tearDown( QString( "h2cli on XDG data dir existed with %1" ).arg( pProcessRefFile->exitCode() ));
+		}
+	}
+	if ( ! Filesystem::dirExists( sTestKitOldPath, true ) ) {
+		tearDown( "Test kit was not installed to XDG data dir as expected." );
+	}
+
+	// Cleanup
+		if ( bOldUserDirBackedUp ) {
+			QDir dir;
+			// Move the whole folder
+			rm( sOldUserData );
+			dir.rename( sOldUserDataBackupPath, sOldUserData );
+		}
+		if ( bTestKitOldBackedUp ) {
+			QDir dir;
+			rm( sTestKitOldPath );
+			dir.rename( sTestKitOldBackupPath, sTestKitOldPath );
+		}
+
+	Filesystem::rm( sXdgTmpData, true );
+	Filesystem::rm( sXdgTmpConfig, true );
+	Filesystem::rm( sXdgTmpCache, true );
+	Filesystem::rm( sTestKitOldBackupPath, true );
+
+	___INFOLOG( "passed" );
+}
+#endif

--- a/src/tests/CliTest.cpp
+++ b/src/tests/CliTest.cpp
@@ -169,7 +169,18 @@ void CliTest::testXdgPaths() {
 
 	QStringList argsRefFile;
 	argsRefFile << "-i" << sKitPath << "-VDebug";
-	{
+
+	const QString sXdgTmpData = Filesystem::tmpDir() + "/tmpXdgData";
+	const QString sXdgTmpCache = Filesystem::tmpDir() + "/tmpXdgCache";
+	const QString sXdgTmpConfig = Filesystem::tmpDir() + "/tmpXdgConfig";
+	rm( sXdgTmpCache );
+	rm( sXdgTmpConfig );
+	rm( sXdgTmpData );
+
+	auto startProcess = [&]( bool bUseXdg ) {
+		const QString sContext = bUseXdg ? "XDG dir" : "old user dir";
+
+		___INFOLOG( QString( "Starting process [%1]" ).arg( sContext ) );
 		auto pProcessRefFile = new QProcess();
 		// Connect signals to slots or lambdas to read output as it arrives
 		QObject::connect(
@@ -191,15 +202,27 @@ void CliTest::testXdgPaths() {
 				___DEBUGLOG( QString( "Stderr: %1" ).arg( error ) );
 			}
 		);
+		if ( bUseXdg ) {
+			auto env = QProcessEnvironment::systemEnvironment();
+			env.insert( "XDG_CONFIG_HOME", sXdgTmpConfig );
+			env.insert( "XDG_CACHE_HOME", sXdgTmpCache );
+			env.insert( "XDG_DATA_HOME", sXdgTmpData );
+			pProcessRefFile->setProcessEnvironment( env );
+		}
 		pProcessRefFile->start( m_sCliPath, argsRefFile );
 		if ( !pProcessRefFile->waitForFinished() ) {
-			tearDown( "h2cli on old data dir did not return" );
+			tearDown( QString( "h2cli on [%1] did not return" ).arg( sContext )
+			);
 		}
 		if ( pProcessRefFile->exitCode() != 0 ) {
-			tearDown( QString( "h2cli on old data dir existed with %1" )
+			tearDown( QString( "h2cli on [%1] existed with %1" )
+						  .arg( sContext )
 						  .arg( pProcessRefFile->exitCode() ) );
 		}
-	}
+	};
+
+	startProcess( false );
+
 	if ( ! Filesystem::dirExists( sTestKitOldPath, true ) ) {
 		tearDown( "Test kit was not installed to old data dir as expected." );
 	}
@@ -209,29 +232,10 @@ void CliTest::testXdgPaths() {
 	}
 
 	// Now we test the same thing with the XDG counter part.
-	const QString sXdgTmpData = Filesystem::tmpDir() + "/tmpXdgData";
-	const QString sXdgTmpCache = Filesystem::tmpDir() + "/tmpXdgCache";
-	const QString sXdgTmpConfig = Filesystem::tmpDir() + "/tmpXdgConfig";
-	rm( sXdgTmpCache );
-	rm( sXdgTmpConfig );
-	rm( sXdgTmpData );
-	const QString sTestKitXdgPath = sXdgTmpData + "drumkits/testKit";
-	{
-		auto pProcessRefFile = new QProcess();
-		auto env = QProcessEnvironment::systemEnvironment();
-		env.insert( "XDG_CONFIG_HOME", sXdgTmpConfig );
-		env.insert( "XDG_CACHE_HOME", sXdgTmpCache );
-		env.insert( "XDG_DATA_HOME", sXdgTmpData );
-		pProcessRefFile->setProcessEnvironment( env );
-		pProcessRefFile->start( m_sCliPath, argsRefFile );
-		if ( ! pProcessRefFile->waitForFinished() ) {
-			tearDown( "h2cli on XDG data dir did not return" );
-		}
-		if ( pProcessRefFile->exitCode() != 0 ) {
-			tearDown( QString( "h2cli on XDG data dir existed with %1" ).arg( pProcessRefFile->exitCode() ));
-		}
-	}
-	if ( ! Filesystem::dirExists( sTestKitOldPath, true ) ) {
+	const QString sTestKitXdgPath = sXdgTmpData + "/hydrogen/drumkits/testKit";
+	startProcess( true );
+
+	if ( ! Filesystem::dirExists( sTestKitXdgPath, true ) ) {
 		tearDown( "Test kit was not installed to XDG data dir as expected." );
 	}
 

--- a/src/tests/CliTest.cpp
+++ b/src/tests/CliTest.cpp
@@ -116,13 +116,13 @@ void CliTest::testXdgPaths() {
 	const QString sKitPath = H2TEST_FILE( "drumkits/testKit.h2drumkit" );
 	CPPUNIT_ASSERT( Filesystem::fileExists( sKitPath ) );
 
-	const QString sOldUserData = QDir::homePath().append( "/" H2_USR_PATH "/data/" );
-	const bool bOldUserDataPresent = Filesystem::dirExists( sOldUserData, true );
+	const QString sOldUserDir = QDir::homePath().append( "/" H2_USR_PATH "/" );
+	const bool bOldUserDirPresent = Filesystem::dirExists( sOldUserDir, true );
 	bool bTestKitOldBackedUp = false;
-	const QString sTestKitOldPath = sOldUserData + "/drumkits/testKit";
+	const QString sTestKitOldPath = sOldUserDir + "data/drumkits/testKit";
 	const QString sTestKitOldBackupPath = Filesystem::tmpDir() + "/oldTestKit";
 	rm( sTestKitOldBackupPath );
-	if ( bOldUserDataPresent && Filesystem::dirExists( sTestKitOldPath, true ) ) {
+	if ( bOldUserDirPresent && Filesystem::dirExists( sTestKitOldPath, true ) ) {
 		QDir dir;
 		// Move the whole folder
 		CPPUNIT_ASSERT( dir.rename( sTestKitOldPath, sTestKitOldBackupPath ) );
@@ -131,12 +131,12 @@ void CliTest::testXdgPaths() {
 
 	// We back up the user-level data folder as well.
 	bool bOldUserDirBackedUp = false;
-	const QString sOldUserDataBackupPath = Filesystem::tmpDir() + "/oldUserData";
-	rm( sOldUserDataBackupPath );
-	if ( bOldUserDataPresent ) {
+	const QString sOldUserDirBackupPath = Filesystem::tmpDir() + "/oldUserData";
+	rm( sOldUserDirBackupPath );
+	if ( bOldUserDirPresent ) {
 		QDir dir;
 		// Move the whole folder
-		if ( ! dir.rename( sOldUserData, sOldUserDataBackupPath ) ) {
+		if ( ! dir.rename( sOldUserDir, sOldUserDirBackupPath ) ) {
 			// Cleanup
 			if ( bTestKitOldBackedUp ) {
 				dir.rename( sTestKitOldBackupPath, sTestKitOldPath );
@@ -150,7 +150,7 @@ void CliTest::testXdgPaths() {
 		if ( bOldUserDirBackedUp ) {
 			QDir dir;
 			// Move the whole folder
-			dir.rename( sOldUserDataBackupPath, sOldUserData );
+			dir.rename( sOldUserDirBackupPath, sOldUserDir );
 		}
 		if ( bTestKitOldBackedUp ) {
 			QDir dir;
@@ -160,11 +160,11 @@ void CliTest::testXdgPaths() {
 	};
 
 	// First, we check whether the old data folder is honored.
-	if ( Filesystem::dirExists( sOldUserData, true ) ) {
-		tearDown( "Old data dir must not be present prior to test" );
+	if ( Filesystem::dirExists( sOldUserDir, true ) ) {
+		tearDown( "Old user dir must not be present prior to test" );
 	}
-	if ( ! Filesystem::mkdir( sOldUserData ) ) {
-		tearDown( "Unable to create old data dir" );
+	if ( ! Filesystem::mkdir( sOldUserDir ) ) {
+		tearDown( "Unable to create old user dir" );
 	}
 
 	QStringList argsRefFile;
@@ -204,8 +204,8 @@ void CliTest::testXdgPaths() {
 		tearDown( "Test kit was not installed to old data dir as expected." );
 	}
 
-	if ( ! Filesystem::rm( sOldUserData, true ) ) {
-		tearDown( "Unable to remove old data dir." );
+	if ( ! Filesystem::rm( sOldUserDir, true ) ) {
+		tearDown( "Unable to remove old user dir." );
 	}
 
 	// Now we test the same thing with the XDG counter part.
@@ -239,8 +239,8 @@ void CliTest::testXdgPaths() {
 		if ( bOldUserDirBackedUp ) {
 			QDir dir;
 			// Move the whole folder
-			rm( sOldUserData );
-			dir.rename( sOldUserDataBackupPath, sOldUserData );
+			rm( sOldUserDir );
+			dir.rename( sOldUserDirBackupPath, sOldUserDir );
 		}
 		if ( bTestKitOldBackedUp ) {
 			QDir dir;

--- a/src/tests/CliTest.h
+++ b/src/tests/CliTest.h
@@ -28,20 +28,34 @@
 #include <cppunit/extensions/HelperMacros.h>
 
 class CliTest : public CppUnit::TestCase {
-	CPPUNIT_TEST_SUITE(CliTest);
-	CPPUNIT_TEST(testKitToDrumkitMap);
+	CPPUNIT_TEST_SUITE( CliTest );
+	CPPUNIT_TEST( testKitToDrumkitMap );
+#if defined( Q_OS_MACX ) || defined( WIN32 )
+#else
+	CPPUNIT_TEST( testXdgPaths );
+#endif
 	CPPUNIT_TEST_SUITE_END();
 
-	public:
-		/** Note that since h2cli is a runtime dependency, we don't have to add
-		 * it to CMakeLists.txt of the test folder but just check its present
-		 * when running the unit tests.*/
-		void setUp();
-		void testKitToDrumkitMap();
+   public:
+	/** Note that since h2cli is a runtime dependency, we don't have to add
+	 * it to CMakeLists.txt of the test folder but just check its present
+	 * when running the unit tests.*/
+	void setUp();
+	void testKitToDrumkitMap();
+#if defined( Q_OS_MACX ) || defined( WIN32 )
+#else
+	/** Checkes whether the h2cli binary correctly uses an existing
+	 * $HOME/.hydrogen folder and falls back to the XDG paths on Linux in
+	 * case it does not exist.
+	 *
+	 * Note that the test imports (and removes) a drumkit called "testKit" into
+	 * the users drumkit data folder and temporarily moves the ~/.hydrogen
+	 * folder (if present). */
+	void testXdgPaths();
+#endif
 
-	private:
-		QString m_sCliPath;
+   private:
+	QString m_sCliPath;
 };
-
 
 #endif

--- a/src/tests/MidiActionTest.cpp
+++ b/src/tests/MidiActionTest.cpp
@@ -66,6 +66,7 @@ void MidiActionTest::tearDown()
 	Preferences::get_instance()->getMidiEventMap()->reset();
 }
 
+#ifndef Q_OS_MACX
 void MidiActionTest::testBeatCounterAction()
 {
 	___INFOLOG( "" );
@@ -148,6 +149,7 @@ void MidiActionTest::testBeatCounterAction()
 
 	___INFOLOG( "done" );
 }
+#endif
 
 void MidiActionTest::testBpmCcRelativeAction()
 {

--- a/src/tests/MidiActionTest.h
+++ b/src/tests/MidiActionTest.h
@@ -40,7 +40,9 @@ class MidiMessage;
  * to maintain and comprehend. */
 class MidiActionTest : public CppUnit::TestCase {
 	CPPUNIT_TEST_SUITE( MidiActionTest );
+#ifndef Q_OS_MACX
 	CPPUNIT_TEST( testBeatCounterAction );
+#endif
 	CPPUNIT_TEST( testBpmCcRelativeAction );
 	CPPUNIT_TEST( testBpmDecreaseAction );
 	CPPUNIT_TEST( testBpmFineCcRelativeAction );
@@ -104,7 +106,12 @@ class MidiActionTest : public CppUnit::TestCase {
 	virtual void setUp();
 	virtual void tearDown();
 
+#ifndef Q_OS_MACX
+	/** Our macOS pipeline is really slow. Occasionally, messages take so
+	 * long they exceed the maximum difference allowed for beat counter
+	 * events. */
 	void testBeatCounterAction();
+#endif
 	void testBpmCcRelativeAction();
 	void testBpmDecreaseAction();
 	void testBpmFineCcRelativeAction();


### PR DESCRIPTION
With this patch new Hydrogen installations on Linux will respect XDG paths:

- The config file is written to  `$XDG_CONFIG_HOME/hydrogen/hydrogen.conf`
- The cache folder goes to `$XDG_CACHE_HOME/hydrogen/`
- All the data subfolders (drumkits, plugins, playlists, etc.) along with the hydrogen.log file go to `$XDG_DATA_HOME/hydrogen/ `

If old folder (`~/.hydrogen/`) is found, `hydrogen` uses this one instead. To port an existing installation to XDG paths, move the `~/.hydrogen` folder to a different location (and copy all data and the configuration into the new folders).

Note that this only affects Linux since it only was requested by Linux users.

Fixes #643
Supersedes #1624 