### PR TITLE
Set desktop file name for the application

### DIFF
--- a/src/gui/src/main.cpp
+++ b/src/gui/src/main.cpp
@@ -301,6 +301,7 @@ int main(int argc, char *argv[])
 		H2QApplication* pQApp = new H2QApplication( argc, argv );
 		pQApp->setApplicationName( "Hydrogen" );
 		pQApp->setApplicationVersion( QString::fromStdString( H2Core::get_version() ) );
+		pQApp->setDesktopFileName( "org.hydrogenmusic.Hydrogen" );
 
 		// Process any pending events before showing splash screen. This allows macOS to show previous-crash
 		// warning dialogs before they are covered by the splash screen.


### PR DESCRIPTION
This ensures that the XDG toplevel app ID matches with the desktop file name, so Wayland compositors could match the window with the application and show the appropriate icon for them.

Without this change, the app ID is `hydrogen`, but the desktop file is called as [`org.hydrogenmusic.Hydrogen`](https://github.com/hydrogen-music/hydrogen/blob/90c2733e1eedd7d29f8d2ab6cf9c60c1b516f23c/linux/org.hydrogenmusic.Hydrogen.desktop).

References:
- https://github.com/qt/qtbase/blob/bf1ae5862807ec2b9a411506d59ccd566937a4c7/src/plugins/platforms/wayland/qwaylandwindow.cpp#L152C20-L177
- https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_app_id