### PR TITLE
Fix Preferences crash (#2343)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ All notable changes to this project will be documented in this file.
 - Fix linker error on OpenBSD by @rrrapha.
 - Fixed performance issue when using JACK audio with rubberband.
 - Parameter loss in the MIDI table within the preferences (#2328).
+- Fix segfault when opening the Preferences dialog due to a missing font or a
+  corrupt font database (#2343).
 
 ## [1.2.6] - 2025-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to this project will be documented in this file.
   tempo changes via keyboard shortcuts, MIDI, or OSC commands as well as
   Beat Counter and Tap Tempo are now discarded.
 - Big update of the `hydrogen` man page.
+- Instead of using the raw font family names of the config file, they are
+  validated first and might trigger a fallback to a safer font. This was done to
+  prevent crashes of `libfontconfig` on Linux (#2343).
+- Default font was changed to "Sans Serif" (#2343).
 
 ### Fixed
 
@@ -38,8 +42,6 @@ All notable changes to this project will be documented in this file.
 - Fix linker error on OpenBSD by @rrrapha.
 - Fixed performance issue when using JACK audio with rubberband.
 - Parameter loss in the MIDI table within the preferences (#2328).
-- Fix segfault when opening the Preferences dialog due to a missing font or a
-  corrupt font database (#2343).
 
 ## [1.2.6] - 2025-07-29
 

--- a/src/core/Preferences/Preferences.cpp
+++ b/src/core/Preferences/Preferences.cpp
@@ -45,6 +45,8 @@
 
 #include <QDir>
 #include <QProcess>
+#include <QFontDatabase>
+#include <QFont>
 //#include <QApplication>
 
 namespace H2Core
@@ -286,6 +288,31 @@ Preferences::~Preferences()
 {
 	INFOLOG( "DESTROY" );
 	__instance = nullptr;
+}
+
+QString Preferences::validateFontFamily( const QString& family ) {
+	if ( family.isEmpty() ) {
+		return QFont().family();
+	}
+	static QFontDatabase s_fontDb;
+	if ( !s_fontDb.families().contains( family ) ) {
+		WARNINGLOG( QString( "Font family '%1' not found, falling back to default" )
+					.arg( family ) );
+		return QFont().family();
+	}
+	return family;
+}
+
+QString Preferences::getApplicationFontFamily() const {
+	return validateFontFamily( getApplicationFontFamilyRaw() );
+}
+
+QString Preferences::getLevel2FontFamily() const {
+	return validateFontFamily( getLevel2FontFamilyRaw() );
+}
+
+QString Preferences::getLevel3FontFamily() const {
+	return validateFontFamily( getLevel3FontFamilyRaw() );
 }
 
 ///
@@ -587,11 +614,11 @@ bool Preferences::loadPreferences( bool bGlobal )
 				}
 
 				// Font fun
-				setApplicationFontFamily( guiNode.read_string( "application_font_family", getApplicationFontFamily(), false, false ) );
+				setApplicationFontFamily( guiNode.read_string( "application_font_family", getApplicationFontFamilyRaw(), false, false ) );
 				// The value defaults to m_sApplicationFontFamily on
 				// purpose to provide backward compatibility.
-				setLevel2FontFamily( guiNode.read_string( "level2_font_family", getLevel2FontFamily(), false, false ) );
-				setLevel3FontFamily( guiNode.read_string( "level3_font_family", getLevel3FontFamily(), false, false ) );
+				setLevel2FontFamily( guiNode.read_string( "level2_font_family", getLevel2FontFamilyRaw(), false, false ) );
+				setLevel3FontFamily( guiNode.read_string( "level3_font_family", getLevel3FontFamilyRaw(), false, false ) );
 				setFontSize( static_cast<FontTheme::FontSize>(
 					guiNode.read_int( "font_size",
 									  static_cast<int>(FontTheme::FontSize::Medium), false, false ) ) );
@@ -1047,9 +1074,9 @@ bool Preferences::savePreferences()
 	XMLNode guiNode = rootNode.createNode( "gui" );
 	{
 		guiNode.write_string( "QTStyle", getQTStyle() );
-		guiNode.write_string( "application_font_family", getApplicationFontFamily() );
-		guiNode.write_string( "level2_font_family", getLevel2FontFamily() );
-		guiNode.write_string( "level3_font_family", getLevel3FontFamily() );
+		guiNode.write_string( "application_font_family", getApplicationFontFamilyRaw() );
+		guiNode.write_string( "level2_font_family", getLevel2FontFamilyRaw() );
+		guiNode.write_string( "level3_font_family", getLevel3FontFamilyRaw() );
 		guiNode.write_int( "font_size", static_cast<int>(getFontSize()) );
 		guiNode.write_float( "mixer_falloff_speed", getMixerFalloffSpeed() );
 		guiNode.write_int( "patternEditorGridResolution", m_nPatternEditorGridResolution );

--- a/src/core/Preferences/Preferences.h
+++ b/src/core/Preferences/Preferences.h
@@ -479,11 +479,14 @@ public:
 	const QString&	getQTStyle();
 	void			setQTStyle( const QString& sStyle );
 
-	const QString&	getApplicationFontFamily() const;
+	QString			getApplicationFontFamily() const;
+	const QString&	getApplicationFontFamilyRaw() const;
 	void			setApplicationFontFamily( const QString& family );
-	const QString&	getLevel2FontFamily() const;
+	QString			getLevel2FontFamily() const;
+	const QString&	getLevel2FontFamilyRaw() const;
 	void			setLevel2FontFamily( const QString& family );
-	const QString&	getLevel3FontFamily() const;
+	QString			getLevel3FontFamily() const;
+	const QString&	getLevel3FontFamilyRaw() const;
 	void			setLevel3FontFamily( const QString& family );
 
 	FontTheme::FontSize		getFontSize() const;
@@ -692,6 +695,12 @@ private:
 	 * accessed with get_instance().
 	 */
 	static Preferences *		__instance;
+
+	/**
+	 * Validates a font family name against QFontDatabase.
+	 * Returns the family if available, otherwise the system default.
+	 */
+	static QString			validateFontFamily( const QString& family );
 
 	std::shared_ptr<Theme>		m_pTheme;
 	
@@ -1182,21 +1191,21 @@ inline const QString& Preferences::getQTStyle() {
 inline void Preferences::setQTStyle( const QString& sStyle ) {
 	m_pTheme->getInterfaceTheme()->m_sQTStyle = sStyle;
 }
-inline const QString& Preferences::getApplicationFontFamily() const {
+inline const QString& Preferences::getApplicationFontFamilyRaw() const {
 	return m_pTheme->getFontTheme()->m_sApplicationFontFamily;
 }
 inline void Preferences::setApplicationFontFamily( const QString& family ) {
 	m_pTheme->getFontTheme()->m_sApplicationFontFamily = family;
 }
 
-inline const QString& Preferences::getLevel2FontFamily() const {
+inline const QString& Preferences::getLevel2FontFamilyRaw() const {
 	return m_pTheme->getFontTheme()->m_sLevel2FontFamily;
 }
 inline void Preferences::setLevel2FontFamily( const QString& family ) {
 	m_pTheme->getFontTheme()->m_sLevel2FontFamily = family;
 }
 
-inline const QString& Preferences::getLevel3FontFamily() const {
+inline const QString& Preferences::getLevel3FontFamilyRaw() const {
 	return m_pTheme->getFontTheme()->m_sLevel3FontFamily;
 }
 inline void Preferences::setLevel3FontFamily( const QString& family ) {

--- a/src/core/Preferences/Theme.cpp
+++ b/src/core/Preferences/Theme.cpp
@@ -187,9 +187,9 @@ InterfaceTheme::InterfaceTheme( const std::shared_ptr<InterfaceTheme> pOther )
 }
 
 FontTheme::FontTheme()
-	: m_sApplicationFontFamily( "Lucida Grande" )
-	, m_sLevel2FontFamily( "Lucida Grande" )
-	, m_sLevel3FontFamily( "Lucida Grande" )
+	: m_sApplicationFontFamily( "Sans Serif" )
+	, m_sLevel2FontFamily( "Sans Serif" )
+	, m_sLevel3FontFamily( "Sans Serif" )
 	, m_fontSize( FontTheme::FontSize::Medium ) {
 }
 

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -2403,10 +2403,34 @@ void PreferencesDialog::updateAppearanceTab( const std::shared_ptr<H2Core::Theme
 		}
 	}
 
-	// Fonts
-	applicationFontComboBox->setCurrentFont( QFont( pTheme->getFontTheme()->m_sApplicationFontFamily ) );
-	level2FontComboBox->setCurrentFont( QFont( pTheme->getFontTheme()->m_sLevel2FontFamily ) );
-	level3FontComboBox->setCurrentFont( QFont( pTheme->getFontTheme()->m_sLevel3FontFamily ) );
+	// Fonts - use QFontDatabase to validate font families before setting them
+	// to prevent crashes in fontconfig when invalid font names are used
+	QString sApplicationFont = pTheme->getFontTheme()->m_sApplicationFontFamily;
+	QString sLevel2Font = pTheme->getFontTheme()->m_sLevel2FontFamily;
+	QString sLevel3Font = pTheme->getFontTheme()->m_sLevel3FontFamily;
+
+	// Validate font families and fall back to system defaults if invalid
+	QFontDatabase fontDatabase;
+	if ( !fontDatabase.families().contains( sApplicationFont ) ) {
+		WARNINGLOG( QString( "Application font family '%1' not found, falling back to default" )
+					.arg( sApplicationFont ) );
+		sApplicationFont = QFont().family();
+	}
+	if ( !fontDatabase.families().contains( sLevel2Font ) ) {
+		WARNINGLOG( QString( "Level2 font family '%1' not found, falling back to default" )
+					.arg( sLevel2Font ) );
+		sLevel2Font = QFont().family();
+	}
+	if ( !fontDatabase.families().contains( sLevel3Font ) ) {
+		WARNINGLOG( QString( "Level3 font family '%1' not found, falling back to default" )
+					.arg( sLevel3Font ) );
+		sLevel3Font = QFont().family();
+	}
+
+	applicationFontComboBox->setCurrentFont( QFont( sApplicationFont ) );
+	level2FontComboBox->setCurrentFont( QFont( sLevel2Font ) );
+	level3FontComboBox->setCurrentFont( QFont( sLevel3Font ) );
+
 	switch( pTheme->getFontTheme()->m_fontSize ) {
 	case FontTheme::FontSize::Small:
 		fontSizeComboBox->setCurrentIndex( 0 );

--- a/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
+++ b/src/gui/src/PreferencesDialog/PreferencesDialog.cpp
@@ -2403,33 +2403,12 @@ void PreferencesDialog::updateAppearanceTab( const std::shared_ptr<H2Core::Theme
 		}
 	}
 
-	// Fonts - use QFontDatabase to validate font families before setting them
-	// to prevent crashes in fontconfig when invalid font names are used
-	QString sApplicationFont = pTheme->getFontTheme()->m_sApplicationFontFamily;
-	QString sLevel2Font = pTheme->getFontTheme()->m_sLevel2FontFamily;
-	QString sLevel3Font = pTheme->getFontTheme()->m_sLevel3FontFamily;
-
-	// Validate font families and fall back to system defaults if invalid
-	QFontDatabase fontDatabase;
-	if ( !fontDatabase.families().contains( sApplicationFont ) ) {
-		WARNINGLOG( QString( "Application font family '%1' not found, falling back to default" )
-					.arg( sApplicationFont ) );
-		sApplicationFont = QFont().family();
-	}
-	if ( !fontDatabase.families().contains( sLevel2Font ) ) {
-		WARNINGLOG( QString( "Level2 font family '%1' not found, falling back to default" )
-					.arg( sLevel2Font ) );
-		sLevel2Font = QFont().family();
-	}
-	if ( !fontDatabase.families().contains( sLevel3Font ) ) {
-		WARNINGLOG( QString( "Level3 font family '%1' not found, falling back to default" )
-					.arg( sLevel3Font ) );
-		sLevel3Font = QFont().family();
-	}
-
-	applicationFontComboBox->setCurrentFont( QFont( sApplicationFont ) );
-	level2FontComboBox->setCurrentFont( QFont( sLevel2Font ) );
-	level3FontComboBox->setCurrentFont( QFont( sLevel3Font ) );
+	// Font families are now validated by Preferences::getApplicationFontFamily() et al.
+	// which fall back to the system default if the stored family is not available.
+	auto pPref = Preferences::get_instance();
+	applicationFontComboBox->setCurrentFont( QFont( pPref->getApplicationFontFamily() ) );
+	level2FontComboBox->setCurrentFont( QFont( pPref->getLevel2FontFamily() ) );
+	level3FontComboBox->setCurrentFont( QFont( pPref->getLevel3FontFamily() ) );
 
 	switch( pTheme->getFontTheme()->m_fontSize ) {
 	case FontTheme::FontSize::Small:


### PR DESCRIPTION
The crash was caused by **invalid or unavailable font family names** being used to construct `QFont` objects without validation:

1. **Default font issue**: The default font family was "Lucida Grande", which is not available on all Linux (it's more common on macOS systems). To circumvent this problem entirely, the default font was changed to a
generic family name which should work on all platforms
2. **Unsafe font construction**: `QFont` objects were created directly  from potentially invalid font family strings without
  validation (PreferencesDialog.cpp:2407-2409)
3. **Fontconfig crash**: When Qt constructs a `QFont` with an invalid/unavailable font family, it queries fontconfig to find fallbacks and check character availability, which can crash in `FcCharSetHasChar`  if the fontconfig database is corrupted or the font name is invalid

Fixes #2343 